### PR TITLE
feat(email): auto-categorization (Social / Promotions / Purchases / General) + icon rail UI

### DIFF
--- a/docs/superpowers/plans/2026-04-10-email-categories.md
+++ b/docs/superpowers/plans/2026-04-10-email-categories.md
@@ -1,0 +1,1209 @@
+# Email Categories Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace text folder sidebar with icon rail, add auto-categorization tabs (General/Promotions/Social/Purchases) for inbox, categorize new and historical emails using configurable rules.
+
+**Architecture:** Database migration adds a `category` column and a `category_rules` seed table. A pure-function categorizer runs during sync and during a one-time per-account backfill. UI extracts `IconRail` and `CategoryTabs` into separate files to keep `email-inbox.tsx` maintainable.
+
+**Tech Stack:** Next.js 16, React 19, Supabase, TypeScript, Tailwind CSS, Lucide icons
+
+**Spec:** `docs/superpowers/specs/2026-04-10-email-categories-design.md`
+
+---
+
+## Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migration-build27-categories.sql`
+
+- [ ] **Step 1: Create the migration SQL file**
+
+Create `supabase/migration-build27-categories.sql` with the following content:
+
+```sql
+-- ============================================
+-- Build 27 Migration: Email Categories
+-- Run this in the Supabase SQL Editor
+-- ============================================
+
+-- 1. Add category column to emails
+ALTER TABLE emails ADD COLUMN category text DEFAULT 'general';
+CREATE INDEX idx_emails_category ON emails(category);
+
+-- 2. Track whether each account has had historical emails backfilled
+ALTER TABLE email_accounts ADD COLUMN category_backfill_completed_at timestamptz;
+
+-- 3. Rules table
+CREATE TABLE category_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  match_type text NOT NULL,
+  match_value text NOT NULL,
+  category text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_category_rules_active ON category_rules(is_active) WHERE is_active = true;
+
+ALTER TABLE category_rules ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all on category_rules" ON category_rules FOR ALL USING (true) WITH CHECK (true);
+
+-- 4. Seed default rules
+
+-- Social (sender_domain)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'facebook.com', 'social'),
+  ('sender_domain', 'facebookmail.com', 'social'),
+  ('sender_domain', 'linkedin.com', 'social'),
+  ('sender_domain', 'twitter.com', 'social'),
+  ('sender_domain', 'x.com', 'social'),
+  ('sender_domain', 'instagram.com', 'social'),
+  ('sender_domain', 'nextdoor.com', 'social'),
+  ('sender_domain', 'pinterest.com', 'social'),
+  ('sender_domain', 'reddit.com', 'social'),
+  ('sender_domain', 'tiktok.com', 'social'),
+  ('sender_domain', 'snapchat.com', 'social'),
+  ('sender_domain', 'messenger.com', 'social');
+
+-- Promotions (sender_domain — ESPs)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'mailchimp.com', 'promotions'),
+  ('sender_domain', 'sendgrid.net', 'promotions'),
+  ('sender_domain', 'constantcontact.com', 'promotions'),
+  ('sender_domain', 'hubspot.com', 'promotions'),
+  ('sender_domain', 'klaviyo.com', 'promotions');
+
+-- Promotions (header presence)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('header', 'list-unsubscribe', 'promotions');
+
+-- Purchases (sender_domain)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'amazon.com', 'purchases'),
+  ('sender_domain', 'paypal.com', 'purchases'),
+  ('sender_domain', 'venmo.com', 'purchases'),
+  ('sender_domain', 'square.com', 'purchases'),
+  ('sender_domain', 'stripe.com', 'purchases'),
+  ('sender_domain', 'shopify.com', 'purchases'),
+  ('sender_domain', 'ebay.com', 'purchases'),
+  ('sender_domain', 'ups.com', 'purchases'),
+  ('sender_domain', 'fedex.com', 'purchases'),
+  ('sender_domain', 'usps.com', 'purchases');
+
+-- Purchases (subject pattern)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('subject_pattern', 'order confirm|receipt|shipping|delivered|invoice|payment received|your order', 'purchases');
+```
+
+- [ ] **Step 2: User runs migration in Supabase SQL Editor**
+
+**This is a manual step.** The engineer does NOT run this via psql or CLI. Tell the user to copy the contents of `supabase/migration-build27-categories.sql` into the Supabase SQL Editor and run it. Wait for confirmation before proceeding to Task 2.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migration-build27-categories.sql
+git commit -m "feat(db): add category column, rules table, and default seed"
+```
+
+---
+
+## Task 2: Categorizer Module
+
+**Files:**
+- Create: `src/lib/email-categorizer.ts`
+
+- [ ] **Step 1: Create the categorizer file**
+
+Create `src/lib/email-categorizer.ts` with the following content:
+
+```ts
+export type Category = "general" | "promotions" | "social" | "purchases";
+
+export interface CategoryRule {
+  match_type: "sender_address" | "sender_domain" | "header" | "subject_pattern";
+  match_value: string;
+  category: Category;
+}
+
+export interface EmailForCategorization {
+  from_address: string;
+  subject: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Categorize an email by matching against a pre-loaded list of rules.
+ * Match order (first match wins):
+ *   1. sender_address (exact, case-insensitive)
+ *   2. sender_domain (suffix match on domain portion of from_address)
+ *   3. header (case-insensitive presence of the named header)
+ *   4. subject_pattern (case-insensitive regex match against subject)
+ * Fallback: "general".
+ */
+export function categorizeEmail(
+  email: EmailForCategorization,
+  rules: CategoryRule[]
+): Category {
+  const fromLower = email.from_address.toLowerCase();
+  const subject = email.subject || "";
+  const headers = email.headers || {};
+
+  // Extract domain from "name@domain.tld" — take everything after the last "@"
+  const atIdx = fromLower.lastIndexOf("@");
+  const fromDomain = atIdx >= 0 ? fromLower.slice(atIdx + 1) : "";
+
+  // 1. sender_address exact match
+  for (const rule of rules) {
+    if (rule.match_type === "sender_address") {
+      if (rule.match_value.toLowerCase() === fromLower) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 2. sender_domain suffix match
+  for (const rule of rules) {
+    if (rule.match_type === "sender_domain") {
+      const target = rule.match_value.toLowerCase();
+      if (fromDomain === target || fromDomain.endsWith("." + target)) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 3. header presence
+  for (const rule of rules) {
+    if (rule.match_type === "header") {
+      const headerName = rule.match_value.toLowerCase();
+      if (headerName in headers) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 4. subject_pattern regex
+  for (const rule of rules) {
+    if (rule.match_type === "subject_pattern") {
+      try {
+        const re = new RegExp(rule.match_value, "i");
+        if (re.test(subject)) {
+          return rule.category;
+        }
+      } catch {
+        // Invalid regex in DB — skip
+      }
+    }
+  }
+
+  return "general";
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `npx tsc --noEmit src/lib/email-categorizer.ts 2>&1 | head -20`
+Expected: no errors (or the command may not take a single file — use `npx next build 2>&1 | tail -5` as an alternative).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/email-categorizer.ts
+git commit -m "feat(email): add email-categorizer utility"
+```
+
+---
+
+## Task 3: List API — Category Filter
+
+**Files:**
+- Modify: `src/app/api/email/list/route.ts`
+
+- [ ] **Step 1: Add category query param support**
+
+Open `src/app/api/email/list/route.ts`. Find the block that reads search params and add a `category` read. Find:
+
+```ts
+  const folder = searchParams.get("folder") || "inbox";
+  const accountId = searchParams.get("accountId"); // null = all accounts
+  const search = searchParams.get("search") || "";
+  const page = parseInt(searchParams.get("page") || "1");
+  const limit = parseInt(searchParams.get("limit") || "50");
+  const starred = searchParams.get("starred");
+```
+
+Add a `category` line after `starred`:
+
+```ts
+  const folder = searchParams.get("folder") || "inbox";
+  const accountId = searchParams.get("accountId"); // null = all accounts
+  const search = searchParams.get("search") || "";
+  const page = parseInt(searchParams.get("page") || "1");
+  const limit = parseInt(searchParams.get("limit") || "50");
+  const starred = searchParams.get("starred");
+  const category = searchParams.get("category");
+```
+
+- [ ] **Step 2: Apply the category filter when folder is inbox**
+
+Find the block that applies folder/account/search filters. After the account filter and before the search filter, add:
+
+```ts
+  // Filter by category (only applies to inbox)
+  if (category && folder === "inbox" && starred !== "true") {
+    query = query.eq("category", category);
+  }
+```
+
+The complete sequence of filters should end up looking like:
+
+```ts
+  // Filter by folder (unless showing starred across all folders)
+  if (starred === "true") {
+    query = query.eq("is_starred", true);
+  } else {
+    query = query.eq("folder", folder);
+  }
+
+  // Filter by account
+  if (accountId) {
+    query = query.eq("account_id", accountId);
+  }
+
+  // Filter by category (only applies to inbox)
+  if (category && folder === "inbox" && starred !== "true") {
+    query = query.eq("category", category);
+  }
+
+  // Search in subject, from_address, from_name, snippet
+  if (search) {
+    query = query.or(
+      `subject.ilike.%${search}%,from_address.ilike.%${search}%,from_name.ilike.%${search}%,snippet.ilike.%${search}%`
+    );
+  }
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/email/list/route.ts
+git commit -m "feat(email): support category filter in list API"
+```
+
+---
+
+## Task 4: Counts API — Category Unread
+
+**Files:**
+- Modify: `src/app/api/email/counts/route.ts`
+
+- [ ] **Step 1: Add category unread aggregation**
+
+Open `src/app/api/email/counts/route.ts`. After the starred count block (before the final `return NextResponse.json(counts);`), add:
+
+```ts
+  // Category unread counts for inbox only
+  let categoryQuery = supabase
+    .from("emails")
+    .select("category")
+    .eq("folder", "inbox")
+    .eq("is_read", false);
+
+  if (accountId) {
+    categoryQuery = categoryQuery.eq("account_id", accountId);
+  }
+
+  const { data: categoryData } = await categoryQuery;
+
+  const categoryUnread: Record<string, number> = {
+    general: 0,
+    promotions: 0,
+    social: 0,
+    purchases: 0,
+  };
+
+  for (const row of (categoryData || []) as { category: string | null }[]) {
+    const cat = row.category || "general";
+    if (cat in categoryUnread) categoryUnread[cat]++;
+  }
+```
+
+- [ ] **Step 2: Include categoryUnread in the response**
+
+Change the return statement from:
+
+```ts
+  return NextResponse.json(counts);
+```
+
+to:
+
+```ts
+  return NextResponse.json({ ...counts, categoryUnread });
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/email/counts/route.ts
+git commit -m "feat(email): add categoryUnread to counts API response"
+```
+
+---
+
+## Task 5: Sync — Categorize New Emails
+
+**Files:**
+- Modify: `src/app/api/email/sync/route.ts`
+
+- [ ] **Step 1: Import categorizer and extend ParsedEmail**
+
+Open `src/app/api/email/sync/route.ts`. Add an import after the existing imports at the top:
+
+```ts
+import { categorizeEmail, type CategoryRule, type Category } from "@/lib/email-categorizer";
+```
+
+Find the `ParsedEmail` interface near the top of the file and add a `headers` field:
+
+```ts
+interface ParsedEmail {
+  uid: number;
+  messageId: string;
+  threadId: string;
+  fromAddr: string;
+  fromName: string | null;
+  toAddresses: { email: string; name?: string }[];
+  ccAddresses: { email: string; name?: string }[];
+  subject: string;
+  bodyText: string | null;
+  bodyHtml: string | null;
+  snippet: string | null;
+  hasAttachments: boolean;
+  receivedAt: Date;
+  parsedAttachments: Attachment[];
+  headers: Record<string, string>;
+}
+```
+
+- [ ] **Step 2: Pre-fetch category rules alongside jobs/contacts cache**
+
+Find the block that pre-fetches jobs and contacts (around `// Pre-fetch job matching cache`). After the `matcherCache` assignment, add:
+
+```ts
+    // Pre-fetch category rules (once for entire sync)
+    const { data: rulesData } = await supabase
+      .from("category_rules")
+      .select("match_type, match_value, category")
+      .eq("is_active", true);
+    const categoryRules = (rulesData || []) as CategoryRule[];
+```
+
+- [ ] **Step 3: Capture headers during message parsing**
+
+Find the block inside the message loop that does `const parsedMsg = await simpleParser(msg.source);`. After it, before the `hasAttachments` update, add header extraction. The current code looks like:
+
+```ts
+            if (msg.source) {
+              const parsedMsg = await simpleParser(msg.source);
+              bodyText = parsedMsg.text || "";
+              bodyHtml = typeof parsedMsg.html === "string" ? parsedMsg.html : "";
+              msgAttachments = parsedMsg.attachments || [];
+              hasAttachments = msgAttachments.length > 0;
+            }
+```
+
+Replace with:
+
+```ts
+            let msgHeaders: Record<string, string> = {};
+            if (msg.source) {
+              const parsedMsg = await simpleParser(msg.source);
+              bodyText = parsedMsg.text || "";
+              bodyHtml = typeof parsedMsg.html === "string" ? parsedMsg.html : "";
+              msgAttachments = parsedMsg.attachments || [];
+              hasAttachments = msgAttachments.length > 0;
+              // Flatten mailparser headers Map to a lowercased plain object
+              if (parsedMsg.headers) {
+                for (const [key, value] of parsedMsg.headers) {
+                  msgHeaders[key.toLowerCase()] = String(value);
+                }
+              }
+            }
+```
+
+- [ ] **Step 4: Add headers to the ParsedEmail push**
+
+Find the `parsed.push({ ... })` call in the sync route. Add `headers: msgHeaders,` at the end of the object literal, before the closing `});`. The push should look like:
+
+```ts
+            parsed.push({
+              uid,
+              messageId,
+              threadId,
+              fromAddr,
+              fromName: fromName || null,
+              toAddresses,
+              ccAddresses,
+              subject,
+              bodyText: bodyText || null,
+              bodyHtml: bodyHtml || null,
+              snippet: snippet || null,
+              hasAttachments,
+              receivedAt: date,
+              parsedAttachments: msgAttachments,
+              headers: msgHeaders,
+            });
+```
+
+- [ ] **Step 5: Categorize during batch insert**
+
+Find the batch insert `rows = parsed.map((p) => { ... })` block. Inside the map callback, after the `match = matchEmailToJob(...)` call and before the return statement, add the categorization call. Then include `category` in the returned row.
+
+The existing code:
+
+```ts
+          const rows = parsed.map((p) => {
+            const match = matchEmailToJob(
+              matcherCache,
+              { from_address: p.fromAddr, to_addresses: p.toAddresses, subject: p.subject, body_text: p.bodyText },
+              account.email_address
+            );
+
+            return {
+              account_id: accountId,
+              job_id: match?.job_id || null,
+              ...
+              received_at: p.receivedAt,
+            };
+          });
+```
+
+Update it to:
+
+```ts
+          const rows = parsed.map((p) => {
+            const match = matchEmailToJob(
+              matcherCache,
+              { from_address: p.fromAddr, to_addresses: p.toAddresses, subject: p.subject, body_text: p.bodyText },
+              account.email_address
+            );
+
+            const category = categorizeEmail(
+              { from_address: p.fromAddr, subject: p.subject, headers: p.headers },
+              categoryRules
+            );
+
+            return {
+              account_id: accountId,
+              job_id: match?.job_id || null,
+              message_id: p.messageId,
+              thread_id: p.threadId,
+              folder,
+              from_address: p.fromAddr,
+              from_name: p.fromName,
+              to_addresses: p.toAddresses,
+              cc_addresses: p.ccAddresses,
+              bcc_addresses: [],
+              subject: p.subject,
+              body_text: p.bodyText,
+              body_html: p.bodyHtml,
+              snippet: p.snippet,
+              is_read: folder === "sent" || folder === "drafts",
+              is_starred: false,
+              has_attachments: p.hasAttachments,
+              matched_by: match?.matched_by || null,
+              uid: p.uid,
+              received_at: p.receivedAt,
+              category,
+            };
+          });
+```
+
+- [ ] **Step 6: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/api/email/sync/route.ts
+git commit -m "feat(email): categorize new emails during sync"
+```
+
+---
+
+## Task 6: Sync — Auto-Backfill
+
+**Files:**
+- Modify: `src/app/api/email/sync/route.ts`
+
+- [ ] **Step 1: Add backfill block after categoryRules fetch**
+
+Open `src/app/api/email/sync/route.ts`. Find the `const categoryRules = ...` line added in Task 5. Immediately after it, insert the backfill block:
+
+```ts
+    // One-time per-account backfill of historical emails
+    if (!account.category_backfill_completed_at) {
+      let offset = 0;
+      while (true) {
+        const { data: oldEmails } = await supabase
+          .from("emails")
+          .select("id, from_address, subject")
+          .eq("account_id", accountId)
+          .eq("category", "general")
+          .range(offset, offset + 199);
+
+        if (!oldEmails || oldEmails.length === 0) break;
+
+        const byCategory = new Map<Category, string[]>();
+        for (const e of oldEmails as { id: string; from_address: string; subject: string }[]) {
+          const cat = categorizeEmail(
+            { from_address: e.from_address, subject: e.subject },
+            categoryRules
+          );
+          if (cat !== "general") {
+            if (!byCategory.has(cat)) byCategory.set(cat, []);
+            byCategory.get(cat)!.push(e.id);
+          }
+        }
+
+        for (const [cat, ids] of byCategory) {
+          await supabase.from("emails").update({ category: cat }).in("id", ids);
+        }
+
+        if (oldEmails.length < 200) break;
+        offset += 200;
+      }
+
+      await supabase
+        .from("email_accounts")
+        .update({ category_backfill_completed_at: new Date().toISOString() })
+        .eq("id", accountId);
+    }
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/email/sync/route.ts
+git commit -m "feat(email): auto-backfill historical emails on first sync"
+```
+
+---
+
+## Task 7: IconRail Component
+
+**Files:**
+- Create: `src/components/email/icon-rail.tsx`
+
+- [ ] **Step 1: Create the component**
+
+First ensure the directory exists:
+
+```bash
+mkdir -p src/components/email
+```
+
+Create `src/components/email/icon-rail.tsx`:
+
+```tsx
+"use client";
+
+import {
+  Inbox,
+  Send,
+  FileText,
+  Trash2,
+  Archive,
+  ShieldAlert,
+  Star,
+  SquarePen,
+} from "lucide-react";
+
+interface FolderCounts {
+  [key: string]: { total: number; unread: number };
+}
+
+interface IconRailProps {
+  folder: string;
+  counts: FolderCounts;
+  onFolderChange: (key: string) => void;
+  onCompose: () => void;
+}
+
+const FOLDER_ICONS = [
+  { key: "inbox", label: "Inbox", icon: Inbox },
+  { key: "sent", label: "Sent", icon: Send },
+  { key: "drafts", label: "Drafts", icon: FileText },
+  { key: "trash", label: "Trash", icon: Trash2 },
+  { key: "archive", label: "Archive", icon: Archive },
+  { key: "spam", label: "Spam", icon: ShieldAlert },
+  { key: "starred", label: "Starred", icon: Star },
+];
+
+export default function IconRail({
+  folder,
+  counts,
+  onFolderChange,
+  onCompose,
+}: IconRailProps) {
+  return (
+    <div className="w-14 border-r border-border bg-muted/50 shrink-0 flex flex-col items-center py-2 gap-1">
+      {/* Compose button */}
+      <button
+        onClick={onCompose}
+        className="w-10 h-10 rounded-lg bg-[image:var(--gradient-primary)] text-white flex items-center justify-center shadow-sm hover:brightness-110 hover:shadow-md transition-all"
+        title="Compose"
+      >
+        <SquarePen size={18} />
+      </button>
+
+      {/* Divider */}
+      <div className="border-t border-border my-2 w-8" />
+
+      {/* Folder icons */}
+      {FOLDER_ICONS.map(({ key, label, icon: Icon }) => {
+        const isActive = folder === key;
+        const unread = counts[key]?.unread || 0;
+        const total = counts[key]?.total || 0;
+        const showBadge =
+          (key === "inbox" && unread > 0) ||
+          (key === "starred" && total > 0);
+        const badgeValue = key === "starred" ? total : unread;
+
+        return (
+          <button
+            key={key}
+            onClick={() => onFolderChange(key)}
+            title={label}
+            className={`relative w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
+              isActive
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-primary/5"
+            }`}
+          >
+            <Icon size={18} />
+            {showBadge && (
+              <span className="absolute -top-1 -right-1 bg-primary text-white text-[10px] font-bold rounded-full min-w-[16px] h-[16px] px-1 flex items-center justify-center">
+                {badgeValue > 99 ? "99+" : badgeValue}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/email/icon-rail.tsx
+git commit -m "feat(email): add IconRail component"
+```
+
+---
+
+## Task 8: CategoryTabs Component
+
+**Files:**
+- Create: `src/components/email/category-tabs.tsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `src/components/email/category-tabs.tsx`:
+
+```tsx
+"use client";
+
+import type { Category } from "@/lib/email-categorizer";
+
+interface CategoryTabsProps {
+  category: Category;
+  categoryCounts: Record<string, number>;
+  onChange: (cat: Category) => void;
+}
+
+const TABS: { key: Category; label: string }[] = [
+  { key: "general", label: "General" },
+  { key: "promotions", label: "Promotions" },
+  { key: "social", label: "Social" },
+  { key: "purchases", label: "Purchases" },
+];
+
+export default function CategoryTabs({
+  category,
+  categoryCounts,
+  onChange,
+}: CategoryTabsProps) {
+  return (
+    <div className="flex overflow-x-auto border-b border-border/50 shrink-0">
+      {TABS.map(({ key, label }) => {
+        const isActive = category === key;
+        const unread = categoryCounts[key] || 0;
+
+        return (
+          <button
+            key={key}
+            onClick={() => onChange(key)}
+            className={`px-4 py-2 text-sm flex items-center gap-2 border-b-2 whitespace-nowrap transition-colors ${
+              isActive
+                ? "border-primary text-primary font-medium"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {label}
+            {unread > 0 && (
+              <span className="text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
+                {unread}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npx next build 2>&1 | tail -5`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/email/category-tabs.tsx
+git commit -m "feat(email): add CategoryTabs component"
+```
+
+---
+
+## Task 9: EmailInbox — Integrate IconRail and Categories
+
+**Files:**
+- Modify: `src/components/email-inbox.tsx`
+
+This is the largest task. It integrates the new components, adds category state, removes sidebar resize state, and cleans up the top toolbar.
+
+- [ ] **Step 1: Update imports**
+
+Open `src/components/email-inbox.tsx`. Replace the existing lucide-react import block:
+
+```ts
+import {
+  Inbox,
+  Send,
+  FileEdit,
+  Trash2,
+  Archive,
+  AlertCircle,
+  Star,
+  Search,
+  RefreshCw,
+  Paperclip,
+  Briefcase,
+  MailPlus,
+  MailCheck,
+  ChevronDown,
+  Settings,
+  X,
+} from "lucide-react";
+```
+
+With (removing unused folder icons now that IconRail owns them, and removing MailPlus since Compose moves to the rail):
+
+```ts
+import {
+  Inbox,
+  Trash2,
+  Archive,
+  Star,
+  Search,
+  RefreshCw,
+  Paperclip,
+  Briefcase,
+  MailCheck,
+  ChevronDown,
+  Settings,
+  X,
+} from "lucide-react";
+```
+
+Then add imports for the new components and the Category type after the existing `import ComposeEmailModal from "@/components/compose-email";` line:
+
+```ts
+import IconRail from "@/components/email/icon-rail";
+import CategoryTabs from "@/components/email/category-tabs";
+import type { Category } from "@/lib/email-categorizer";
+```
+
+- [ ] **Step 2: Remove the FOLDERS constant**
+
+Find and delete the existing `FOLDERS` constant block (it's no longer used in EmailInbox — IconRail has its own):
+
+```ts
+const FOLDERS = [
+  { key: "inbox", label: "Inbox", icon: Inbox },
+  { key: "sent", label: "Sent", icon: Send },
+  { key: "drafts", label: "Drafts", icon: FileEdit },
+  { key: "trash", label: "Trash", icon: Trash2 },
+  { key: "archive", label: "Archive", icon: Archive },
+  { key: "spam", label: "Spam", icon: AlertCircle },
+  { key: "starred", label: "Starred", icon: Star },
+];
+```
+
+- [ ] **Step 3: Remove sidebar width state and its initializer**
+
+Find and delete this block:
+
+```ts
+  // Resizable pane widths
+  const [sidebarWidth, setSidebarWidth] = useState(() => {
+    if (typeof window === "undefined") return 208;
+    try {
+      const saved = localStorage.getItem("email-pane-widths");
+      if (saved) return JSON.parse(saved).sidebar ?? 208;
+    } catch {}
+    return 208;
+  });
+```
+
+The `listWidth` state stays. Then update the persistence effect (which currently writes both sidebar and list) to write only list:
+
+Find:
+
+```ts
+  // Persist widths to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        "email-pane-widths",
+        JSON.stringify({ sidebar: sidebarWidth, list: listWidth })
+      );
+    } catch {}
+  }, [sidebarWidth, listWidth]);
+```
+
+Replace with:
+
+```ts
+  // Persist list width to localStorage
+  useEffect(() => {
+    try {
+      localStorage.setItem(
+        "email-pane-widths",
+        JSON.stringify({ list: listWidth })
+      );
+    } catch {}
+  }, [listWidth]);
+```
+
+- [ ] **Step 4: Add category state**
+
+Find the block that declares `selectedEmailId` state. After it (or before the resizable pane comments that you just cleaned up), add:
+
+```ts
+  // Category filter (inbox only)
+  const [category, setCategory] = useState<Category>("general");
+  const [categoryCounts, setCategoryCounts] = useState<Record<string, number>>({
+    general: 0,
+    promotions: 0,
+    social: 0,
+    purchases: 0,
+  });
+```
+
+- [ ] **Step 5: Include category in loadEmails**
+
+Find the `loadEmails` useCallback:
+
+```ts
+  const loadEmails = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (folder === "starred") {
+        params.set("starred", "true");
+      } else {
+        params.set("folder", folder);
+      }
+      if (selectedAccountId) params.set("accountId", selectedAccountId);
+      if (searchDebounced) params.set("search", searchDebounced);
+      params.set("page", page.toString());
+
+      const res = await fetch(`/api/email/list?${params}`);
+      const data: ListResponse = await res.json();
+      setEmails(data.emails);
+      setTotal(data.total);
+      setHasMore(data.hasMore);
+    } catch {
+      toast.error("Failed to load emails");
+    }
+    setLoading(false);
+  }, [folder, selectedAccountId, searchDebounced, page]);
+```
+
+Replace with:
+
+```ts
+  const loadEmails = useCallback(async () => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (folder === "starred") {
+        params.set("starred", "true");
+      } else {
+        params.set("folder", folder);
+      }
+      if (selectedAccountId) params.set("accountId", selectedAccountId);
+      if (searchDebounced) params.set("search", searchDebounced);
+      params.set("page", page.toString());
+      if (folder === "inbox") params.set("category", category);
+
+      const res = await fetch(`/api/email/list?${params}`);
+      const data: ListResponse = await res.json();
+      setEmails(data.emails);
+      setTotal(data.total);
+      setHasMore(data.hasMore);
+    } catch {
+      toast.error("Failed to load emails");
+    }
+    setLoading(false);
+  }, [folder, selectedAccountId, searchDebounced, page, category]);
+```
+
+- [ ] **Step 6: Update loadCounts to read categoryUnread**
+
+Find the `loadCounts` useCallback:
+
+```ts
+  const loadCounts = useCallback(async () => {
+    try {
+      const params = selectedAccountId
+        ? `?accountId=${selectedAccountId}`
+        : "";
+      const res = await fetch(`/api/email/counts${params}`);
+      const data = await res.json();
+      setCounts(data);
+    } catch {
+      // silent
+    }
+  }, [selectedAccountId]);
+```
+
+Replace with:
+
+```ts
+  const loadCounts = useCallback(async () => {
+    try {
+      const params = selectedAccountId
+        ? `?accountId=${selectedAccountId}`
+        : "";
+      const res = await fetch(`/api/email/counts${params}`);
+      const data = await res.json();
+      setCounts(data);
+      if (data.categoryUnread) {
+        setCategoryCounts(data.categoryUnread);
+      }
+    } catch {
+      // silent
+    }
+  }, [selectedAccountId]);
+```
+
+- [ ] **Step 7: Update handleFolderChange to reset category**
+
+Find:
+
+```ts
+  function handleFolderChange(key: string) {
+    setFolder(key);
+    setPage(1);
+    setSelectedEmailId(null);
+    setSelectedIds(new Set());
+  }
+```
+
+Replace with:
+
+```ts
+  function handleFolderChange(key: string) {
+    setFolder(key);
+    setPage(1);
+    setSelectedEmailId(null);
+    setSelectedIds(new Set());
+    setCategory("general");
+  }
+```
+
+- [ ] **Step 8: Add handleCategoryChange**
+
+After `handleFolderChange`, add:
+
+```ts
+  function handleCategoryChange(cat: Category) {
+    setCategory(cat);
+    setPage(1);
+    setSelectedEmailId(null);
+    setSelectedIds(new Set());
+  }
+```
+
+- [ ] **Step 9: Remove Compose button from top toolbar**
+
+Find the Compose button in the top bar (inside the `{/* Top bar */}` div). It looks like:
+
+```tsx
+          <button
+            onClick={handleCompose}
+            className="flex items-center gap-1.5 px-4 py-1.5 bg-[image:var(--gradient-primary)] text-white rounded-lg text-sm font-medium shadow-sm hover:brightness-110 hover:shadow-md transition-all"
+          >
+            <MailPlus size={14} />
+            Compose
+          </button>
+```
+
+Delete the entire button (it moves into the IconRail).
+
+- [ ] **Step 10: Replace the sidebar column with IconRail**
+
+Find the 3-column layout section. The current sidebar column looks like:
+
+```tsx
+        {/* Column 1: Folder sidebar */}
+        <div style={{ width: sidebarWidth }} className="border-r border-border bg-muted/50 shrink-0 flex flex-col">
+          <nav className="flex-1 py-2">
+            {FOLDERS.map(({ key, label, icon: Icon }) => {
+              const isActive = folder === key;
+              const unread = counts[key]?.unread || 0;
+              const total2 = counts[key]?.total || 0;
+
+              return (
+                <button
+                  key={key}
+                  onClick={() => handleFolderChange(key)}
+                  className={`w-full flex items-center gap-2.5 px-4 py-2 text-sm transition-colors ${
+                    isActive
+                      ? "bg-primary/10 text-primary font-medium"
+                      : "text-muted-foreground hover:bg-primary/5"
+                  }`}
+                >
+                  <Icon size={16} />
+                  <span className="flex-1 text-left">{label}</span>
+                  {key === "starred" && total2 > 0 && (
+                    <span className="text-xs text-muted-foreground/60">{total2}</span>
+                  )}
+                  {key !== "starred" && unread > 0 && (
+                    <span className="text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
+                      {unread}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </nav>
+        </div>
+
+        <ResizeHandle
+          onResize={(delta) => {
+            setSidebarWidth((prev: number) => Math.min(300, Math.max(160, prev + delta)));
+          }}
+        />
+```
+
+Replace this entire block (the sidebar div AND the ResizeHandle that follows it) with:
+
+```tsx
+        {/* Column 1: Icon rail */}
+        <IconRail
+          folder={folder}
+          counts={counts}
+          onFolderChange={handleFolderChange}
+          onCompose={handleCompose}
+        />
+```
+
+- [ ] **Step 11: Render CategoryTabs above the list header**
+
+Find the email list column (it begins with `{/* Column 2: Email list */}`). Inside it, find the list header block (it starts with `{/* List header / Bulk action bar */}`). Immediately BEFORE the list header div, add:
+
+```tsx
+          {folder === "inbox" && (
+            <CategoryTabs
+              category={category}
+              categoryCounts={categoryCounts}
+              onChange={handleCategoryChange}
+            />
+          )}
+```
+
+- [ ] **Step 12: Verify build**
+
+Run: `npx next build 2>&1 | tail -10`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add src/components/email-inbox.tsx
+git commit -m "feat(email): integrate IconRail and CategoryTabs into EmailInbox"
+```
+
+---
+
+## Task 10: Manual Verification
+
+**Files:** None
+
+- [ ] **Step 1: Start the dev server and navigate to /email**
+
+Run: `npm run dev`
+Open `http://localhost:3000/email` in the browser.
+
+- [ ] **Step 2: Visual checks**
+
+Verify:
+1. Left side shows a narrow (56px) icon rail with Compose button at top, then folder icons stacked vertically
+2. Hovering over each icon shows a tooltip with the folder name
+3. Inbox has an unread count badge in the top-right corner
+4. Active folder icon is highlighted with `bg-primary/10 text-primary`
+5. Between the top toolbar and the email list, 4 tabs appear: General, Promotions, Social, Purchases
+6. Tabs are only visible when viewing Inbox (switch to Sent/Drafts — tabs disappear)
+7. The top toolbar no longer has a Compose button (it's in the rail)
+8. Clicking Compose in the rail opens the compose modal
+9. Clicking a category tab filters the email list (may initially show the same emails until backfill runs)
+
+- [ ] **Step 3: Test backfill + categorization by running a sync**
+
+Click "Sync" in the top toolbar. Wait for completion. Navigate between General/Promotions/Social/Purchases tabs — emails from social networks should now appear in Social, Amazon/UPS/etc. in Purchases, mailchimp/list-unsubscribe senders in Promotions.
+
+- [ ] **Step 4: No commit for this task**
+
+This is a verification task. If any check fails, report back and fix the relevant prior task.

--- a/docs/superpowers/specs/2026-04-10-email-categories-design.md
+++ b/docs/superpowers/specs/2026-04-10-email-categories-design.md
@@ -1,0 +1,290 @@
+# Email Inbox UI Restructure + Auto-Categorization
+
+**Date:** 2026-04-10
+**Scope:** Replace text-based folder sidebar with icon rail; add auto-categorization tabs (General/Promotions/Social/Purchases) for inbox
+
+## 1. Database (supabase/migration-build27-categories.sql)
+
+Single SQL migration file following the existing `migration-*.sql` pattern (run manually in Supabase SQL editor).
+
+### Schema changes
+
+```sql
+-- Add category column to emails
+ALTER TABLE emails ADD COLUMN category text DEFAULT 'general';
+CREATE INDEX idx_emails_category ON emails(category);
+
+-- Track whether each account has had historical emails backfilled
+ALTER TABLE email_accounts ADD COLUMN category_backfill_completed_at timestamptz;
+
+-- Rules table
+CREATE TABLE category_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  match_type text NOT NULL, -- 'sender_address' | 'sender_domain' | 'header' | 'subject_pattern'
+  match_value text NOT NULL,
+  category text NOT NULL, -- 'promotions' | 'social' | 'purchases' (no rules needed for 'general')
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_category_rules_active ON category_rules(is_active) WHERE is_active = true;
+
+ALTER TABLE category_rules ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all on category_rules" ON category_rules FOR ALL USING (true) WITH CHECK (true);
+```
+
+### Seed data
+
+~30 rules inserted at the bottom of the migration:
+
+**Social (sender_domain):** facebook.com, facebookmail.com, linkedin.com, twitter.com, x.com, instagram.com, nextdoor.com, pinterest.com, reddit.com, tiktok.com, snapchat.com, messenger.com
+
+**Promotions (sender_domain):** mailchimp.com, sendgrid.net, constantcontact.com, hubspot.com, klaviyo.com
+
+**Promotions (header):** `list-unsubscribe` (presence of this header → promotions)
+
+**Purchases (sender_domain):** amazon.com, paypal.com, venmo.com, square.com, stripe.com, shopify.com, ebay.com, ups.com, fedex.com, usps.com
+
+**Purchases (subject_pattern):** `order confirm|receipt|shipping|delivered|invoice|payment received|your order` (single regex, case-insensitive)
+
+## 2. Categorization engine (src/lib/email-categorizer.ts)
+
+Pure synchronous function, same pattern as refactored `email-matcher.ts`.
+
+```ts
+export type Category = 'general' | 'promotions' | 'social' | 'purchases';
+
+export interface CategoryRule {
+  match_type: 'sender_address' | 'sender_domain' | 'header' | 'subject_pattern';
+  match_value: string;
+  category: Category;
+}
+
+export function categorizeEmail(
+  email: { from_address: string; subject: string; headers?: Record<string, string> },
+  rules: CategoryRule[]
+): Category
+```
+
+**Match order (first match wins):**
+1. `sender_address` — exact case-insensitive match on `from_address`
+2. `sender_domain` — suffix match on the domain portion of `from_address` (e.g., `facebookmail.com` matches `noreply@notifications.facebookmail.com`)
+3. `header` — presence of the named header (lowercased lookup) in the optional `headers` object
+4. `subject_pattern` — case-insensitive regex match against `subject`
+
+Fallback: `'general'`. Rules are pre-loaded at sync start and passed in.
+
+## 3. Sync integration (src/app/api/email/sync/route.ts)
+
+**Cache pre-fetch (at start of sync, alongside jobs/contacts):**
+```ts
+const { data: rulesData } = await supabase
+  .from("category_rules")
+  .select("match_type, match_value, category")
+  .eq("is_active", true);
+const categoryRules = (rulesData || []) as CategoryRule[];
+```
+
+**Header capture:** `simpleParser()` already exposes `parsed.headers` as a `Map`. Convert to a plain object for `list-unsubscribe` lookup:
+```ts
+const headers: Record<string, string> = {};
+if (parsedMsg.headers) {
+  for (const [key, value] of parsedMsg.headers) {
+    headers[key.toLowerCase()] = String(value);
+  }
+}
+```
+
+**Categorize at batch insert:** Add `category` field to each row:
+```ts
+const category = categorizeEmail(
+  { from_address: p.fromAddr, subject: p.subject, headers: p.headers },
+  categoryRules
+);
+// include `category` in the insert row
+```
+
+The `ParsedEmail` interface gets a new `headers?: Record<string, string>` field.
+
+**Auto-backfill:** After IMAP connection established, before the folder loop:
+
+```ts
+if (!account.category_backfill_completed_at) {
+  // Backfill existing emails for this account in batches of 200
+  let offset = 0;
+  while (true) {
+    const { data: oldEmails } = await supabase
+      .from("emails")
+      .select("id, from_address, subject")
+      .eq("account_id", accountId)
+      .eq("category", "general")
+      .range(offset, offset + 199);
+
+    if (!oldEmails || oldEmails.length === 0) break;
+
+    // Recategorize (no headers available for historical emails — skip header rules)
+    const updates: { id: string; category: Category }[] = [];
+    for (const e of oldEmails) {
+      const cat = categorizeEmail(
+        { from_address: e.from_address, subject: e.subject },
+        categoryRules
+      );
+      if (cat !== "general") {
+        updates.push({ id: e.id, category: cat });
+      }
+    }
+
+    // Apply updates (Supabase doesn't support batch update with different values per row,
+    // so group by category and do one update per category)
+    const byCategory = new Map<Category, string[]>();
+    for (const u of updates) {
+      if (!byCategory.has(u.category)) byCategory.set(u.category, []);
+      byCategory.get(u.category)!.push(u.id);
+    }
+    for (const [cat, ids] of byCategory) {
+      await supabase.from("emails").update({ category: cat }).in("id", ids);
+    }
+
+    if (oldEmails.length < 200) break;
+    offset += 200;
+  }
+
+  await supabase
+    .from("email_accounts")
+    .update({ category_backfill_completed_at: new Date().toISOString() })
+    .eq("id", accountId);
+}
+```
+
+After this one-time backfill, every subsequent sync categorizes new emails during the normal batch insert.
+
+## 4. UI — Icon Rail (src/components/email/icon-rail.tsx)
+
+New component extracted from `EmailInbox`. Props:
+
+```ts
+interface IconRailProps {
+  folder: string;
+  counts: FolderCounts;
+  onFolderChange: (key: string) => void;
+  onCompose: () => void;
+}
+```
+
+**Structure:**
+- Fixed 56px wide, `border-r border-border bg-muted/50`, `flex flex-col items-center`
+- Top: Compose button (40×40, gradient background matching existing compose button styling, `SquarePen` icon, white)
+- Thin divider line (`border-t border-border my-2 w-8`)
+- Folder icons stacked vertically (`flex flex-col gap-1 py-2`):
+  - Inbox (`Inbox`)
+  - Sent (`Send`)
+  - Drafts (`FileText`)
+  - Trash (`Trash2`)
+  - Archive (`Archive`)
+  - Spam (`ShieldAlert`)
+  - Starred (`Star`)
+- Each icon button: 40×40, rounded, with `title` attribute for native tooltip
+- Active: `bg-primary/10 text-primary`
+- Inactive: `text-muted-foreground hover:bg-primary/5`
+- Unread badge on Inbox: absolutely positioned pill top-right (`absolute -top-1 -right-1 bg-primary text-white text-[10px] font-bold rounded-full min-w-[16px] h-[16px] px-1 flex items-center justify-center`)
+- Starred shows total count (not unread), same positioning, different color
+
+## 5. UI — Category Tabs (src/components/email/category-tabs.tsx)
+
+New component. Props:
+
+```ts
+interface CategoryTabsProps {
+  category: Category;
+  categoryCounts: Record<Category, number>;
+  onChange: (cat: Category) => void;
+}
+```
+
+**Structure:**
+- Horizontal bar `border-b border-border/50 flex overflow-x-auto` (scrollable on narrow screens)
+- 4 buttons: General, Promotions, Social, Purchases
+- Each: `px-4 py-2 text-sm border-b-2 flex items-center gap-2`
+- Active: `border-primary text-primary font-medium`
+- Inactive: `border-transparent text-muted-foreground hover:text-foreground`
+- Unread badge (only shown when count > 0): `text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center`
+
+Only rendered by the parent when `folder === 'inbox'`.
+
+## 6. Email list API and counts
+
+### List route (src/app/api/email/list/route.ts)
+
+Add `category` query param handling:
+
+```ts
+const category = searchParams.get("category");
+// ...
+if (category && folder === "inbox") {
+  query = query.eq("category", category);
+}
+```
+
+Only applies filter when querying inbox (other folders show all emails in that folder regardless of category).
+
+### Counts route (src/app/api/email/counts/route.ts)
+
+Add `categoryUnread` field to the response:
+
+```ts
+let categoryQuery = supabase
+  .from("emails")
+  .select("category")
+  .eq("folder", "inbox")
+  .eq("is_read", false);
+if (accountId) {
+  categoryQuery = categoryQuery.eq("account_id", accountId);
+}
+const { data: categoryData } = await categoryQuery;
+
+const categoryUnread: Record<string, number> = { general: 0, promotions: 0, social: 0, purchases: 0 };
+for (const row of categoryData || []) {
+  const cat = row.category || 'general';
+  if (cat in categoryUnread) categoryUnread[cat]++;
+}
+
+// Add to response:
+return NextResponse.json({ ...counts, categoryUnread });
+```
+
+## 7. EmailInbox integration (src/components/email-inbox.tsx)
+
+### State changes
+- **Remove:** `sidebarWidth`, its initializer, the localStorage sidebar read in the persistence effect (keep `listWidth`)
+- **Add:** `const [category, setCategory] = useState<Category>('general')`
+- **Add:** `const [categoryCounts, setCategoryCounts] = useState<Record<Category, number>>({ general: 0, promotions: 0, social: 0, purchases: 0 })`
+
+### Effects
+- `loadEmails` dependency array gets `category`; param string appends `&category=${category}` when `folder === 'inbox'`
+- `loadCounts` also sets `categoryCounts` from response
+
+### Handlers
+- `handleFolderChange`: reset `category` to `'general'` on every folder change
+- New `handleCategoryChange(cat)`: sets category, resets page to 1, clears selection
+
+### Rendering
+- Top toolbar: remove the Compose button (moves into rail), keep Sync + Settings + search + account selector
+- Replace sidebar column with `<IconRail ...>` (no resize handle after it)
+- Inside email list column, above the list header / bulk action bar:
+  ```tsx
+  {folder === 'inbox' && (
+    <CategoryTabs category={category} categoryCounts={categoryCounts} onChange={handleCategoryChange} />
+  )}
+  ```
+- Keep the resize handle between email list and reader
+
+### localStorage key cleanup
+The `email-pane-widths` key currently stores `{sidebar, list}`. After removing sidebar resize, it only stores `{list}`. The read code handles missing `sidebar` gracefully (nothing to read). The write continues to store `list` only.
+
+## 8. Out of scope (explicitly not in this build)
+
+- Category rules settings UI (spec says "later")
+- Per-category rule editing
+- Custom categories beyond the 4 defaults
+- Moving emails between categories manually
+- Changing the color palette, fonts, or theme

--- a/src/app/api/email/counts/route.ts
+++ b/src/app/api/email/counts/route.ts
@@ -49,5 +49,30 @@ export async function GET(request: NextRequest) {
   const starredResult = await starredQuery;
   counts.starred = { total: starredResult.count || 0, unread: 0 };
 
-  return NextResponse.json(counts);
+  // Category unread counts for inbox only
+  let categoryQuery = supabase
+    .from("emails")
+    .select("category")
+    .eq("folder", "inbox")
+    .eq("is_read", false);
+
+  if (accountId) {
+    categoryQuery = categoryQuery.eq("account_id", accountId);
+  }
+
+  const { data: categoryData } = await categoryQuery;
+
+  const categoryUnread: Record<string, number> = {
+    general: 0,
+    promotions: 0,
+    social: 0,
+    purchases: 0,
+  };
+
+  for (const row of (categoryData || []) as { category: string | null }[]) {
+    const cat = row.category || "general";
+    if (cat in categoryUnread) categoryUnread[cat]++;
+  }
+
+  return NextResponse.json({ ...counts, categoryUnread });
 }

--- a/src/app/api/email/list/route.ts
+++ b/src/app/api/email/list/route.ts
@@ -10,6 +10,7 @@ export async function GET(request: NextRequest) {
   const page = parseInt(searchParams.get("page") || "1");
   const limit = parseInt(searchParams.get("limit") || "50");
   const starred = searchParams.get("starred");
+  const category = searchParams.get("category");
 
   const supabase = createApiClient();
   const offset = (page - 1) * limit;
@@ -28,6 +29,11 @@ export async function GET(request: NextRequest) {
   // Filter by account
   if (accountId) {
     query = query.eq("account_id", accountId);
+  }
+
+  // Filter by category (only applies to inbox)
+  if (category && folder === "inbox" && starred !== "true") {
+    query = query.eq("category", category);
   }
 
   // Search in subject, from_address, from_name, snippet

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -146,15 +146,25 @@ export async function POST(request: NextRequest) {
       .eq("is_active", true);
     const categoryRules = (rulesData || []) as CategoryRule[];
 
+    // Discover available IMAP folders up front (needed for backfill Pass 2
+    // which re-fetches headers, as well as for the main folder loop below).
+    const folders = await client.list();
+    const folderPaths = folders.map((f) => f.path);
+
     // One-time per-account backfill of historical emails.
-    // Paginates by keyset (id) instead of offset because the category filter
-    // shrinks as rows get updated — offset-based pagination would skip rows.
+    // Paginates by keyset (id) because the category filter shrinks as rows
+    // get updated — offset-based pagination would skip rows.
+    //
+    // Pass 1: use stored from_address/subject/body_text (fast, no IMAP)
+    // Pass 2: re-fetch headers from IMAP for any remaining general emails
+    //         (catches List-Unsubscribe and other header-based rules)
     if (!account.category_backfill_completed_at) {
+      // ---- Pass 1: body/subject/domain-based backfill ----
       let lastId: string | null = null;
       while (true) {
         let batchQuery = supabase
           .from("emails")
-          .select("id, from_address, subject")
+          .select("id, from_address, subject, body_text")
           .eq("account_id", accountId)
           .eq("category", "general")
           .order("id", { ascending: true })
@@ -169,9 +179,9 @@ export async function POST(request: NextRequest) {
         if (!oldEmails || oldEmails.length === 0) break;
 
         const byCategory = new Map<Category, string[]>();
-        for (const e of oldEmails as { id: string; from_address: string; subject: string }[]) {
+        for (const e of oldEmails as { id: string; from_address: string; subject: string; body_text: string | null }[]) {
           const cat = categorizeEmail(
-            { from_address: e.from_address, subject: e.subject },
+            { from_address: e.from_address, subject: e.subject, body_text: e.body_text },
             categoryRules
           );
           if (cat !== "general") {
@@ -185,12 +195,110 @@ export async function POST(request: NextRequest) {
         }
 
         // Advance the keyset cursor to the last id we saw.
-        // Rows whose category got changed are excluded from the next query by
-        // the category filter; rows that stayed "general" are skipped by the
-        // `id > lastId` cursor, so we make forward progress every iteration.
         lastId = (oldEmails[oldEmails.length - 1] as { id: string }).id;
 
         if (oldEmails.length < 200) break;
+      }
+
+      // ---- Pass 2: IMAP header re-fetch for remaining general emails ----
+      // Only needed if we have header-based rules (e.g. list-unsubscribe).
+      // Cap at 500 re-fetches per sync to bound runtime.
+      const hasHeaderRules = categoryRules.some((r) => r.match_type === "header");
+      if (hasHeaderRules) {
+        const { data: remainingEmails } = await supabase
+          .from("emails")
+          .select("id, from_address, subject, body_text, folder, uid")
+          .eq("account_id", accountId)
+          .eq("category", "general")
+          .not("uid", "is", null)
+          .order("id", { ascending: true })
+          .limit(500);
+
+        if (remainingEmails && remainingEmails.length > 0) {
+          // Group by IMAP folder so we only open each mailbox once
+          const byFolder = new Map<string, { id: string; uid: number; fromAddr: string; subject: string; bodyText: string | null }[]>();
+          for (const e of remainingEmails as { id: string; from_address: string; subject: string; body_text: string | null; folder: string; uid: number }[]) {
+            if (!byFolder.has(e.folder)) byFolder.set(e.folder, []);
+            byFolder.get(e.folder)!.push({
+              id: e.id,
+              uid: e.uid,
+              fromAddr: e.from_address,
+              subject: e.subject,
+              bodyText: e.body_text,
+            });
+          }
+
+          // Map our normalized folder name back to an IMAP path we can open
+          const imapFolderPath = new Map<string, string>();
+          for (const path of folderPaths) {
+            const mapped = mapFolder(path);
+            if (!imapFolderPath.has(mapped)) imapFolderPath.set(mapped, path);
+          }
+
+          for (const [folderName, emails] of byFolder) {
+            const imapPath = imapFolderPath.get(folderName);
+            if (!imapPath) continue;
+
+            try {
+              await client.mailboxOpen(imapPath);
+              const uidsToFetch = emails.map((e) => e.uid).join(",");
+              const emailByUid = new Map(emails.map((e) => [e.uid, e]));
+              const updatesByCategory = new Map<Category, string[]>();
+
+              try {
+                for await (const msg of client.fetch(
+                  uidsToFetch,
+                  { uid: true, headers: true },
+                  { uid: true }
+                )) {
+                  const matchedEmail = emailByUid.get(msg.uid);
+                  if (!matchedEmail) continue;
+
+                  // Parse headers — ImapFlow returns a Buffer or Headers map
+                  const msgHeaders: Record<string, string> = {};
+                  if (msg.headers) {
+                    const raw = msg.headers.toString("utf-8");
+                    for (const line of raw.split(/\r?\n/)) {
+                      const idx = line.indexOf(":");
+                      if (idx > 0) {
+                        const key = line.slice(0, idx).trim().toLowerCase();
+                        const value = line.slice(idx + 1).trim();
+                        if (key && !(key in msgHeaders)) {
+                          msgHeaders[key] = value;
+                        }
+                      }
+                    }
+                  }
+
+                  const cat = categorizeEmail(
+                    {
+                      from_address: matchedEmail.fromAddr,
+                      subject: matchedEmail.subject,
+                      headers: msgHeaders,
+                      body_text: matchedEmail.bodyText,
+                    },
+                    categoryRules
+                  );
+
+                  if (cat !== "general") {
+                    if (!updatesByCategory.has(cat)) updatesByCategory.set(cat, []);
+                    updatesByCategory.get(cat)!.push(matchedEmail.id);
+                  }
+                }
+              } catch {
+                // Folder fetch error — skip this folder
+              }
+
+              for (const [cat, ids] of updatesByCategory) {
+                await supabase.from("emails").update({ category: cat }).in("id", ids);
+              }
+
+              await client.mailboxClose();
+            } catch {
+              // Folder open error — skip
+            }
+          }
+        }
       }
 
       await supabase
@@ -198,10 +306,6 @@ export async function POST(request: NextRequest) {
         .update({ category_backfill_completed_at: new Date().toISOString() })
         .eq("id", accountId);
     }
-
-    // Discover available folders
-    const folders = await client.list();
-    const folderPaths = folders.map((f) => f.path);
 
     // Determine which folders to sync
     const foldersToSync: string[] = [];

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -146,6 +146,45 @@ export async function POST(request: NextRequest) {
       .eq("is_active", true);
     const categoryRules = (rulesData || []) as CategoryRule[];
 
+    // One-time per-account backfill of historical emails
+    if (!account.category_backfill_completed_at) {
+      let offset = 0;
+      while (true) {
+        const { data: oldEmails } = await supabase
+          .from("emails")
+          .select("id, from_address, subject")
+          .eq("account_id", accountId)
+          .eq("category", "general")
+          .range(offset, offset + 199);
+
+        if (!oldEmails || oldEmails.length === 0) break;
+
+        const byCategory = new Map<Category, string[]>();
+        for (const e of oldEmails as { id: string; from_address: string; subject: string }[]) {
+          const cat = categorizeEmail(
+            { from_address: e.from_address, subject: e.subject },
+            categoryRules
+          );
+          if (cat !== "general") {
+            if (!byCategory.has(cat)) byCategory.set(cat, []);
+            byCategory.get(cat)!.push(e.id);
+          }
+        }
+
+        for (const [cat, ids] of byCategory) {
+          await supabase.from("emails").update({ category: cat }).in("id", ids);
+        }
+
+        if (oldEmails.length < 200) break;
+        offset += 200;
+      }
+
+      await supabase
+        .from("email_accounts")
+        .update({ category_backfill_completed_at: new Date().toISOString() })
+        .eq("id", accountId);
+    }
+
     // Discover available folders
     const folders = await client.list();
     const folderPaths = folders.map((f) => f.path);

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -146,16 +146,25 @@ export async function POST(request: NextRequest) {
       .eq("is_active", true);
     const categoryRules = (rulesData || []) as CategoryRule[];
 
-    // One-time per-account backfill of historical emails
+    // One-time per-account backfill of historical emails.
+    // Paginates by keyset (id) instead of offset because the category filter
+    // shrinks as rows get updated — offset-based pagination would skip rows.
     if (!account.category_backfill_completed_at) {
-      let offset = 0;
+      let lastId: string | null = null;
       while (true) {
-        const { data: oldEmails } = await supabase
+        let batchQuery = supabase
           .from("emails")
           .select("id, from_address, subject")
           .eq("account_id", accountId)
           .eq("category", "general")
-          .range(offset, offset + 199);
+          .order("id", { ascending: true })
+          .limit(200);
+
+        if (lastId) {
+          batchQuery = batchQuery.gt("id", lastId);
+        }
+
+        const { data: oldEmails } = await batchQuery;
 
         if (!oldEmails || oldEmails.length === 0) break;
 
@@ -175,8 +184,13 @@ export async function POST(request: NextRequest) {
           await supabase.from("emails").update({ category: cat }).in("id", ids);
         }
 
+        // Advance the keyset cursor to the last id we saw.
+        // Rows whose category got changed are excluded from the next query by
+        // the category filter; rows that stayed "general" are skipped by the
+        // `id > lastId` cursor, so we make forward progress every iteration.
+        lastId = (oldEmails[oldEmails.length - 1] as { id: string }).id;
+
         if (oldEmails.length < 200) break;
-        offset += 200;
       }
 
       await supabase

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -4,6 +4,7 @@ import { decrypt } from "@/lib/encryption";
 import { ImapFlow, FetchMessageObject } from "imapflow";
 import { matchEmailToJob, type MatcherCache, type JobRow, type ContactRow } from "@/lib/email-matcher";
 import { simpleParser, Attachment } from "mailparser";
+import { categorizeEmail, type CategoryRule, type Category } from "@/lib/email-categorizer";
 
 interface ParsedEmail {
   uid: number;
@@ -20,6 +21,7 @@ interface ParsedEmail {
   hasAttachments: boolean;
   receivedAt: Date;
   parsedAttachments: Attachment[];
+  headers: Record<string, string>;
 }
 
 // Map IMAP folder names to our normalized folder enum
@@ -137,6 +139,13 @@ export async function POST(request: NextRequest) {
 
     const matcherCache: MatcherCache = { jobs, contacts };
 
+    // Pre-fetch category rules (once for entire sync)
+    const { data: rulesData } = await supabase
+      .from("category_rules")
+      .select("match_type, match_value, category")
+      .eq("is_active", true);
+    const categoryRules = (rulesData || []) as CategoryRule[];
+
     // Discover available folders
     const folders = await client.list();
     const folderPaths = folders.map((f) => f.path);
@@ -207,12 +216,19 @@ export async function POST(request: NextRequest) {
             let hasAttachments = false;
             let msgAttachments: Attachment[] = [];
 
+            const msgHeaders: Record<string, string> = {};
             if (msg.source) {
               const parsedMsg = await simpleParser(msg.source);
               bodyText = parsedMsg.text || "";
               bodyHtml = typeof parsedMsg.html === "string" ? parsedMsg.html : "";
               msgAttachments = parsedMsg.attachments || [];
               hasAttachments = msgAttachments.length > 0;
+              // Flatten mailparser headers Map to a lowercased plain object
+              if (parsedMsg.headers) {
+                for (const [key, value] of parsedMsg.headers) {
+                  msgHeaders[key.toLowerCase()] = String(value);
+                }
+              }
             }
 
             if (!hasAttachments && msg.bodyStructure) {
@@ -258,6 +274,7 @@ export async function POST(request: NextRequest) {
               hasAttachments,
               receivedAt: date,
               parsedAttachments: msgAttachments,
+              headers: msgHeaders,
             });
           } catch (msgErr) {
             errors.push(folderPath + ": " + (msgErr instanceof Error ? msgErr.message : "unknown"));
@@ -271,6 +288,11 @@ export async function POST(request: NextRequest) {
               matcherCache,
               { from_address: p.fromAddr, to_addresses: p.toAddresses, subject: p.subject, body_text: p.bodyText },
               account.email_address
+            );
+
+            const category = categorizeEmail(
+              { from_address: p.fromAddr, subject: p.subject, headers: p.headers },
+              categoryRules
             );
 
             return {
@@ -294,6 +316,7 @@ export async function POST(request: NextRequest) {
               matched_by: match?.matched_by || null,
               uid: p.uid,
               received_at: p.receivedAt,
+              category,
             };
           });
 

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -69,18 +69,30 @@ export default function EmailInbox() {
     purchases: 0,
   });
 
-  // Resizable pane widths
-  const [listWidth, setListWidth] = useState(() => {
-    if (typeof window === "undefined") return 384;
+  // Resizable pane widths. Initialize with the default on both server and
+  // client to avoid hydration mismatch, then hydrate from localStorage in
+  // an effect after mount.
+  const [listWidth, setListWidth] = useState(384);
+  const listWidthHydrated = useRef(false);
+
+  useEffect(() => {
     try {
       const saved = localStorage.getItem("email-pane-widths");
-      if (saved) return JSON.parse(saved).list ?? 384;
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        if (typeof parsed.list === "number") {
+          setListWidth(parsed.list);
+        }
+      }
     } catch {}
-    return 384;
-  });
+    listWidthHydrated.current = true;
+  }, []);
 
-  // Persist list width to localStorage
+  // Persist list width to localStorage (skip the initial render before
+  // we've hydrated from localStorage, to avoid writing the default over
+  // the saved value).
   useEffect(() => {
+    if (!listWidthHydrated.current) return;
     try {
       localStorage.setItem(
         "email-pane-widths",

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -4,17 +4,13 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { format, isToday, isYesterday } from "date-fns";
 import {
   Inbox,
-  Send,
-  FileEdit,
   Trash2,
   Archive,
-  AlertCircle,
   Star,
   Search,
   RefreshCw,
   Paperclip,
   Briefcase,
-  MailPlus,
   MailCheck,
   ChevronDown,
   Settings,
@@ -24,6 +20,9 @@ import { toast } from "sonner";
 import type { Email, EmailAccount } from "@/lib/types";
 import EmailReader from "@/components/email-reader";
 import ComposeEmailModal from "@/components/compose-email";
+import IconRail from "@/components/email/icon-rail";
+import CategoryTabs from "@/components/email/category-tabs";
+import type { Category } from "@/lib/email-categorizer";
 
 interface FolderCounts {
   [key: string]: { total: number; unread: number };
@@ -36,15 +35,6 @@ interface ListResponse {
   hasMore: boolean;
 }
 
-const FOLDERS = [
-  { key: "inbox", label: "Inbox", icon: Inbox },
-  { key: "sent", label: "Sent", icon: Send },
-  { key: "drafts", label: "Drafts", icon: FileEdit },
-  { key: "trash", label: "Trash", icon: Trash2 },
-  { key: "archive", label: "Archive", icon: Archive },
-  { key: "spam", label: "Spam", icon: AlertCircle },
-  { key: "starred", label: "Starred", icon: Star },
-];
 
 function formatEmailDate(dateStr: string): string {
   const date = new Date(dateStr);
@@ -70,15 +60,16 @@ export default function EmailInbox() {
 
   const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null);
 
-  // Resizable pane widths
-  const [sidebarWidth, setSidebarWidth] = useState(() => {
-    if (typeof window === "undefined") return 208;
-    try {
-      const saved = localStorage.getItem("email-pane-widths");
-      if (saved) return JSON.parse(saved).sidebar ?? 208;
-    } catch {}
-    return 208;
+  // Category filter (inbox only)
+  const [category, setCategory] = useState<Category>("general");
+  const [categoryCounts, setCategoryCounts] = useState<Record<string, number>>({
+    general: 0,
+    promotions: 0,
+    social: 0,
+    purchases: 0,
   });
+
+  // Resizable pane widths
   const [listWidth, setListWidth] = useState(() => {
     if (typeof window === "undefined") return 384;
     try {
@@ -88,15 +79,15 @@ export default function EmailInbox() {
     return 384;
   });
 
-  // Persist widths to localStorage
+  // Persist list width to localStorage
   useEffect(() => {
     try {
       localStorage.setItem(
         "email-pane-widths",
-        JSON.stringify({ sidebar: sidebarWidth, list: listWidth })
+        JSON.stringify({ list: listWidth })
       );
     } catch {}
-  }, [sidebarWidth, listWidth]);
+  }, [listWidth]);
 
   // Bulk selection
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -236,6 +227,7 @@ export default function EmailInbox() {
       if (selectedAccountId) params.set("accountId", selectedAccountId);
       if (searchDebounced) params.set("search", searchDebounced);
       params.set("page", page.toString());
+      if (folder === "inbox") params.set("category", category);
 
       const res = await fetch(`/api/email/list?${params}`);
       const data: ListResponse = await res.json();
@@ -246,7 +238,7 @@ export default function EmailInbox() {
       toast.error("Failed to load emails");
     }
     setLoading(false);
-  }, [folder, selectedAccountId, searchDebounced, page]);
+  }, [folder, selectedAccountId, searchDebounced, page, category]);
 
   useEffect(() => {
     loadEmails();
@@ -261,6 +253,9 @@ export default function EmailInbox() {
       const res = await fetch(`/api/email/counts${params}`);
       const data = await res.json();
       setCounts(data);
+      if (data.categoryUnread) {
+        setCategoryCounts(data.categoryUnread);
+      }
     } catch {
       // silent
     }
@@ -468,6 +463,14 @@ export default function EmailInbox() {
     setPage(1);
     setSelectedEmailId(null);
     setSelectedIds(new Set());
+    setCategory("general");
+  }
+
+  function handleCategoryChange(cat: Category) {
+    setCategory(cat);
+    setPage(1);
+    setSelectedEmailId(null);
+    setSelectedIds(new Set());
   }
 
   return (
@@ -529,13 +532,6 @@ export default function EmailInbox() {
             />
             {syncing ? "Syncing..." : "Sync"}
           </button>
-          <button
-            onClick={handleCompose}
-            className="flex items-center gap-1.5 px-4 py-1.5 bg-[image:var(--gradient-primary)] text-white rounded-lg text-sm font-medium shadow-sm hover:brightness-110 hover:shadow-md transition-all"
-          >
-            <MailPlus size={14} />
-            Compose
-          </button>
           <a
             href="/settings/email"
             className="p-1.5 text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent rounded"
@@ -548,44 +544,12 @@ export default function EmailInbox() {
 
       {/* 3-column layout */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Column 1: Folder sidebar */}
-        <div style={{ width: sidebarWidth }} className="border-r border-border bg-muted/50 shrink-0 flex flex-col">
-          <nav className="flex-1 py-2">
-            {FOLDERS.map(({ key, label, icon: Icon }) => {
-              const isActive = folder === key;
-              const unread = counts[key]?.unread || 0;
-              const total2 = counts[key]?.total || 0;
-
-              return (
-                <button
-                  key={key}
-                  onClick={() => handleFolderChange(key)}
-                  className={`w-full flex items-center gap-2.5 px-4 py-2 text-sm transition-colors ${
-                    isActive
-                      ? "bg-primary/10 text-primary font-medium"
-                      : "text-muted-foreground hover:bg-primary/5"
-                  }`}
-                >
-                  <Icon size={16} />
-                  <span className="flex-1 text-left">{label}</span>
-                  {key === "starred" && total2 > 0 && (
-                    <span className="text-xs text-muted-foreground/60">{total2}</span>
-                  )}
-                  {key !== "starred" && unread > 0 && (
-                    <span className="text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
-                      {unread}
-                    </span>
-                  )}
-                </button>
-              );
-            })}
-          </nav>
-        </div>
-
-        <ResizeHandle
-          onResize={(delta) => {
-            setSidebarWidth((prev: number) => Math.min(300, Math.max(160, prev + delta)));
-          }}
+        {/* Column 1: Icon rail */}
+        <IconRail
+          folder={folder}
+          counts={counts}
+          onFolderChange={handleFolderChange}
+          onCompose={handleCompose}
         />
 
         {/* Column 2: Email list */}
@@ -595,6 +559,14 @@ export default function EmailInbox() {
             selectedEmailId ? "hidden lg:flex" : "flex"
           }`}
         >
+          {folder === "inbox" && (
+            <CategoryTabs
+              category={category}
+              categoryCounts={categoryCounts}
+              onChange={handleCategoryChange}
+            />
+          )}
+
           {/* List header / Bulk action bar */}
           <div className="px-4 py-2 border-b border-border/50 text-xs text-muted-foreground/60 flex items-center justify-between">
             {selectedIds.size > 0 ? (

--- a/src/components/email/category-tabs.tsx
+++ b/src/components/email/category-tabs.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { Category } from "@/lib/email-categorizer";
+
+interface CategoryTabsProps {
+  category: Category;
+  categoryCounts: Record<string, number>;
+  onChange: (cat: Category) => void;
+}
+
+const TABS: { key: Category; label: string }[] = [
+  { key: "general", label: "General" },
+  { key: "promotions", label: "Promotions" },
+  { key: "social", label: "Social" },
+  { key: "purchases", label: "Purchases" },
+];
+
+export default function CategoryTabs({
+  category,
+  categoryCounts,
+  onChange,
+}: CategoryTabsProps) {
+  return (
+    <div className="flex overflow-x-auto border-b border-border/50 shrink-0">
+      {TABS.map(({ key, label }) => {
+        const isActive = category === key;
+        const unread = categoryCounts[key] || 0;
+
+        return (
+          <button
+            key={key}
+            onClick={() => onChange(key)}
+            className={`px-4 py-2 text-sm flex items-center gap-2 border-b-2 whitespace-nowrap transition-colors ${
+              isActive
+                ? "border-primary text-primary font-medium"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {label}
+            {unread > 0 && (
+              <span className="text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
+                {unread}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/email/icon-rail.tsx
+++ b/src/components/email/icon-rail.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {
+  Inbox,
+  Send,
+  FileText,
+  Trash2,
+  Archive,
+  ShieldAlert,
+  Star,
+  SquarePen,
+} from "lucide-react";
+
+interface FolderCounts {
+  [key: string]: { total: number; unread: number };
+}
+
+interface IconRailProps {
+  folder: string;
+  counts: FolderCounts;
+  onFolderChange: (key: string) => void;
+  onCompose: () => void;
+}
+
+const FOLDER_ICONS = [
+  { key: "inbox", label: "Inbox", icon: Inbox },
+  { key: "sent", label: "Sent", icon: Send },
+  { key: "drafts", label: "Drafts", icon: FileText },
+  { key: "trash", label: "Trash", icon: Trash2 },
+  { key: "archive", label: "Archive", icon: Archive },
+  { key: "spam", label: "Spam", icon: ShieldAlert },
+  { key: "starred", label: "Starred", icon: Star },
+];
+
+export default function IconRail({
+  folder,
+  counts,
+  onFolderChange,
+  onCompose,
+}: IconRailProps) {
+  return (
+    <div className="w-14 border-r border-border bg-muted/50 shrink-0 flex flex-col items-center py-2 gap-1">
+      {/* Compose button */}
+      <button
+        onClick={onCompose}
+        className="w-10 h-10 rounded-lg bg-[image:var(--gradient-primary)] text-white flex items-center justify-center shadow-sm hover:brightness-110 hover:shadow-md transition-all"
+        title="Compose"
+      >
+        <SquarePen size={18} />
+      </button>
+
+      {/* Divider */}
+      <div className="border-t border-border my-2 w-8" />
+
+      {/* Folder icons */}
+      {FOLDER_ICONS.map(({ key, label, icon: Icon }) => {
+        const isActive = folder === key;
+        const unread = counts[key]?.unread || 0;
+        const total = counts[key]?.total || 0;
+        const showBadge =
+          (key === "inbox" && unread > 0) ||
+          (key === "starred" && total > 0);
+        const badgeValue = key === "starred" ? total : unread;
+
+        return (
+          <button
+            key={key}
+            onClick={() => onFolderChange(key)}
+            title={label}
+            className={`relative w-10 h-10 rounded-lg flex items-center justify-center transition-colors ${
+              isActive
+                ? "bg-primary/10 text-primary"
+                : "text-muted-foreground hover:bg-primary/5"
+            }`}
+          >
+            <Icon size={18} />
+            {showBadge && (
+              <span className="absolute -top-1 -right-1 bg-primary text-white text-[10px] font-bold rounded-full min-w-[16px] h-[16px] px-1 flex items-center justify-center">
+                {badgeValue > 99 ? "99+" : badgeValue}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/email-categorizer.ts
+++ b/src/lib/email-categorizer.ts
@@ -1,0 +1,80 @@
+export type Category = "general" | "promotions" | "social" | "purchases";
+
+export interface CategoryRule {
+  match_type: "sender_address" | "sender_domain" | "header" | "subject_pattern";
+  match_value: string;
+  category: Category;
+}
+
+export interface EmailForCategorization {
+  from_address: string;
+  subject: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Categorize an email by matching against a pre-loaded list of rules.
+ * Match order (first match wins):
+ *   1. sender_address (exact, case-insensitive)
+ *   2. sender_domain (suffix match on domain portion of from_address)
+ *   3. header (case-insensitive presence of the named header)
+ *   4. subject_pattern (case-insensitive regex match against subject)
+ * Fallback: "general".
+ */
+export function categorizeEmail(
+  email: EmailForCategorization,
+  rules: CategoryRule[]
+): Category {
+  const fromLower = email.from_address.toLowerCase();
+  const subject = email.subject || "";
+  const headers = email.headers || {};
+
+  // Extract domain from "name@domain.tld" — take everything after the last "@"
+  const atIdx = fromLower.lastIndexOf("@");
+  const fromDomain = atIdx >= 0 ? fromLower.slice(atIdx + 1) : "";
+
+  // 1. sender_address exact match
+  for (const rule of rules) {
+    if (rule.match_type === "sender_address") {
+      if (rule.match_value.toLowerCase() === fromLower) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 2. sender_domain suffix match
+  for (const rule of rules) {
+    if (rule.match_type === "sender_domain") {
+      const target = rule.match_value.toLowerCase();
+      if (fromDomain === target || fromDomain.endsWith("." + target)) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 3. header presence
+  for (const rule of rules) {
+    if (rule.match_type === "header") {
+      const headerName = rule.match_value.toLowerCase();
+      if (headerName in headers) {
+        return rule.category;
+      }
+    }
+  }
+
+  // 4. subject_pattern regex
+  for (const rule of rules) {
+    if (rule.match_type === "subject_pattern") {
+      try {
+        const re = new RegExp(rule.match_value, "i");
+        if (re.test(subject)) {
+          return rule.category;
+        }
+      } catch {
+        // Invalid regex in DB — skip
+      }
+    }
+  }
+
+  return "general";
+}

--- a/src/lib/email-categorizer.ts
+++ b/src/lib/email-categorizer.ts
@@ -1,7 +1,7 @@
 export type Category = "general" | "promotions" | "social" | "purchases";
 
 export interface CategoryRule {
-  match_type: "sender_address" | "sender_domain" | "header" | "subject_pattern";
+  match_type: "sender_address" | "sender_domain" | "header" | "body_pattern" | "subject_pattern";
   match_value: string;
   category: Category;
 }
@@ -10,6 +10,7 @@ export interface EmailForCategorization {
   from_address: string;
   subject: string;
   headers?: Record<string, string>;
+  body_text?: string | null;
 }
 
 /**
@@ -18,7 +19,8 @@ export interface EmailForCategorization {
  *   1. sender_address (exact, case-insensitive)
  *   2. sender_domain (suffix match on domain portion of from_address)
  *   3. header (case-insensitive presence of the named header)
- *   4. subject_pattern (case-insensitive regex match against subject)
+ *   4. body_pattern (case-insensitive regex match against body_text)
+ *   5. subject_pattern (case-insensitive regex match against subject)
  * Fallback: "general".
  */
 export function categorizeEmail(
@@ -28,6 +30,7 @@ export function categorizeEmail(
   const fromLower = email.from_address.toLowerCase();
   const subject = email.subject || "";
   const headers = email.headers || {};
+  const bodyText = email.body_text || "";
 
   // Extract domain from "name@domain.tld" — take everything after the last "@"
   const atIdx = fromLower.lastIndexOf("@");
@@ -62,7 +65,23 @@ export function categorizeEmail(
     }
   }
 
-  // 4. subject_pattern regex
+  // 4. body_pattern regex
+  if (bodyText) {
+    for (const rule of rules) {
+      if (rule.match_type === "body_pattern") {
+        try {
+          const re = new RegExp(rule.match_value, "i");
+          if (re.test(bodyText)) {
+            return rule.category;
+          }
+        } catch {
+          // Invalid regex in DB — skip
+        }
+      }
+    }
+  }
+
+  // 5. subject_pattern regex
   for (const rule of rules) {
     if (rule.match_type === "subject_pattern") {
       try {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,6 +181,7 @@ export interface Email {
   is_starred: boolean;
   has_attachments: boolean;
   matched_by: "contact" | "claim_number" | "address" | "job_id" | "manual" | null;
+  category: "general" | "promotions" | "social" | "purchases" | null;
   uid: number | null;
   received_at: string;
   created_at: string;

--- a/supabase/migration-build27-categories.sql
+++ b/supabase/migration-build27-categories.sql
@@ -1,0 +1,72 @@
+-- ============================================
+-- Build 27 Migration: Email Categories
+-- Run this in the Supabase SQL Editor
+-- ============================================
+
+-- 1. Add category column to emails
+ALTER TABLE emails ADD COLUMN category text DEFAULT 'general';
+CREATE INDEX idx_emails_category ON emails(category);
+
+-- 2. Track whether each account has had historical emails backfilled
+ALTER TABLE email_accounts ADD COLUMN category_backfill_completed_at timestamptz;
+
+-- 3. Rules table
+CREATE TABLE category_rules (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  match_type text NOT NULL,
+  match_value text NOT NULL,
+  category text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_category_rules_active ON category_rules(is_active) WHERE is_active = true;
+
+ALTER TABLE category_rules ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all on category_rules" ON category_rules FOR ALL USING (true) WITH CHECK (true);
+
+-- 4. Seed default rules
+
+-- Social (sender_domain)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'facebook.com', 'social'),
+  ('sender_domain', 'facebookmail.com', 'social'),
+  ('sender_domain', 'linkedin.com', 'social'),
+  ('sender_domain', 'twitter.com', 'social'),
+  ('sender_domain', 'x.com', 'social'),
+  ('sender_domain', 'instagram.com', 'social'),
+  ('sender_domain', 'nextdoor.com', 'social'),
+  ('sender_domain', 'pinterest.com', 'social'),
+  ('sender_domain', 'reddit.com', 'social'),
+  ('sender_domain', 'tiktok.com', 'social'),
+  ('sender_domain', 'snapchat.com', 'social'),
+  ('sender_domain', 'messenger.com', 'social');
+
+-- Promotions (sender_domain — ESPs)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'mailchimp.com', 'promotions'),
+  ('sender_domain', 'sendgrid.net', 'promotions'),
+  ('sender_domain', 'constantcontact.com', 'promotions'),
+  ('sender_domain', 'hubspot.com', 'promotions'),
+  ('sender_domain', 'klaviyo.com', 'promotions');
+
+-- Promotions (header presence)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('header', 'list-unsubscribe', 'promotions');
+
+-- Purchases (sender_domain)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('sender_domain', 'amazon.com', 'purchases'),
+  ('sender_domain', 'paypal.com', 'purchases'),
+  ('sender_domain', 'venmo.com', 'purchases'),
+  ('sender_domain', 'square.com', 'purchases'),
+  ('sender_domain', 'stripe.com', 'purchases'),
+  ('sender_domain', 'shopify.com', 'purchases'),
+  ('sender_domain', 'ebay.com', 'purchases'),
+  ('sender_domain', 'ups.com', 'purchases'),
+  ('sender_domain', 'fedex.com', 'purchases'),
+  ('sender_domain', 'usps.com', 'purchases');
+
+-- Purchases (subject pattern)
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('subject_pattern', 'order confirm|receipt|shipping|delivered|invoice|payment received|your order', 'purchases');

--- a/supabase/migration-build28-body-patterns.sql
+++ b/supabase/migration-build28-body-patterns.sql
@@ -1,0 +1,25 @@
+-- ============================================
+-- Build 28 Migration: Body-pattern rules + re-backfill
+-- Run this in the Supabase SQL Editor
+-- ============================================
+
+-- 1. Add body_pattern rules for promotional email detection.
+-- These match against body_text (fetched during sync, stored per email).
+-- Order of insertion doesn't matter; the categorizer iterates all of them.
+
+INSERT INTO category_rules (match_type, match_value, category) VALUES
+  ('body_pattern', 'unsubscribe', 'promotions'),
+  ('body_pattern', 'view (this |it )?(in|on) (your )?browser', 'promotions'),
+  ('body_pattern', '(update|manage) your (email )?(preferences|subscription)', 'promotions'),
+  ('body_pattern', 'opt.?out', 'promotions'),
+  ('body_pattern', 'stop receiving (these )?emails', 'promotions'),
+  ('body_pattern', 'email preferences', 'promotions'),
+  ('body_pattern', 'you.{1,10}receiv(ed|ing) this (email|message) because', 'promotions');
+
+-- 2. Reset backfill flag on all accounts so the next sync re-runs the
+-- enhanced backfill with body_pattern matching + IMAP header re-fetch.
+-- This only affects emails still categorized as 'general' — already
+-- categorized emails (social, purchases, etc.) are untouched by the
+-- backfill query which filters WHERE category = 'general'.
+
+UPDATE email_accounts SET category_backfill_completed_at = NULL;


### PR DESCRIPTION
## Summary
- New **auto-categorization engine** for inbound emails. Every email is classified into one of four categories: `general` (default), `social`, `promotions`, or `purchases`.
- Rules-based classifier (`src/lib/email-categorizer.ts`) driven by a new `category_rules` table with ~36 seed rules covering sender domains (facebook, linkedin, amazon, paypal, ups, fedex, etc.), the `list-unsubscribe` header, subject patterns, and body-text patterns.
- New **CategoryTabs** component in the email inbox UI. Switches between categories; each tab shows its own unread count.
- New **IconRail** component replacing the text folder sidebar in `EmailInbox`. Icon-first navigation; more compact layout.
- **Auto-backfill** on first sync: historical emails get categorized the first time the account syncs after migration, tracked per-account via `email_accounts.category_backfill_completed_at`.
- **Keyset pagination** for the backfill so it scales to large inboxes without loading everything into memory.
- IMAP header re-fetch during backfill so body-pattern matching can work on older messages.

## Schema changes (already applied to production Supabase)
Both migrations were already applied in a previous session against the shared dev/prod Supabase project:
- `supabase/migration-build27-categories.sql` — adds `emails.category`, `email_accounts.category_backfill_completed_at`, creates `category_rules` table + RLS policy + seed rules
- `supabase/migration-build28-body-patterns.sql` — adds 7 body_pattern rules + resets backfill flags

A duplicate-cleanup was run today (build28 had been applied twice; cleaned back to 7 unique body_pattern rules). Final state verified: 36 total rules.

**No further migration steps are required before merge.**

## Full design
- Spec: `docs/superpowers/specs/2026-04-10-email-categories-design.md`
- Plan: `docs/superpowers/plans/2026-04-10-email-categories.md`

## Test plan
- [x] TypeScript compiles cleanly on the branch (`tsc --noEmit` → 0 errors)
- [x] Migrations applied to production Supabase, seed data verified at 36 rules
- [x] Duplicate body_pattern rules cleaned up (14 → 7)
- [ ] Email inbox loads on production after merge — IconRail renders, CategoryTabs render
- [ ] Unread counts populate per category
- [ ] New incoming emails are categorized during sync
- [ ] Historical backfill runs on first sync post-deploy (watch server logs)
- [ ] Selecting a CategoryTab filters the email list correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
