### PR TITLE
fix(17b): hide AppShell sidebar on /pay/* for logged-in admins

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 const AUTH_ROUTES = ["/login", "/logout"];
 const FULL_BLEED_ROUTES = ["/email"];
 // Public customer-facing routes render without the internal app chrome.
-const PUBLIC_ROUTES = ["/sign"];
+const PUBLIC_ROUTES = ["/sign", "/pay"];
 // Internal routes that still require auth (handled in the page itself)
 // but render full-screen without the sidebar — used for the tablet
 // in-person signing handoff where the iPad is given to the customer.


### PR DESCRIPTION
## Summary

- `src/components/app-shell.tsx` kept `/pay` out of `PUBLIC_ROUTES`, so `/pay/[token]` rendered the full authenticated app chrome (sidebar, topbar) whenever an admin viewed the page in the same browser. Unauthenticated customers were unaffected thanks to the middleware bypass.
- One-line fix: add `/pay` to `PUBLIC_ROUTES` so AppShell treats it identically to `/sign/*`.

## Verification

- Loaded `http://localhost:3000/pay/invalid.garbage.token` as a logged-in admin — confirmed sidebar no longer renders (only the public-card ErrorShell). Matches the `/sign/*` behavior in Build 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)