### PR TITLE
fix: white signature pad on tablet view

### DIFF
--- a/src/app/contracts/[id]/sign-in-person/tablet-signing-form.tsx
+++ b/src/app/contracts/[id]/sign-in-person/tablet-signing-form.tsx
@@ -230,14 +230,17 @@ export default function TabletSigningForm({
         </div>
 
         <div
-          className="relative rounded-xl bg-background/40 border border-dashed border-border/70"
+          className="relative rounded-xl bg-white border border-border shadow-inner overflow-hidden"
           style={{ height: 200 }}
         >
           <canvas ref={canvasRef} className="w-full h-full block touch-none" />
+          <span className="absolute top-2 left-3 text-[10px] uppercase tracking-wider font-semibold text-gray-400 pointer-events-none">
+            Sign here
+          </span>
           <button
             type="button"
             onClick={clearSignature}
-            className="absolute bottom-2 right-3 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            className="absolute bottom-2 right-3 text-xs font-medium text-gray-500 hover:text-gray-800 transition-colors"
           >
             Clear
           </button>


### PR DESCRIPTION
## Summary
Tablet sign pad now has a solid white card background (instead of translucent dark), so the customer can see their dark ink clearly while signing. Rest of the tablet UI stays dark. Adds a "SIGN HERE" corner hint.

## Test plan
- [ ] Visit a draft contract's /contracts/[id]/sign-in-person → sig pad is a clean white card with "SIGN HERE" in the corner and "Clear" bottom-right
- [ ] Draw → strokes render as dark ink, clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)