### PR TITLE
fix: mobile header overlapping page content

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -35,7 +35,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       <Sidebar />
       <main
         className={cn(
-          "pt-14 lg:pt-0 min-h-screen transition-[margin] duration-200 ease-out",
+          "pt-[calc(env(safe-area-inset-top)+3.5rem)] lg:pt-0 min-h-screen transition-[margin] duration-200 ease-out",
           collapsed ? "lg:ml-16" : "lg:ml-52",
         )}
       >

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -535,7 +535,7 @@ export default function EmailInbox() {
   }
 
   return (
-    <div className="h-[calc(100vh-3.5rem)] lg:h-screen flex flex-col">
+    <div className="h-[calc(100dvh-env(safe-area-inset-top)-3.5rem)] lg:h-screen flex flex-col">
       {/* Top bar */}
       <div className="flex items-center gap-3 px-4 py-3 bg-card border-b border-border shrink-0">
         <h1 className="text-lg font-bold text-foreground mr-2">Email</h1>

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -46,10 +46,14 @@ export default function Sidebar() {
 
   return (
     <>
-      {/* Mobile top bar */}
-      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 gradient-sidebar border-b border-white/10 px-4 py-3 flex items-center justify-between">
+      {/* Mobile top bar. Top padding includes the iOS safe-area inset so the
+          bar's content sits below the notch / status bar on Capacitor. The
+          rendered logo is sized to keep the bar's content area at h-14, which
+          is what consumers (AppShell, email inbox) assume when computing
+          their own offsets. */}
+      <div className="lg:hidden fixed top-0 left-0 right-0 z-50 gradient-sidebar border-b border-white/10 px-4 pb-2.5 pt-[calc(env(safe-area-inset-top)+0.625rem)] flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <Image src="/logo.png" alt="AAA Logo" width={120} height={44} />
+          <Image src="/logo.png" alt="AAA Logo" width={120} height={44} className="h-9 w-auto" />
         </div>
         <div className="flex items-center gap-1">
           <NotificationBell />


### PR DESCRIPTION
## Summary

The mobile top bar in `src/components/nav.tsx` was 68px tall (`py-3` + a 44px logo) but `AppShell` only gave `<main>` `pt-14` (56px) of clearance, so the top of every page was hidden behind the header on mobile. The email page already hardcoded its height to `calc(100vh - 3.5rem)`, confirming the bar was *meant* to be `h-14`.

Two fixes:

- Constrain the rendered logo with `h-9 w-auto` so the bar's content area is exactly `h-14` — restoring the contract the rest of the layout assumes.
- Add `env(safe-area-inset-top)` to both the bar's top padding and `main`'s top padding so the bar sits below the iOS notch on Capacitor. On desktop browsers without a safe area, `env()` resolves to 0 and the layout is unchanged. The email panel's height calc subtracts the inset so its bottom isn't clipped on notched devices.

Verified: bar measures 57px (56 + 1px border) at mobile width, desktop layout unchanged (bar `display: none`, main `pt-0` + `ml-52`).

## Test plan

- [ ] On the iPhone app, open `/jobs/[id]` — the "Back to Jobs" link and customer-name H1 should be fully visible just below the AAA header (not clipped by it)
- [ ] On the iPhone app, open `/email` — the inbox toolbar and email list start cleanly below the header, and the bottom of the list is not cut off above the home-indicator area
- [ ] On a desktop browser, sidebar layout is unchanged (no top bar, no extra top padding on `<main>`)
- [ ] On a non-Capacitor mobile browser (e.g. iPhone Safari at aaaplatform.vercel.app), header still sits at top with content cleanly below

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)