### PR TITLE
feat: add in-person signing, multi-signer, and reminders (Build 15c)

### DIFF
--- a/src/app/api/contracts/[id]/remind/route.ts
+++ b/src/app/api/contracts/[id]/remind/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { sendContractReminder } from "@/lib/contracts/reminders";
+import type { Contract, ContractSigner, ContractEmailSettings } from "@/lib/contracts/types";
+
+// POST /api/contracts/[id]/remind
+// Manual reminder trigger — the Remind button on sent/viewed contract
+// rows. Fires a single reminder email to the currently active (unsigned)
+// signer and records a 'reminder_sent' audit event. Intentionally does
+// NOT shift contracts.next_reminder_at — the auto cron continues on its
+// schedule. Reuses the configured reminder subject/body templates.
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const authClient = await createServerSupabaseClient();
+  const { data: { user }, error: authErr } = await authClient.auth.getUser();
+  if (authErr || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+  const supabase = createServiceClient();
+
+  const { data: settings } = await supabase
+    .from("contract_email_settings")
+    .select("*")
+    .limit(1)
+    .maybeSingle<ContractEmailSettings>();
+  if (!settings) {
+    return NextResponse.json({ error: "Email settings missing" }, { status: 500 });
+  }
+  if (!settings.send_from_email || !settings.send_from_name) {
+    return NextResponse.json(
+      { error: "Set a send-from email and display name in Settings → Contracts." },
+      { status: 400 },
+    );
+  }
+
+  const { data: contract } = await supabase
+    .from("contracts")
+    .select("*")
+    .eq("id", id)
+    .maybeSingle<Contract>();
+  if (!contract) {
+    return NextResponse.json({ error: "Contract not found" }, { status: 404 });
+  }
+  if (!["sent", "viewed"].includes(contract.status)) {
+    return NextResponse.json(
+      { error: "Only sent / viewed contracts can be reminded" },
+      { status: 409 },
+    );
+  }
+
+  const { data: signers } = await supabase
+    .from("contract_signers")
+    .select("*")
+    .eq("contract_id", contract.id)
+    .order("signer_order");
+  if (!signers?.length) {
+    return NextResponse.json({ error: "Contract has no signers" }, { status: 500 });
+  }
+
+  try {
+    const result = await sendContractReminder(
+      supabase,
+      contract,
+      signers as ContractSigner[],
+      settings,
+      { skipSchedule: true },
+    );
+    return NextResponse.json({ ok: true, sentTo: result.signerEmail });
+  } catch (e) {
+    return NextResponse.json(
+      { error: e instanceof Error ? e.message : String(e) },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/api/contracts/[id]/sign/route.ts
+++ b/src/app/api/contracts/[id]/sign/route.ts
@@ -1,10 +1,13 @@
 import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
 import { createServiceClient } from "@/lib/supabase-api";
-import { verifySigningToken, InvalidSigningTokenError } from "@/lib/contracts/tokens";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { verifySigningToken, InvalidSigningTokenError, generateSigningToken } from "@/lib/contracts/tokens";
 import { generateSignedPdf } from "@/lib/contracts/pdf";
 import { resolveEmailTemplate } from "@/lib/contracts/email-merge-fields";
 import { sendContractEmail, resolveInternalRecipient } from "@/lib/contracts/email";
 import { writeContractEvent, getRequestIp, getRequestUserAgent } from "@/lib/contracts/audit";
+import { computeInitialNextReminderAt } from "@/lib/contracts/reminders";
 import type {
   Contract,
   ContractSigner,
@@ -12,7 +15,12 @@ import type {
 } from "@/lib/contracts/types";
 
 interface SignBody {
-  token: string;
+  // Remote (token) mode:
+  token?: string;
+  // In-person (session auth) mode:
+  in_person?: boolean;
+  signerId?: string;
+  // Common:
   signatureDataUrl: string;
   typedName: string;
 }
@@ -24,36 +32,68 @@ function appUrl(): string {
 }
 
 // POST /api/contracts/[id]/sign
-// Public endpoint — authenticated via the signing token in the body.
-// On a successful signature:
-//   1. upload the captured PNG to storage
-//   2. record_signer_signature RPC → atomic signer update + event
-//   3. if all signers done, generate PDF, upload, mark_contract_signed RPC
-//   4. dispatch customer + internal confirmation emails (best-effort)
+// Two auth modes:
+//   Remote  — body.token is a signed JWT (magic-link flow).
+//   In-person — body.in_person=true + authenticated session. Used by the
+//     tablet signing view; no token needed because the user sits at an
+//     Eric/tech's iPad and is already logged in.
+//
+// Signing happens in three phases:
+//   1. Upload the PNG + record_signer_signature RPC (atomic signer update
+//      + 'signed' event).
+//   2. If more signers remain: in-person → no-op (tablet swaps to next);
+//      remote → generate next signer's token, activate_next_signer RPC,
+//      send the signing-request email to that signer, schedule their
+//      first reminder.
+//   3. If all signers are done: generate the PDF, upload it, mark the
+//      contract signed, dispatch customer + internal confirmation emails.
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id: contractId } = await params;
   const body = (await request.json().catch(() => null)) as SignBody | null;
-  if (!body?.token || !body?.signatureDataUrl || !body?.typedName) {
+  if (!body?.signatureDataUrl || !body?.typedName) {
     return NextResponse.json(
-      { error: "token, signatureDataUrl, and typedName are required" },
+      { error: "signatureDataUrl and typedName are required" },
       { status: 400 },
     );
   }
 
-  let payload;
-  try {
-    payload = verifySigningToken(body.token);
-  } catch (e) {
-    if (e instanceof InvalidSigningTokenError) {
-      return NextResponse.json({ error: "invalid_token" }, { status: 401 });
+  const inPerson = body.in_person === true;
+  let signerId: string;
+
+  if (inPerson) {
+    if (!body.signerId) {
+      return NextResponse.json(
+        { error: "signerId is required for in_person mode" },
+        { status: 400 },
+      );
     }
-    throw e;
-  }
-  if (payload.contract_id !== contractId) {
-    return NextResponse.json({ error: "token_mismatch" }, { status: 401 });
+    // Auth: in-person mode requires a logged-in platform user.
+    const authClient = await createServerSupabaseClient();
+    const { data: { user }, error: authErr } = await authClient.auth.getUser();
+    if (authErr || !user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    signerId = body.signerId;
+  } else {
+    if (!body.token) {
+      return NextResponse.json({ error: "token is required" }, { status: 400 });
+    }
+    let payload;
+    try {
+      payload = verifySigningToken(body.token);
+    } catch (e) {
+      if (e instanceof InvalidSigningTokenError) {
+        return NextResponse.json({ error: "invalid_token" }, { status: 401 });
+      }
+      throw e;
+    }
+    if (payload.contract_id !== contractId) {
+      return NextResponse.json({ error: "token_mismatch" }, { status: 401 });
+    }
+    signerId = payload.signer_id;
   }
 
   const supabase = createServiceClient();
@@ -66,28 +106,40 @@ export async function POST(
   if (cErr || !contract) {
     return NextResponse.json({ error: cErr?.message || "Contract not found" }, { status: 404 });
   }
-  if (contract.link_token !== body.token) {
-    return NextResponse.json({ error: "stale_token" }, { status: 410 });
-  }
   if (contract.status === "voided") {
     return NextResponse.json({ error: "voided" }, { status: 410 });
   }
   if (contract.status === "signed") {
     return NextResponse.json({ error: "already_signed" }, { status: 409 });
   }
-  if (
-    contract.link_expires_at &&
-    new Date(contract.link_expires_at).getTime() < Date.now()
-  ) {
-    return NextResponse.json({ error: "expired" }, { status: 410 });
+  if (!inPerson) {
+    // Remote flow: enforce token freshness + expiry.
+    if (contract.link_token !== body.token) {
+      return NextResponse.json({ error: "stale_token" }, { status: 410 });
+    }
+    if (
+      contract.link_expires_at &&
+      new Date(contract.link_expires_at).getTime() < Date.now()
+    ) {
+      return NextResponse.json({ error: "expired" }, { status: 410 });
+    }
+  } else {
+    // In-person flow: contract must still be draft or in-flight. The
+    // normal path is draft → signed (skipping sent/viewed).
+    if (!["draft", "sent", "viewed"].includes(contract.status)) {
+      return NextResponse.json(
+        { error: `Contract cannot be signed from status '${contract.status}'` },
+        { status: 409 },
+      );
+    }
   }
 
   const { data: signer } = await supabase
     .from("contract_signers")
     .select("*")
-    .eq("id", payload.signer_id)
+    .eq("id", signerId)
     .maybeSingle<ContractSigner>();
-  if (!signer) {
+  if (!signer || signer.contract_id !== contract.id) {
     return NextResponse.json({ error: "signer_not_found" }, { status: 404 });
   }
   if (signer.signed_at) {
@@ -139,11 +191,110 @@ export async function POST(
   }
   const allSigned = Array.isArray(rpcRows) && rpcRows[0]?.all_signed === true;
 
+  // --- Not all signers done → sequential handoff ---
   if (!allSigned) {
+    // Load remaining signers so we know who's next.
+    const { data: signersAll } = await supabase
+      .from("contract_signers")
+      .select("*")
+      .eq("contract_id", contract.id)
+      .order("signer_order");
+    const nextSigner =
+      (signersAll as ContractSigner[] | null)?.find((s) => !s.signed_at) ?? null;
+
+    if (!nextSigner) {
+      // Shouldn't happen — allSigned would be true — but fail safe.
+      return NextResponse.json({ ok: true, finalized: false });
+    }
+
+    if (inPerson) {
+      // Tablet handoff: no email, no token rotation. The tablet page swaps
+      // to the next signer using the returned info.
+      return NextResponse.json({
+        ok: true,
+        finalized: false,
+        nextSigner: {
+          id: nextSigner.id,
+          name: nextSigner.name,
+          role_label: nextSigner.role_label,
+          signer_order: nextSigner.signer_order,
+        },
+      });
+    }
+
+    // Remote multi-signer: generate next signer's token, rotate
+    // contracts.link_token, email them, schedule first reminder.
+    try {
+      const { data: settings } = await supabase
+        .from("contract_email_settings")
+        .select("*")
+        .limit(1)
+        .maybeSingle<ContractEmailSettings>();
+      if (!settings) throw new Error("contract_email_settings row missing");
+
+      const expiryDays = Math.max(
+        1,
+        Math.min(30, settings.default_link_expiry_days),
+      );
+      const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
+      const newToken = generateSigningToken({
+        contractId: contract.id,
+        signerId: nextSigner.id,
+        expiresAt,
+      });
+
+      const { error: actErr } = await supabase.rpc("activate_next_signer", {
+        p_contract_id: contract.id,
+        p_next_signer_id: nextSigner.id,
+        p_link_token: newToken,
+        p_link_expires_at: expiresAt.toISOString(),
+      });
+      if (actErr) throw new Error(actErr.message);
+
+      const { subject, html } = await resolveEmailTemplate(
+        supabase,
+        settings.signing_request_subject_template,
+        settings.signing_request_body_template,
+        contract.job_id,
+        {
+          signing_link: `${appUrl()}/sign/${newToken}`,
+          document_title: contract.title,
+        },
+      );
+      await sendContractEmail(supabase, settings, {
+        to: nextSigner.email,
+        subject,
+        html,
+      });
+
+      // Schedule signer 2's first auto-reminder.
+      const firstReminder = computeInitialNextReminderAt(
+        new Date(),
+        settings.reminder_day_offsets,
+      );
+      if (firstReminder) {
+        await supabase.rpc("schedule_first_reminder", {
+          p_contract_id: contract.id,
+          p_next_reminder_at: firstReminder.toISOString(),
+        });
+      }
+    } catch (e) {
+      // Activation/email failure is logged via audit; the customer-facing
+      // signer 1 submission still succeeded (their signature is recorded).
+      await writeContractEvent(supabase, {
+        contractId: contract.id,
+        eventType: "email_delivered",
+        metadata: {
+          kind: "next_signer_activation",
+          error: e instanceof Error ? e.message : String(e),
+        },
+      }).catch(() => undefined);
+    }
+
     return NextResponse.json({ ok: true, finalized: false });
   }
 
-  // --- Finalize: PDF + confirmation emails ---
+  // --- All signers done → finalize: PDF + confirmation emails ---
   try {
     const [{ data: signersAll }, { data: settings }, { data: companyRows }, { data: jobRow }] =
       await Promise.all([
@@ -212,12 +363,17 @@ export async function POST(
     });
     if (markErr) throw new Error(`Failed to mark contract signed: ${markErr.message}`);
 
-    // --- Post-signing emails (best-effort) ---
+    // --- Post-signing confirmation emails (best-effort, same as 15b) ---
     const pdfAttachment = {
       filename: `${contract.title.replace(/[\\/:*?"<>|]/g, "_")}.pdf`,
       content: Buffer.from(pdfBytes),
       contentType: "application/pdf",
     };
+
+    // Send customer confirmation to signer 1 (primary).
+    const primarySigner =
+      (signersAll as ContractSigner[]).find((s) => s.signer_order === 1) ??
+      (signersAll as ContractSigner[])[0];
 
     try {
       const customer = await resolveEmailTemplate(
@@ -228,7 +384,7 @@ export async function POST(
         { signing_link: "", document_title: contract.title },
       );
       await sendContractEmail(supabase, settings, {
-        to: signer.email,
+        to: primarySigner.email,
         subject: customer.subject,
         html: customer.html,
         attachments: [pdfAttachment],
@@ -295,9 +451,10 @@ export async function POST(
       }).catch(() => undefined);
     }
 
-    // Silence unused-var warning for jobRow when we don't need job number
-    // in the current resolver (merge fields cover it).
     void jobRow;
+    // Quiet an unused-binding warning when randomUUID isn't referenced
+    // in a given code-path. It IS used below via generateSigningToken.
+    void randomUUID;
 
     return NextResponse.json({ ok: true, finalized: true, pdfPath });
   } catch (e) {

--- a/src/app/api/contracts/[id]/void/route.ts
+++ b/src/app/api/contracts/[id]/void/route.ts
@@ -1,9 +1,20 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
+import { stampVoidWatermark } from "@/lib/contracts/pdf-void-watermark";
+import type { Contract } from "@/lib/contracts/types";
 
 // POST /api/contracts/[id]/void
 // Body: { reason?: string }
+// Build 15c additions:
+//   * Blocks voids when any invoice on the same job has a recorded payment.
+//     Rationale: a signed work authorization is the basis for billing;
+//     voiding after payment breaks the audit chain. Eric has to refund or
+//     void the payment first.
+//   * For contracts that are already 'signed', downloads the stored PDF,
+//     stamps a diagonal "VOIDED" watermark, and re-uploads at the same
+//     path before flipping status. Preserves signed_at + signed_pdf_path
+//     for audit.
 export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -19,6 +30,67 @@ export async function POST(
   const reason = (body.reason || "").toString().slice(0, 500) || null;
 
   const supabase = createServiceClient();
+
+  const { data: contract, error: loadErr } = await supabase
+    .from("contracts")
+    .select("id, job_id, status, signed_pdf_path")
+    .eq("id", id)
+    .maybeSingle<Pick<Contract, "id" | "job_id" | "status" | "signed_pdf_path">>();
+  if (loadErr || !contract) {
+    return NextResponse.json({ error: loadErr?.message || "Contract not found" }, { status: 404 });
+  }
+  if (contract.status === "voided") {
+    return NextResponse.json({ error: "Already voided" }, { status: 409 });
+  }
+
+  // --- Block if any invoice on this job has a payment on record ---
+  const { data: invoices } = await supabase
+    .from("invoices")
+    .select("id")
+    .eq("job_id", contract.job_id);
+  const invoiceIds = (invoices ?? []).map((r: { id: string }) => r.id);
+  if (invoiceIds.length > 0) {
+    const { count: paymentCount } = await supabase
+      .from("payments")
+      .select("id", { count: "exact", head: true })
+      .in("invoice_id", invoiceIds);
+    if ((paymentCount ?? 0) > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "Cannot void this contract — related invoices have recorded payments. Refund or void payments first.",
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  // --- If already signed, watermark the stored PDF in place ---
+  if (contract.status === "signed" && contract.signed_pdf_path) {
+    try {
+      const dl = await supabase.storage
+        .from("contracts")
+        .download(contract.signed_pdf_path);
+      if (!dl.data) throw new Error("Failed to load existing PDF");
+      const existing = new Uint8Array(await dl.data.arrayBuffer());
+      const stamped = await stampVoidWatermark(existing);
+      const { error: upErr } = await supabase.storage
+        .from("contracts")
+        .upload(contract.signed_pdf_path, stamped, {
+          contentType: "application/pdf",
+          upsert: true,
+        });
+      if (upErr) throw new Error(upErr.message);
+    } catch (e) {
+      return NextResponse.json(
+        {
+          error: `Failed to watermark signed PDF: ${e instanceof Error ? e.message : String(e)}`,
+        },
+        { status: 500 },
+      );
+    }
+  }
+
   const { error } = await supabase.rpc("void_contract", {
     p_contract_id: id,
     p_voided_by: user.id,

--- a/src/app/api/contracts/by-job/[jobId]/route.ts
+++ b/src/app/api/contracts/by-job/[jobId]/route.ts
@@ -12,13 +12,24 @@ interface DbRow {
   link_expires_at: string | null;
   void_reason: string | null;
   signed_pdf_path: string | null;
+  reminder_count: number;
+  next_reminder_at: string | null;
   created_at: string;
-  signers: Array<{ id: string; signer_order: number; name: string | null; ip_address: string | null }>;
+  signers: Array<{
+    id: string;
+    signer_order: number;
+    name: string | null;
+    role_label: string | null;
+    signed_at: string | null;
+    ip_address: string | null;
+  }>;
 }
 
-// GET /api/contracts/by-job/[jobId] — list contracts for the job detail
-// Overview tab's Contracts section. Includes just enough signer metadata
-// for the status-driven row rendering (name + truncated IP for signed).
+// GET /api/contracts/by-job/[jobId] — contracts for the Contracts section
+// on the job detail Overview tab. Build 15c extends the returned shape
+// with per-signer status (for multi-signer sequential UI) and the auto-
+// reminder counters (for the "reminders sent: N" indicator on the job
+// header).
 export async function GET(
   _req: Request,
   { params }: { params: Promise<{ jobId: string }> },
@@ -29,8 +40,9 @@ export async function GET(
     .from("contracts")
     .select(
       `id, title, status, sent_at, first_viewed_at, signed_at,
-       link_expires_at, void_reason, signed_pdf_path, created_at,
-       signers:contract_signers(id, signer_order, name, ip_address)`,
+       link_expires_at, void_reason, signed_pdf_path, reminder_count,
+       next_reminder_at, created_at,
+       signers:contract_signers(id, signer_order, name, role_label, signed_at, ip_address)`,
     )
     .eq("job_id", jobId)
     .order("created_at", { ascending: false });
@@ -39,7 +51,10 @@ export async function GET(
 
   const rows: ContractListItem[] = (data ?? []).map((row) => {
     const r = row as unknown as DbRow;
-    const primary = (r.signers ?? []).find((s) => s.signer_order === 1) ?? r.signers?.[0];
+    const ordered = [...(r.signers ?? [])].sort(
+      (a, b) => a.signer_order - b.signer_order,
+    );
+    const primary = ordered[0];
     return {
       id: r.id,
       title: r.title,
@@ -52,7 +67,16 @@ export async function GET(
       signed_pdf_path: r.signed_pdf_path,
       primary_signer_name: primary?.name ?? null,
       primary_signer_ip: primary?.ip_address ?? null,
-      signer_count: r.signers?.length ?? 0,
+      signer_count: ordered.length,
+      signers: ordered.map((s) => ({
+        id: s.id,
+        signer_order: s.signer_order,
+        name: s.name,
+        role_label: s.role_label,
+        signed_at: s.signed_at,
+      })),
+      reminder_count: r.reminder_count ?? 0,
+      next_reminder_at: r.next_reminder_at,
       created_at: r.created_at,
     };
   });

--- a/src/app/api/contracts/in-person/start/route.ts
+++ b/src/app/api/contracts/in-person/start/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { randomUUID, createHash } from "crypto";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { resolveMergeFields } from "@/lib/contracts/merge-fields";
+
+interface SignerInput {
+  name: string;
+  email: string;
+  roleLabel?: string;
+}
+
+interface StartBody {
+  jobId: string;
+  templateId: string;
+  signers: SignerInput[];
+  title?: string;
+}
+
+// POST /api/contracts/in-person/start
+// Creates a draft contract + signer rows for the in-person (iPad) flow.
+// No link_token, no expiry, no email. Caller redirects to the internal
+// /contracts/[id]/sign-in-person route once this returns.
+export async function POST(request: Request) {
+  const authClient = await createServerSupabaseClient();
+  const { data: { user }, error: authErr } = await authClient.auth.getUser();
+  if (authErr || !user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = (await request.json().catch(() => null)) as StartBody | null;
+  if (!body?.jobId || !body?.templateId || !Array.isArray(body?.signers) || !body.signers.length) {
+    return NextResponse.json(
+      { error: "jobId, templateId, and at least one signer are required" },
+      { status: 400 },
+    );
+  }
+  if (body.signers.length > 2) {
+    return NextResponse.json({ error: "At most 2 signers" }, { status: 400 });
+  }
+  for (const s of body.signers) {
+    if (!s.name?.trim() || !s.email?.trim()) {
+      return NextResponse.json(
+        { error: "Every signer needs a name and email" },
+        { status: 400 },
+      );
+    }
+  }
+
+  const supabase = createServiceClient();
+
+  const { data: tpl, error: tErr } = await supabase
+    .from("contract_templates")
+    .select("id, name, content_html, version, is_active, signer_role_label")
+    .eq("id", body.templateId)
+    .maybeSingle<{
+      id: string;
+      name: string;
+      content_html: string;
+      version: number;
+      is_active: boolean;
+      signer_role_label: string | null;
+    }>();
+  if (tErr || !tpl) {
+    return NextResponse.json({ error: tErr?.message || "Template not found" }, { status: 404 });
+  }
+  if (!tpl.is_active) {
+    return NextResponse.json({ error: "Template is archived" }, { status: 400 });
+  }
+  if (!tpl.content_html?.trim()) {
+    return NextResponse.json({ error: "Template has no content" }, { status: 400 });
+  }
+
+  const { data: job, error: jErr } = await supabase
+    .from("jobs")
+    .select("id")
+    .eq("id", body.jobId)
+    .maybeSingle();
+  if (jErr || !job) {
+    return NextResponse.json({ error: jErr?.message || "Job not found" }, { status: 404 });
+  }
+
+  const { html: filledHtml } = await resolveMergeFields(supabase, tpl.content_html, body.jobId);
+  const filledHash = createHash("sha256").update(filledHtml).digest("hex");
+
+  const contractId = randomUUID();
+  const signerIds = body.signers.map(() => randomUUID());
+  const primary = body.signers[0];
+  const title = (body.title?.trim() || `${tpl.name} — ${primary.name}`).slice(0, 200);
+
+  const signersPayload = body.signers.map((s, idx) => ({
+    id: signerIds[idx],
+    signer_order: idx + 1,
+    role_label: s.roleLabel || tpl.signer_role_label || "Signer",
+    name: s.name.trim(),
+    email: s.email.trim(),
+  }));
+
+  const { error: rpcErr } = await supabase.rpc("create_contract_with_signers", {
+    p_contract_id: contractId,
+    p_job_id: body.jobId,
+    p_template_id: tpl.id,
+    p_template_version: tpl.version,
+    p_title: title,
+    p_filled_content_html: filledHtml,
+    p_filled_content_hash: filledHash,
+    p_link_token: null,
+    p_link_expires_at: null,
+    p_sent_by: user.id,
+    p_signers: signersPayload,
+  });
+  if (rpcErr) {
+    return NextResponse.json(
+      { error: `Failed to create contract: ${rpcErr.message}` },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ contractId });
+}

--- a/src/app/api/contracts/reminders/route.ts
+++ b/src/app/api/contracts/reminders/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  hasRecentReminder,
+  sendContractReminder,
+} from "@/lib/contracts/reminders";
+import type { Contract, ContractSigner, ContractEmailSettings } from "@/lib/contracts/types";
+
+// GET /api/contracts/reminders
+// Vercel Cron endpoint, fires hourly (see vercel.json). Reads:
+//   Authorization: Bearer <CRON_SECRET>   (Vercel sends this automatically
+//     when CRON_SECRET is set as a project env var)
+//
+// Idempotency: for each contract that's due (next_reminder_at <= now and
+// status in sent/viewed), we check contract_events for any reminder_sent
+// record within the last hour. If present, skip — this guards against
+// Vercel double-firing the cron. The mark_reminder_sent RPC then bumps
+// the counter and recomputes next_reminder_at atomically.
+export async function GET(request: Request) {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured on the server" },
+      { status: 500 },
+    );
+  }
+  const auth = request.headers.get("authorization") || "";
+  if (auth !== `Bearer ${expected}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const startedAt = Date.now();
+  const supabase = createServiceClient();
+
+  const { data: settings } = await supabase
+    .from("contract_email_settings")
+    .select("*")
+    .limit(1)
+    .maybeSingle<ContractEmailSettings>();
+  if (!settings) {
+    return NextResponse.json(
+      { error: "contract_email_settings missing" },
+      { status: 500 },
+    );
+  }
+  if (!settings.send_from_email || !settings.send_from_name) {
+    // No sender configured — skip quietly; auto-reminders stay off until
+    // Eric fills in the Settings → Contracts page.
+    return NextResponse.json({ ok: true, sent: 0, skipped: "no_sender" });
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data: due, error } = await supabase
+    .from("contracts")
+    .select("*")
+    .in("status", ["sent", "viewed"])
+    .not("next_reminder_at", "is", null)
+    .lte("next_reminder_at", nowIso);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const results: Array<{ contractId: string; status: "sent" | "skipped" | "failed"; reason?: string }> = [];
+  for (const contract of (due ?? []) as Contract[]) {
+    try {
+      if (await hasRecentReminder(supabase, contract.id)) {
+        results.push({ contractId: contract.id, status: "skipped", reason: "recent_reminder" });
+        continue;
+      }
+      const { data: signers } = await supabase
+        .from("contract_signers")
+        .select("*")
+        .eq("contract_id", contract.id)
+        .order("signer_order");
+      if (!signers?.length) {
+        results.push({ contractId: contract.id, status: "skipped", reason: "no_signers" });
+        continue;
+      }
+      await sendContractReminder(
+        supabase,
+        contract,
+        signers as ContractSigner[],
+        settings,
+      );
+      results.push({ contractId: contract.id, status: "sent" });
+    } catch (e) {
+      results.push({
+        contractId: contract.id,
+        status: "failed",
+        reason: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  const sentCount = results.filter((r) => r.status === "sent").length;
+  const durationMs = Date.now() - startedAt;
+  // Log line picked up by Vercel logs for observability.
+  // eslint-disable-next-line no-console
+  console.log(
+    `[contracts-reminders] due=${(due ?? []).length} sent=${sentCount} durationMs=${durationMs}`,
+  );
+
+  return NextResponse.json({ ok: true, sent: sentCount, durationMs, results });
+}

--- a/src/app/api/contracts/send/route.ts
+++ b/src/app/api/contracts/send/route.ts
@@ -6,6 +6,7 @@ import { resolveMergeFields } from "@/lib/contracts/merge-fields";
 import { resolveEmailTemplate } from "@/lib/contracts/email-merge-fields";
 import { sendContractEmail } from "@/lib/contracts/email";
 import { generateSigningToken } from "@/lib/contracts/tokens";
+import { computeInitialNextReminderAt } from "@/lib/contracts/reminders";
 import type { ContractEmailSettings } from "@/lib/contracts/types";
 
 interface SendSignerInput {
@@ -31,14 +32,12 @@ function appUrl(): string {
 }
 
 // POST /api/contracts/send
-// Atomic-ish send pipeline:
-//   1. Validate inputs + fetch template + fetch email settings
-//   2. Resolve merge fields into filled HTML + SHA-256 hash
-//   3. RPC create_contract_draft (contract + signer + 'created' event)
-//   4. Send email via Resend or SMTP
-//   5. RPC mark_contract_sent — only after email succeeds
-// A send that fails at step 4 leaves a draft contract the user can Edit or
-// Discard from the Contracts section.
+// Build 15c extensions over 15b:
+//   - Supports up to 2 signers. In multi-signer mode, only signer 1
+//     receives the initial email; signer 2 is emailed after signer 1
+//     completes (see /api/contracts/[id]/sign → activate_next_signer).
+//   - Stamps the initial next_reminder_at so the hourly cron can pick
+//     the contract up once the first offset elapses.
 export async function POST(request: Request) {
   const authClient = await createServerSupabaseClient();
   const { data: { user }, error: authErr } = await authClient.auth.getUser();
@@ -56,19 +55,13 @@ export async function POST(request: Request) {
   if (body.signers.length > 2) {
     return NextResponse.json({ error: "At most 2 signers" }, { status: 400 });
   }
-  // 15b scope: single-signer only; multi-signer sequential flow is 15c.
-  if (body.signers.length > 1) {
-    return NextResponse.json(
-      { error: "Multi-signer contracts will be available in Build 15c" },
-      { status: 400 },
-    );
-  }
-  const primary = body.signers[0];
-  if (!primary.name || !primary.email) {
-    return NextResponse.json(
-      { error: "Signer name and email are required" },
-      { status: 400 },
-    );
+  for (const s of body.signers) {
+    if (!s.name?.trim() || !s.email?.trim()) {
+      return NextResponse.json(
+        { error: "Every signer needs a name and email" },
+        { status: 400 },
+      );
+    }
   }
   if (!body.emailSubject || !body.emailBody) {
     return NextResponse.json(
@@ -79,7 +72,7 @@ export async function POST(request: Request) {
 
   const supabase = createServiceClient();
 
-  // --- Fetch settings (must have send-from configured) ---
+  // --- Fetch settings ---
   const { data: settings, error: sErr } = await supabase
     .from("contract_email_settings")
     .select("*")
@@ -93,10 +86,7 @@ export async function POST(request: Request) {
   }
   if (!settings.send_from_email || !settings.send_from_name) {
     return NextResponse.json(
-      {
-        error:
-          "Set a send-from email and display name in Settings → Contracts before sending.",
-      },
+      { error: "Set a send-from email and display name in Settings → Contracts before sending." },
       { status: 400 },
     );
   }
@@ -140,7 +130,10 @@ export async function POST(request: Request) {
 
   // --- Compute IDs, token, expiry ---
   const contractId = randomUUID();
-  const signerId = randomUUID();
+  const signerIds = body.signers.map(() => randomUUID());
+  const primary = body.signers[0];
+  const primarySignerId = signerIds[0];
+
   const expiryDays = Math.max(
     1,
     Math.min(30, body.expiryDays ?? settings.default_link_expiry_days),
@@ -148,16 +141,23 @@ export async function POST(request: Request) {
   const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000);
   const token = generateSigningToken({
     contractId,
-    signerId,
+    signerId: primarySignerId,
     expiresAt,
   });
 
   const title = (body.title?.trim() || `${tpl.name} — ${primary.name}`).slice(0, 200);
 
-  // --- Create draft (atomic RPC) ---
-  const { error: rpcErr } = await supabase.rpc("create_contract_draft", {
+  // --- Create draft + all signer rows atomically ---
+  const signersPayload = body.signers.map((s, idx) => ({
+    id: signerIds[idx],
+    signer_order: idx + 1,
+    role_label: s.roleLabel || tpl.signer_role_label || "Signer",
+    name: s.name.trim(),
+    email: s.email.trim(),
+  }));
+
+  const { error: rpcErr } = await supabase.rpc("create_contract_with_signers", {
     p_contract_id: contractId,
-    p_signer_id: signerId,
     p_job_id: body.jobId,
     p_template_id: tpl.id,
     p_template_version: tpl.version,
@@ -166,11 +166,8 @@ export async function POST(request: Request) {
     p_filled_content_hash: filledHash,
     p_link_token: token,
     p_link_expires_at: expiresAt.toISOString(),
-    p_signer_order: 1,
-    p_signer_role_label: primary.roleLabel || tpl.signer_role_label || "Signer",
-    p_signer_name: primary.name,
-    p_signer_email: primary.email,
     p_sent_by: user.id,
+    p_signers: signersPayload,
   });
   if (rpcErr) {
     return NextResponse.json(
@@ -179,7 +176,7 @@ export async function POST(request: Request) {
     );
   }
 
-  // --- Resolve email body + send ---
+  // --- Resolve email body + send (to signer 1 only) ---
   try {
     const signingLink = `${appUrl()}/sign/${token}`;
     const { subject, html } = await resolveEmailTemplate(
@@ -209,6 +206,18 @@ export async function POST(request: Request) {
         },
         { status: 500 },
       );
+    }
+
+    // --- Schedule first auto-reminder based on settings.reminder_day_offsets ---
+    const firstReminder = computeInitialNextReminderAt(
+      new Date(),
+      settings.reminder_day_offsets,
+    );
+    if (firstReminder) {
+      await supabase.rpc("schedule_first_reminder", {
+        p_contract_id: contractId,
+        p_next_reminder_at: firstReminder.toISOString(),
+      });
     }
 
     return NextResponse.json({ contractId, messageId: sent.messageId });

--- a/src/app/contracts/[id]/sign-in-person/complete/page.tsx
+++ b/src/app/contracts/[id]/sign-in-person/complete/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { CheckCircle2, Download, ArrowLeft, Eye } from "lucide-react";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import type { Contract } from "@/lib/contracts/types";
+
+export default async function SignInPersonCompletePage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const authClient = await createServerSupabaseClient();
+  const { data: { user }, error: authErr } = await authClient.auth.getUser();
+  if (authErr || !user) {
+    redirect(`/login?next=/contracts/${id}/sign-in-person/complete`);
+  }
+
+  const supabase = createServiceClient();
+  const { data: contract } = await supabase
+    .from("contracts")
+    .select("id, job_id, title, status, signed_pdf_path, signed_at")
+    .eq("id", id)
+    .maybeSingle<Pick<Contract, "id" | "job_id" | "title" | "status" | "signed_pdf_path" | "signed_at">>();
+
+  if (!contract) {
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="bg-card border border-border rounded-xl p-8 max-w-md w-full text-center">
+          <h1 className="text-lg font-semibold mb-2 text-foreground">Contract not found</h1>
+        </div>
+      </div>
+    );
+  }
+
+  const signedLabel = contract.signed_at
+    ? new Date(contract.signed_at).toLocaleString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+      })
+    : "—";
+
+  return (
+    <div className="min-h-screen bg-background text-foreground flex items-center justify-center px-6 py-10">
+      <div className="max-w-xl w-full bg-card border border-border rounded-2xl p-10 text-center">
+        <div className="mx-auto w-16 h-16 rounded-full bg-[rgba(29,158,117,0.15)] flex items-center justify-center mb-5">
+          <CheckCircle2 size={40} className="text-[#5DCAA5]" />
+        </div>
+        <h1 className="text-2xl font-semibold mb-2">Contract signed</h1>
+        <p className="text-sm text-muted-foreground mb-1">{contract.title}</p>
+        <p className="text-xs text-muted-foreground mb-8">Signed {signedLabel}</p>
+
+        {contract.signed_pdf_path && (
+          <Link
+            href={`/api/contracts/${contract.id}/pdf?inline=1`}
+            target="_blank"
+            className="inline-flex items-center gap-2 text-sm text-[var(--brand-primary)] hover:underline mb-6"
+          >
+            <Eye size={14} /> View signed PDF
+          </Link>
+        )}
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Link
+            href={`/jobs/${contract.job_id}`}
+            className="inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold border border-border bg-muted/30 hover:bg-muted/60 transition-colors"
+          >
+            <ArrowLeft size={14} /> Return to Job
+          </Link>
+          {contract.signed_pdf_path && (
+            <a
+              href={`/api/contracts/${contract.id}/pdf`}
+              className="inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-semibold bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-all"
+            >
+              <Download size={14} /> Download PDF
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/contracts/[id]/sign-in-person/page.tsx
+++ b/src/app/contracts/[id]/sign-in-person/page.tsx
@@ -1,0 +1,143 @@
+import { redirect } from "next/navigation";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import type { Contract, ContractSigner } from "@/lib/contracts/types";
+import TabletSigningForm from "./tablet-signing-form";
+
+interface CompanyBrand {
+  name: string;
+  phone: string;
+  email: string;
+  address: string;
+  logoUrl: string | null;
+}
+
+async function loadCompany(): Promise<CompanyBrand> {
+  const supabase = createServiceClient();
+  const { data } = await supabase
+    .from("company_settings")
+    .select("key, value")
+    .in("key", ["company_name", "phone", "email", "address", "logo_url"]);
+  const m = new Map<string, string | null>(
+    (data ?? []).map((r: { key: string; value: string | null }) => [r.key, r.value]),
+  );
+  return {
+    name: m.get("company_name") || "",
+    phone: m.get("phone") || "",
+    email: m.get("email") || "",
+    address: m.get("address") || "",
+    logoUrl: m.get("logo_url") || null,
+  };
+}
+
+// /contracts/[id]/sign-in-person — full-screen internal tablet view.
+// Auth-required: Eric or a tech must be logged in; the iPad is theirs,
+// they hand it to the customer for the signature + consent + submit.
+export default async function SignInPersonPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
+  const authClient = await createServerSupabaseClient();
+  const { data: { user }, error: authErr } = await authClient.auth.getUser();
+  if (authErr || !user) {
+    redirect(`/login?next=/contracts/${id}/sign-in-person`);
+  }
+
+  const supabase = createServiceClient();
+  const [{ data: contract }, { data: signersRaw }, company] = await Promise.all([
+    supabase
+      .from("contracts")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle<Contract>(),
+    supabase
+      .from("contract_signers")
+      .select("*")
+      .eq("contract_id", id)
+      .order("signer_order"),
+    loadCompany(),
+  ]);
+
+  if (!contract) {
+    return <ErrorShell title="Contract not found" subtitle="This signing session is no longer valid." />;
+  }
+  if (contract.status === "voided") {
+    return <ErrorShell title="This contract has been voided" subtitle="Return to the job to see history." />;
+  }
+  if (contract.status === "signed") {
+    redirect(`/contracts/${id}/sign-in-person/complete`);
+  }
+
+  const signers = (signersRaw ?? []) as ContractSigner[];
+  if (!signers.length) {
+    return <ErrorShell title="Contract has no signers" subtitle="Return to the job and recreate the contract." />;
+  }
+  const active = signers.find((s) => !s.signed_at);
+  if (!active) {
+    redirect(`/contracts/${id}/sign-in-person/complete`);
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        <HeaderBlock
+          company={company}
+          title={contract.title}
+        />
+        <TabletSigningForm
+          contractId={contract.id}
+          contractTitle={contract.title}
+          filledContentHtml={contract.filled_content_html}
+          signers={signers.map((s) => ({
+            id: s.id,
+            name: s.name,
+            role_label: s.role_label,
+            signer_order: s.signer_order,
+            signed_at: s.signed_at,
+          }))}
+          initialActiveSignerId={active!.id}
+        />
+      </div>
+    </div>
+  );
+}
+
+function HeaderBlock({ company, title }: { company: CompanyBrand; title: string }) {
+  return (
+    <div className="flex items-start justify-between gap-4 mb-6 pb-4 border-b border-border">
+      <div className="flex items-center gap-3 min-w-0">
+        {company.logoUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={company.logoUrl}
+            alt={company.name || "Company logo"}
+            className="w-10 h-10 rounded-md object-contain bg-white/5"
+          />
+        ) : null}
+        <div className="min-w-0">
+          <div className="text-sm font-semibold text-foreground truncate">
+            {company.name || "Contract"}
+          </div>
+          <div className="text-base font-medium text-muted-foreground truncate">{title}</div>
+        </div>
+      </div>
+      <span className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-wider font-semibold px-2 py-1 rounded-full bg-[rgba(15,110,86,0.15)] text-[#5DCAA5] border border-[rgba(15,110,86,0.35)] whitespace-nowrap">
+        Hand to Customer
+      </span>
+    </div>
+  );
+}
+
+function ErrorShell({ title, subtitle }: { title: string; subtitle: string }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="bg-card border border-border rounded-xl p-8 max-w-md w-full text-center">
+        <h1 className="text-lg font-semibold mb-2 text-foreground">{title}</h1>
+        <p className="text-sm text-muted-foreground">{subtitle}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/contracts/[id]/sign-in-person/tablet-signing-form.tsx
+++ b/src/app/contracts/[id]/sign-in-person/tablet-signing-form.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import SignaturePad from "signature_pad";
+import { Loader2, CheckCircle2, ArrowRight } from "lucide-react";
+import { toast } from "sonner";
+
+interface SignerSlice {
+  id: string;
+  name: string;
+  role_label: string | null;
+  signer_order: number;
+  signed_at: string | null;
+}
+
+interface Props {
+  contractId: string;
+  contractTitle: string;
+  filledContentHtml: string;
+  signers: SignerSlice[];
+  initialActiveSignerId: string;
+}
+
+const ESIGN_CONSENT_TEXT =
+  "I agree that my electronic signature is the legal equivalent of my manual signature on this document, and I consent to conduct business electronically under the U.S. ESIGN Act.";
+
+// Tablet-optimized signing form for /contracts/[id]/sign-in-person.
+// Dark theme matching the platform; larger signature pad, larger body
+// type, larger tap targets than the remote /sign/[token] view. For
+// multi-signer contracts this component stays mounted across signers —
+// on submit we swap local state to the next signer without navigating.
+export default function TabletSigningForm({
+  contractId,
+  contractTitle,
+  filledContentHtml,
+  signers,
+  initialActiveSignerId,
+}: Props) {
+  const router = useRouter();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const padRef = useRef<SignaturePad | null>(null);
+
+  const [activeSignerId, setActiveSignerId] = useState(initialActiveSignerId);
+  const [signedIds, setSignedIds] = useState<Set<string>>(
+    () => new Set(signers.filter((s) => s.signed_at).map((s) => s.id)),
+  );
+  const activeSigner = signers.find((s) => s.id === activeSignerId) ?? signers[0];
+
+  const [hasSignature, setHasSignature] = useState(false);
+  const [typedName, setTypedName] = useState(activeSigner.name);
+  const [consent, setConsent] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const todayLabel = new Date().toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  const resizeCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    const pad = padRef.current;
+    if (!canvas || !pad) return;
+    const ratio = Math.max(window.devicePixelRatio || 1, 1);
+    const width = canvas.offsetWidth;
+    const height = canvas.offsetHeight;
+    canvas.width = width * ratio;
+    canvas.height = height * ratio;
+    const ctx = canvas.getContext("2d");
+    ctx?.scale(ratio, ratio);
+    pad.clear();
+    setHasSignature(false);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const pad = new SignaturePad(canvas, {
+      backgroundColor: "rgba(0,0,0,0)",
+      penColor: "#ffffff",
+      minWidth: 1.0,
+      maxWidth: 3.0,
+    });
+    pad.addEventListener("endStroke", () => setHasSignature(!pad.isEmpty()));
+    padRef.current = pad;
+    resizeCanvas();
+    const onResize = () => resizeCanvas();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      pad.off();
+    };
+  }, [resizeCanvas]);
+
+  function clearSignature() {
+    padRef.current?.clear();
+    setHasSignature(false);
+  }
+
+  function resetForNextSigner(nextSigner: SignerSlice) {
+    setActiveSignerId(nextSigner.id);
+    setTypedName(nextSigner.name);
+    setConsent(false);
+    setError(null);
+    padRef.current?.clear();
+    setHasSignature(false);
+  }
+
+  async function submit() {
+    setError(null);
+    const pad = padRef.current;
+    if (!pad || pad.isEmpty()) {
+      setError("Please provide your signature before submitting.");
+      return;
+    }
+    if (!typedName.trim()) {
+      setError("Please type your full name.");
+      return;
+    }
+    if (!consent) {
+      setError("You must agree to the ESIGN consent to continue.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const dataUrl = pad.toDataURL("image/png");
+      const res = await fetch(`/api/contracts/${contractId}/sign`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          in_person: true,
+          signerId: activeSignerId,
+          signatureDataUrl: dataUrl,
+          typedName: typedName.trim(),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || "Signing failed. Please try again.");
+      }
+
+      const justSignedId = activeSignerId;
+      setSignedIds((prev) => {
+        const next = new Set(prev);
+        next.add(justSignedId);
+        return next;
+      });
+
+      if (data.finalized) {
+        router.push(`/contracts/${contractId}/sign-in-person/complete`);
+        router.refresh();
+        return;
+      }
+
+      if (data.nextSigner?.id) {
+        const nextStub: SignerSlice = {
+          id: data.nextSigner.id,
+          name: data.nextSigner.name,
+          role_label: data.nextSigner.role_label ?? null,
+          signer_order: data.nextSigner.signer_order,
+          signed_at: null,
+        };
+        toast.success(`Signer ${data.nextSigner.signer_order} — please hand to ${data.nextSigner.name}`);
+        resetForNextSigner(nextStub);
+      } else {
+        // Defensive fallback — reload to pick up whatever the server did.
+        router.refresh();
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Signing failed");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const totalSigners = signers.length;
+  const activeIndex = signers.findIndex((s) => s.id === activeSignerId);
+  const progressLabel =
+    totalSigners > 1
+      ? `Signer ${activeIndex + 1} of ${totalSigners}: ${activeSigner.role_label || activeSigner.name}`
+      : null;
+
+  return (
+    <>
+      {progressLabel && (
+        <div className="flex items-center gap-3 mb-4">
+          <ProgressDots
+            total={totalSigners}
+            activeIndex={activeIndex}
+            signedIds={signedIds}
+            signers={signers}
+          />
+          <div className="text-sm font-medium text-foreground">{progressLabel}</div>
+        </div>
+      )}
+
+      {/* Document card — white card over the dark page background for readability */}
+      <div className="rounded-2xl bg-white text-[#111827] shadow-2xl p-8 mb-5 max-h-[55vh] overflow-y-auto">
+        <div
+          className="tablet-doc-body"
+          style={{ fontSize: 17, lineHeight: 1.8 }}
+          dangerouslySetInnerHTML={{ __html: filledContentHtml }}
+        />
+      </div>
+
+      {/* Signature section — dark card, larger pad */}
+      <div className="rounded-2xl bg-card border border-border p-6 mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <div className="text-sm font-semibold text-foreground">
+              {activeSigner.name}
+              {activeSigner.role_label ? (
+                <span className="ml-2 text-xs uppercase tracking-wider text-muted-foreground">
+                  {activeSigner.role_label}
+                </span>
+              ) : null}
+            </div>
+            <div className="text-xs text-muted-foreground">{todayLabel}</div>
+          </div>
+          <div className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Sign below
+          </div>
+        </div>
+
+        <div
+          className="relative rounded-xl bg-background/40 border border-dashed border-border/70"
+          style={{ height: 200 }}
+        >
+          <canvas ref={canvasRef} className="w-full h-full block touch-none" />
+          <button
+            type="button"
+            onClick={clearSignature}
+            className="absolute bottom-2 right-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Clear
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-5">
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">Full name</label>
+            <input
+              type="text"
+              value={typedName}
+              onChange={(e) => setTypedName(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-border bg-background/60 px-3 py-3 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/30"
+            />
+          </div>
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">Date</label>
+            <input
+              type="text"
+              value={todayLabel}
+              readOnly
+              className="mt-1 w-full rounded-lg border border-border bg-muted/40 px-3 py-3 text-base text-muted-foreground cursor-default"
+            />
+          </div>
+        </div>
+
+        <label className="flex items-start gap-3 mt-5 cursor-pointer text-sm text-foreground">
+          <input
+            type="checkbox"
+            checked={consent}
+            onChange={(e) => setConsent(e.target.checked)}
+            className="mt-1 w-5 h-5"
+            style={{ accentColor: "#0F6E56" }}
+          />
+          <span className="leading-relaxed">{ESIGN_CONSENT_TEXT}</span>
+        </label>
+
+        {error && (
+          <div
+            className="mt-4 px-3 py-2 text-sm rounded-lg"
+            style={{
+              backgroundColor: "rgba(228, 75, 74, 0.12)",
+              color: "#F09595",
+              border: "1px solid rgba(228, 75, 74, 0.3)",
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || !consent || !hasSignature || !typedName.trim()}
+          className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-xl text-base font-semibold bg-[image:var(--gradient-primary)] text-white shadow-lg hover:brightness-110 transition-all disabled:opacity-50 min-w-[160px]"
+        >
+          {submitting ? (
+            <Loader2 size={18} className="animate-spin" />
+          ) : (
+            <CheckCircle2 size={18} />
+          )}
+          Sign
+          {totalSigners > 1 && activeIndex < totalSigners - 1 ? (
+            <ArrowRight size={16} />
+          ) : null}
+        </button>
+      </div>
+    </>
+  );
+}
+
+function ProgressDots({
+  total,
+  activeIndex,
+  signedIds,
+  signers,
+}: {
+  total: number;
+  activeIndex: number;
+  signedIds: Set<string>;
+  signers: SignerSlice[];
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {Array.from({ length: total }).map((_, i) => {
+        const s = signers[i];
+        const signed = signedIds.has(s.id);
+        const active = i === activeIndex;
+        return (
+          <span
+            key={s.id}
+            className={
+              signed
+                ? "w-3 h-3 rounded-full bg-[#5DCAA5]"
+                : active
+                  ? "w-3 h-3 rounded-full bg-[var(--brand-primary)] ring-2 ring-[var(--brand-primary)]/30"
+                  : "w-3 h-3 rounded-full bg-muted"
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -9,17 +9,24 @@ const AUTH_ROUTES = ["/login", "/logout"];
 const FULL_BLEED_ROUTES = ["/email"];
 // Public customer-facing routes render without the internal app chrome.
 const PUBLIC_ROUTES = ["/sign"];
+// Internal routes that still require auth (handled in the page itself)
+// but render full-screen without the sidebar — used for the tablet
+// in-person signing handoff where the iPad is given to the customer.
+const INTERNAL_FULLSCREEN_PATTERNS: RegExp[] = [
+  /^\/contracts\/[^/]+\/sign-in-person(\/|$)/,
+];
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { collapsed } = useSidebarCollapse();
   const isAuthPage = AUTH_ROUTES.some((r) => pathname.startsWith(r));
   const isPublicPage = PUBLIC_ROUTES.some((r) => pathname.startsWith(r));
+  const isInternalFullscreen = INTERNAL_FULLSCREEN_PATTERNS.some((re) => re.test(pathname));
   const isFullBleed = FULL_BLEED_ROUTES.some(
     (r) => pathname === r || pathname.startsWith(`${r}/`),
   );
 
-  if (isAuthPage || isPublicPage) {
+  if (isAuthPage || isPublicPage || isInternalFullscreen) {
     return <>{children}</>;
   }
 

--- a/src/components/contracts/contracts-section.tsx
+++ b/src/components/contracts/contracts-section.tsx
@@ -14,11 +14,13 @@ import {
   Trash2,
   Ban,
   Pencil,
+  Check,
 } from "lucide-react";
 import { toast } from "sonner";
 import SendContractModal from "./send-contract-modal";
+import SignInPersonModal from "./sign-in-person-modal";
 import VoidContractDialog from "./void-contract-dialog";
-import type { ContractListItem } from "@/lib/contracts/types";
+import type { ContractListItem, ContractListSigner } from "@/lib/contracts/types";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -31,6 +33,7 @@ interface Props {
 export default function ContractsSection({ jobId, customerEmail, customerName, onChanged }: Props) {
   const [rows, setRows] = useState<ContractListItem[] | null>(null);
   const [sendOpen, setSendOpen] = useState(false);
+  const [inPersonOpen, setInPersonOpen] = useState(false);
   const [menuId, setMenuId] = useState<string | null>(null);
   const [voidTarget, setVoidTarget] = useState<ContractListItem | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
@@ -39,9 +42,6 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
     const res = await fetch(`/api/contracts/by-job/${jobId}`);
     if (res.ok) {
       const data = (await res.json()) as ContractListItem[];
-      // Client-side lazy-expiry: if a row is still 'sent' or 'viewed' but
-      // its link is past expiry, render as expired until the next page
-      // load when the server catches up.
       const now = Date.now();
       const decorated = data.map((r) => {
         if (
@@ -72,10 +72,34 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
     return () => document.removeEventListener("mousedown", onDoc);
   }, [menuId]);
 
+  async function handleRemind(id: string) {
+    setBusyId(id);
+    try {
+      const res = await fetch(`/api/contracts/${id}/remind`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(data.error || "Reminder failed");
+      toast.success(`Reminder sent to ${data.sentTo || "signer"}`);
+      await refresh();
+      onChanged?.();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Reminder failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
   async function handleResend(id: string) {
     setBusyId(id);
     try {
-      const res = await fetch(`/api/contracts/${id}/resend`, { method: "POST", headers: { "Content-Type": "application/json" }, body: "{}" });
+      const res = await fetch(`/api/contracts/${id}/resend`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data.error || "Resend failed");
       toast.success("Signing link re-sent");
@@ -91,7 +115,6 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
   async function handleDiscard(id: string) {
     setBusyId(id);
     try {
-      // A draft with no audit history can simply be voided with no email.
       const res = await fetch(`/api/contracts/${id}/void`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -131,9 +154,8 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
         <div className="flex items-center gap-2">
           <button
             type="button"
-            disabled
-            title="Coming in Build 15c"
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 border border-border text-muted-foreground/60 cursor-not-allowed gap-1.5"
+            onClick={() => setInPersonOpen(true)}
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 border border-border text-foreground hover:bg-accent transition-colors gap-1.5"
           >
             <Users size={14} />
             Sign In Person
@@ -155,7 +177,7 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
         </div>
       ) : rows.length === 0 ? (
         <div className="text-sm text-muted-foreground text-center py-6 border border-dashed border-border/70 rounded-lg">
-          No contracts yet. Click <span className="text-foreground font-medium">Send for Signature</span> to create one.
+          No contracts yet. Click <span className="text-foreground font-medium">Send for Signature</span> or <span className="text-foreground font-medium">Sign In Person</span> to create one.
         </div>
       ) : (
         <div className="space-y-2">
@@ -168,6 +190,7 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
               onMenuToggle={() => setMenuId(menuId === row.id ? null : row.id)}
               onClose={() => setMenuId(null)}
               onResend={() => handleResend(row.id)}
+              onRemind={() => handleRemind(row.id)}
               onDiscard={() => handleDiscard(row.id)}
               onVoid={() => {
                 setVoidTarget(row);
@@ -188,6 +211,14 @@ export default function ContractsSection({ jobId, customerEmail, customerName, o
           await refresh();
           onChanged?.();
         }}
+      />
+
+      <SignInPersonModal
+        open={inPersonOpen}
+        onOpenChange={setInPersonOpen}
+        jobId={jobId}
+        defaultSignerName={customerName}
+        defaultSignerEmail={customerEmail}
       />
 
       <VoidContractDialog
@@ -212,6 +243,7 @@ interface RowProps {
   onMenuToggle: () => void;
   onClose: () => void;
   onResend: () => void;
+  onRemind: () => void;
   onDiscard: () => void;
   onVoid: () => void;
 }
@@ -255,11 +287,13 @@ function ContractRow({
   menuOpen,
   onMenuToggle,
   onResend,
+  onRemind,
   onDiscard,
   onVoid,
 }: RowProps) {
   const style = STATUS_STYLES[row.status];
   const isVoided = row.status === "voided";
+  const isMultiSigner = row.signer_count > 1;
 
   return (
     <div
@@ -286,6 +320,11 @@ function ContractRow({
           >
             {style.label}
           </span>
+          {row.reminder_count > 0 && (row.status === "sent" || row.status === "viewed") && (
+            <span className="text-[10px] text-muted-foreground">
+              · {row.reminder_count} reminder{row.reminder_count === 1 ? "" : "s"} sent
+            </span>
+          )}
         </div>
         <div className="text-xs text-muted-foreground mt-1 space-y-0.5">
           {row.status === "signed" && (
@@ -305,6 +344,9 @@ function ContractRow({
                 <> · Expires {formatDateTime(row.link_expires_at)}</>
               )}
             </div>
+          )}
+          {isMultiSigner && row.status !== "draft" && (
+            <MultiSignerStatus signers={row.signers} />
           )}
           {row.status === "draft" && (
             <div>Draft — send failed or not yet dispatched.</div>
@@ -349,7 +391,7 @@ function ContractRow({
         {(row.status === "sent" || row.status === "viewed") && (
           <button
             type="button"
-            onClick={onResend}
+            onClick={onRemind}
             disabled={busy}
             className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
           >
@@ -397,7 +439,7 @@ function ContractRow({
                   <button
                     type="button"
                     disabled
-                    title="Edit flow lands in 15c"
+                    title="Edit flow lands post-15c"
                     className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground/60 cursor-not-allowed"
                   >
                     <Pencil size={14} /> Edit
@@ -412,6 +454,28 @@ function ContractRow({
   );
 }
 
+function MultiSignerStatus({ signers }: { signers: ContractListSigner[] }) {
+  if (!signers?.length) return null;
+  return (
+    <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px]">
+      {signers.map((s) => (
+        <span key={s.id} className="inline-flex items-center gap-1">
+          <span className="text-muted-foreground/80">
+            Signer {s.signer_order}:
+          </span>
+          {s.signed_at ? (
+            <span className="text-[#5DCAA5] inline-flex items-center gap-0.5">
+              <Check size={11} /> Signed {formatDate(s.signed_at)}
+            </span>
+          ) : (
+            <span className="text-[#FAC775]">Awaiting signature</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function formatDateTime(iso: string): string {
   try {
     const d = new Date(iso);
@@ -421,6 +485,14 @@ function formatDateTime(iso: string): string {
       hour: "numeric",
       minute: "2-digit",
     });
+  } catch {
+    return iso;
+  }
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", { month: "short", day: "numeric" });
   } catch {
     return iso;
   }

--- a/src/components/contracts/sign-in-person-modal.tsx
+++ b/src/components/contracts/sign-in-person-modal.tsx
@@ -1,22 +1,17 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import TiptapEditor from "@/components/tiptap-editor";
 import PreviewContractModal from "./preview-contract-modal";
-import { Loader2, Send, FileText, Plus, Trash2 } from "lucide-react";
+import { Loader2, Users, FileText, Plus, Trash2 } from "lucide-react";
 import { toast } from "sonner";
-import type { ContractTemplateListItem, ContractEmailSettings } from "@/lib/contracts/types";
-
-interface SignerRow {
-  name: string;
-  email: string;
-}
+import type { ContractTemplateListItem } from "@/lib/contracts/types";
 
 interface Props {
   open: boolean;
@@ -24,7 +19,6 @@ interface Props {
   jobId: string;
   defaultSignerName: string | null;
   defaultSignerEmail: string | null;
-  onSent: () => void | Promise<void>;
 }
 
 interface PreviewData {
@@ -34,62 +28,44 @@ interface PreviewData {
   defaultTitle: string;
 }
 
-export default function SendContractModal({
+interface SignerRow {
+  name: string;
+  email: string;
+}
+
+// Setup modal for the Sign In Person (tablet) flow. Structurally mirrors
+// SendContractModal minus the email composition — when the user clicks
+// Start Signing we POST the draft to /api/contracts/in-person/start and
+// redirect them straight to the full-screen tablet signing view.
+export default function SignInPersonModal({
   open,
   onOpenChange,
   jobId,
   defaultSignerName,
   defaultSignerEmail,
-  onSent,
 }: Props) {
+  const router = useRouter();
   const [templates, setTemplates] = useState<ContractTemplateListItem[] | null>(null);
-  const [settings, setSettings] = useState<ContractEmailSettings | null>(null);
   const [templateId, setTemplateId] = useState<string>("");
-  const [signers, setSigners] = useState<SignerRow[]>([
-    { name: defaultSignerName ?? "", email: defaultSignerEmail ?? "" },
-  ]);
-  const [expiryDays, setExpiryDays] = useState<number>(7);
-  const [emailSubject, setEmailSubject] = useState("");
-  const [emailBody, setEmailBody] = useState("");
+  const [signers, setSigners] = useState<SignerRow[]>([{ name: "", email: "" }]);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [previewing, setPreviewing] = useState(false);
   const [preview, setPreview] = useState<PreviewData | null>(null);
-  const [sending, setSending] = useState(false);
+  const [starting, setStarting] = useState(false);
 
-  // Reset form whenever the modal reopens.
   useEffect(() => {
     if (!open) return;
     setSigners([{ name: defaultSignerName ?? "", email: defaultSignerEmail ?? "" }]);
     setPreview(null);
   }, [open, defaultSignerName, defaultSignerEmail]);
 
-  function updateSigner(idx: number, patch: Partial<SignerRow>) {
-    setSigners((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
-  }
-  function addSigner() {
-    setSigners((prev) => (prev.length < 2 ? [...prev, { name: "", email: "" }] : prev));
-  }
-  function removeSigner(idx: number) {
-    setSigners((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== idx) : prev));
-  }
-
   const load = useCallback(async () => {
-    const [tRes, sRes] = await Promise.all([
-      fetch("/api/settings/contract-templates"),
-      fetch("/api/settings/contract-email"),
-    ]);
-    if (tRes.ok) {
-      const data = (await tRes.json()) as ContractTemplateListItem[];
+    const res = await fetch("/api/settings/contract-templates");
+    if (res.ok) {
+      const data = (await res.json()) as ContractTemplateListItem[];
       const active = data.filter((t) => t.is_active);
       setTemplates(active);
       if (active.length && !templateId) setTemplateId(active[0].id);
-    }
-    if (sRes.ok) {
-      const data = (await sRes.json()) as ContractEmailSettings;
-      setSettings(data);
-      setExpiryDays(data.default_link_expiry_days);
-      setEmailSubject(data.signing_request_subject_template);
-      setEmailBody(data.signing_request_body_template);
     }
   }, [templateId]);
 
@@ -97,7 +73,17 @@ export default function SendContractModal({
     if (open) load();
   }, [open, load]);
 
-  const setupIncomplete = !!settings && (!settings.send_from_email || !settings.send_from_name);
+  function updateSigner(idx: number, patch: Partial<SignerRow>) {
+    setSigners((prev) => prev.map((s, i) => (i === idx ? { ...s, ...patch } : s)));
+  }
+
+  function addSigner() {
+    setSigners((prev) => (prev.length < 2 ? [...prev, { name: "", email: "" }] : prev));
+  }
+
+  function removeSigner(idx: number) {
+    setSigners((prev) => (prev.length > 1 ? prev.filter((_, i) => i !== idx) : prev));
+  }
 
   async function doPreview() {
     if (!templateId) return;
@@ -119,7 +105,7 @@ export default function SendContractModal({
     }
   }
 
-  async function doSend() {
+  async function startSigning() {
     if (!templateId) {
       toast.error("Pick a template first");
       return;
@@ -130,54 +116,38 @@ export default function SendContractModal({
         return;
       }
     }
-    if (!emailSubject.trim() || !emailBody.trim()) {
-      toast.error("Email subject and body are required");
-      return;
-    }
-    setSending(true);
+    setStarting(true);
     try {
-      const res = await fetch("/api/contracts/send", {
+      const res = await fetch("/api/contracts/in-person/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           jobId,
           templateId,
           signers: signers.map((s) => ({ name: s.name.trim(), email: s.email.trim() })),
-          expiryDays,
-          emailSubject,
-          emailBody,
         }),
       });
       const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Send failed");
-      toast.success("Contract sent for signature");
-      await onSent();
-      onOpenChange(false);
+      if (!res.ok) throw new Error(data.error || "Unable to start signing");
+      router.push(`/contracts/${data.contractId}/sign-in-person`);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "Send failed");
+      toast.error(e instanceof Error ? e.message : "Unable to start signing");
     } finally {
-      setSending(false);
+      setStarting(false);
     }
   }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <Send size={18} className="text-[var(--brand-primary)]" />
-            Send for Signature
+            <Users size={18} className="text-[var(--brand-primary)]" />
+            Sign In Person
           </DialogTitle>
         </DialogHeader>
 
-        {setupIncomplete && (
-          <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-200">
-            Contract email settings are incomplete — set a send-from address in Settings → Contracts first.
-          </div>
-        )}
-
         <div className="space-y-4">
-          {/* Template */}
           <div>
             <label className="text-xs font-medium text-muted-foreground">Template</label>
             {templates === null ? (
@@ -203,12 +173,9 @@ export default function SendContractModal({
             )}
           </div>
 
-          {/* Signers */}
           <div>
             <div className="flex items-center justify-between mb-1">
-              <label className="text-xs font-medium text-muted-foreground">
-                Signer{signers.length > 1 ? "s" : ""}
-              </label>
+              <label className="text-xs font-medium text-muted-foreground">Signers</label>
               {signers.length < 2 && (
                 <button
                   type="button"
@@ -221,10 +188,7 @@ export default function SendContractModal({
             </div>
             <div className="space-y-2">
               {signers.map((s, idx) => (
-                <div
-                  key={idx}
-                  className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-2 items-center"
-                >
+                <div key={idx} className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-2">
                   <input
                     type="text"
                     placeholder={`Signer ${idx + 1} full name`}
@@ -254,48 +218,8 @@ export default function SendContractModal({
                 </div>
               ))}
             </div>
-            {signers.length > 1 && (
-              <p className="text-[11px] text-muted-foreground mt-2">
-                The second signer receives their link after the first signs.
-              </p>
-            )}
-          </div>
-
-          {/* Expiry */}
-          <div>
-            <label className="text-xs font-medium text-muted-foreground">Link expiration (days)</label>
-            <input
-              type="number"
-              min={1}
-              max={30}
-              value={expiryDays}
-              onChange={(e) => setExpiryDays(Math.max(1, Math.min(30, Number(e.target.value))))}
-              className="mt-1 w-28 rounded-lg border border-border bg-background/60 px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/30"
-            />
-          </div>
-
-          {/* Email subject + body */}
-          <div>
-            <label className="text-xs font-medium text-muted-foreground">Email subject</label>
-            <input
-              type="text"
-              value={emailSubject}
-              onChange={(e) => setEmailSubject(e.target.value)}
-              className="mt-1 w-full rounded-lg border border-border bg-background/60 px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/30"
-            />
-          </div>
-
-          <div>
-            <label className="text-xs font-medium text-muted-foreground">Email body</label>
-            <div className="mt-1">
-              <TiptapEditor
-                content={emailBody}
-                onChange={setEmailBody}
-                placeholder="Email body shown to the signer"
-              />
-            </div>
-            <p className="text-[11px] text-muted-foreground mt-1">
-              {`{{signing_link}}`} and {`{{document_title}}`} resolve automatically when sent.
+            <p className="text-[11px] text-muted-foreground mt-2">
+              Email is used for the signed-confirmation copy. No signing link will be sent for in-person signing.
             </p>
           </div>
         </div>
@@ -320,12 +244,12 @@ export default function SendContractModal({
             </button>
             <button
               type="button"
-              onClick={doSend}
-              disabled={sending || setupIncomplete || !templateId}
+              onClick={startSigning}
+              disabled={starting || !templateId}
               className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-all disabled:opacity-60"
             >
-              {sending ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
-              Send
+              {starting ? <Loader2 size={14} className="animate-spin" /> : <Users size={14} />}
+              Start Signing
             </button>
           </div>
         </div>

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -88,6 +88,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
   const [editInsuranceOpen, setEditInsuranceOpen] = useState(false);
   const [addAdjusterOpen, setAddAdjusterOpen] = useState(false);
   const [photoCount, setPhotoCount] = useState(0);
+  const [pendingReminderTotal, setPendingReminderTotal] = useState(0);
 
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -162,6 +163,24 @@ export default function JobDetail({ jobId }: { jobId: string }) {
       .select("field_key, field_value")
       .eq("job_id", jobId);
     if (cfData) setCustomFields(cfData);
+
+    // Aggregate reminder count across any sent/viewed contracts for the
+    // "· N reminders sent" indicator next to the Awaiting-signature pill.
+    const { data: pendingContracts } = await supabase
+      .from("contracts")
+      .select("reminder_count")
+      .eq("job_id", jobId)
+      .in("status", ["sent", "viewed"]);
+    if (pendingContracts) {
+      setPendingReminderTotal(
+        pendingContracts.reduce(
+          (sum: number, c: { reminder_count: number | null }) => sum + (c.reminder_count ?? 0),
+          0,
+        ),
+      );
+    } else {
+      setPendingReminderTotal(0);
+    }
 
     setLoading(false);
   }, [jobId]);
@@ -264,11 +283,18 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                 Contract signed
               </Badge>
             ) : job.has_pending_contract ? (
-              <Badge
-                className="text-xs font-medium px-2 py-0.5 rounded-md bg-[rgba(239,159,39,0.12)] text-[#FAC775] border border-[rgba(239,159,39,0.3)]"
-              >
-                Awaiting signature
-              </Badge>
+              <>
+                <Badge
+                  className="text-xs font-medium px-2 py-0.5 rounded-md bg-[rgba(239,159,39,0.12)] text-[#FAC775] border border-[rgba(239,159,39,0.3)]"
+                >
+                  Awaiting signature
+                </Badge>
+                {pendingReminderTotal > 0 && (
+                  <span className="text-[11px] text-muted-foreground">
+                    · {pendingReminderTotal} reminder{pendingReminderTotal === 1 ? "" : "s"} sent
+                  </span>
+                )}
+              </>
             ) : null}
           </div>
         </div>

--- a/src/lib/contracts/pdf-void-watermark.ts
+++ b/src/lib/contracts/pdf-void-watermark.ts
@@ -1,0 +1,39 @@
+import { PDFDocument, StandardFonts, degrees, rgb } from "pdf-lib";
+
+// Stamps a large, semi-transparent "VOIDED" diagonally across every page
+// of an existing signed PDF. Used when retroactively voiding a contract
+// whose customer has already signed — the original pages, signatures,
+// and Signature Certificate remain intact; the watermark just makes the
+// voided state unambiguous when the file is reopened later.
+export async function stampVoidWatermark(pdfBytes: Uint8Array): Promise<Uint8Array> {
+  const doc = await PDFDocument.load(pdfBytes);
+  const font = await doc.embedFont(StandardFonts.HelveticaBold);
+  const pages = doc.getPages();
+
+  for (const page of pages) {
+    const { width, height } = page.getSize();
+    const text = "VOIDED";
+    const size = Math.min(width, height) * 0.28;
+    const textWidth = font.widthOfTextAtSize(text, size);
+    // Rotate 45° around the page center so the stamp reads diagonally.
+    const angleRad = (45 * Math.PI) / 180;
+    const cx = width / 2;
+    const cy = height / 2;
+    const halfW = textWidth / 2;
+    const halfH = size / 2;
+    const x = cx - halfW * Math.cos(angleRad) + halfH * Math.sin(angleRad);
+    const y = cy - halfW * Math.sin(angleRad) - halfH * Math.cos(angleRad);
+
+    page.drawText(text, {
+      x,
+      y,
+      size,
+      font,
+      color: rgb(0.8, 0.15, 0.15),
+      opacity: 0.22,
+      rotate: degrees(45),
+    });
+  }
+
+  return doc.save();
+}

--- a/src/lib/contracts/reminders.ts
+++ b/src/lib/contracts/reminders.ts
@@ -1,0 +1,111 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { resolveEmailTemplate } from "./email-merge-fields";
+import { sendContractEmail } from "./email";
+import type { Contract, ContractEmailSettings, ContractSigner } from "./types";
+
+function appUrl(): string {
+  const u = process.env.NEXT_PUBLIC_APP_URL;
+  if (!u) throw new Error("NEXT_PUBLIC_APP_URL is not set");
+  return u.replace(/\/$/, "");
+}
+
+// The "active" signer for a contract awaiting signatures = the lowest
+// signer_order that hasn't signed yet. In single-signer contracts that's
+// signer 1. In multi-signer, it flips from 1 → 2 as each completes.
+export function pickActiveSigner(signers: ContractSigner[]): ContractSigner | null {
+  const sorted = [...signers].sort((a, b) => a.signer_order - b.signer_order);
+  for (const s of sorted) {
+    if (!s.signed_at) return s;
+  }
+  return null;
+}
+
+export interface SendReminderResult {
+  ok: true;
+  messageId: string;
+  signerEmail: string;
+}
+
+// Sends exactly one reminder email for a contract and atomically records
+// the reminder_sent event + bumps reminder_count + reschedules next via
+// the mark_reminder_sent RPC. Caller is responsible for the dedup check
+// (cron) or for bypass intent (manual Remind button, which should NOT
+// shift next_reminder_at — manual path uses its own skipSchedule option).
+export async function sendContractReminder(
+  supabase: SupabaseClient,
+  contract: Contract,
+  signers: ContractSigner[],
+  settings: ContractEmailSettings,
+  opts: { skipSchedule?: boolean } = {},
+): Promise<SendReminderResult> {
+  if (!contract.link_token) {
+    throw new Error("Contract has no active signing link");
+  }
+  const active = pickActiveSigner(signers);
+  if (!active) throw new Error("No active (unsigned) signer to remind");
+
+  const signingLink = `${appUrl()}/sign/${contract.link_token}`;
+  const { subject, html } = await resolveEmailTemplate(
+    supabase,
+    settings.reminder_subject_template,
+    settings.reminder_body_template,
+    contract.job_id,
+    { signing_link: signingLink, document_title: contract.title },
+  );
+
+  const sent = await sendContractEmail(supabase, settings, {
+    to: active.email,
+    subject,
+    html,
+  });
+
+  if (opts.skipSchedule) {
+    // Manual reminder path: audit only, don't touch counter or schedule.
+    const { error } = await supabase.from("contract_events").insert({
+      contract_id: contract.id,
+      signer_id: active.id,
+      event_type: "reminder_sent",
+      metadata: { manual: true, message_id: sent.messageId },
+    });
+    if (error) throw new Error(`Failed to log reminder_sent: ${error.message}`);
+  } else {
+    const { error: rpcErr } = await supabase.rpc("mark_reminder_sent", {
+      p_contract_id: contract.id,
+      p_offsets: settings.reminder_day_offsets,
+    });
+    if (rpcErr) throw new Error(`Failed to record reminder: ${rpcErr.message}`);
+  }
+
+  return { ok: true, messageId: sent.messageId, signerEmail: active.email };
+}
+
+// Convert reminder_day_offsets + sent_at into the initial next_reminder_at.
+// Returns null if offsets is empty (no auto-reminders configured).
+export function computeInitialNextReminderAt(
+  sentAt: Date,
+  offsets: number[],
+): Date | null {
+  if (!offsets || offsets.length === 0) return null;
+  const first = Number(offsets[0]);
+  if (!Number.isFinite(first) || first <= 0) return null;
+  return new Date(sentAt.getTime() + first * 24 * 60 * 60 * 1000);
+}
+
+// Guard used by the cron handler: returns true if a reminder_sent event
+// already exists for this contract within the last hour. Protects against
+// Vercel firing the cron twice in the same window.
+export async function hasRecentReminder(
+  supabase: SupabaseClient,
+  contractId: string,
+  withinMs: number = 60 * 60 * 1000,
+): Promise<boolean> {
+  const since = new Date(Date.now() - withinMs).toISOString();
+  const { count, error } = await supabase
+    .from("contract_events")
+    .select("id", { count: "exact", head: true })
+    .eq("contract_id", contractId)
+    .eq("event_type", "reminder_sent")
+    .gte("created_at", since);
+  if (error) throw new Error(`Failed to check recent reminders: ${error.message}`);
+  return (count ?? 0) > 0;
+}

--- a/src/lib/contracts/types.ts
+++ b/src/lib/contracts/types.ts
@@ -138,6 +138,16 @@ export interface ContractEmailSettings {
   updated_at: string;
 }
 
+// Per-signer slice surfaced on list rows so the Contracts section on the
+// job detail tab can render sequential status for multi-signer contracts.
+export interface ContractListSigner {
+  id: string;
+  signer_order: number;
+  name: string | null;
+  role_label: string | null;
+  signed_at: string | null;
+}
+
 // Row shape returned by /api/contracts/by-job for the Contracts section
 // on the job-detail Overview tab.
 export interface ContractListItem {
@@ -153,6 +163,9 @@ export interface ContractListItem {
   primary_signer_name: string | null;
   primary_signer_ip: string | null;
   signer_count: number;
+  signers: ContractListSigner[];
+  reminder_count: number;
+  next_reminder_at: string | null;
   created_at: string;
 }
 

--- a/supabase/migration-build34-contract-reminders.sql
+++ b/supabase/migration-build34-contract-reminders.sql
@@ -1,0 +1,175 @@
+-- ============================================
+-- Build 34 Migration: Build 15c — In-person signing, multi-signer, reminders
+-- Adds RPCs for:
+--   * create_contract_with_signers (atomic create + signer rows, with or
+--     without a link token — supports both remote multi-signer create and
+--     in-person draft create)
+--   * activate_next_signer (after signer 1 completes on multi-signer remote,
+--     rotates contracts.link_token to signer 2's token and resets reminders)
+--   * schedule_first_reminder (set initial next_reminder_at after send)
+--   * mark_reminder_sent (atomic: count++, recompute next_reminder_at
+--     from offsets, log audit event)
+-- No schema column additions; contract.link_token is rotated across
+-- signers rather than stored per-signer. Run this in the Supabase SQL
+-- Editor. Not idempotent.
+-- ============================================
+
+-- ============================================
+-- 1. create_contract_with_signers
+-- Replaces the single-signer create_contract_draft for 15c paths. Handles
+-- 1-2 signers, with or without a link token. p_signers is a JSON array:
+--   [{ id, signer_order, role_label, name, email }, ...]
+-- p_link_token/p_link_expires_at can be NULL for in-person creates.
+-- ============================================
+CREATE OR REPLACE FUNCTION create_contract_with_signers(
+  p_contract_id uuid,
+  p_job_id uuid,
+  p_template_id uuid,
+  p_template_version integer,
+  p_title text,
+  p_filled_content_html text,
+  p_filled_content_hash text,
+  p_link_token text,
+  p_link_expires_at timestamptz,
+  p_sent_by uuid,
+  p_signers jsonb
+) RETURNS uuid AS $$
+DECLARE
+  signer jsonb;
+BEGIN
+  INSERT INTO contracts (
+    id, job_id, template_id, template_version, title, status,
+    filled_content_html, filled_content_hash,
+    link_token, link_expires_at, sent_by
+  ) VALUES (
+    p_contract_id, p_job_id, p_template_id, p_template_version, p_title, 'draft',
+    p_filled_content_html, p_filled_content_hash,
+    p_link_token, p_link_expires_at, p_sent_by
+  );
+
+  FOR signer IN SELECT * FROM jsonb_array_elements(p_signers) LOOP
+    INSERT INTO contract_signers (
+      id, contract_id, signer_order, role_label, name, email
+    ) VALUES (
+      (signer->>'id')::uuid,
+      p_contract_id,
+      (signer->>'signer_order')::integer,
+      signer->>'role_label',
+      signer->>'name',
+      signer->>'email'
+    );
+  END LOOP;
+
+  INSERT INTO contract_events (contract_id, event_type)
+  VALUES (p_contract_id, 'created');
+
+  RETURN p_contract_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- 2. activate_next_signer
+-- Rotates contracts.link_token to the next signer's token and resets
+-- per-signer view + reminder state so the new signer gets a clean slate.
+-- Called after signer N completes but more signers remain.
+-- ============================================
+CREATE OR REPLACE FUNCTION activate_next_signer(
+  p_contract_id uuid,
+  p_next_signer_id uuid,
+  p_link_token text,
+  p_link_expires_at timestamptz
+) RETURNS void AS $$
+BEGIN
+  UPDATE contracts
+    SET link_token = p_link_token,
+        link_expires_at = p_link_expires_at,
+        first_viewed_at = NULL,
+        last_viewed_at = NULL,
+        reminder_count = 0,
+        next_reminder_at = NULL
+    WHERE id = p_contract_id AND status IN ('sent', 'viewed');
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Contract % is not in sent/viewed state', p_contract_id;
+  END IF;
+
+  INSERT INTO contract_events (contract_id, signer_id, event_type, metadata)
+  VALUES (
+    p_contract_id, p_next_signer_id, 'sent',
+    jsonb_build_object('activated_next_signer', true)
+  );
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- 3. schedule_first_reminder
+-- Called after mark_contract_sent (and after activate_next_signer) to
+-- stamp the initial next_reminder_at. Kept as its own RPC so /send and
+-- /sign remain simple and the transition is auditable.
+-- ============================================
+CREATE OR REPLACE FUNCTION schedule_first_reminder(
+  p_contract_id uuid,
+  p_next_reminder_at timestamptz
+) RETURNS void AS $$
+BEGIN
+  UPDATE contracts
+    SET next_reminder_at = p_next_reminder_at
+    WHERE id = p_contract_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Contract % not found', p_contract_id;
+  END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- 4. mark_reminder_sent
+-- Atomic: increment reminder_count, recompute next_reminder_at from the
+-- settings offsets array, write the 'reminder_sent' event.
+--   offsets = [1, 3]
+--   count 0 → next_reminder_at = sent_at + 1 day (set at send time)
+--   after first reminder fires: count = 1, next = sent_at + 3 days
+--   after second fires: count = 2, next = NULL (no more auto reminders)
+-- Row-level lock on contracts serializes concurrent cron workers.
+-- ============================================
+CREATE OR REPLACE FUNCTION mark_reminder_sent(
+  p_contract_id uuid,
+  p_offsets jsonb
+) RETURNS void AS $$
+DECLARE
+  v_sent_at timestamptz;
+  v_new_count integer;
+  v_next timestamptz;
+  v_offset_count integer;
+  v_next_offset integer;
+BEGIN
+  UPDATE contracts
+    SET reminder_count = reminder_count + 1
+    WHERE id = p_contract_id
+    RETURNING sent_at, reminder_count INTO v_sent_at, v_new_count;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Contract % not found for reminder update', p_contract_id;
+  END IF;
+
+  v_offset_count := jsonb_array_length(p_offsets);
+  IF v_new_count < v_offset_count THEN
+    v_next_offset := (p_offsets->>(v_new_count))::integer;
+    IF v_sent_at IS NOT NULL THEN
+      v_next := v_sent_at + (v_next_offset::text || ' days')::interval;
+    ELSE
+      v_next := NULL;
+    END IF;
+  ELSE
+    v_next := NULL;
+  END IF;
+
+  UPDATE contracts SET next_reminder_at = v_next WHERE id = p_contract_id;
+
+  INSERT INTO contract_events (contract_id, event_type, metadata)
+  VALUES (
+    p_contract_id, 'reminder_sent',
+    jsonb_build_object('reminder_count', v_new_count)
+  );
+END;
+$$ LANGUAGE plpgsql;

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "crons": [
-    { "path": "/api/contracts/reminders", "schedule": "0 * * * *" }
+    { "path": "/api/contracts/reminders", "schedule": "0 13 * * *" }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "crons": [
+    { "path": "/api/contracts/reminders", "schedule": "0 * * * *" }
+  ]
+}


### PR DESCRIPTION
## Summary
- **In-person signing:** new "Sign In Person" button on the job Contracts section opens a compose modal (no email) and redirects to a full-screen tablet view at `/contracts/[id]/sign-in-person` (dark theme, 200px pad, 17px/1.8 body, sidebar suppressed). Multi-signer contracts swap to the next signer in place without navigating.
- **Multi-signer remote:** `POST /api/contracts/send` now accepts up to 2 signers and only emails signer 1. When signer 1 completes, `/api/contracts/[id]/sign` rotates `contracts.link_token` to signer 2 via a new `activate_next_signer` RPC, emails them, and restarts the reminder clock.
- **Reminder cron:** hourly Vercel cron at `/api/contracts/reminders` guarded by `CRON_SECRET` bearer auth + a 1h `contract_events` lookback for idempotency. Manual `/api/contracts/[id]/remind` lets Eric push an ad-hoc nudge that doesn't advance `next_reminder_at`.
- **Void hardening:** blocks voids when related invoices have recorded payments, watermarks already-signed PDFs in-place before flipping status, preserves `signed_at` + `signed_pdf_path` for audit.
- **DB (manual run required):** `supabase/migration-build34-contract-reminders.sql` adds four RPCs: `create_contract_with_signers`, `activate_next_signer`, `schedule_first_reminder`, `mark_reminder_sent`. No schema column additions.

## Test plan
- [ ] Apply `supabase/migration-build34-contract-reminders.sql` in the Supabase SQL Editor before merging to main
- [ ] Set `CRON_SECRET` (32+ char hex) in Vercel project env vars — Production, Preview, Development
- [ ] Send a single-signer contract → confirm row shows "Sent" and no per-signer breakdown
- [ ] Send a 2-signer contract → confirm only signer 1 is emailed; after signer 1 signs, confirm signer 2 receives a fresh email and the row shows "Signer 1: ✓ Signed … · Signer 2: Awaiting signature"
- [ ] Click "Sign In Person" → confirm setup modal opens without email fields; Start Signing redirects to the dark tablet view
- [ ] Complete in-person signing with 1 signer → redirects to /complete page, confirmation emails arrive
- [ ] Complete in-person signing with 2 signers on the same tablet → tablet swaps to signer 2 after first submit; PDF has both signatures; /complete renders
- [ ] Backdate a contract's `next_reminder_at` via SQL and hit `curl.exe -H "Authorization: Bearer <secret>" https://aaaplatform.vercel.app/api/contracts/reminders` → reminder email sent, `reminder_count` bumps, `next_reminder_at` recomputes
- [ ] Call the cron route twice in quick succession → second call returns `skipped: recent_reminder` (no duplicate email)
- [ ] Try to void a contract whose job has a recorded payment → blocked with "Cannot void — related invoices have recorded payments"
- [ ] Void a signed contract → stored PDF now has a diagonal "VOIDED" watermark; `signed_pdf_path` and `signed_at` preserved
- [ ] Confirm the Contract pending pill on the job header shows "· N reminders sent" when `reminder_count > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)