### PR TITLE
fix: drop empty space above first nav item

### DIFF
--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -130,8 +130,9 @@ export default function Sidebar() {
           </div>
         )}
 
-        {/* Navigation */}
-        <nav className="scrollbar-subtle flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 py-4 space-y-1">
+        {/* Navigation. No top padding so the first item sits flush with the
+            logo area's bottom border. */}
+        <nav className="scrollbar-subtle flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 pb-4 space-y-1">
           {sortedNavItems.map((item) => {
             const isActive =
               item.href === "/"


### PR DESCRIPTION
## Summary

The sidebar's `<nav>` had `py-4`, leaving a 16px strip between the logo area's bottom border and the first item ("Jarvis") in both the mobile sidebar drawer and the desktop sidebar. Per #34, that empty space should be removed so the first item sits right below the header.

Changed `py-4` → `pb-4` on the nav element. Top padding is now 0 (verified via computed style); bottom padding (16px) is preserved so the last item still has breathing room above the workspace switcher.

## Test plan

- [ ] On the iPhone app, tap the hamburger to open the mobile sidebar — "Jarvis" sits flush with the divider below the AAA logo, no empty navy strip
- [ ] On desktop, the expanded sidebar's first item ("Jarvis") sits directly under the logo's bottom border
- [ ] On desktop, the collapsed sidebar (small width) — first icon still has appropriate spacing (not jammed up against the divider)

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)