### PR TITLE
feat: redesign job detail with 3-column layout, multi-adjuster support, and insurance editing

### DIFF
--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
     // Pre-fetch job matching cache (once for entire sync)
     const { data: jobsData } = await supabase
       .from("jobs")
-      .select("id, job_number, claim_number, property_address, contact_id, adjuster_contact_id")
+      .select("id, job_number, claim_number, property_address, contact_id, job_adjusters(contact_id)")
       .not("status", "eq", "cancelled");
 
     const jobs = (jobsData || []) as JobRow[];
@@ -124,7 +124,11 @@ export async function POST(request: NextRequest) {
     const contactIds = new Set<string>();
     for (const job of jobs) {
       contactIds.add(job.contact_id);
-      if (job.adjuster_contact_id) contactIds.add(job.adjuster_contact_id);
+      if (job.job_adjusters) {
+        for (const ja of job.job_adjusters) {
+          contactIds.add(ja.contact_id);
+        }
+      }
     }
 
     let contacts: ContactRow[] = [];

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -72,7 +72,7 @@ export async function POST(request: NextRequest) {
       const { data: job } = await supabase
         .from("jobs")
         .select(
-          "*, contact:contacts!contact_id(first_name, last_name), adjuster:contacts!adjuster_contact_id(first_name, last_name, email)"
+          "*, contact:contacts!contact_id(first_name, last_name), job_adjusters(*, adjuster:contacts!contact_id(first_name, last_name, email))"
         )
         .eq("id", job_id)
         .single();
@@ -90,10 +90,11 @@ export async function POST(request: NextRequest) {
           urgency: job.urgency,
           insuranceCompany: job.insurance_company,
           claimNumber: job.claim_number,
-          adjusterName: job.adjuster
-            ? `${job.adjuster.first_name} ${job.adjuster.last_name}`
-            : null,
-          adjusterEmail: job.adjuster?.email || null,
+          adjusterName: (() => {
+            const adj = job.job_adjusters?.find((ja: any) => ja.is_primary)?.adjuster;
+            return adj ? `${adj.first_name} ${adj.last_name}` : null;
+          })(),
+          adjusterEmail: job.job_adjusters?.find((ja: any) => ja.is_primary)?.adjuster?.email || null,
           createdAt: job.created_at,
         };
       }

--- a/src/app/api/jarvis/field-ops/route.ts
+++ b/src/app/api/jarvis/field-ops/route.ts
@@ -98,7 +98,7 @@ async function executeFieldOpsTool(
         // Get job with contact info
         const { data: job, error: jobError } = await supabase
           .from("jobs")
-          .select("*, contact:contacts(*), adjuster:contacts!adjuster_contact_id(*)")
+          .select("*, contact:contacts(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
           .eq("id", jobId)
           .single();
 

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -107,6 +107,7 @@ export default function IntakeForm() {
             last_name: nameParts.slice(1).join(" ") || "",
             phone: getVal("adjuster_phone") || null,
             role: "adjuster",
+            title: getVal("adjuster_title") || null,
           })
           .select()
           .single();
@@ -130,13 +131,24 @@ export default function IntakeForm() {
           urgency: getVal("urgency") || "scheduled",
           insurance_company: getVal("insurance_company") || null,
           claim_number: getVal("claim_number") || null,
-          adjuster_contact_id: adjusterContactId,
           access_notes: getVal("access_notes") || null,
         })
         .select()
         .single();
 
       if (jobErr) throw jobErr;
+
+      // Link adjuster to job via job_adjusters if one was created
+      if (adjusterContactId && job) {
+        const { error: adjLinkErr } = await supabase
+          .from("job_adjusters")
+          .insert({
+            job_id: job.id,
+            contact_id: adjusterContactId,
+            is_primary: true,
+          });
+        if (adjLinkErr) throw adjLinkErr;
+      }
 
       // 4. Save custom fields (fields without maps_to)
       if (formConfig) {

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase";
-import { Job, JobActivity, Payment, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
+import { Job, JobAdjuster, Contact, JobActivity, Payment, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -84,6 +84,8 @@ export default function JobDetail({ jobId }: { jobId: string }) {
   const [annotatorUrl, setAnnotatorUrl] = useState("");
   const [editJobOpen, setEditJobOpen] = useState(false);
   const [editContactOpen, setEditContactOpen] = useState(false);
+  const [editInsuranceOpen, setEditInsuranceOpen] = useState(false);
+  const [addAdjusterOpen, setAddAdjusterOpen] = useState(false);
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 
@@ -93,7 +95,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
     const [jobRes, activitiesRes, paymentsRes, photosRes, tagsRes, reportsRes, emailsRes] = await Promise.all([
       supabase
         .from("jobs")
-        .select("*, contact:contacts!contact_id(*), adjuster:contacts!adjuster_contact_id(*)")
+        .select("*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
         .eq("id", jobId)
         .single(),
       supabase
@@ -259,121 +261,163 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         </div>
       </div>
 
-      {/* Info grid */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
-        {/* Job Info */}
-        <div className="bg-card rounded-xl border border-border p-5">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-base font-semibold text-foreground">
-              Job Info
-            </h3>
-            <button
-              onClick={() => setEditJobOpen(true)}
-              className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-              title="Edit Job Info"
-            >
-              <Pencil size={14} />
-            </button>
-          </div>
-          <div className="space-y-3 text-sm">
-            <InfoRow icon={MapPin} label="Address" value={job.property_address} />
-            {job.property_type && (
-              <InfoRow
-                icon={Home}
-                label="Property Type"
-                value={propertyTypeLabels[job.property_type] || job.property_type}
-              />
-            )}
-            {job.property_sqft && (
-              <InfoRow icon={Ruler} label="Sq Ft" value={`${job.property_sqft.toLocaleString()} sq ft`} />
-            )}
-            {job.property_stories && (
-              <InfoRow icon={Layers} label="Stories" value={String(job.property_stories)} />
-            )}
-            {job.damage_source && (
-              <InfoRow icon={Droplets} label="Damage Source" value={job.damage_source} />
-            )}
-            {job.affected_areas && (
-              <InfoRow icon={MapPin} label="Affected Areas" value={job.affected_areas} />
-            )}
-            {job.access_notes && (
-              <InfoRow icon={KeyRound} label="Access Notes" value={job.access_notes} />
-            )}
-            <InfoRow
-              icon={FileText}
-              label="Intake Date"
-              value={format(new Date(job.created_at), "MMM d, yyyy 'at' h:mm a")}
-            />
-          </div>
-        </div>
-
-        {/* Contact & Insurance */}
-        <div className="bg-card rounded-xl border border-border p-5">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-base font-semibold text-foreground">
-              Contact & Insurance
-            </h3>
-            <button
-              onClick={() => setEditContactOpen(true)}
-              className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
-              title="Edit Contact & Insurance"
-            >
-              <Pencil size={14} />
-            </button>
-          </div>
-          <div className="space-y-3 text-sm">
-            <InfoRow icon={User} label="Contact" value={contactName} />
-            {job.contact?.phone && (
-              <InfoRow icon={Phone} label="Phone" value={job.contact.phone} />
-            )}
-            {job.contact?.email && (
-              <InfoRow icon={Mail} label="Email" value={job.contact.email} />
-            )}
-            {job.contact?.role && (
-              <InfoRow
-                icon={User}
-                label="Relationship"
-                value={job.contact.role.replace("_", " ")}
-              />
-            )}
-
-            {(job.insurance_company || job.claim_number) && (
-              <>
-                <div className="border-t border-border/50 pt-3 mt-3" />
-                {job.insurance_company && (
-                  <InfoRow
-                    icon={Building}
-                    label="Insurance"
-                    value={job.insurance_company}
-                  />
-                )}
-                {job.claim_number && (
-                  <InfoRow
-                    icon={FileText}
-                    label="Claim #"
-                    value={job.claim_number}
-                  />
-                )}
-              </>
-            )}
-
-            {job.adjuster && (
-              <>
-                <div className="border-t border-border/50 pt-3 mt-3" />
+      {/* Info card — 3 columns */}
+      <div className="rounded-xl border border-border bg-card p-6 mb-6">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_1px_1fr_1px_1fr] gap-0">
+          {/* Column 1: Job Info */}
+          <div className="pr-0 lg:pr-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold text-foreground">Job Info</h3>
+              <button
+                onClick={() => setEditJobOpen(true)}
+                className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                title="Edit Job Info"
+              >
+                <Pencil size={14} />
+              </button>
+            </div>
+            <div className="space-y-3 text-sm">
+              <InfoRow icon={MapPin} label="Address" value={job.property_address} />
+              {job.property_type && (
                 <InfoRow
-                  icon={User}
-                  label="Adjuster"
-                  value={`${job.adjuster.first_name} ${job.adjuster.last_name}`}
+                  icon={Home}
+                  label="Property Type"
+                  value={propertyTypeLabels[job.property_type] || job.property_type}
                 />
-                {job.adjuster.phone && (
-                  <InfoRow
-                    icon={Phone}
-                    label="Adjuster Phone"
-                    value={job.adjuster.phone}
-                  />
-                )}
-              </>
+              )}
+              {job.damage_source && (
+                <InfoRow icon={Droplets} label="Damage Source" value={job.damage_source} />
+              )}
+              {job.affected_areas && (
+                <InfoRow icon={MapPin} label="Affected Areas" value={job.affected_areas} />
+              )}
+              <InfoRow
+                icon={FileText}
+                label="Intake Date"
+                value={format(new Date(job.created_at), "MMM d, yyyy 'at' h:mm a")}
+              />
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="hidden lg:block bg-border/50" />
+
+          {/* Column 2: Contact + Adjusters */}
+          <div className="px-0 lg:px-6 pt-6 lg:pt-0">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold text-foreground">Contact</h3>
+              <button
+                onClick={() => setEditContactOpen(true)}
+                className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                title="Edit Contact"
+              >
+                <Pencil size={14} />
+              </button>
+            </div>
+
+            {/* Condensed homeowner card */}
+            {job.contact && (
+              <div className="rounded-lg border border-border bg-background/50 p-3 mb-3">
+                <div className="flex items-center justify-between mb-1">
+                  <span className="text-sm font-medium text-foreground">
+                    {job.contact.first_name} {job.contact.last_name}
+                  </span>
+                  <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-400 uppercase">
+                    {job.contact.role === "property_manager" ? "Prop Manager" : job.contact.role}
+                  </span>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {[job.contact.phone, job.contact.email].filter(Boolean).join(" \u00b7 ")}
+                </p>
+              </div>
             )}
+
+            {/* Adjusters sub-section */}
+            <div className="mt-4">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">Adjusters</span>
+                <button
+                  onClick={() => setAddAdjusterOpen(true)}
+                  className="w-5 h-5 rounded flex items-center justify-center text-xs font-bold bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/20 transition-colors"
+                  title="Add Adjuster"
+                >
+                  +
+                </button>
+              </div>
+              {(job.job_adjusters && job.job_adjusters.length > 0) ? (
+                <div className="space-y-2">
+                  {[...job.job_adjusters]
+                    .sort((a, b) => (b.is_primary ? 1 : 0) - (a.is_primary ? 1 : 0))
+                    .map((ja) => (
+                      <AdjusterCard key={ja.id} jobAdjuster={ja} jobId={jobId} onUpdated={fetchData} />
+                    ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground/60 py-2">No adjusters assigned</p>
+              )}
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div className="hidden lg:block bg-border/50" />
+
+          {/* Column 3: Insurance + HOA */}
+          <div className="pl-0 lg:pl-6 pt-6 lg:pt-0">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-base font-semibold text-foreground">Insurance</h3>
+              <button
+                onClick={() => setEditInsuranceOpen(true)}
+                className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                title="Edit Insurance"
+              >
+                <Pencil size={14} />
+              </button>
+            </div>
+
+            {/* Insurance card */}
+            {(job.insurance_company || job.claim_number || job.policy_number) ? (
+              <div className="rounded-lg border border-border bg-background/50 p-3 mb-3">
+                {job.insurance_company && (
+                  <p className="text-sm font-medium text-foreground mb-1">{job.insurance_company}</p>
+                )}
+                <p className="text-xs text-muted-foreground">
+                  {[
+                    job.claim_number ? `Claim: ${job.claim_number}` : null,
+                    job.policy_number ? `Policy: ${job.policy_number}` : null,
+                  ].filter(Boolean).join(" \u00b7 ")}
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {[
+                    job.date_of_loss ? `DOL: ${format(new Date(job.date_of_loss), "MMM d, yyyy")}` : null,
+                    job.deductible != null ? `Deductible: $${Number(job.deductible).toLocaleString()}` : null,
+                  ].filter(Boolean).join(" \u00b7 ")}
+                </p>
+              </div>
+            ) : (
+              <p className="text-xs text-muted-foreground/60 py-2">No insurance info</p>
+            )}
+
+            {/* HOA sub-section */}
+            <div className="mt-4">
+              <span className="text-[10px] font-medium text-muted-foreground uppercase tracking-wider">HOA</span>
+              {(job.hoa_name || job.hoa_contact_name) ? (
+                <div className="rounded-lg border border-border bg-background/50 p-3 mt-2">
+                  {job.hoa_name && (
+                    <p className="text-sm font-medium text-foreground mb-1">{job.hoa_name}</p>
+                  )}
+                  {job.hoa_contact_name && (
+                    <p className="text-xs text-muted-foreground">
+                      {[job.hoa_contact_name, job.hoa_contact_phone].filter(Boolean).join(" \u00b7 ")}
+                    </p>
+                  )}
+                  {job.hoa_contact_email && (
+                    <p className="text-xs text-muted-foreground mt-0.5">{job.hoa_contact_email}</p>
+                  )}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground/60 py-2">No HOA info</p>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -387,12 +431,30 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         onSaved={fetchData}
       />
 
-      {/* Edit Contact & Insurance Dialog */}
+      {/* Edit Contact Dialog */}
       <EditContactDialog
         open={editContactOpen}
         onOpenChange={setEditContactOpen}
         job={job}
         jobId={jobId}
+        onSaved={fetchData}
+      />
+
+      {/* Edit Insurance Dialog */}
+      <EditInsuranceDialog
+        open={editInsuranceOpen}
+        onOpenChange={setEditInsuranceOpen}
+        job={job}
+        jobId={jobId}
+        onSaved={fetchData}
+      />
+
+      {/* Add Adjuster Dialog */}
+      <AddAdjusterDialog
+        open={addAdjusterOpen}
+        onOpenChange={setAddAdjusterOpen}
+        jobId={jobId}
+        existingAdjusterIds={(job.job_adjusters || []).map((ja) => ja.contact_id)}
         onSaved={fetchData}
       />
 
@@ -705,7 +767,8 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           </h3>
           <button
             onClick={() => {
-              const defaultTo = job.contact?.email || job.adjuster?.email || "";
+              const primaryAdj = (job.job_adjusters || []).find((ja) => ja.is_primary)?.adjuster;
+              const defaultTo = job.contact?.email || primaryAdj?.email || "";
               const defaultSubject = job.job_number ? `Re: ${job.job_number}` : "";
               setComposeDefaults({ to: defaultTo, subject: defaultSubject, replyToMessageId: "" });
               setComposeOpen(true);
@@ -798,6 +861,72 @@ function InfoRow({
         <p className="text-xs text-muted-foreground">{label}</p>
         <p className="text-foreground">{value}</p>
       </div>
+    </div>
+  );
+}
+
+function AdjusterCard({
+  jobAdjuster,
+  jobId,
+  onUpdated,
+}: {
+  jobAdjuster: JobAdjuster;
+  jobId: string;
+  onUpdated: () => void;
+}) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const adj = jobAdjuster.adjuster;
+  if (!adj) return null;
+
+  const handleSetPrimary = async () => {
+    const supabase = createClient();
+    await supabase.from("job_adjusters").update({ is_primary: false }).eq("job_id", jobId);
+    await supabase.from("job_adjusters").update({ is_primary: true }).eq("id", jobAdjuster.id);
+    setMenuOpen(false);
+    onUpdated();
+  };
+
+  const handleRemove = async () => {
+    const supabase = createClient();
+    await supabase.from("job_adjusters").delete().eq("id", jobAdjuster.id);
+    setMenuOpen(false);
+    onUpdated();
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-background/50 p-3 group relative">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-sm font-medium text-foreground">
+          {adj.first_name} {adj.last_name}
+        </span>
+        <div className="flex items-center gap-1.5">
+          {jobAdjuster.is_primary && (
+            <span className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-primary/10 text-primary uppercase">
+              Primary
+            </span>
+          )}
+          <div className="relative">
+            <Button variant="ghost" size="icon" className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+              onClick={() => setMenuOpen(!menuOpen)}>
+              <span className="text-muted-foreground text-xs">&bull;&bull;&bull;</span>
+            </Button>
+            {menuOpen && (
+              <div className="absolute right-0 top-7 z-50 bg-popover border border-border rounded-md shadow-lg py-1 min-w-[140px]">
+                {!jobAdjuster.is_primary && (
+                  <button className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent text-foreground" onClick={handleSetPrimary}>
+                    Set as Primary
+                  </button>
+                )}
+                <button className="w-full text-left px-3 py-1.5 text-xs hover:bg-accent text-destructive" onClick={handleRemove}>
+                  Remove
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <p className="text-xs text-muted-foreground">{[adj.title, adj.company].filter(Boolean).join(" \u00b7 ")}</p>
+      <p className="text-xs text-muted-foreground mt-0.5">{[adj.phone, adj.email].filter(Boolean).join(" \u00b7 ")}</p>
     </div>
   );
 }
@@ -912,8 +1041,6 @@ function EditJobInfoDialog({
     damage_source: "",
     affected_areas: "",
     access_notes: "",
-    insurance_company: "",
-    claim_number: "",
   });
 
   useEffect(() => {
@@ -926,8 +1053,6 @@ function EditJobInfoDialog({
         damage_source: job.damage_source || "",
         affected_areas: job.affected_areas || "",
         access_notes: job.access_notes || "",
-        insurance_company: job.insurance_company || "",
-        claim_number: job.claim_number || "",
       });
     }
   }, [open, job]);
@@ -949,8 +1074,6 @@ function EditJobInfoDialog({
         damage_source: form.damage_source.trim() || null,
         affected_areas: form.affected_areas.trim() || null,
         access_notes: form.access_notes.trim() || null,
-        insurance_company: form.insurance_company.trim() || null,
-        claim_number: form.claim_number.trim() || null,
       })
       .eq("id", jobId);
 
@@ -1016,19 +1139,6 @@ function EditJobInfoDialog({
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">Access Notes</label>
             <Textarea value={form.access_notes} onChange={(e) => update("access_notes", e.target.value)} rows={2} placeholder="Gate code, lockbox, etc." />
-          </div>
-          <div className="border-t border-border/50 pt-4">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">Insurance</p>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">Insurance Company</label>
-                <Input value={form.insurance_company} onChange={(e) => update("insurance_company", e.target.value)} />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-muted-foreground mb-1">Claim #</label>
-                <Input value={form.claim_number} onChange={(e) => update("claim_number", e.target.value)} />
-              </div>
-            </div>
           </div>
         </div>
         <DialogFooter>
@@ -1162,6 +1272,373 @@ function EditContactDialog({
             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save Changes"}
           </Button>
         </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ── Edit Insurance Dialog ── */
+
+function EditInsuranceDialog({
+  open,
+  onOpenChange,
+  job,
+  jobId,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  job: Job;
+  jobId: string;
+  onSaved: () => void;
+}) {
+  const [saving, setSaving] = useState(false);
+  const [form, setForm] = useState({
+    insurance_company: "",
+    claim_number: "",
+    policy_number: "",
+    date_of_loss: "",
+    deductible: "",
+    hoa_name: "",
+    hoa_contact_name: "",
+    hoa_contact_phone: "",
+    hoa_contact_email: "",
+  });
+
+  useEffect(() => {
+    if (open) {
+      setForm({
+        insurance_company: job.insurance_company || "",
+        claim_number: job.claim_number || "",
+        policy_number: job.policy_number || "",
+        date_of_loss: job.date_of_loss || "",
+        deductible: job.deductible != null ? String(job.deductible) : "",
+        hoa_name: job.hoa_name || "",
+        hoa_contact_name: job.hoa_contact_name || "",
+        hoa_contact_phone: job.hoa_contact_phone || "",
+        hoa_contact_email: job.hoa_contact_email || "",
+      });
+    }
+  }, [open, job]);
+
+  async function handleSave() {
+    setSaving(true);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("jobs")
+      .update({
+        insurance_company: form.insurance_company.trim() || null,
+        claim_number: form.claim_number.trim() || null,
+        policy_number: form.policy_number.trim() || null,
+        date_of_loss: form.date_of_loss || null,
+        deductible: form.deductible ? Number(form.deductible) : null,
+        hoa_name: form.hoa_name.trim() || null,
+        hoa_contact_name: form.hoa_contact_name.trim() || null,
+        hoa_contact_phone: form.hoa_contact_phone.trim() || null,
+        hoa_contact_email: form.hoa_contact_email.trim() || null,
+      })
+      .eq("id", jobId);
+
+    if (error) {
+      toast.error("Failed to update insurance info.");
+    } else {
+      toast.success("Insurance info updated.");
+      onOpenChange(false);
+      onSaved();
+    }
+    setSaving(false);
+  }
+
+  function update(field: string, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Edit Insurance &amp; HOA</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 pt-2 max-h-[70vh] overflow-y-auto">
+          <div>
+            <label className="block text-sm font-medium text-muted-foreground mb-1">Insurance Company</label>
+            <Input value={form.insurance_company} onChange={(e) => update("insurance_company", e.target.value)} placeholder="e.g. State Farm" />
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Claim #</label>
+              <Input value={form.claim_number} onChange={(e) => update("claim_number", e.target.value)} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Policy #</label>
+              <Input value={form.policy_number} onChange={(e) => update("policy_number", e.target.value)} />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Date of Loss</label>
+              <Input type="date" value={form.date_of_loss} onChange={(e) => update("date_of_loss", e.target.value)} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Deductible</label>
+              <Input type="number" value={form.deductible} onChange={(e) => update("deductible", e.target.value)} placeholder="e.g. 1000" />
+            </div>
+          </div>
+          <div className="border-t border-border/50 pt-4">
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">HOA</p>
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">HOA Name</label>
+              <Input value={form.hoa_name} onChange={(e) => update("hoa_name", e.target.value)} placeholder="e.g. Lakewood HOA" />
+            </div>
+            <div className="grid grid-cols-2 gap-3 mt-3">
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">Contact Name</label>
+                <Input value={form.hoa_contact_name} onChange={(e) => update("hoa_contact_name", e.target.value)} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">Contact Phone</label>
+                <Input type="tel" value={form.hoa_contact_phone} onChange={(e) => update("hoa_contact_phone", e.target.value)} />
+              </div>
+            </div>
+            <div className="mt-3">
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Contact Email</label>
+              <Input type="email" value={form.hoa_contact_email} onChange={(e) => update("hoa_contact_email", e.target.value)} />
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button variant="gradient" onClick={handleSave} disabled={saving}>
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : "Save Changes"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ── Add Adjuster Dialog ── */
+
+function AddAdjusterDialog({
+  open,
+  onOpenChange,
+  jobId,
+  existingAdjusterIds,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  jobId: string;
+  existingAdjusterIds: string[];
+  onSaved: () => void;
+}) {
+  const [mode, setMode] = useState<"search" | "create">("search");
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<Contact[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    first_name: "",
+    last_name: "",
+    title: "",
+    company: "",
+    phone: "",
+    email: "",
+  });
+
+  useEffect(() => {
+    if (!open) {
+      setMode("search");
+      setSearch("");
+      setResults([]);
+      setCreateForm({ first_name: "", last_name: "", title: "", company: "", phone: "", email: "" });
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (mode !== "search" || !search.trim()) {
+      setResults([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      setSearching(true);
+      const supabase = createClient();
+      const term = `%${search.trim()}%`;
+      const { data } = await supabase
+        .from("contacts")
+        .select("*")
+        .eq("role", "adjuster")
+        .or(`first_name.ilike.${term},last_name.ilike.${term},company.ilike.${term},email.ilike.${term}`)
+        .limit(10);
+      if (data) {
+        setResults(data.filter((c: Contact) => !existingAdjusterIds.includes(c.id)));
+      }
+      setSearching(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search, mode, existingAdjusterIds]);
+
+  async function linkAdjuster(contactId: string) {
+    setSaving(true);
+    const supabase = createClient();
+    const isPrimary = existingAdjusterIds.length === 0;
+    const { error } = await supabase.from("job_adjusters").insert({
+      job_id: jobId,
+      contact_id: contactId,
+      is_primary: isPrimary,
+    });
+    if (error) {
+      toast.error("Failed to add adjuster.");
+    } else {
+      toast.success("Adjuster added.");
+      onOpenChange(false);
+      onSaved();
+    }
+    setSaving(false);
+  }
+
+  async function handleCreate() {
+    if (!createForm.first_name.trim() || !createForm.last_name.trim()) {
+      toast.error("First and last name are required.");
+      return;
+    }
+    setSaving(true);
+    const supabase = createClient();
+    const { data: newContact, error: contactError } = await supabase
+      .from("contacts")
+      .insert({
+        first_name: createForm.first_name.trim(),
+        last_name: createForm.last_name.trim(),
+        title: createForm.title.trim() || null,
+        company: createForm.company.trim() || null,
+        phone: createForm.phone.trim() || null,
+        email: createForm.email.trim() || null,
+        role: "adjuster",
+      })
+      .select()
+      .single();
+
+    if (contactError || !newContact) {
+      toast.error("Failed to create adjuster contact.");
+      setSaving(false);
+      return;
+    }
+
+    const isPrimary = existingAdjusterIds.length === 0;
+    const { error: linkError } = await supabase.from("job_adjusters").insert({
+      job_id: jobId,
+      contact_id: newContact.id,
+      is_primary: isPrimary,
+    });
+
+    if (linkError) {
+      toast.error("Contact created but failed to link to job.");
+    } else {
+      toast.success("Adjuster created and added.");
+      onOpenChange(false);
+      onSaved();
+    }
+    setSaving(false);
+  }
+
+  function updateCreate(field: string, value: string) {
+    setCreateForm((prev) => ({ ...prev, [field]: value }));
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Adjuster</DialogTitle>
+        </DialogHeader>
+
+        {/* Mode tabs */}
+        <div className="flex gap-1 bg-muted rounded-lg p-1">
+          <button
+            className={cn("flex-1 text-sm py-1.5 rounded-md transition-colors", mode === "search" ? "bg-background shadow-sm font-medium" : "text-muted-foreground hover:text-foreground")}
+            onClick={() => setMode("search")}
+          >
+            Search Existing
+          </button>
+          <button
+            className={cn("flex-1 text-sm py-1.5 rounded-md transition-colors", mode === "create" ? "bg-background shadow-sm font-medium" : "text-muted-foreground hover:text-foreground")}
+            onClick={() => setMode("create")}
+          >
+            Create New
+          </button>
+        </div>
+
+        {mode === "search" ? (
+          <div className="space-y-3">
+            <Input
+              placeholder="Search by name, company, or email..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              autoFocus
+            />
+            {searching && (
+              <div className="flex items-center justify-center py-4">
+                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+              </div>
+            )}
+            {!searching && results.length > 0 && (
+              <div className="space-y-2 max-h-60 overflow-y-auto">
+                {results.map((c) => (
+                  <button
+                    key={c.id}
+                    className="w-full text-left rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors"
+                    onClick={() => linkAdjuster(c.id)}
+                    disabled={saving}
+                  >
+                    <p className="text-sm font-medium text-foreground">{c.first_name} {c.last_name}</p>
+                    <p className="text-xs text-muted-foreground">{[c.title, c.company].filter(Boolean).join(" \u00b7 ")}</p>
+                    <p className="text-xs text-muted-foreground">{[c.phone, c.email].filter(Boolean).join(" \u00b7 ")}</p>
+                  </button>
+                ))}
+              </div>
+            )}
+            {!searching && search.trim() && results.length === 0 && (
+              <p className="text-sm text-muted-foreground/60 text-center py-4">No matching adjusters found</p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">First Name *</label>
+                <Input value={createForm.first_name} onChange={(e) => updateCreate("first_name", e.target.value)} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">Last Name *</label>
+                <Input value={createForm.last_name} onChange={(e) => updateCreate("last_name", e.target.value)} />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">Title</label>
+                <Input value={createForm.title} onChange={(e) => updateCreate("title", e.target.value)} placeholder="e.g. Field Adjuster" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-muted-foreground mb-1">Company</label>
+                <Input value={createForm.company} onChange={(e) => updateCreate("company", e.target.value)} placeholder="e.g. State Farm" />
+              </div>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Phone</label>
+              <Input type="tel" value={createForm.phone} onChange={(e) => updateCreate("phone", e.target.value)} placeholder="(512) 555-0101" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-muted-foreground mb-1">Email</label>
+              <Input type="email" value={createForm.email} onChange={(e) => updateCreate("email", e.target.value)} placeholder="adjuster@company.com" />
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+              <Button variant="gradient" onClick={handleCreate} disabled={saving}>
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : "Create & Add"}
+              </Button>
+            </DialogFooter>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/lib/email-matcher.ts
+++ b/src/lib/email-matcher.ts
@@ -9,7 +9,7 @@ export interface JobRow {
   claim_number: string | null;
   property_address: string;
   contact_id: string;
-  adjuster_contact_id: string | null;
+  job_adjusters?: { contact_id: string }[];
 }
 
 export interface ContactRow {
@@ -66,7 +66,7 @@ export function matchEmailToJob(
       const job = jobs.find(
         (j) =>
           j.contact_id === matchedContact.id ||
-          j.adjuster_contact_id === matchedContact.id
+          (j.job_adjusters || []).some((ja) => ja.contact_id === matchedContact.id)
       );
       if (job) {
         return { job_id: job.id, matched_by: "contact" };

--- a/src/lib/jarvis/tools.ts
+++ b/src/lib/jarvis/tools.ts
@@ -281,7 +281,7 @@ async function toolGetJobDetails(
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
     .select(
-      "*, contact:contacts!contact_id(*), adjuster:contacts!adjuster_contact_id(*)"
+      "*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))"
     )
     .eq("id", input.job_id)
     .single();
@@ -344,8 +344,9 @@ async function toolGetJobDetails(
   const contactName = job.contact
     ? `${job.contact.first_name} ${job.contact.last_name}`
     : "Unknown";
-  const adjusterName = job.adjuster
-    ? `${job.adjuster.first_name} ${job.adjuster.last_name}`
+  const primaryAdj = job.job_adjusters?.find((ja: any) => ja.is_primary)?.adjuster;
+  const adjusterName = primaryAdj
+    ? `${primaryAdj.first_name} ${primaryAdj.last_name}`
     : null;
 
   return {
@@ -364,8 +365,8 @@ async function toolGetJobDetails(
     insurance_company: job.insurance_company,
     claim_number: job.claim_number,
     adjuster_name: adjusterName,
-    adjuster_phone: job.adjuster?.phone || null,
-    adjuster_email: job.adjuster?.email || null,
+    adjuster_phone: primaryAdj?.phone || null,
+    adjuster_email: primaryAdj?.email || null,
     affected_areas: job.affected_areas,
     access_notes: job.access_notes,
     created_at: job.created_at,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface Contact {
   email: string | null;
   role: "homeowner" | "tenant" | "property_manager" | "adjuster" | "insurance";
   company: string | null;
+  title: string | null;
   notes: string | null;
   created_at: string;
   updated_at: string;
@@ -26,12 +27,27 @@ export interface Job {
   affected_areas: string | null;
   insurance_company: string | null;
   claim_number: string | null;
-  adjuster_contact_id: string | null;
+  policy_number: string | null;
+  date_of_loss: string | null;
+  deductible: number | null;
+  hoa_name: string | null;
+  hoa_contact_name: string | null;
+  hoa_contact_phone: string | null;
+  hoa_contact_email: string | null;
   access_notes: string | null;
   created_at: string;
   updated_at: string;
   // Joined fields
   contact?: Contact;
+  job_adjusters?: JobAdjuster[];
+}
+
+export interface JobAdjuster {
+  id: string;
+  job_id: string;
+  contact_id: string;
+  is_primary: boolean;
+  created_at: string;
   adjuster?: Contact;
 }
 

--- a/supabase/migration-build31-insurance-redesign.sql
+++ b/supabase/migration-build31-insurance-redesign.sql
@@ -1,0 +1,40 @@
+-- Build 31: Insurance & Contact Redesign
+-- Adds insurance detail columns (policy_number, date_of_loss, deductible),
+-- HOA fields, job_adjusters junction table, contacts.title column.
+-- Migrates existing adjuster_contact_id data and drops the old column.
+
+-- 1. Add new insurance + HOA columns to jobs
+ALTER TABLE jobs ADD COLUMN policy_number text;
+ALTER TABLE jobs ADD COLUMN date_of_loss date;
+ALTER TABLE jobs ADD COLUMN deductible numeric(10,2);
+ALTER TABLE jobs ADD COLUMN hoa_name text;
+ALTER TABLE jobs ADD COLUMN hoa_contact_name text;
+ALTER TABLE jobs ADD COLUMN hoa_contact_phone text;
+ALTER TABLE jobs ADD COLUMN hoa_contact_email text;
+
+-- 2. Add title column to contacts
+ALTER TABLE contacts ADD COLUMN title text;
+
+-- 3. Create job_adjusters junction table
+CREATE TABLE job_adjusters (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
+  contact_id uuid NOT NULL REFERENCES contacts(id),
+  is_primary boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE(job_id, contact_id)
+);
+
+-- 4. Enable RLS on job_adjusters (match other tables)
+ALTER TABLE job_adjusters ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow all for authenticated users" ON job_adjusters
+  FOR ALL USING (true) WITH CHECK (true);
+
+-- 5. Migrate existing adjuster_contact_id data into job_adjusters
+INSERT INTO job_adjusters (job_id, contact_id, is_primary)
+SELECT id, adjuster_contact_id, true
+FROM jobs
+WHERE adjuster_contact_id IS NOT NULL;
+
+-- 6. Drop the old adjuster_contact_id column
+ALTER TABLE jobs DROP COLUMN adjuster_contact_id;


### PR DESCRIPTION
## Summary
- Restructure the job detail header from two cards into a **single unified card with three columns** separated by vertical dividers: Job Info | Contact + Adjusters | Insurance + HOA
- Add support for **multiple insurance adjusters** per job via a new `job_adjusters` junction table (replaces the old single `adjuster_contact_id` FK)
- Add **editable insurance fields**: policy number, date of loss, deductible, plus HOA information
- New **EditInsuranceDialog** for editing all insurance + HOA fields
- New **AddAdjusterDialog** with search existing contacts / create new adjuster modes
- **AdjusterCard** component with set-as-primary and remove actions

## Database Changes (Migration build31)
- New columns on `jobs`: `policy_number`, `date_of_loss`, `deductible`, `hoa_name`, `hoa_contact_name`, `hoa_contact_phone`, `hoa_contact_email`
- New `job_adjusters` junction table with `is_primary` flag
- New `title` column on `contacts`
- Migrated existing `adjuster_contact_id` data → dropped the old column

## Test plan
- [ ] Verify 3-column layout renders correctly on job detail page
- [ ] Test editing insurance info via pencil icon on Insurance column
- [ ] Test adding an adjuster via + button (both search and create modes)
- [ ] Test set-as-primary and remove actions on adjuster cards
- [ ] Verify intake form still creates jobs with adjusters correctly
- [ ] Verify Jarvis AI assistant still loads job context with adjuster info

🤖 Generated with [Claude Code](https://claude.com/claude-code)