### PR TITLE
feat: copy property address button on job detail

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -42,6 +42,7 @@ import {
   Send,
   Clock,
   Loader2,
+  Copy,
 } from "lucide-react";
 import {
   statusColors,
@@ -459,7 +460,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
               </button>
             </div>
             <div className="space-y-3 text-sm">
-              <InfoRow icon={MapPin} label="Address" value={job.property_address} />
+              <AddressRow address={job.property_address} />
               {job.property_type && (
                 <InfoRow
                   icon={Home}
@@ -924,6 +925,38 @@ function InfoRow({
         <p className="text-xs text-muted-foreground">{label}</p>
         <p className="text-foreground">{value}</p>
       </div>
+    </div>
+  );
+}
+
+function AddressRow({ address }: { address: string }) {
+  async function handleCopy() {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      toast.success("Address copied");
+    } catch {
+      toast.error("Couldn't copy address");
+    }
+  }
+  return (
+    <div className="flex items-start gap-3">
+      <MapPin size={16} className="text-primary/60 flex-shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-muted-foreground">Address</p>
+        <p className="text-foreground break-words">{address}</p>
+      </div>
+      {address && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy address"
+          title="Copy address"
+          className="p-1.5 -mt-0.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-accent transition-colors flex-shrink-0"
+        >
+          <Copy size={14} />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a Copy icon button next to the property address in the Job Info card on the job detail page. Tapping it writes the address to the clipboard via `navigator.clipboard.writeText` so the user can paste into Apple Maps, Google Maps, or wherever they navigate from.

The address's generic `InfoRow` is replaced with a dedicated `AddressRow` component so the copy affordance is scoped to addresses (not surfaced on every `InfoRow`). A `sonner` toast confirms on success; the `catch` branch handles clipboard-permission denials with an error toast.

## Test plan

- [ ] On a job detail page, click the Copy icon next to the address — a "Address copied" toast appears, and pasting (Cmd+V / iOS paste) yields the address text
- [ ] On the iPhone app, the Copy icon is tappable and the OS-native paste action works in Apple Maps / Google Maps after copying
- [ ] If the job has no `property_address` (empty string), the Copy button does not render
- [ ] Other `InfoRow` rows (Property Type, Damage Source, Affected Areas, Intake Date) are unaffected — no copy button on those

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)