### PR TITLE
Overhaul email inbox UX

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  serverExternalPackages: ["imapflow"],
 };
 
 export default nextConfig;

--- a/src/app/api/email/bulk/route.ts
+++ b/src/app/api/email/bulk/route.ts
@@ -35,6 +35,9 @@ export async function PATCH(request: NextRequest) {
     case "trash":
       updates = { folder: "trash" };
       break;
+    case "spam":
+      updates = { folder: "spam" };
+      break;
     case "assign_job":
       if (!jobId) {
         return NextResponse.json({ error: "jobId required for assign_job" }, { status: 400 });

--- a/src/app/api/email/counts/route.ts
+++ b/src/app/api/email/counts/route.ts
@@ -67,12 +67,28 @@ export async function GET(request: NextRequest) {
     promotions: 0,
     social: 0,
     purchases: 0,
+    starred: 0,
   };
 
   for (const row of (categoryData || []) as { category: string | null }[]) {
     const cat = row.category || "general";
     if (cat in categoryUnread) categoryUnread[cat]++;
   }
+
+  // Starred count for the inbox tab (total, not unread — starred status is
+  // independent of read state and users want to see the full set).
+  let starredInboxQuery = supabase
+    .from("emails")
+    .select("id", { count: "exact", head: true })
+    .eq("folder", "inbox")
+    .eq("is_starred", true);
+
+  if (accountId) {
+    starredInboxQuery = starredInboxQuery.eq("account_id", accountId);
+  }
+
+  const starredInboxResult = await starredInboxQuery;
+  categoryUnread.starred = starredInboxResult.count || 0;
 
   return NextResponse.json({ ...counts, categoryUnread });
 }

--- a/src/app/api/email/list/route.ts
+++ b/src/app/api/email/list/route.ts
@@ -31,9 +31,14 @@ export async function GET(request: NextRequest) {
     query = query.eq("account_id", accountId);
   }
 
-  // Filter by category (only applies to inbox)
+  // Filter by category (only applies to inbox). "starred" is a pseudo-category
+  // that filters the inbox to starred emails only.
   if (category && folder === "inbox" && starred !== "true") {
-    query = query.eq("category", category);
+    if (category === "starred") {
+      query = query.eq("is_starred", true);
+    } else {
+      query = query.eq("category", category);
+    }
   }
 
   // Search in subject, from_address, from_name, snippet

--- a/src/app/email/page.tsx
+++ b/src/app/email/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import EmailInbox from "@/components/email-inbox";
+import dynamic from "next/dynamic";
+
+const EmailInbox = dynamic(() => import("@/components/email-inbox"), {
+  ssr: false,
+});
 
 export default function EmailPage() {
   return <EmailInbox />;

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -6,11 +6,15 @@ import { useSidebarCollapse } from "@/lib/sidebar-collapse-context";
 import { cn } from "@/lib/utils";
 
 const AUTH_ROUTES = ["/login", "/logout"];
+const FULL_BLEED_ROUTES = ["/email"];
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { collapsed } = useSidebarCollapse();
   const isAuthPage = AUTH_ROUTES.some((r) => pathname.startsWith(r));
+  const isFullBleed = FULL_BLEED_ROUTES.some(
+    (r) => pathname === r || pathname.startsWith(`${r}/`),
+  );
 
   if (isAuthPage) {
     return <>{children}</>;
@@ -25,7 +29,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           collapsed ? "lg:ml-16" : "lg:ml-52",
         )}
       >
-        <div className="p-6 lg:p-8">{children}</div>
+        {isFullBleed ? children : <div className="p-6 lg:p-8">{children}</div>}
       </main>
     </>
   );

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -21,8 +21,7 @@ import type { Email, EmailAccount } from "@/lib/types";
 import EmailReader from "@/components/email-reader";
 import ComposeEmailModal from "@/components/compose-email";
 import IconRail from "@/components/email/icon-rail";
-import CategoryTabs from "@/components/email/category-tabs";
-import type { Category } from "@/lib/email-categorizer";
+import CategoryTabs, { type CategoryFilter } from "@/components/email/category-tabs";
 
 interface FolderCounts {
   [key: string]: { total: number; unread: number };
@@ -61,12 +60,13 @@ export default function EmailInbox() {
   const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null);
 
   // Category filter (inbox only)
-  const [category, setCategory] = useState<Category>("general");
+  const [category, setCategory] = useState<CategoryFilter>("general");
   const [categoryCounts, setCategoryCounts] = useState<Record<string, number>>({
     general: 0,
     promotions: 0,
     social: 0,
     purchases: 0,
+    starred: 0,
   });
 
   // Resizable pane widths. Initialize with the default on both server and
@@ -226,9 +226,12 @@ export default function EmailInbox() {
     return () => clearTimeout(timer);
   }, [search]);
 
+  const [loadingMore, setLoadingMore] = useState(false);
+
   // Load emails when folder, account, search, or page changes
   const loadEmails = useCallback(async () => {
-    setLoading(true);
+    if (page === 1) setLoading(true);
+    else setLoadingMore(true);
     try {
       const params = new URLSearchParams();
       if (folder === "starred") {
@@ -243,18 +246,41 @@ export default function EmailInbox() {
 
       const res = await fetch(`/api/email/list?${params}`);
       const data: ListResponse = await res.json();
-      setEmails(data.emails);
+      setEmails((prev) => {
+        const merged = page === 1 ? data.emails : [...prev, ...data.emails];
+        const byId = new Map<string, Email>();
+        for (const e of merged) byId.set(e.id, e);
+        return Array.from(byId.values());
+      });
       setTotal(data.total);
       setHasMore(data.hasMore);
     } catch {
       toast.error("Failed to load emails");
     }
     setLoading(false);
+    setLoadingMore(false);
   }, [folder, selectedAccountId, searchDebounced, page, category]);
 
   useEffect(() => {
     loadEmails();
   }, [loadEmails]);
+
+  // Infinite scroll: bump page when sentinel enters view
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node || !hasMore || loading || loadingMore) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setPage((p) => p + 1);
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    obs.observe(node);
+    return () => obs.disconnect();
+  }, [hasMore, loading, loadingMore, emails.length]);
 
   // Load folder counts
   const loadCounts = useCallback(async () => {
@@ -478,7 +504,7 @@ export default function EmailInbox() {
     setCategory("general");
   }
 
-  function handleCategoryChange(cat: Category) {
+  function handleCategoryChange(cat: CategoryFilter) {
     setCategory(cat);
     setPage(1);
     setSelectedEmailId(null);
@@ -486,7 +512,7 @@ export default function EmailInbox() {
   }
 
   return (
-    <div className="h-[calc(100vh-2rem)] flex flex-col">
+    <div className="h-[calc(100vh-3.5rem)] lg:h-screen flex flex-col">
       {/* Top bar */}
       <div className="flex items-center gap-3 px-4 py-3 bg-card border-b border-border shrink-0">
         <h1 className="text-lg font-bold text-foreground mr-2">Email</h1>
@@ -500,6 +526,7 @@ export default function EmailInbox() {
               setPage(1);
             }}
             className="text-sm border border-border rounded-lg pl-3 pr-8 py-1.5 bg-card focus:outline-none focus:ring-2 focus:ring-primary/30 appearance-none"
+            suppressHydrationWarning
           >
             <option value="">All Inboxes</option>
             {accounts.map((acc) => (
@@ -699,14 +726,6 @@ export default function EmailInbox() {
                       Mark all read
                     </button>
                   )}
-                  {hasMore && (
-                    <button
-                      onClick={() => setPage((p) => p + 1)}
-                      className="text-primary hover:underline"
-                    >
-                      Load more
-                    </button>
-                  )}
                 </div>
               </>
             )}
@@ -740,24 +759,13 @@ export default function EmailInbox() {
               ))
             )}
 
-            {/* Pagination */}
-            {!loading && total > 50 && (
-              <div className="flex items-center justify-center gap-2 py-3 border-t border-border/50">
-                <button
-                  onClick={() => setPage((p) => Math.max(1, p - 1))}
-                  disabled={page <= 1}
-                  className="px-3 py-1 text-xs border border-border rounded disabled:opacity-30 hover:bg-accent"
-                >
-                  Previous
-                </button>
-                <span className="text-xs text-muted-foreground/60">Page {page}</span>
-                <button
-                  onClick={() => setPage((p) => p + 1)}
-                  disabled={!hasMore}
-                  className="px-3 py-1 text-xs border border-border rounded disabled:opacity-30 hover:bg-accent"
-                >
-                  Next
-                </button>
+            {/* Infinite scroll sentinel */}
+            {!loading && hasMore && (
+              <div
+                ref={sentinelRef}
+                className="flex items-center justify-center py-3 text-xs text-muted-foreground/60"
+              >
+                {loadingMore ? "Loading more…" : ""}
               </div>
             )}
           </div>
@@ -771,7 +779,7 @@ export default function EmailInbox() {
 
         {/* Column 3: Reading pane */}
         <div
-          className={`flex-1 bg-muted/50 ${
+          className={`flex-1 min-w-0 bg-muted/50 ${
             selectedEmailId ? "flex" : "hidden lg:flex"
           }`}
         >
@@ -783,6 +791,11 @@ export default function EmailInbox() {
               onReplyAll={handleReplyAll}
               onForward={handleForward}
               onStarToggle={handleStarToggle}
+              onActioned={() => {
+                setSelectedEmailId(null);
+                setPage(1);
+                loadCounts();
+              }}
             />
           ) : (
             <div className="flex-1 flex flex-col items-center justify-center text-muted-foreground/60">
@@ -885,35 +898,34 @@ function EmailRow({
           : "bg-primary/5 hover:bg-primary/10"
       }`}
     >
-      {/* Checkbox */}
-      <input
-        type="checkbox"
-        checked={isChecked}
-        onChange={(e) => {
-          e.stopPropagation();
-          onToggleCheck();
-        }}
-        onClick={(e) => e.stopPropagation()}
-        className="mt-1 shrink-0 rounded border-border accent-primary"
-      />
-
-      {/* Star */}
-      <button
-        onClick={(e) => {
-          e.stopPropagation();
-          onStar();
-        }}
-        className="mt-0.5 shrink-0"
-      >
-        <Star
-          size={14}
-          className={
-            email.is_starred
-              ? "fill-yellow-400 text-yellow-400"
-              : "text-gray-300 hover:text-gray-400"
-          }
+      {/* Checkbox + Star (stacked) */}
+      <div className="flex flex-col items-center gap-1.5 mt-0.5 shrink-0">
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={(e) => {
+            e.stopPropagation();
+            onToggleCheck();
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="rounded border-border accent-primary"
         />
-      </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onStar();
+          }}
+        >
+          <Star
+            size={14}
+            className={
+              email.is_starred
+                ? "fill-yellow-400 text-yellow-400"
+                : "text-gray-300 hover:text-gray-400"
+            }
+          />
+        </button>
+      </div>
 
       {/* Content */}
       <div className="flex-1 min-w-0">

--- a/src/components/email-reader.tsx
+++ b/src/components/email-reader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { format } from "date-fns";
 import {
   ArrowLeft,
@@ -14,8 +14,56 @@ import {
   ChevronUp,
   Download,
   FileIcon,
+  Trash2,
+  ShieldAlert,
+  Search,
 } from "lucide-react";
+import { toast } from "sonner";
 import type { Email } from "@/lib/types";
+
+function EmailBodyFrame({ html }: { html: string }) {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(200);
+
+  useEffect(() => {
+    const iframe = ref.current;
+    if (!iframe) return;
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+
+    const baseStyles = `
+      :root { color-scheme: light; }
+      html, body { margin: 0; padding: 0; background: #fff; color: #333;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 14px; line-height: 1.5; word-wrap: break-word; }
+      img { max-width: 100%; height: auto; }
+      a { color: #2B5EA7; }
+      table { max-width: 100%; }
+    `;
+
+    doc.open();
+    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8"><base target="_blank"><style>${baseStyles}</style></head><body>${html}</body></html>`);
+    doc.close();
+
+    const resize = () => {
+      if (!doc.body) return;
+      setHeight(doc.body.scrollHeight + 16);
+    };
+    resize();
+    const obs = new ResizeObserver(resize);
+    if (doc.body) obs.observe(doc.body);
+    return () => obs.disconnect();
+  }, [html]);
+
+  return (
+    <iframe
+      ref={ref}
+      title="Email body"
+      sandbox="allow-same-origin allow-popups"
+      style={{ width: "100%", height, border: 0, display: "block" }}
+    />
+  );
+}
 
 interface EmailReaderProps {
   emailId: string;
@@ -24,6 +72,13 @@ interface EmailReaderProps {
   onReplyAll: (email: Email) => void;
   onForward: (email: Email) => void;
   onStarToggle: (id: string, starred: boolean) => void;
+  onActioned?: () => void;
+}
+
+interface JobOption {
+  id: string;
+  job_number: string;
+  property_address: string;
 }
 
 export default function EmailReader({
@@ -33,10 +88,16 @@ export default function EmailReader({
   onReplyAll,
   onForward,
   onStarToggle,
+  onActioned,
 }: EmailReaderProps) {
   const [thread, setThread] = useState<Email[]>([]);
   const [loading, setLoading] = useState(true);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [actionLoading, setActionLoading] = useState(false);
+  const [jobPickerOpen, setJobPickerOpen] = useState(false);
+  const [jobSearch, setJobSearch] = useState("");
+  const [jobResults, setJobResults] = useState<JobOption[]>([]);
+  const jobPickerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     loadThread();
@@ -82,6 +143,56 @@ export default function EmailReader({
     setLoading(false);
   }
 
+  async function runAction(action: string, jobId?: string) {
+    setActionLoading(true);
+    try {
+      const res = await fetch("/api/email/bulk", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: [emailId], action, jobId }),
+      });
+      if (!res.ok) throw new Error("Action failed");
+      if (action === "trash") toast.success("Moved to trash");
+      else if (action === "spam") toast.success("Marked as spam");
+      else if (action === "assign_job") toast.success("Assigned to job");
+      onActioned?.();
+    } catch {
+      toast.error("Action failed");
+    }
+    setActionLoading(false);
+    setJobPickerOpen(false);
+  }
+
+  // Debounced job search
+  useEffect(() => {
+    if (!jobPickerOpen || jobSearch.length < 1) {
+      setJobResults([]);
+      return;
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/jobs/search?q=${encodeURIComponent(jobSearch)}&limit=8`);
+        const data = await res.json();
+        setJobResults(data.jobs || []);
+      } catch {
+        setJobResults([]);
+      }
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [jobSearch, jobPickerOpen]);
+
+  // Close job picker on outside click
+  useEffect(() => {
+    if (!jobPickerOpen) return;
+    function handleClickOutside(e: MouseEvent) {
+      if (jobPickerRef.current && !jobPickerRef.current.contains(e.target as Node)) {
+        setJobPickerOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [jobPickerOpen]);
+
   function toggleExpand(id: string) {
     setExpandedIds((prev) => {
       const next = new Set(prev);
@@ -104,53 +215,124 @@ export default function EmailReader({
   const latestEmail = thread[thread.length - 1];
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-w-0">
       {/* Header */}
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200 bg-white shrink-0">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-border bg-card shrink-0">
         <button
           onClick={onBack}
-          className="lg:hidden p-1 text-[#666] hover:text-[#333] rounded"
+          className="lg:hidden p-1 text-muted-foreground hover:text-foreground rounded"
         >
           <ArrowLeft size={18} />
         </button>
-        <h2 className="text-base font-semibold text-[#333] truncate flex-1">
+        <h2 className="text-base font-semibold text-foreground truncate flex-1 min-w-0">
           {latestEmail.subject || "(no subject)"}
         </h2>
         {thread.length > 1 && (
-          <span className="text-xs text-[#999] bg-gray-100 rounded-full px-2 py-0.5">
+          <span className="text-xs text-muted-foreground bg-muted rounded-full px-2 py-0.5">
             {thread.length} messages
           </span>
         )}
         <button
           onClick={() => onStarToggle(latestEmail.id, !latestEmail.is_starred)}
-          className="p-1 hover:bg-gray-100 rounded"
+          className="p-1 hover:bg-accent rounded"
         >
           <Star
             size={16}
             className={
               latestEmail.is_starred
                 ? "fill-yellow-400 text-yellow-400"
-                : "text-[#ccc]"
+                : "text-muted-foreground/60"
             }
           />
         </button>
+        <div className="relative" ref={jobPickerRef}>
+          <button
+            onClick={() => setJobPickerOpen((v) => !v)}
+            disabled={actionLoading}
+            title={latestEmail.job ? `Job ${latestEmail.job.job_number}` : "Assign to job"}
+            className={`p-1.5 rounded hover:bg-accent disabled:opacity-50 ${
+              latestEmail.job ? "text-primary" : "text-muted-foreground"
+            }`}
+          >
+            <Briefcase size={16} />
+          </button>
+          {jobPickerOpen && (
+            <div className="absolute right-0 top-full mt-1 w-72 bg-popover border border-border rounded-lg shadow-lg z-20 p-2">
+              <div className="relative mb-2">
+                <Search
+                  size={14}
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground/60"
+                />
+                <input
+                  type="text"
+                  autoFocus
+                  placeholder="Search jobs…"
+                  value={jobSearch}
+                  onChange={(e) => setJobSearch(e.target.value)}
+                  className="w-full pl-8 pr-2 py-1.5 text-sm border border-border rounded bg-card focus:outline-none focus:ring-2 focus:ring-primary/30"
+                />
+              </div>
+              {latestEmail.job && (
+                <button
+                  onClick={() => runAction("assign_job", "")}
+                  className="w-full text-left px-2 py-1.5 text-xs text-muted-foreground hover:bg-accent rounded mb-1"
+                >
+                  Unassign from job {latestEmail.job.job_number}
+                </button>
+              )}
+              <div className="max-h-60 overflow-y-auto">
+                {jobResults.length === 0 && jobSearch.length > 0 && (
+                  <p className="text-xs text-muted-foreground/60 px-2 py-2">No matches</p>
+                )}
+                {jobResults.map((job) => (
+                  <button
+                    key={job.id}
+                    onClick={() => runAction("assign_job", job.id)}
+                    className="w-full text-left px-2 py-1.5 text-sm hover:bg-accent rounded"
+                  >
+                    <div className="font-medium text-foreground">{job.job_number}</div>
+                    <div className="text-xs text-muted-foreground truncate">
+                      {job.property_address}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => runAction("trash")}
+          disabled={actionLoading}
+          title="Delete"
+          className="p-1.5 rounded hover:bg-accent text-muted-foreground disabled:opacity-50"
+        >
+          <Trash2 size={16} />
+        </button>
+        <button
+          onClick={() => runAction("spam")}
+          disabled={actionLoading}
+          title="Mark as spam"
+          className="p-1.5 rounded hover:bg-accent text-muted-foreground disabled:opacity-50"
+        >
+          <ShieldAlert size={16} />
+        </button>
         <button
           onClick={() => onReply(latestEmail)}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-[#2B5EA7] text-white rounded-lg text-sm font-medium hover:bg-[#234b87]"
+          className="flex items-center gap-1.5 px-3 py-1.5 border border-border text-muted-foreground rounded-lg text-sm font-medium hover:bg-accent"
+          title="Reply"
         >
           <Reply size={14} />
-          Reply
         </button>
         <button
           onClick={() => onReplyAll(latestEmail)}
-          className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 text-[#666] rounded-lg text-sm font-medium hover:bg-gray-50"
+          className="flex items-center gap-1.5 px-3 py-1.5 border border-border text-muted-foreground rounded-lg text-sm font-medium hover:bg-accent"
           title="Reply All"
         >
           <ReplyAll size={14} />
         </button>
         <button
           onClick={() => onForward(latestEmail)}
-          className="flex items-center gap-1.5 px-3 py-1.5 border border-gray-200 text-[#666] rounded-lg text-sm font-medium hover:bg-gray-50"
+          className="flex items-center gap-1.5 px-3 py-1.5 border border-border text-muted-foreground rounded-lg text-sm font-medium hover:bg-accent"
           title="Forward"
         >
           <Forward size={14} />
@@ -243,10 +425,7 @@ export default function EmailReader({
                   {/* Body */}
                   <div className="px-4 py-4">
                     {email.body_html ? (
-                      <div
-                        className="prose prose-sm max-w-none text-[#333] [&_img]:max-w-full [&_a]:text-[#2B5EA7]"
-                        dangerouslySetInnerHTML={{ __html: email.body_html }}
-                      />
+                      <EmailBodyFrame html={email.body_html} />
                     ) : (
                       <pre className="text-sm text-[#333] whitespace-pre-wrap font-sans leading-relaxed">
                         {email.body_text || "(empty)"}

--- a/src/components/email/category-tabs.tsx
+++ b/src/components/email/category-tabs.tsx
@@ -1,18 +1,23 @@
 "use client";
 
+import { Inbox, Tag, Users, ShoppingBag, Star } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import type { Category } from "@/lib/email-categorizer";
 
+export type CategoryFilter = Category | "starred";
+
 interface CategoryTabsProps {
-  category: Category;
+  category: CategoryFilter;
   categoryCounts: Record<string, number>;
-  onChange: (cat: Category) => void;
+  onChange: (cat: CategoryFilter) => void;
 }
 
-const TABS: { key: Category; label: string }[] = [
-  { key: "general", label: "General" },
-  { key: "promotions", label: "Promotions" },
-  { key: "social", label: "Social" },
-  { key: "purchases", label: "Purchases" },
+const TABS: { key: CategoryFilter; label: string; icon: LucideIcon }[] = [
+  { key: "general", label: "General", icon: Inbox },
+  { key: "promotions", label: "Promotions", icon: Tag },
+  { key: "social", label: "Social", icon: Users },
+  { key: "purchases", label: "Purchases", icon: ShoppingBag },
+  { key: "starred", label: "Starred", icon: Star },
 ];
 
 export default function CategoryTabs({
@@ -22,7 +27,7 @@ export default function CategoryTabs({
 }: CategoryTabsProps) {
   return (
     <div className="flex overflow-x-auto border-b border-border/50 shrink-0">
-      {TABS.map(({ key, label }) => {
+      {TABS.map(({ key, label, icon: Icon }) => {
         const isActive = category === key;
         const unread = categoryCounts[key] || 0;
 
@@ -30,13 +35,16 @@ export default function CategoryTabs({
           <button
             key={key}
             onClick={() => onChange(key)}
-            className={`px-4 py-2 text-sm flex items-center gap-2 border-b-2 whitespace-nowrap transition-colors ${
+            title={label}
+            aria-label={label}
+            className={`px-3 py-2 text-sm flex items-center gap-2 border-b-2 whitespace-nowrap transition-colors ${
               isActive
                 ? "border-primary text-primary font-medium"
                 : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
           >
-            {label}
+            <Icon size={16} />
+            {isActive && <span>{label}</span>}
             {unread > 0 && (
               <span className="text-xs font-bold text-primary bg-primary/10 rounded-full px-1.5 py-0.5 min-w-[20px] text-center">
                 {unread}

--- a/src/components/email/icon-rail.tsx
+++ b/src/components/email/icon-rail.tsx
@@ -39,7 +39,7 @@ export default function IconRail({
   onCompose,
 }: IconRailProps) {
   return (
-    <div className="w-14 border-r border-border bg-muted/50 shrink-0 flex flex-col items-center py-2 gap-1">
+    <div className="w-14 border-r border-border bg-muted shrink-0 flex flex-col items-center py-2 gap-1">
       {/* Compose button */}
       <button
         onClick={onCompose}


### PR DESCRIPTION
## Summary
- Full-bleed email page (no shell padding), sandboxed email bodies in iframe, fixed long-subject overflow, themed reader header
- Category tabs become icon-only except active; added **Starred** tab
- Infinite scroll replaces Previous/Next pagination (Map-based dedup)
- Quick actions in reader: **delete**, **mark as spam**, **assign to job** (with debounced job picker)
- Small polish: stacked checkbox/star in list rows, outlined Reply button, dark-themed chrome resistant to email CSS leakage

## Infra fixes
- \`serverExternalPackages: ["imapflow"]\` in next.config so Turbopack doesn't bundle it
- \`/email\` page now renders client-only via \`next/dynamic\` to bypass browser-extension hydration artifacts

## Test plan
- [x] TypeScript compiles cleanly (outside pre-existing jarvis/neural-network errors)
- [x] Verified in local preview: category filter, infinite scroll (50→100→150 rows), dedup, Starred tab, reader header buttons
- [ ] After deploy: smoke-test /email on aaaplatform.vercel.app (open a few emails, scroll, assign to job, mark spam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)