### PR TITLE
build65a-followup: rename ios app display name to Nookleus

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from '@capacitor/cli';
 
 const config: CapacitorConfig = {
   appId: 'com.aaacontracting.platform',
-  appName: 'AAA Disaster Recovery',
+  appName: 'Nookleus',
   webDir: 'out',
   backgroundColor: '#0a0a0aff',
   server: {

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-        <string>AAA Disaster Recovery</string>
+        <string>Nookleus</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Summary
- iOS Home Screen label renamed from "AAA Disaster Recovery" to "Nookleus"
- `capacitor.config.ts` `appName` and `ios/App/App/Info.plist` `CFBundleDisplayName` only
- Bundle ID (`com.aaacontracting.platform`) and asset catalog unchanged

## Test plan
- [x] `npm run build && npx cap sync ios` passes locally on Windows
- [x] Generated `ios/App/App/capacitor.config.json` shows `"appName": "Nookleus"`
- [ ] Mac session: open in Xcode, build to iPhone, confirm Home Screen says "Nookleus"

🤖 Generated with [Claude Code](https://claude.com/claude-code)