### PR TITLE
feat: add Back to job link on tablet signing page

### DIFF
--- a/src/app/contracts/[id]/sign-in-person/page.tsx
+++ b/src/app/contracts/[id]/sign-in-person/page.tsx
@@ -1,4 +1,6 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import type { Contract, ContractSigner } from "@/lib/contracts/types";
@@ -83,6 +85,13 @@ export default async function SignInPersonPage({
   return (
     <div className="min-h-screen bg-background text-foreground">
       <div className="max-w-4xl mx-auto px-6 py-8">
+        <Link
+          href={`/jobs/${contract.job_id}`}
+          className="inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors mb-4"
+        >
+          <ArrowLeft size={14} />
+          Back to job
+        </Link>
         <HeaderBlock
           company={company}
           title={contract.title}


### PR DESCRIPTION
## Summary
Muted "← Back to job" link at the top-left of /contracts/[id]/sign-in-person. Lets Eric bail out to the job page mid-flow without finishing a signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)