### PR TITLE
Build 15a: contract template system

### DIFF
--- a/src/app/api/settings/contract-templates/[id]/duplicate/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/duplicate/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { createApiClient } from "@/lib/supabase-api";
+
+// POST /api/settings/contract-templates/[id]/duplicate
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = createApiClient();
+
+  const { data: source, error: fetchErr } = await supabase
+    .from("contract_templates")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (fetchErr) return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+  if (!source) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+
+  const { data: inserted, error: insertErr } = await supabase
+    .from("contract_templates")
+    .insert({
+      name: `${source.name} (Copy)`,
+      description: source.description,
+      content: source.content,
+      content_html: source.content_html,
+      default_signer_count: source.default_signer_count,
+      signer_role_label: source.signer_role_label,
+      is_active: true,
+    })
+    .select()
+    .single();
+
+  if (insertErr) return NextResponse.json({ error: insertErr.message }, { status: 500 });
+  return NextResponse.json(inserted, { status: 201 });
+}

--- a/src/app/api/settings/contract-templates/[id]/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { createApiClient } from "@/lib/supabase-api";
+
+// GET /api/settings/contract-templates/[id]
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = createApiClient();
+  const { data, error } = await supabase
+    .from("contract_templates")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  if (!data) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  return NextResponse.json(data);
+}
+
+// PATCH /api/settings/contract-templates/[id] — update any of the editable
+// fields. Increments version whenever content changes so the send flow in
+// Build 15b can snapshot which template revision produced a given contract.
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const body = await request.json().catch(() => ({}));
+
+  const update: Record<string, unknown> = {};
+  if (typeof body.name === "string") update.name = body.name.slice(0, 120);
+  if (body.description === null || typeof body.description === "string") {
+    update.description = body.description;
+  }
+  if (body.default_signer_count === 1 || body.default_signer_count === 2) {
+    update.default_signer_count = body.default_signer_count;
+  }
+  if (typeof body.signer_role_label === "string") {
+    update.signer_role_label = body.signer_role_label.slice(0, 120);
+  }
+  if (typeof body.is_active === "boolean") update.is_active = body.is_active;
+
+  const contentChanged = body.content !== undefined || body.content_html !== undefined;
+  if (body.content !== undefined) update.content = body.content;
+  if (typeof body.content_html === "string") update.content_html = body.content_html;
+
+  const supabase = createApiClient();
+
+  if (contentChanged) {
+    // Atomic version bump alongside the content update.
+    const { data: existing, error: fetchErr } = await supabase
+      .from("contract_templates")
+      .select("version")
+      .eq("id", id)
+      .maybeSingle();
+    if (fetchErr) return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+    if (!existing) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
+    update.version = (existing.version ?? 1) + 1;
+  }
+
+  const { data, error } = await supabase
+    .from("contract_templates")
+    .update(update)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data);
+}
+
+// DELETE /api/settings/contract-templates/[id] — soft archive by flipping
+// is_active=false. Templates are never hard-deleted because signed contracts
+// in Build 15b will reference them historically.
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = createApiClient();
+  const { error } = await supabase
+    .from("contract_templates")
+    .update({ is_active: false })
+    .eq("id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/settings/contract-templates/jobs/route.ts
+++ b/src/app/api/settings/contract-templates/jobs/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { createApiClient } from "@/lib/supabase-api";
+
+// GET /api/settings/contract-templates/jobs
+// Minimal job list used to populate the Preview modal's job picker.
+// Returns the 25 most recent jobs with their job_number + customer name
+// so the author can eyeball which job the preview is rendering against.
+export async function GET() {
+  const supabase = createApiClient();
+  const { data, error } = await supabase
+    .from("jobs")
+    .select("id, job_number, property_address, created_at, contact:contacts!contact_id(first_name, last_name)")
+    .order("created_at", { ascending: false })
+    .limit(25);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+  type JobRow = {
+    id: string;
+    job_number: string | null;
+    property_address: string | null;
+    contact: { first_name: string | null; last_name: string | null } | { first_name: string | null; last_name: string | null }[] | null;
+  };
+
+  const options = (data ?? []).map((rawRow) => {
+    const row = rawRow as JobRow;
+    const contact = Array.isArray(row.contact) ? row.contact[0] : row.contact;
+    const customer = contact
+      ? [contact.first_name, contact.last_name].filter(Boolean).join(" ")
+      : "";
+    const addr = row.property_address ?? "";
+    const prefix = row.job_number ?? row.id.slice(0, 8);
+    const trailing = [customer, addr].filter(Boolean).join(" — ");
+    return {
+      id: row.id,
+      label: trailing ? `${prefix} — ${trailing}` : prefix,
+    };
+  });
+
+  return NextResponse.json(options);
+}

--- a/src/app/api/settings/contract-templates/preview/route.ts
+++ b/src/app/api/settings/contract-templates/preview/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { createApiClient } from "@/lib/supabase-api";
+import { resolveMergeFields } from "@/lib/contracts/merge-fields";
+
+// POST /api/settings/contract-templates/preview
+// Body: { jobId: string, contentHtml: string }
+// Returns the merge-field-resolved HTML plus the list of fields that
+// had no data on that job so the modal can flag them to the author.
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.jobId !== "string" || typeof body.contentHtml !== "string") {
+    return NextResponse.json(
+      { error: "jobId and contentHtml are required" },
+      { status: 400 },
+    );
+  }
+
+  const supabase = createApiClient();
+  const result = await resolveMergeFields(supabase, body.contentHtml, body.jobId);
+  return NextResponse.json(result);
+}

--- a/src/app/api/settings/contract-templates/route.ts
+++ b/src/app/api/settings/contract-templates/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { createApiClient } from "@/lib/supabase-api";
+
+// GET /api/settings/contract-templates — list all templates (active + archived).
+export async function GET() {
+  const supabase = createApiClient();
+  const { data, error } = await supabase
+    .from("contract_templates")
+    .select(
+      "id, name, description, default_signer_count, is_active, updated_at",
+    )
+    .order("updated_at", { ascending: false });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data ?? []);
+}
+
+// POST /api/settings/contract-templates — create a new blank template.
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const name: string = (body?.name || "Untitled Template").toString().slice(0, 120);
+
+  const supabase = createApiClient();
+  const { data, error } = await supabase
+    .from("contract_templates")
+    .insert({
+      name,
+      description: body?.description ?? null,
+      content: {
+        type: "doc",
+        content: [{ type: "paragraph" }],
+      },
+      content_html: "",
+    })
+    .select()
+    .single();
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/settings/users/route.ts
+++ b/src/app/api/settings/users/route.ts
@@ -7,6 +7,7 @@ const ALL_PERMISSIONS = [
   "view_billing", "record_payments",
   "view_email", "send_email",
   "manage_reports", "access_settings",
+  "manage_contract_templates",
 ];
 
 const ROLE_DEFAULTS: Record<string, string[]> = {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -272,6 +272,99 @@
   animation: shimmer 1.5s ease-in-out infinite;
 }
 
+/* ============================================
+ * Contract-template merge fields (Build 15a)
+ * ============================================ */
+
+/* Purple pill — used in Tiptap editor, sidebar, and saved content_html. */
+.merge-field-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(127, 119, 221, 0.15);
+  color: #AFA9EC;
+  border: 1px solid rgba(127, 119, 221, 0.25);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.82em;
+  line-height: 1.35;
+  white-space: nowrap;
+  user-select: none;
+  vertical-align: baseline;
+}
+
+/* Pill hover state in the editor (not when static in saved HTML). */
+.ProseMirror .merge-field-pill {
+  cursor: grab;
+}
+.ProseMirror .merge-field-pill:hover {
+  background: rgba(127, 119, 221, 0.22);
+}
+.ProseMirror .merge-field-pill.ProseMirror-selectednode {
+  outline: 2px solid rgba(127, 119, 221, 0.6);
+  outline-offset: 1px;
+}
+
+/* Placeholder for fields without source data when the contract is previewed. */
+.merge-field-unresolved {
+  display: inline-block;
+  min-width: 120px;
+  padding: 0 2px;
+  color: var(--muted-foreground);
+  border-bottom: 1px dashed var(--muted-foreground);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  font-size: 0.9em;
+  opacity: 0.7;
+  letter-spacing: 0.05em;
+}
+
+/* Tiptap editor surface used by the contract-template editor. Prose defaults
+ * dark-mode OK from prose-invert; these tweaks tighten spacing and make the
+ * heading sizes feel like a document rather than a blog post. */
+.contract-template-prose {
+  min-height: 520px;
+}
+.contract-template-prose h1 {
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+.contract-template-prose h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-top: 0.9em;
+  margin-bottom: 0.4em;
+}
+.contract-template-prose h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-top: 0.8em;
+  margin-bottom: 0.35em;
+}
+.contract-template-prose p {
+  margin: 0.45em 0;
+}
+.contract-template-prose hr {
+  margin: 1.1em 0;
+  border-color: var(--border);
+}
+.contract-template-prose ul,
+.contract-template-prose ol {
+  margin: 0.5em 0;
+  padding-left: 1.4em;
+}
+
+/* Tiptap ProseMirror placeholder (from @tiptap/extension-placeholder). */
+.contract-template-prose p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  float: left;
+  color: var(--muted-foreground);
+  opacity: 0.5;
+  pointer-events: none;
+  height: 0;
+}
+
 /* Hide scrollbar for quick actions horizontal scroll */
 .scrollbar-none::-webkit-scrollbar {
   display: none;

--- a/src/app/settings/contract-templates/[id]/edit/page.tsx
+++ b/src/app/settings/contract-templates/[id]/edit/page.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { use, useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, Eye, Save, Loader2, Lock } from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/lib/auth-context";
+import TemplateEditor, { type TemplateEditorHandle } from "@/components/contracts/template-editor";
+import MergeFieldSidebar from "@/components/contracts/merge-field-sidebar";
+import PreviewModal from "@/components/contracts/preview-modal";
+import type { ContractTemplate } from "@/lib/contracts/types";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default function ContractTemplateEditPage({ params }: PageProps) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { hasPermission, loading: authLoading } = useAuth();
+  const allowed = hasPermission("manage_contract_templates");
+
+  const [template, setTemplate] = useState<ContractTemplate | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  // Editable metadata + settings mirror DB state; edits go through local
+  // state until Save flushes them.
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [defaultSignerCount, setDefaultSignerCount] = useState<1 | 2>(1);
+  const [signerRoleLabel, setSignerRoleLabel] = useState("Homeowner");
+  const [isActive, setIsActive] = useState(true);
+
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const editorHandleRef = useRef<TemplateEditorHandle | null>(null);
+  const handleEditorReady = useCallback((h: TemplateEditorHandle) => {
+    editorHandleRef.current = h;
+  }, []);
+
+  useEffect(() => {
+    if (!authLoading && allowed) {
+      (async () => {
+        const res = await fetch(`/api/settings/contract-templates/${id}`);
+        if (res.status === 404) {
+          setNotFound(true);
+          return;
+        }
+        if (!res.ok) {
+          toast.error("Failed to load template");
+          return;
+        }
+        const data = (await res.json()) as ContractTemplate;
+        setTemplate(data);
+        setName(data.name ?? "");
+        setDescription(data.description ?? "");
+        setDefaultSignerCount(data.default_signer_count ?? 1);
+        setSignerRoleLabel(data.signer_role_label ?? "Homeowner");
+        setIsActive(data.is_active ?? true);
+      })();
+    }
+  }, [authLoading, allowed, id]);
+
+  async function handleSave() {
+    if (!editorHandleRef.current) return;
+    setSaving(true);
+    try {
+      const content = editorHandleRef.current.getJSON();
+      const contentHtml = editorHandleRef.current.getHTML();
+      const res = await fetch(`/api/settings/contract-templates/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim() || "Untitled Template",
+          description: description.trim() || null,
+          default_signer_count: defaultSignerCount,
+          signer_role_label: signerRoleLabel.trim() || "Homeowner",
+          is_active: isActive,
+          content,
+          content_html: contentHtml,
+        }),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      const updated = (await res.json()) as ContractTemplate;
+      setTemplate(updated);
+      setDirty(false);
+      toast.success(`Saved — version ${updated.version}`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function openPreview() {
+    if (!editorHandleRef.current) {
+      toast.error("Editor not ready");
+      return;
+    }
+    setPreviewOpen(true);
+  }
+
+  // Warn on unload with unsaved edits.
+  useEffect(() => {
+    if (!dirty) return;
+    function beforeUnload(e: BeforeUnloadEvent) {
+      e.preventDefault();
+      e.returnValue = "";
+    }
+    window.addEventListener("beforeunload", beforeUnload);
+    return () => window.removeEventListener("beforeunload", beforeUnload);
+  }, [dirty]);
+
+  if (authLoading) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <Loader2 size={20} className="inline animate-spin mr-2" /> Loading…
+      </div>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8 text-center">
+        <Lock size={28} className="mx-auto text-muted-foreground mb-3" />
+        <h2 className="text-lg font-semibold text-foreground">Access restricted</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          You don&apos;t have permission to edit contract templates.
+        </p>
+      </div>
+    );
+  }
+
+  if (notFound) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8 text-center">
+        <h2 className="text-lg font-semibold text-foreground">Template not found</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          This template may have been deleted.
+        </p>
+        <Link
+          href="/settings/contract-templates"
+          className="inline-flex items-center gap-1 mt-4 text-sm text-[var(--brand-primary)] hover:underline"
+        >
+          <ArrowLeft size={14} /> Back to templates
+        </Link>
+      </div>
+    );
+  }
+
+  if (!template) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <Loader2 size={20} className="inline animate-spin mr-2" /> Loading template…
+      </div>
+    );
+  }
+
+  const currentHtml = editorHandleRef.current?.getHTML() ?? template.content_html;
+
+  return (
+    <div className="space-y-4">
+      {/* Header bar */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={() => {
+              if (dirty && !confirm("Discard unsaved changes?")) return;
+              router.push("/settings/contract-templates");
+            }}
+            className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shrink-0"
+            aria-label="Back to templates"
+          >
+            <ArrowLeft size={18} />
+          </button>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setDirty(true);
+            }}
+            placeholder="Template name"
+            className="flex-1 min-w-0 bg-transparent border-0 focus:outline-none text-lg font-semibold text-foreground placeholder:text-muted-foreground/60"
+          />
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            v{template.version}
+            {dirty && <span className="ml-2 text-[var(--brand-primary)]">• unsaved</span>}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            type="button"
+            onClick={openPreview}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium border border-border text-foreground hover:bg-accent transition-colors"
+          >
+            <Eye size={15} /> Preview
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 hover:shadow-md transition-all disabled:opacity-60"
+          >
+            {saving ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
+            Save
+          </button>
+        </div>
+      </div>
+
+      {/* Description field */}
+      <div>
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => {
+            setDescription(e.target.value);
+            setDirty(true);
+          }}
+          placeholder="Optional internal description (not shown to customers)"
+          className="w-full bg-transparent border-0 focus:outline-none text-sm text-muted-foreground placeholder:text-muted-foreground/60"
+        />
+      </div>
+
+      {/* Two-column layout: 60% editor, 40% sidebar */}
+      <div className="grid grid-cols-1 lg:grid-cols-5 gap-4">
+        <div className="lg:col-span-3 min-w-0">
+          <TemplateEditor
+            initialContent={template.content}
+            onReady={handleEditorReady}
+            onDirtyChange={(d) => {
+              if (d) setDirty(true);
+            }}
+          />
+        </div>
+        <div className="lg:col-span-2 min-w-0">
+          <MergeFieldSidebar
+            onInsert={(fieldName) => {
+              editorHandleRef.current?.insertMergeField(fieldName);
+            }}
+            defaultSignerCount={defaultSignerCount}
+            onDefaultSignerCountChange={(c) => {
+              setDefaultSignerCount(c);
+              setDirty(true);
+            }}
+            signerRoleLabel={signerRoleLabel}
+            onSignerRoleLabelChange={(l) => {
+              setSignerRoleLabel(l);
+              setDirty(true);
+            }}
+            isActive={isActive}
+            onIsActiveChange={(a) => {
+              setIsActive(a);
+              setDirty(true);
+            }}
+          />
+        </div>
+      </div>
+
+      <PreviewModal
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        contentHtml={currentHtml}
+      />
+    </div>
+  );
+}

--- a/src/app/settings/contract-templates/page.tsx
+++ b/src/app/settings/contract-templates/page.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  Plus,
+  Pencil,
+  Copy,
+  Archive,
+  ArchiveRestore,
+  FileText,
+  Loader2,
+  Lock,
+  MoreHorizontal,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/lib/auth-context";
+import type { ContractTemplateListItem } from "@/lib/contracts/types";
+
+export default function ContractTemplatesPage() {
+  const { hasPermission, loading: authLoading } = useAuth();
+  const router = useRouter();
+  const allowed = hasPermission("manage_contract_templates");
+
+  const [templates, setTemplates] = useState<ContractTemplateListItem[] | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const res = await fetch("/api/settings/contract-templates");
+    if (res.ok) {
+      const data = (await res.json()) as ContractTemplateListItem[];
+      setTemplates(data);
+    } else {
+      toast.error("Failed to load templates");
+      setTemplates([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!authLoading && allowed) {
+      refresh();
+    }
+  }, [authLoading, allowed, refresh]);
+
+  // Close row menu on outside click.
+  useEffect(() => {
+    function onDocClick() {
+      setOpenMenuId(null);
+    }
+    if (openMenuId) document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [openMenuId]);
+
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      const res = await fetch("/api/settings/contract-templates", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Untitled Template" }),
+      });
+      if (!res.ok) throw new Error("Failed to create template");
+      const created = (await res.json()) as { id: string };
+      router.push(`/settings/contract-templates/${created.id}/edit`);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create template");
+      setCreating(false);
+    }
+  }
+
+  async function handleDuplicate(id: string) {
+    setOpenMenuId(null);
+    const res = await fetch(`/api/settings/contract-templates/${id}/duplicate`, {
+      method: "POST",
+    });
+    if (res.ok) {
+      toast.success("Template duplicated");
+      refresh();
+    } else {
+      toast.error("Failed to duplicate");
+    }
+  }
+
+  async function handleToggleArchive(t: ContractTemplateListItem) {
+    setOpenMenuId(null);
+    if (t.is_active) {
+      // Archive via DELETE (soft, sets is_active=false).
+      const res = await fetch(`/api/settings/contract-templates/${t.id}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        toast.success("Template archived");
+        refresh();
+      } else {
+        toast.error("Failed to archive");
+      }
+    } else {
+      // Restore via PATCH.
+      const res = await fetch(`/api/settings/contract-templates/${t.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ is_active: true }),
+      });
+      if (res.ok) {
+        toast.success("Template restored");
+        refresh();
+      } else {
+        toast.error("Failed to restore");
+      }
+    }
+  }
+
+  async function handleToggleActive(t: ContractTemplateListItem, next: boolean) {
+    // Optimistic update.
+    setTemplates((prev) =>
+      prev ? prev.map((row) => (row.id === t.id ? { ...row, is_active: next } : row)) : prev,
+    );
+    const res = await fetch(`/api/settings/contract-templates/${t.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: next }),
+    });
+    if (!res.ok) {
+      toast.error("Failed to update");
+      refresh();
+    }
+  }
+
+  if (authLoading) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        <Loader2 size={20} className="inline animate-spin mr-2" /> Loading…
+      </div>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-8 text-center">
+        <Lock size={28} className="mx-auto text-muted-foreground mb-3" />
+        <h2 className="text-lg font-semibold text-foreground">Access restricted</h2>
+        <p className="text-sm text-muted-foreground mt-1 max-w-md mx-auto">
+          You don&apos;t have permission to manage contract templates. Ask an admin to grant you
+          <span className="font-mono text-xs"> manage_contract_templates</span> in Users &amp; Crew.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-foreground flex items-center gap-2">
+            <FileText size={18} className="text-[var(--brand-primary)]" />
+            Contract Templates
+          </h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Templates define the body of contracts sent for signature. Merge fields resolve to job data at send time.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={creating}
+          className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 hover:shadow-md transition-all disabled:opacity-60"
+        >
+          {creating ? <Loader2 size={16} className="animate-spin" /> : <Plus size={16} />}
+          New Template
+        </button>
+      </div>
+
+      {/* Table */}
+      {templates === null ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <Loader2 size={20} className="inline animate-spin mr-2" /> Loading templates…
+        </div>
+      ) : templates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-10 text-center">
+          <FileText size={32} className="mx-auto text-muted-foreground mb-3" />
+          <p className="text-sm text-foreground font-medium">No contract templates yet</p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Create your first template to start sending contracts for signature.
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="text-left font-medium px-4 py-3">Name</th>
+                <th className="text-left font-medium px-4 py-3 hidden md:table-cell">Description</th>
+                <th className="text-left font-medium px-4 py-3 whitespace-nowrap">Signers</th>
+                <th className="text-left font-medium px-4 py-3">Active</th>
+                <th className="text-left font-medium px-4 py-3 hidden sm:table-cell">Last Edited</th>
+                <th className="w-10" />
+              </tr>
+            </thead>
+            <tbody>
+              {templates.map((t) => (
+                <tr
+                  key={t.id}
+                  className="border-t border-border hover:bg-muted/20 transition-colors"
+                >
+                  <td className="px-4 py-3">
+                    <Link
+                      href={`/settings/contract-templates/${t.id}/edit`}
+                      className="font-medium text-foreground hover:text-[var(--brand-primary)] transition-colors"
+                    >
+                      {t.name}
+                    </Link>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground max-w-[28ch] truncate hidden md:table-cell">
+                    {t.description || <span className="text-muted-foreground/50">—</span>}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">{t.default_signer_count}</td>
+                  <td className="px-4 py-3">
+                    <label className="inline-flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={t.is_active}
+                        onChange={(e) => handleToggleActive(t, e.target.checked)}
+                        className="h-4 w-4 rounded border-border accent-[var(--brand-primary)]"
+                      />
+                      <span
+                        className={
+                          t.is_active
+                            ? "text-xs text-[var(--brand-primary)]"
+                            : "text-xs text-muted-foreground"
+                        }
+                      >
+                        {t.is_active ? "Active" : "Archived"}
+                      </span>
+                    </label>
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">
+                    {formatLastEdited(t.updated_at)}
+                  </td>
+                  <td className="px-2 py-3 relative text-right">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOpenMenuId(openMenuId === t.id ? null : t.id);
+                      }}
+                      className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                      aria-label="Row actions"
+                    >
+                      <MoreHorizontal size={16} />
+                    </button>
+                    {openMenuId === t.id && (
+                      <div
+                        className="absolute right-2 top-10 z-10 w-40 rounded-lg border border-border bg-popover text-popover-foreground shadow-xl overflow-hidden"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Link
+                          href={`/settings/contract-templates/${t.id}/edit`}
+                          className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent"
+                        >
+                          <Pencil size={14} /> Edit
+                        </Link>
+                        <button
+                          type="button"
+                          onClick={() => handleDuplicate(t.id)}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent text-left"
+                        >
+                          <Copy size={14} /> Duplicate
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleToggleArchive(t)}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-accent text-left"
+                        >
+                          {t.is_active ? (
+                            <>
+                              <Archive size={14} /> Archive
+                            </>
+                          ) : (
+                            <>
+                              <ArchiveRestore size={14} /> Restore
+                            </>
+                          )}
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatLastEdited(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const now = Date.now();
+    const diffMs = now - d.getTime();
+    const day = 24 * 60 * 60 * 1000;
+    if (diffMs < day) {
+      return d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
+    }
+    if (diffMs < 7 * day) {
+      return d.toLocaleDateString("en-US", { weekday: "short" });
+    }
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+  } catch {
+    return iso;
+  }
+}

--- a/src/components/contracts/merge-field-node.ts
+++ b/src/components/contracts/merge-field-node.ts
@@ -1,0 +1,77 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+
+export interface MergeFieldOptions {
+  HTMLAttributes: Record<string, string>;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    mergeField: {
+      insertMergeField: (fieldName: string) => ReturnType;
+    };
+  }
+}
+
+/**
+ * Inline atomic node representing a merge-field token inside a contract
+ * template. Renders as <span class="merge-field-pill" data-field-name="…">
+ * so the resolver can match it later. Draggable so authors can reposition
+ * tokens without retyping them; atomic so clicks and delete behave as a unit.
+ */
+export const MergeField = Node.create<MergeFieldOptions>({
+  name: "mergeField",
+  group: "inline",
+  inline: true,
+  atom: true,
+  draggable: true,
+  selectable: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      fieldName: {
+        default: "",
+        parseHTML: (element) => element.getAttribute("data-field-name") ?? "",
+        renderHTML: (attrs) => ({ "data-field-name": attrs.fieldName }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: "span[data-merge-field]",
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const fieldName =
+      (HTMLAttributes["data-field-name"] as string | undefined) ?? "";
+    return [
+      "span",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
+        class: "merge-field-pill",
+        "data-merge-field": "true",
+      }),
+      `{{${fieldName}}}`,
+    ];
+  },
+
+  addCommands() {
+    return {
+      insertMergeField:
+        (fieldName: string) =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs: { fieldName },
+          }),
+    };
+  },
+});

--- a/src/components/contracts/merge-field-sidebar.tsx
+++ b/src/components/contracts/merge-field-sidebar.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { MERGE_FIELD_CATEGORIES, mergeFieldsByCategory } from "@/lib/contracts/merge-fields";
+
+interface MergeFieldSidebarProps {
+  onInsert: (fieldName: string) => void;
+  // Template settings
+  defaultSignerCount: 1 | 2;
+  onDefaultSignerCountChange: (count: 1 | 2) => void;
+  signerRoleLabel: string;
+  onSignerRoleLabelChange: (label: string) => void;
+  isActive: boolean;
+  onIsActiveChange: (active: boolean) => void;
+}
+
+export default function MergeFieldSidebar({
+  onInsert,
+  defaultSignerCount,
+  onDefaultSignerCountChange,
+  signerRoleLabel,
+  onSignerRoleLabelChange,
+  isActive,
+  onIsActiveChange,
+}: MergeFieldSidebarProps) {
+  const grouped = mergeFieldsByCategory();
+
+  return (
+    <div className="flex flex-col gap-4 min-w-0">
+      {/* Available merge fields */}
+      <section className="rounded-xl border border-border bg-card p-4">
+        <header className="mb-3">
+          <h3 className="text-sm font-semibold text-foreground">Merge Fields</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Click or drag a field into the editor. They resolve when a contract is previewed or sent.
+          </p>
+        </header>
+        <div className="space-y-3">
+          {MERGE_FIELD_CATEGORIES.map((cat) => (
+            <div key={cat}>
+              <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground mb-1.5">
+                {cat}
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {grouped[cat].map((f) => (
+                  <button
+                    key={f.name}
+                    type="button"
+                    onClick={() => onInsert(f.name)}
+                    title={f.label}
+                    className="merge-field-pill cursor-pointer hover:brightness-110 text-left"
+                  >
+                    {`{{${f.name}}}`}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Template settings */}
+      <section className="rounded-xl border border-border bg-card p-4">
+        <header className="mb-3">
+          <h3 className="text-sm font-semibold text-foreground">Settings</h3>
+        </header>
+        <div className="space-y-3">
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">
+              Default Signer Count
+            </label>
+            <select
+              value={defaultSignerCount}
+              onChange={(e) =>
+                onDefaultSignerCountChange(Number(e.target.value) === 2 ? 2 : 1)
+              }
+              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20"
+            >
+              <option value={1}>1 — Single signer</option>
+              <option value={2}>2 — Co-signer</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">
+              Signer Role Label
+            </label>
+            <input
+              type="text"
+              value={signerRoleLabel}
+              onChange={(e) => onSignerRoleLabelChange(e.target.value)}
+              placeholder="e.g. Homeowner, Property Manager"
+              className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20"
+            />
+            <p className="text-[11px] text-muted-foreground mt-1">
+              Displayed on the signing page above the signer&apos;s signature line.
+            </p>
+          </div>
+
+          <div>
+            <label className="flex items-center justify-between gap-3 rounded-lg border border-border bg-background px-3 py-2 cursor-pointer">
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">Active</div>
+                <div className="text-[11px] text-muted-foreground">
+                  Inactive templates are hidden from send menus but kept for audit.
+                </div>
+              </div>
+              <input
+                type="checkbox"
+                checked={isActive}
+                onChange={(e) => onIsActiveChange(e.target.checked)}
+                className="h-4 w-4 rounded border-border accent-[var(--brand-primary)] shrink-0"
+              />
+            </label>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/contracts/preview-modal.tsx
+++ b/src/components/contracts/preview-modal.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X, Loader2, AlertTriangle } from "lucide-react";
+import { toast } from "sonner";
+
+interface JobOption {
+  id: string;
+  label: string;
+}
+
+interface PreviewModalProps {
+  open: boolean;
+  onClose: () => void;
+  contentHtml: string;
+}
+
+interface PreviewResponse {
+  html: string;
+  unresolvedFields: string[];
+}
+
+export default function PreviewModal({ open, onClose, contentHtml }: PreviewModalProps) {
+  const [jobs, setJobs] = useState<JobOption[] | null>(null);
+  const [selectedJobId, setSelectedJobId] = useState<string>("");
+  const [preview, setPreview] = useState<PreviewResponse | null>(null);
+  const [loadingPreview, setLoadingPreview] = useState(false);
+
+  // Fetch job list once when modal opens.
+  useEffect(() => {
+    if (!open || jobs !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/contract-templates/jobs");
+        if (!res.ok) throw new Error("Failed to load jobs");
+        const data = (await res.json()) as JobOption[];
+        if (cancelled) return;
+        setJobs(data);
+        if (data.length > 0) setSelectedJobId(data[0].id);
+      } catch (err) {
+        if (!cancelled) {
+          toast.error(err instanceof Error ? err.message : "Failed to load jobs");
+          setJobs([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, jobs]);
+
+  // Fetch resolved preview whenever the selection or content changes.
+  useEffect(() => {
+    if (!open || !selectedJobId) {
+      setPreview(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadingPreview(true);
+    (async () => {
+      try {
+        const res = await fetch("/api/settings/contract-templates/preview", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jobId: selectedJobId, contentHtml }),
+        });
+        if (!res.ok) throw new Error("Preview failed");
+        const data = (await res.json()) as PreviewResponse;
+        if (!cancelled) setPreview(data);
+      } catch (err) {
+        if (!cancelled) {
+          toast.error(err instanceof Error ? err.message : "Preview failed");
+        }
+      } finally {
+        if (!cancelled) setLoadingPreview(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, selectedJobId, contentHtml]);
+
+  // ESC closes.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-4xl max-h-[90vh] flex flex-col rounded-2xl border border-border bg-card shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-border shrink-0">
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-foreground">Template Preview</h2>
+            <p className="text-xs text-muted-foreground">
+              Merge fields resolved using data from the selected job.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close preview"
+            className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Controls */}
+        <div className="px-5 py-3 border-b border-border flex items-center gap-3 shrink-0">
+          <label className="text-xs font-medium text-muted-foreground">Preview with job:</label>
+          {jobs === null ? (
+            <span className="text-xs text-muted-foreground inline-flex items-center gap-1">
+              <Loader2 size={12} className="animate-spin" /> Loading jobs…
+            </span>
+          ) : jobs.length === 0 ? (
+            <span className="text-xs text-muted-foreground">
+              No jobs available — create a job first to preview real data.
+            </span>
+          ) : (
+            <select
+              value={selectedJobId}
+              onChange={(e) => setSelectedJobId(e.target.value)}
+              className="bg-background border border-border rounded-lg px-3 py-1.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20"
+            >
+              {jobs.map((j) => (
+                <option key={j.id} value={j.id}>
+                  {j.label}
+                </option>
+              ))}
+            </select>
+          )}
+          {loadingPreview && (
+            <Loader2 size={14} className="animate-spin text-muted-foreground" />
+          )}
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 min-h-0 overflow-auto p-6 bg-background/40">
+          {preview ? (
+            <>
+              {preview.unresolvedFields.length > 0 && (
+                <div className="mb-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+                  <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                  <div>
+                    <span className="font-semibold">
+                      {preview.unresolvedFields.length} unresolved field
+                      {preview.unresolvedFields.length === 1 ? "" : "s"}:
+                    </span>{" "}
+                    <span className="font-mono">{preview.unresolvedFields.join(", ")}</span>
+                    <div className="text-amber-200/80 mt-0.5">
+                      These show as blank lines in the contract until the underlying job data is populated.
+                    </div>
+                  </div>
+                </div>
+              )}
+              <article
+                className="contract-template-prose prose prose-sm dark:prose-invert max-w-none text-foreground"
+                dangerouslySetInnerHTML={{ __html: preview.html }}
+              />
+            </>
+          ) : (
+            <div className="text-center text-sm text-muted-foreground py-20">
+              {jobs === null ? "Loading preview…" : "Select a job to see the rendered template."}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/contracts/template-editor.tsx
+++ b/src/components/contracts/template-editor.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEditor, EditorContent } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import Placeholder from "@tiptap/extension-placeholder";
+import {
+  Bold,
+  Italic,
+  Underline as UnderlineIcon,
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Minus,
+  Plus,
+  ChevronDown,
+} from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { MergeField } from "./merge-field-node";
+import { MERGE_FIELD_CATEGORIES, mergeFieldsByCategory } from "@/lib/contracts/merge-fields";
+import { cn } from "@/lib/utils";
+
+export interface TemplateEditorHandle {
+  getHTML: () => string;
+  getJSON: () => unknown;
+  insertMergeField: (fieldName: string) => void;
+  focus: () => void;
+}
+
+interface TemplateEditorProps {
+  initialContent: unknown;
+  onReady?: (handle: TemplateEditorHandle) => void;
+  onDirtyChange?: (dirty: boolean) => void;
+}
+
+export default function TemplateEditor({
+  initialContent,
+  onReady,
+  onDirtyChange,
+}: TemplateEditorProps) {
+  const [mergeOpen, setMergeOpen] = useState(false);
+  const mergeBtnRef = useRef<HTMLDivElement | null>(null);
+
+  const editor = useEditor({
+    extensions: [
+      StarterKit.configure({
+        horizontalRule: {},
+      }),
+      Placeholder.configure({
+        placeholder: "Write your contract template here…",
+      }),
+      MergeField,
+    ],
+    content: initialContent ?? { type: "doc", content: [{ type: "paragraph" }] },
+    immediatelyRender: false,
+    editorProps: {
+      attributes: {
+        class:
+          "contract-template-prose prose prose-sm dark:prose-invert max-w-none min-h-[520px] px-5 py-4 focus:outline-none text-foreground",
+      },
+    },
+    onUpdate: () => {
+      onDirtyChange?.(true);
+    },
+  });
+
+  useEffect(() => {
+    if (!editor) return;
+    onReady?.({
+      getHTML: () => editor.getHTML(),
+      getJSON: () => editor.getJSON(),
+      insertMergeField: (fieldName: string) => {
+        editor.chain().focus().insertMergeField(fieldName).run();
+      },
+      focus: () => editor.commands.focus(),
+    });
+  }, [editor, onReady]);
+
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (!mergeBtnRef.current) return;
+      if (!mergeBtnRef.current.contains(e.target as Element)) {
+        setMergeOpen(false);
+      }
+    }
+    if (mergeOpen) document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [mergeOpen]);
+
+  if (!editor) {
+    return (
+      <div className="h-[560px] rounded-xl border border-border bg-card animate-pulse" />
+    );
+  }
+
+  const grouped = mergeFieldsByCategory();
+
+  return (
+    <div className="rounded-xl border border-border bg-card overflow-hidden flex flex-col min-h-[560px]">
+      {/* Toolbar */}
+      <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-border bg-muted/40 flex-wrap">
+        <ToolbarButton
+          active={editor.isActive("bold")}
+          onClick={() => editor.chain().focus().toggleBold().run()}
+          title="Bold"
+        >
+          <Bold size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={editor.isActive("italic")}
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+          title="Italic"
+        >
+          <Italic size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={editor.isActive("underline")}
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+          title="Underline"
+        >
+          <UnderlineIcon size={15} />
+        </ToolbarButton>
+        <ToolbarDivider />
+        <ToolbarButton
+          active={editor.isActive("heading", { level: 1 })}
+          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+          title="Heading 1"
+        >
+          <Heading1 size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={editor.isActive("heading", { level: 2 })}
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+          title="Heading 2"
+        >
+          <Heading2 size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={editor.isActive("heading", { level: 3 })}
+          onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
+          title="Heading 3"
+        >
+          <Heading3 size={15} />
+        </ToolbarButton>
+        <ToolbarDivider />
+        <ToolbarButton
+          active={editor.isActive("bulletList")}
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+          title="Bullet list"
+        >
+          <List size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={editor.isActive("orderedList")}
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          title="Numbered list"
+        >
+          <ListOrdered size={15} />
+        </ToolbarButton>
+        <ToolbarButton
+          active={false}
+          onClick={() => editor.chain().focus().setHorizontalRule().run()}
+          title="Horizontal rule"
+        >
+          <Minus size={15} />
+        </ToolbarButton>
+
+        <ToolbarDivider />
+
+        {/* Merge field dropdown */}
+        <div ref={mergeBtnRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setMergeOpen((v) => !v)}
+            className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs font-medium text-[var(--brand-primary)] hover:bg-[var(--brand-primary)]/10 transition-colors"
+            title="Insert merge field"
+          >
+            <Plus size={14} /> Merge Field <ChevronDown size={12} />
+          </button>
+          {mergeOpen && (
+            <div className="absolute top-full left-0 mt-1 w-72 max-h-96 overflow-auto rounded-lg border border-border bg-popover text-popover-foreground shadow-xl z-30 p-2">
+              {MERGE_FIELD_CATEGORIES.map((cat) => (
+                <div key={cat} className="mb-2 last:mb-0">
+                  <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                    {cat}
+                  </div>
+                  <div className="flex flex-wrap gap-1">
+                    {grouped[cat].map((f) => (
+                      <button
+                        key={f.name}
+                        type="button"
+                        onClick={() => {
+                          editor.chain().focus().insertMergeField(f.name).run();
+                          setMergeOpen(false);
+                        }}
+                        className="merge-field-pill cursor-pointer hover:brightness-110"
+                      >
+                        {`{{${f.name}}}`}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Editor body */}
+      <div className="flex-1 bg-background/30">
+        <EditorContent editor={editor} />
+      </div>
+    </div>
+  );
+}
+
+function ToolbarDivider() {
+  return <div className="w-px h-4 bg-border mx-1" />;
+}
+
+function ToolbarButton({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={cn(
+        "p-1.5 rounded transition-colors",
+        active
+          ? "bg-[var(--brand-primary)]/10 text-[var(--brand-primary)]"
+          : "text-muted-foreground hover:bg-accent hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/lib/contracts/merge-fields.ts
+++ b/src/lib/contracts/merge-fields.ts
@@ -1,0 +1,262 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MergeFieldCategory, MergeFieldDefinition } from "./types";
+
+export const MERGE_FIELDS: MergeFieldDefinition[] = [
+  // Customer
+  { name: "customer_name", label: "Customer Name", category: "Customer" },
+  { name: "customer_email", label: "Customer Email", category: "Customer" },
+  { name: "customer_phone", label: "Customer Phone", category: "Customer" },
+  { name: "customer_address", label: "Customer Address", category: "Customer" },
+  // Property
+  { name: "property_address", label: "Property Address", category: "Property" },
+  { name: "property_type", label: "Property Type", category: "Property" },
+  // Job
+  { name: "job_number", label: "Job Number", category: "Job" },
+  { name: "damage_type", label: "Damage Type", category: "Job" },
+  { name: "damage_source", label: "Damage Source", category: "Job" },
+  { name: "date_today", label: "Today's Date", category: "Job" },
+  { name: "intake_date", label: "Intake Date", category: "Job" },
+  { name: "affected_areas", label: "Affected Areas", category: "Job" },
+  // Insurance
+  { name: "insurance_company", label: "Insurance Company", category: "Insurance" },
+  { name: "claim_number", label: "Claim Number", category: "Insurance" },
+  { name: "adjuster_name", label: "Adjuster Name", category: "Insurance" },
+  { name: "adjuster_phone", label: "Adjuster Phone", category: "Insurance" },
+  // Company
+  { name: "company_name", label: "Company Name", category: "Company" },
+  { name: "company_phone", label: "Company Phone", category: "Company" },
+  { name: "company_email", label: "Company Email", category: "Company" },
+  { name: "company_address", label: "Company Address", category: "Company" },
+  { name: "company_license", label: "Company License", category: "Company" },
+];
+
+export const MERGE_FIELD_CATEGORIES: MergeFieldCategory[] = [
+  "Customer",
+  "Property",
+  "Job",
+  "Insurance",
+  "Company",
+];
+
+export function mergeFieldsByCategory(): Record<MergeFieldCategory, MergeFieldDefinition[]> {
+  const grouped = {} as Record<MergeFieldCategory, MergeFieldDefinition[]>;
+  for (const cat of MERGE_FIELD_CATEGORIES) grouped[cat] = [];
+  for (const field of MERGE_FIELDS) grouped[field.category].push(field);
+  return grouped;
+}
+
+export function isKnownField(name: string): boolean {
+  return MERGE_FIELDS.some((f) => f.name === name);
+}
+
+interface ContactRow {
+  first_name: string | null;
+  last_name: string | null;
+  email: string | null;
+  phone: string | null;
+}
+
+interface JobRow {
+  id: string;
+  job_number: string | null;
+  damage_type: string | null;
+  damage_source: string | null;
+  property_address: string | null;
+  property_type: string | null;
+  affected_areas: string | null;
+  insurance_company: string | null;
+  claim_number: string | null;
+  created_at: string | null;
+  contact_id: string;
+}
+
+function formatDamageType(raw: string | null): string | null {
+  if (!raw) return null;
+  return raw
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function formatDate(iso: string | null): string | null {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function fullName(c: ContactRow | null): string | null {
+  if (!c) return null;
+  const n = [c.first_name, c.last_name].filter(Boolean).join(" ").trim();
+  return n || null;
+}
+
+/**
+ * Queries job + linked contact + primary adjuster + company settings, then
+ * returns a flat Record of every known merge field → its resolved string
+ * value (or null if data is missing for that field on this particular job).
+ *
+ * Used by both the preview modal (15a) and the send flow (15b).
+ */
+export async function buildMergeFieldValues(
+  supabase: SupabaseClient,
+  jobId: string,
+): Promise<Record<string, string | null>> {
+  const values: Record<string, string | null> = {};
+  for (const f of MERGE_FIELDS) values[f.name] = null;
+
+  // Job
+  const { data: job } = await supabase
+    .from("jobs")
+    .select("id, job_number, damage_type, damage_source, property_address, property_type, affected_areas, insurance_company, claim_number, created_at, contact_id")
+    .eq("id", jobId)
+    .maybeSingle<JobRow>();
+
+  if (job) {
+    values.job_number = job.job_number;
+    values.damage_type = formatDamageType(job.damage_type);
+    values.damage_source = job.damage_source;
+    values.property_address = job.property_address;
+    values.property_type = job.property_type
+      ? formatDamageType(job.property_type) // same title-case helper
+      : null;
+    values.affected_areas = job.affected_areas;
+    values.insurance_company = job.insurance_company;
+    values.claim_number = job.claim_number;
+    values.intake_date = formatDate(job.created_at);
+  }
+  values.date_today = formatDate(new Date().toISOString());
+
+  // Contact (customer)
+  if (job?.contact_id) {
+    const { data: contact } = await supabase
+      .from("contacts")
+      .select("first_name, last_name, email, phone")
+      .eq("id", job.contact_id)
+      .maybeSingle<ContactRow>();
+    if (contact) {
+      values.customer_name = fullName(contact);
+      values.customer_email = contact.email;
+      values.customer_phone = contact.phone;
+    }
+  }
+  // Contacts has no address column; property_address doubles as the
+  // customer's address for homeowner jobs. Confirmed fallback.
+  values.customer_address = values.property_address;
+
+  // Primary adjuster via job_adjusters junction (build31+).
+  if (job?.id) {
+    const { data: adjusterLinks } = await supabase
+      .from("job_adjusters")
+      .select("contact_id, is_primary")
+      .eq("job_id", job.id);
+    const primary = adjusterLinks?.find((a) => a.is_primary) ?? adjusterLinks?.[0];
+    if (primary?.contact_id) {
+      const { data: adj } = await supabase
+        .from("contacts")
+        .select("first_name, last_name, phone")
+        .eq("id", primary.contact_id)
+        .maybeSingle<ContactRow>();
+      if (adj) {
+        values.adjuster_name = fullName(adj);
+        values.adjuster_phone = adj.phone;
+      }
+    }
+  }
+
+  // Company settings (key/value store)
+  const { data: settings } = await supabase
+    .from("company_settings")
+    .select("key, value")
+    .in("key", ["company_name", "phone", "email", "address", "license"]);
+  if (settings) {
+    const map = new Map(settings.map((s: { key: string; value: string | null }) => [s.key, s.value]));
+    values.company_name = map.get("company_name") ?? null;
+    values.company_phone = map.get("phone") ?? null;
+    values.company_email = map.get("email") ?? null;
+    values.company_address = map.get("address") ?? null;
+    values.company_license = map.get("license") ?? null;
+  }
+
+  return values;
+}
+
+const UNRESOLVED_SPAN = '<span class="merge-field-unresolved">________</span>';
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Replaces merge-field markup in a rendered HTML template with values
+ * resolved from the given job. Two shapes are supported:
+ *
+ *   - Tiptap pill span: <span data-field-name="x" ...>{{x}}</span>
+ *   - Raw token:        {{x}}
+ *
+ * Unknown or missing fields render as a visible blank line styled by the
+ * .merge-field-unresolved CSS class so reviewers can see what still needs data.
+ */
+export function applyMergeFieldValues(
+  html: string,
+  values: Record<string, string | null>,
+): { html: string; unresolvedFields: string[] } {
+  const unresolved = new Set<string>();
+  let output = html;
+
+  // 1. Replace Tiptap pill spans (wraps both unknown and known).
+  output = output.replace(
+    /<span\b[^>]*\bdata-field-name="([^"]+)"[^>]*>[\s\S]*?<\/span>/gi,
+    (_match, fieldName: string) => {
+      if (!isKnownField(fieldName)) {
+        unresolved.add(fieldName);
+        return UNRESOLVED_SPAN;
+      }
+      const v = values[fieldName];
+      if (v === null || v === undefined || v === "") {
+        unresolved.add(fieldName);
+        return UNRESOLVED_SPAN;
+      }
+      return escapeHtml(v);
+    },
+  );
+
+  // 2. Replace any remaining bare {{field_name}} tokens.
+  output = output.replace(/\{\{([a-z_][a-z0-9_]*)\}\}/gi, (_match, fieldName: string) => {
+    if (!isKnownField(fieldName)) {
+      unresolved.add(fieldName);
+      return UNRESOLVED_SPAN;
+    }
+    const v = values[fieldName];
+    if (v === null || v === undefined || v === "") {
+      unresolved.add(fieldName);
+      return UNRESOLVED_SPAN;
+    }
+    return escapeHtml(v);
+  });
+
+  return { html: output, unresolvedFields: Array.from(unresolved) };
+}
+
+/**
+ * Convenience wrapper: resolve merge fields for a given job and template HTML
+ * in one call. Build 15b's send flow will use this same path to snapshot the
+ * filled HTML at send time.
+ */
+export async function resolveMergeFields(
+  supabase: SupabaseClient,
+  contentHtml: string,
+  jobId: string,
+): Promise<{ html: string; unresolvedFields: string[] }> {
+  const values = await buildMergeFieldValues(supabase, jobId);
+  return applyMergeFieldValues(contentHtml, values);
+}

--- a/src/lib/contracts/types.ts
+++ b/src/lib/contracts/types.ts
@@ -1,0 +1,42 @@
+export type MergeFieldCategory =
+  | "Customer"
+  | "Property"
+  | "Job"
+  | "Insurance"
+  | "Company";
+
+export interface MergeFieldDefinition {
+  name: string;
+  label: string;
+  category: MergeFieldCategory;
+  description?: string;
+}
+
+export interface ContractTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  content: unknown;
+  content_html: string;
+  default_signer_count: 1 | 2;
+  signer_role_label: string;
+  is_active: boolean;
+  version: number;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ContractTemplateListItem {
+  id: string;
+  name: string;
+  description: string | null;
+  default_signer_count: 1 | 2;
+  is_active: boolean;
+  updated_at: string;
+}
+
+export interface ResolvedPreviewResponse {
+  html: string;
+  unresolvedFields: string[];
+}

--- a/src/lib/settings-nav.ts
+++ b/src/lib/settings-nav.ts
@@ -32,6 +32,7 @@ export const settingsNavItems: SettingsNavItem[] = [
   { href: "/settings/email", label: "Email Accounts", icon: Mail },
   { href: "/settings/signatures", label: "Email Signatures", icon: FileSignature },
   { href: "/settings/intake-form", label: "Intake Form", icon: ClipboardList },
+  { href: "/settings/contract-templates", label: "Contract Templates", icon: FileText },
   { href: "/settings/notifications", label: "Notifications", icon: Bell },
   { href: "/settings/reports", label: "Reports", icon: FileText },
   { href: "/settings/export", label: "Data Export", icon: Download },

--- a/supabase/migration-build32-contract-templates.sql
+++ b/supabase/migration-build32-contract-templates.sql
@@ -1,0 +1,157 @@
+-- ============================================
+-- Build 32 Migration: Contract Templates (Build 15a)
+-- First half of Build 15: template system + merge fields.
+-- Signing flow, contracts table, and email settings come with
+-- Build 15b / 15c in later migrations.
+-- Run this in the Supabase SQL Editor.
+-- ============================================
+
+-- ============================================
+-- 1. CONTRACT TEMPLATES TABLE
+-- ============================================
+CREATE TABLE contract_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  description text,
+  content jsonb NOT NULL DEFAULT '{"type":"doc","content":[]}'::jsonb,
+  content_html text NOT NULL DEFAULT '',
+  default_signer_count integer NOT NULL DEFAULT 1
+    CHECK (default_signer_count IN (1, 2)),
+  signer_role_label text NOT NULL DEFAULT 'Homeowner',
+  is_active boolean NOT NULL DEFAULT true,
+  version integer NOT NULL DEFAULT 1,
+  created_by uuid REFERENCES user_profiles(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================
+-- 2. ROW LEVEL SECURITY
+-- ============================================
+ALTER TABLE contract_templates ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow all for authenticated users"
+  ON contract_templates FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- ============================================
+-- 3. INDEXES
+-- ============================================
+CREATE INDEX idx_contract_templates_is_active ON contract_templates(is_active);
+CREATE INDEX idx_contract_templates_updated_at ON contract_templates(updated_at DESC);
+
+-- ============================================
+-- 4. AUTO-UPDATE TIMESTAMP TRIGGER
+-- ============================================
+CREATE TRIGGER trg_contract_templates_updated_at
+  BEFORE UPDATE ON contract_templates
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+-- ============================================
+-- 5. SEED: Work Authorization placeholder template
+-- Eric will replace content with real legal language post-setup.
+-- ============================================
+INSERT INTO contract_templates (name, description, content, content_html, default_signer_count, signer_role_label)
+VALUES (
+  'Work Authorization',
+  'Primary work authorization and assignment of benefits (AOB) template. Replace placeholder content with finalized legal language.',
+  '{
+    "type": "doc",
+    "content": [
+      {"type": "heading", "attrs": {"level": 1}, "content": [{"type": "text", "text": "Work Authorization"}]},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "This document is a placeholder. Replace the body of this template with your finalized Work Authorization and Assignment of Benefits legal language before sending to customers."}
+      ]},
+      {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Property & Customer"}]},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "Customer: "},
+        {"type": "mergeField", "attrs": {"fieldName": "customer_name"}}
+      ]},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "Property: "},
+        {"type": "mergeField", "attrs": {"fieldName": "property_address"}}
+      ]},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "Job #: "},
+        {"type": "mergeField", "attrs": {"fieldName": "job_number"}},
+        {"type": "text", "text": " — Date: "},
+        {"type": "mergeField", "attrs": {"fieldName": "date_today"}}
+      ]},
+      {"type": "heading", "attrs": {"level": 2}, "content": [{"type": "text", "text": "Insurance"}]},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "Carrier: "},
+        {"type": "mergeField", "attrs": {"fieldName": "insurance_company"}},
+        {"type": "text", "text": " — Claim #: "},
+        {"type": "mergeField", "attrs": {"fieldName": "claim_number"}}
+      ]},
+      {"type": "horizontalRule"},
+      {"type": "paragraph", "content": [
+        {"type": "text", "text": "Authorized by "},
+        {"type": "mergeField", "attrs": {"fieldName": "company_name"}},
+        {"type": "text", "text": " ("},
+        {"type": "mergeField", "attrs": {"fieldName": "company_phone"}},
+        {"type": "text", "text": ")."}
+      ]}
+    ]
+  }'::jsonb,
+  '<h1>Work Authorization</h1><p>This document is a placeholder. Replace the body of this template with your finalized Work Authorization and Assignment of Benefits legal language before sending to customers.</p><h2>Property &amp; Customer</h2><p>Customer: <span class="merge-field-pill" data-field-name="customer_name" data-merge-field="true">{{customer_name}}</span></p><p>Property: <span class="merge-field-pill" data-field-name="property_address" data-merge-field="true">{{property_address}}</span></p><p>Job #: <span class="merge-field-pill" data-field-name="job_number" data-merge-field="true">{{job_number}}</span> — Date: <span class="merge-field-pill" data-field-name="date_today" data-merge-field="true">{{date_today}}</span></p><h2>Insurance</h2><p>Carrier: <span class="merge-field-pill" data-field-name="insurance_company" data-merge-field="true">{{insurance_company}}</span> — Claim #: <span class="merge-field-pill" data-field-name="claim_number" data-merge-field="true">{{claim_number}}</span></p><hr><p>Authorized by <span class="merge-field-pill" data-field-name="company_name" data-merge-field="true">{{company_name}}</span> (<span class="merge-field-pill" data-field-name="company_phone" data-merge-field="true">{{company_phone}}</span>).</p>',
+  1,
+  'Homeowner'
+);
+
+-- ============================================
+-- 6. PERMISSION: manage_contract_templates
+-- Extend the default-permissions function to cover the new key,
+-- then backfill the permission row for every existing user so
+-- their permissions map is complete. Admins default to granted;
+-- crew_lead and crew_member default to denied.
+-- ============================================
+CREATE OR REPLACE FUNCTION set_default_permissions(p_user_id uuid, p_role text)
+RETURNS void AS $$
+DECLARE
+  all_perms text[] := ARRAY[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'manage_reports', 'access_settings',
+    'manage_contract_templates'
+  ];
+  admin_perms text[] := all_perms;
+  lead_perms text[] := ARRAY[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'manage_reports'
+  ];
+  member_perms text[] := ARRAY[
+    'view_jobs', 'log_activities', 'upload_photos'
+  ];
+  granted_perms text[];
+  perm text;
+BEGIN
+  IF p_role = 'admin' THEN
+    granted_perms := admin_perms;
+  ELSIF p_role = 'crew_lead' THEN
+    granted_perms := lead_perms;
+  ELSE
+    granted_perms := member_perms;
+  END IF;
+
+  FOREACH perm IN ARRAY all_perms LOOP
+    INSERT INTO user_permissions (user_id, permission_key, granted)
+    VALUES (p_user_id, perm, perm = ANY(granted_perms))
+    ON CONFLICT (user_id, permission_key) DO UPDATE SET granted = EXCLUDED.granted;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill the new permission for existing users without touching
+-- any of their other permission grants. Admins get it granted, all
+-- other roles default to denied (they can be flipped on in the
+-- Users & Crew settings page by an admin).
+INSERT INTO user_permissions (user_id, permission_key, granted)
+SELECT id, 'manage_contract_templates', (role = 'admin')
+FROM user_profiles
+ON CONFLICT (user_id, permission_key) DO NOTHING;


### PR DESCRIPTION
## Summary
- Adds `contract_templates` table (migration **build32**) with RLS, seed row (Work Authorization placeholder), and a new `manage_contract_templates` permission backfilled for existing users (admin-only by default).
- New Tiptap-based editor at `/settings/contract-templates/[id]/edit` with a custom inline merge-field node (purple pill, draggable) and a 60/40 two-column layout with an available-fields sidebar + template settings panel.
- List page at `/settings/contract-templates` with + New, Edit, Duplicate, Archive/Restore, and an Active toggle; row actions preserved for audit (no hard deletes).
- Preview modal that picks a recent job and renders the template with merge fields resolved server-side via `resolveMergeFields(html, jobId)`; unresolved fields render as a visible dashed blank (`.merge-field-unresolved`).
- Settings sidebar gets a Contract Templates entry (FileText icon) positioned between Intake Form and Notifications.

Signing flow, PDF generation, Resend integration, and contract email settings are intentionally deferred to Build 15b / 15c.

## :warning: Required before this is usable in production
Run [supabase/migration-build32-contract-templates.sql](../blob/main/supabase/migration-build32-contract-templates.sql) in the Supabase SQL editor. Until the migration runs, the list page will toast "Failed to load templates" and show the empty state for admins; non-admins are gated out.

## Design notes
- `customer_address` falls back to `jobs.property_address` (contacts has no address column).
- `intake_date` uses `jobs.created_at`.
- `adjuster_name` / `adjuster_phone` come from the primary row in `job_adjusters` (post-build31).
- Content/HTML edits bump `version`; metadata-only edits don't.
- Archive = `is_active = false` soft-delete; restore flips it back.

## Test plan
- [ ] Run migration in Supabase SQL editor
- [ ] Sign in as admin; confirm **Contract Templates** appears in Settings sidebar between Intake Form and Notifications
- [ ] Open the seeded Work Authorization template; confirm merge-field pills render as purple monospace pills in dark theme
- [ ] Click each merge-field category in the sidebar; confirm pill inserts into the editor
- [ ] Save the template; confirm version increments and toast shows the new version number
- [ ] Click Preview, pick a real job, confirm fields resolve to actual customer/job data and unresolved fields show the dashed blank
- [ ] From list page: Duplicate, Archive, then Restore; confirm toasts and state toggle correctly
- [ ] Sign in as a non-admin (or simulate) and confirm `/settings/contract-templates` shows the Access Restricted card
- [ ] Verify no regressions on other settings pages (Email, Notifications, Users & Crew — touched only by adjacent edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)