### PR TITLE
fix: add viewport-fit=cover so iOS header covers the safe area

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "@/components/ui/sonner";
@@ -18,6 +18,16 @@ const inter = Inter({
 export const metadata: Metadata = {
   title: "AAA Disaster Recovery — Platform",
   description: "Business management platform for AAA Disaster Recovery",
+};
+
+// viewport-fit=cover lets the layout viewport extend edge-to-edge on iOS so
+// `position: fixed; top: 0` anchors to the screen top (covering the notch /
+// status-bar strip) and `env(safe-area-inset-*)` resolves to real values that
+// the mobile header and main padding already use.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

After #29 landed, the AAA mobile header still rendered *below* the iOS notch on the Capacitor app — the status-bar strip stayed uncovered. When the user scrolled, body content moved up into that strip and rendered above the fixed header (per #31's screenshots).

**Root cause:** the page had no viewport meta beyond Next.js's default (`width=device-width`). Without `viewport-fit=cover`, on iOS WKWebView:

- The layout viewport excludes the safe area, so `position: fixed; top: 0` anchors below the notch — leaving the status-bar zone uncovered.
- `env(safe-area-inset-*)` resolves to `0`, so the `pt-[calc(env(safe-area-inset-top)+...)]` rules I added on the bar and on `<main>` in #29 had no effect on the device.

**Fix:** add a Next.js `viewport` export with `viewportFit: 'cover'`. This emits `<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">`. The layout viewport now extends edge-to-edge, so:

- The fixed mobile header anchors at the actual screen top, covering the iOS status-bar strip.
- `env(safe-area-inset-top)` resolves to the real notch height (~47–59px), so the existing CSS in nav.tsx and app-shell.tsx finally pushes the bar's content and main's content below the notch.
- Body content scrolled into the header's zone is hidden behind the fixed header (z-50), instead of bleeding into the empty strip above.

Capacitor's `contentInset: 'automatic'` in `capacitor.config.ts` would normally also be relevant, but that's compiled into the iOS app at build time — it can't be changed via Vercel deploy. This web-only viewport meta change is sufficient for the symptom users see.

## Test plan

- [ ] On the iPhone app, open `/email`, `/jobs/[id]`, `/dashboard` and any other page — scroll up and down. No body content (page H1, toolbars, list rows) should ever appear in the iOS status-bar strip above the AAA header.
- [ ] On the iPhone app, the AAA header background fills the area under the iOS status bar; the bell + menu icons sit below the notch as before.
- [ ] Open the mobile sidebar menu (hamburger). The dark sidebar covers the status-bar strip; no underlying page H1 ("Dashboard", etc.) is visible above it.
- [ ] On a desktop browser, layout is unchanged (no notch, `env()` resolves to 0).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)