### PR TITLE
feat: soft-delete jobs with 30-day trash + permanent purge

### DIFF
--- a/src/app/api/jobs/[id]/delete/route.ts
+++ b/src/app/api/jobs/[id]/delete/route.ts
@@ -1,0 +1,29 @@
+// POST /api/jobs/[id]/delete — soft-delete a job (move to trash).
+// Sets jobs.deleted_at = now(); the row stays in the DB and continues to
+// hide from active queries until either restored or hard-deleted (via
+// /api/jobs/[id] DELETE) or auto-purged after 30 days by GET
+// /api/jobs/trash.
+
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requireJobsDelete } from "@/lib/jobs/auth";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+  const gate = await requireJobsDelete(supabase);
+  if (!gate.ok) return gate.response;
+
+  const { error } = await supabase
+    .from("jobs")
+    .update({ deleted_at: new Date().toISOString() })
+    .eq("id", id)
+    .is("deleted_at", null);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/jobs/[id]/restore/route.ts
+++ b/src/app/api/jobs/[id]/restore/route.ts
@@ -1,0 +1,26 @@
+// POST /api/jobs/[id]/restore — pull a job back out of the trash.
+// Clears jobs.deleted_at. Idempotent: a job that's already active is a
+// no-op.
+
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requireJobsDelete } from "@/lib/jobs/auth";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+  const gate = await requireJobsDelete(supabase);
+  if (!gate.ok) return gate.response;
+
+  const { error } = await supabase
+    .from("jobs")
+    .update({ deleted_at: null })
+    .eq("id", id);
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,31 @@
+// DELETE /api/jobs/[id] — hard-delete (force-purge) a job.
+// Removes every storage object the job owns (photos, job files, photo
+// reports, contracts, expense receipts) then deletes the jobs row, which
+// cascades to all child tables with FK ON DELETE CASCADE. Restricted to
+// admin/office_staff per the same gate as soft-delete.
+
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requireJobsDelete } from "@/lib/jobs/auth";
+import { purgeJobStorage } from "@/lib/jobs/purge";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+  const gate = await requireJobsDelete(supabase);
+  if (!gate.ok) return gate.response;
+
+  const { storageRemoved, storageErrors } = await purgeJobStorage(supabase, id);
+
+  const { error: deleteError } = await supabase.from("jobs").delete().eq("id", id);
+  if (deleteError) {
+    return NextResponse.json(
+      { error: deleteError.message, storageRemoved, storageErrors },
+      { status: 500 },
+    );
+  }
+  return NextResponse.json({ ok: true, storageRemoved, storageErrors });
+}

--- a/src/app/api/jobs/trash/route.ts
+++ b/src/app/api/jobs/trash/route.ts
@@ -1,0 +1,61 @@
+// GET /api/jobs/trash — list jobs currently in the trash, after first
+// auto-purging anything that has been trashed for more than 30 days
+// (lazy purge, per the design decision in #33).
+//
+// Auth: same gate as /api/jobs/[id]/delete — admin or office_staff only.
+// Crew members never see the trash UI, so this endpoint should only be
+// hit by callers that already have the right role; we still enforce it
+// defensively.
+
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requireJobsDelete } from "@/lib/jobs/auth";
+import { purgeJobStorage } from "@/lib/jobs/purge";
+
+const RETENTION_DAYS = 30;
+
+export async function GET() {
+  const supabase = await createServerSupabaseClient();
+  const gate = await requireJobsDelete(supabase);
+  if (!gate.ok) return gate.response;
+
+  // 1. Find anything past the 30-day window in the caller's org.
+  // RLS scopes this to the active organization, so we only see and only
+  // touch rows the caller is allowed to manage.
+  const cutoffIso = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  const { data: expired } = await supabase
+    .from("jobs")
+    .select("id")
+    .not("deleted_at", "is", null)
+    .lt("deleted_at", cutoffIso);
+
+  // 2. For each expired row: clear storage, then hard-delete (cascade
+  // takes the rest). One job at a time so a single failure doesn't strand
+  // the others. Storage errors are logged on the response but do not
+  // block the SQL delete — orphan storage objects are recoverable, but
+  // a half-deleted job row in the trash is not.
+  const purgeFailures: { jobId: string; storageErrors: string[] }[] = [];
+  for (const row of expired ?? []) {
+    const { storageErrors } = await purgeJobStorage(supabase, row.id);
+    if (storageErrors.length > 0) {
+      purgeFailures.push({ jobId: row.id, storageErrors });
+    }
+    await supabase.from("jobs").delete().eq("id", row.id);
+  }
+
+  // 3. List what's left in the trash.
+  const { data: trashed, error } = await supabase
+    .from("jobs")
+    .select("*, contact:contacts!contact_id(*)")
+    .not("deleted_at", "is", null)
+    .order("deleted_at", { ascending: false });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+  return NextResponse.json({
+    jobs: trashed ?? [],
+    autoPurged: expired?.length ?? 0,
+    purgeFailures,
+    retentionDays: RETENTION_DAYS,
+  });
+}

--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
 import { createClient } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
-import { Briefcase, FileText, CalendarDays, Flame } from "lucide-react";
+import { Briefcase, FileText, CalendarDays, Flame, RotateCcw, Trash2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConfig } from "@/lib/config-context";
+import { useAuth } from "@/lib/auth-context";
+import { canDeleteJobs } from "@/lib/jobs/auth";
+import { toast } from "sonner";
+
+const RETENTION_DAYS = 30;
 
 export default function JobsPage() {
   const { statuses } = useConfig();
+  const { profile } = useAuth();
+  const showTrash = canDeleteJobs(profile?.role);
 
   const filterOptions = [
     { value: "all", label: "All" },
@@ -17,16 +25,30 @@ export default function JobsPage() {
     ...statuses
       .filter((s) => !["new", "cancelled"].includes(s.name))
       .map((s) => ({ value: s.name, label: s.display_label })),
+    ...(showTrash ? [{ value: "trash", label: "Trash" }] : []),
   ];
   const [jobs, setJobs] = useState<Job[]>([]);
   const [filter, setFilter] = useState("all");
   const [loading, setLoading] = useState(true);
 
   const fetchJobs = useCallback(async () => {
+    if (filter === "trash") {
+      const res = await fetch("/api/jobs/trash");
+      if (res.ok) {
+        const data = await res.json();
+        setJobs((data.jobs ?? []) as Job[]);
+      } else {
+        setJobs([]);
+      }
+      setLoading(false);
+      return;
+    }
+
     const supabase = createClient();
     let query = supabase
       .from("jobs")
       .select("*, contact:contacts!contact_id(*)")
+      .is("deleted_at", null)
       .order("created_at", { ascending: false });
 
     if (filter === "emergency") {
@@ -44,7 +66,7 @@ export default function JobsPage() {
     fetchJobs();
   }, [fetchJobs]);
 
-  // Compute stats from all jobs (not filtered)
+  // Compute stats from all active (non-trashed) jobs.
   const [stats, setStats] = useState({
     active: 0,
     emergency: 0,
@@ -57,7 +79,8 @@ export default function JobsPage() {
       const supabase = createClient();
       const { data: allJobs } = await supabase
         .from("jobs")
-        .select("status, urgency, created_at");
+        .select("status, urgency, created_at")
+        .is("deleted_at", null);
 
       if (!allJobs) return;
 
@@ -85,12 +108,16 @@ export default function JobsPage() {
     fetchStats();
   }, []);
 
-  // Sort: emergencies first, then by date
-  const sortedJobs = [...jobs].sort((a, b) => {
-    if (a.urgency === "emergency" && b.urgency !== "emergency") return -1;
-    if (b.urgency === "emergency" && a.urgency !== "emergency") return 1;
-    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-  });
+  // Sort: emergencies first, then by date — except in trash, where the
+  // API has already sorted by deletion time (most recent first).
+  const sortedJobs =
+    filter === "trash"
+      ? jobs
+      : [...jobs].sort((a, b) => {
+          if (a.urgency === "emergency" && b.urgency !== "emergency") return -1;
+          if (b.urgency === "emergency" && a.urgency !== "emergency") return 1;
+          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+        });
 
   return (
     <div className="max-w-6xl animate-fade-slide-up">
@@ -157,10 +184,20 @@ export default function JobsPage() {
         <div className="text-center py-12 text-muted-foreground/60">Loading jobs...</div>
       ) : sortedJobs.length === 0 ? (
         <div className="text-center py-12">
-          <p className="text-muted-foreground text-lg">No jobs found</p>
-          <p className="text-muted-foreground/60 text-sm mt-1">
-            Create a new intake to get started.
+          <p className="text-muted-foreground text-lg">
+            {filter === "trash" ? "Trash is empty" : "No jobs found"}
           </p>
+          {filter !== "trash" && (
+            <p className="text-muted-foreground/60 text-sm mt-1">
+              Create a new intake to get started.
+            </p>
+          )}
+        </div>
+      ) : filter === "trash" ? (
+        <div className="space-y-3">
+          {sortedJobs.map((job) => (
+            <TrashRow key={job.id} job={job} onChange={fetchJobs} />
+          ))}
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -169,6 +206,100 @@ export default function JobsPage() {
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+function TrashRow({ job, onChange }: { job: Job; onChange: () => void }) {
+  const [busy, setBusy] = useState<"restore" | "purge" | null>(null);
+
+  // Capture "now" once when the row mounts — the useState initializer can
+  // call Date.now() since it runs before render (lint rule blocks impure
+  // calls from the render body itself). Days remaining is a pure
+  // derivation from that captured timestamp.
+  const [mountedAt] = useState(() => Date.now());
+  const daysRemaining = job.deleted_at
+    ? Math.max(
+        0,
+        RETENTION_DAYS -
+          Math.floor((mountedAt - new Date(job.deleted_at).getTime()) / 86_400_000),
+      )
+    : null;
+
+  async function handleRestore() {
+    setBusy("restore");
+    const res = await fetch(`/api/jobs/${job.id}/restore`, { method: "POST" });
+    setBusy(null);
+    if (!res.ok) {
+      toast.error("Couldn't restore job");
+      return;
+    }
+    toast.success("Job restored");
+    onChange();
+  }
+
+  async function handlePurge() {
+    if (
+      !confirm(
+        "Permanently delete this job and all its photos and files? This cannot be undone.",
+      )
+    ) {
+      return;
+    }
+    setBusy("purge");
+    const res = await fetch(`/api/jobs/${job.id}`, { method: "DELETE" });
+    setBusy(null);
+    if (!res.ok) {
+      toast.error("Couldn't delete job");
+      return;
+    }
+    toast.success("Job permanently deleted");
+    onChange();
+  }
+
+  const customer = job.contact
+    ? `${job.contact.first_name} ${job.contact.last_name}`
+    : "Unknown";
+
+  return (
+    <div className="rounded-xl border border-border bg-card p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <p className="text-xs font-mono text-muted-foreground/60">{job.job_number}</p>
+        <Link
+          href={`/jobs/${job.id}`}
+          className="text-base font-semibold text-foreground hover:underline"
+        >
+          {customer}
+        </Link>
+        <p className="text-sm text-muted-foreground truncate">{job.property_address}</p>
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          {daysRemaining !== null
+            ? daysRemaining === 0
+              ? "Auto-purges today"
+              : `${daysRemaining} day${daysRemaining === 1 ? "" : "s"} until permanent deletion`
+            : null}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          onClick={handleRestore}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
+        >
+          {busy === "restore" ? <Loader2 size={14} className="animate-spin" /> : <RotateCcw size={14} />}
+          Restore
+        </button>
+        <button
+          type="button"
+          onClick={handlePurge}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-destructive/10 border border-destructive/30 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/20 disabled:opacity-50"
+        >
+          {busy === "purge" ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          Delete forever
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,9 +15,13 @@ export default function DashboardPage() {
     async function load() {
       const supabase = createClient();
 
-      // Fetch all jobs + report count for stats
+      // Fetch all active jobs + report count for stats. Trashed jobs
+      // (deleted_at IS NOT NULL) are excluded from the dashboard.
       const [{ data: allJobs }, { count: reportCount }] = await Promise.all([
-        supabase.from("jobs").select("status, urgency, created_at"),
+        supabase
+          .from("jobs")
+          .select("status, urgency, created_at")
+          .is("deleted_at", null),
         supabase.from("photo_reports").select("*", { count: "exact", head: true }),
       ]);
 
@@ -38,10 +42,11 @@ export default function DashboardPage() {
         });
       }
 
-      // Fetch 4 most recent jobs
+      // Fetch 4 most recent active jobs (trashed jobs are hidden).
       const { data: recent } = await supabase
         .from("jobs")
         .select("*, contact:contacts!contact_id(*)")
+        .is("deleted_at", null)
         .order("created_at", { ascending: false })
         .limit(4);
 

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -43,7 +43,10 @@ import {
   Clock,
   Loader2,
   Copy,
+  Trash2,
+  RotateCcw,
 } from "lucide-react";
+import { canDeleteJobs } from "@/lib/jobs/auth";
 import {
   statusColors,
   statusLabels,
@@ -68,7 +71,8 @@ const propertyTypeLabels: Record<string, string> = {
 };
 
 export default function JobDetail({ jobId }: { jobId: string }) {
-  const { hasPermission } = useAuth();
+  const { hasPermission, profile } = useAuth();
+  const showJobDeleteAffordances = canDeleteJobs(profile?.role);
   const [job, setJob] = useState<Job | null>(null);
   const [activities, setActivities] = useState<JobActivity[]>([]);
   const [payments, setPayments] = useState<Payment[]>([]);
@@ -245,6 +249,29 @@ export default function JobDetail({ jobId }: { jobId: string }) {
     }
   }
 
+  async function moveJobToTrash() {
+    if (!confirm("Move this job to the trash? You'll have 30 days to restore it before it's permanently deleted.")) {
+      return;
+    }
+    const res = await fetch(`/api/jobs/${jobId}/delete`, { method: "POST" });
+    if (!res.ok) {
+      toast.error("Couldn't move job to trash.");
+      return;
+    }
+    toast.success("Job moved to trash.");
+    router.push("/jobs");
+  }
+
+  async function restoreJob() {
+    const res = await fetch(`/api/jobs/${jobId}/restore`, { method: "POST" });
+    if (!res.ok) {
+      toast.error("Couldn't restore job.");
+      return;
+    }
+    toast.success("Job restored.");
+    fetchData();
+  }
+
   async function saveCrewLabor(raw: string) {
     const value = raw === "" ? null : Number(raw);
     if (value !== null && (Number.isNaN(value) || value < 0)) {
@@ -293,6 +320,26 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         <ArrowLeft size={16} />
         Back to Jobs
       </Link>
+
+      {/* Trash banner */}
+      {job.deleted_at && (
+        <div className="mb-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3">
+          <div className="text-sm text-foreground">
+            <span className="font-semibold text-destructive">In trash · </span>
+            Moved on {format(new Date(job.deleted_at), "MMM d, yyyy")}. Permanently deleted after 30 days.
+          </div>
+          {showJobDeleteAffordances && (
+            <button
+              type="button"
+              onClick={restoreJob}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-accent shrink-0"
+            >
+              <RotateCcw size={14} />
+              Restore
+            </button>
+          )}
+        </div>
+      )}
 
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4 mb-6">
@@ -367,6 +414,17 @@ export default function JobDetail({ jobId }: { jobId: string }) {
             <option value="completed">Completed</option>
             <option value="cancelled">Cancelled</option>
           </select>
+          {showJobDeleteAffordances && !job.deleted_at && (
+            <button
+              type="button"
+              onClick={moveJobToTrash}
+              aria-label="Move job to trash"
+              title="Move to trash"
+              className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors"
+            >
+              <Trash2 size={16} />
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/lib/jobs/auth.ts
+++ b/src/lib/jobs/auth.ts
@@ -1,0 +1,48 @@
+// Authorization for the soft-delete / restore / force-delete job flows.
+// Per product decision in #33: deleting a job (in any form) is restricted
+// to admins and office_staff — crew members do not see the affordance and
+// cannot reach the API. This is a hard role check, not a permission grant
+// that can be issued to other roles.
+
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+
+const ALLOWED_ROLES = new Set(["admin", "office_staff"]);
+
+export type RequireJobsDeleteResult =
+  | { ok: true; userId: string; role: string }
+  | { ok: false; response: NextResponse };
+
+export async function requireJobsDelete(
+  supabase: SupabaseClient,
+): Promise<RequireJobsDeleteResult> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "not authenticated" }, { status: 401 }),
+    };
+  }
+  const orgId = await getActiveOrganizationId(supabase);
+  const { data: membership } = await supabase
+    .from("user_organizations")
+    .select("role")
+    .eq("user_id", user.id)
+    .eq("organization_id", orgId)
+    .maybeSingle<{ role: string }>();
+  if (!membership || !ALLOWED_ROLES.has(membership.role)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "forbidden" }, { status: 403 }),
+    };
+  }
+  return { ok: true, userId: user.id, role: membership.role };
+}
+
+// Client-side mirror — the same role list, used to gate UI affordances.
+export function canDeleteJobs(role: string | undefined | null): boolean {
+  return !!role && ALLOWED_ROLES.has(role);
+}

--- a/src/lib/jobs/purge.ts
+++ b/src/lib/jobs/purge.ts
@@ -1,0 +1,100 @@
+// Force-delete a job: enumerate every storage object the job owns, remove
+// them from their respective buckets, then DELETE the job row (FK CASCADE
+// takes care of related DB rows). Storage objects must be removed BEFORE
+// the SQL delete, since the related rows hold the paths.
+//
+// Buckets touched (matches src/lib/storage/paths.ts):
+//   photos       — photos.{storage_path,annotated_path,thumbnail_path}
+//   job-files    — job_files.storage_path
+//   reports      — photo_reports.pdf_path
+//   contracts    — contracts.signed_pdf_path
+//   receipts     — expenses.{receipt_path,thumbnail_path}
+//
+// Storage cleanup uses the service-role client because some buckets
+// (job-files, contracts, receipts) are accessible only from server APIs
+// using the service key. RLS-checked actions (verifying the caller can
+// delete this job, the SQL delete itself) run on the cookie-aware client
+// passed in by the route handler.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServiceClient } from "@/lib/supabase-api";
+
+interface PurgeResult {
+  storageRemoved: number;
+  storageErrors: string[];
+}
+
+export async function purgeJobStorage(
+  authedClient: SupabaseClient,
+  jobId: string,
+): Promise<PurgeResult> {
+  const errors: string[] = [];
+  let removed = 0;
+
+  // Read paths via the user's authed client — RLS already constrains this
+  // to rows in the user's org.
+  const [photosRes, filesRes, reportsRes, contractsRes, expensesRes] =
+    await Promise.all([
+      authedClient
+        .from("photos")
+        .select("storage_path, annotated_path, thumbnail_path")
+        .eq("job_id", jobId),
+      authedClient
+        .from("job_files")
+        .select("storage_path")
+        .eq("job_id", jobId),
+      authedClient
+        .from("photo_reports")
+        .select("pdf_path")
+        .eq("job_id", jobId),
+      authedClient
+        .from("contracts")
+        .select("signed_pdf_path")
+        .eq("job_id", jobId),
+      authedClient
+        .from("expenses")
+        .select("receipt_path, thumbnail_path")
+        .eq("job_id", jobId),
+    ]);
+
+  const photoPaths = (photosRes.data ?? []).flatMap((p) =>
+    [p.storage_path, p.annotated_path, p.thumbnail_path].filter(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    ),
+  );
+  const jobFilePaths = (filesRes.data ?? [])
+    .map((f) => f.storage_path)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const reportPaths = (reportsRes.data ?? [])
+    .map((r) => r.pdf_path)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const contractPaths = (contractsRes.data ?? [])
+    .map((c) => c.signed_pdf_path)
+    .filter((v): v is string => typeof v === "string" && v.length > 0);
+  const receiptPaths = (expensesRes.data ?? []).flatMap((e) =>
+    [e.receipt_path, e.thumbnail_path].filter(
+      (v): v is string => typeof v === "string" && v.length > 0,
+    ),
+  );
+
+  const service = createServiceClient();
+  const buckets: { name: string; paths: string[] }[] = [
+    { name: "photos", paths: photoPaths },
+    { name: "job-files", paths: jobFilePaths },
+    { name: "reports", paths: reportPaths },
+    { name: "contracts", paths: contractPaths },
+    { name: "receipts", paths: receiptPaths },
+  ];
+
+  for (const { name, paths } of buckets) {
+    if (paths.length === 0) continue;
+    const { error } = await service.storage.from(name).remove(paths);
+    if (error) {
+      errors.push(`${name}: ${error.message}`);
+    } else {
+      removed += paths.length;
+    }
+  }
+
+  return { storageRemoved: removed, storageErrors: errors };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,7 @@ export interface Job {
   has_pending_contract?: boolean;
   created_at: string;
   updated_at: string;
+  deleted_at?: string | null;
   // Joined fields
   contact?: Contact;
   job_adjusters?: JobAdjuster[];

--- a/supabase/migration-build66-soft-delete-jobs.sql
+++ b/supabase/migration-build66-soft-delete-jobs.sql
@@ -1,0 +1,19 @@
+-- Build 66: Soft-delete + 30-day trash for jobs.
+--
+-- Adds a `deleted_at` timestamp to jobs. NULL = active job; non-NULL = in
+-- trash since that timestamp. Application code filters on this column;
+-- nothing is enforced via RLS so the trash UI can list deleted jobs with
+-- the user's normal session.
+--
+-- Lazy purge (>30 days) and the actual hard-delete are handled in the
+-- API layer (src/app/api/jobs/trash/route.ts and the DELETE handler at
+-- src/app/api/jobs/[id]/route.ts), since they need to delete storage
+-- objects in addition to cascading SQL rows.
+
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+-- Composite index supports both halves of the filter the UI uses:
+--   WHERE organization_id = $1 AND deleted_at IS NULL  -- active list
+--   WHERE organization_id = $1 AND deleted_at IS NOT NULL -- trash list
+CREATE INDEX IF NOT EXISTS idx_jobs_org_deleted_at
+  ON jobs (organization_id, deleted_at);


### PR DESCRIPTION
## Summary

Implements the trash flow for jobs per the product decisions in #33:

- **Soft-delete** moves a job to trash (`jobs.deleted_at = now()`).
- **Restore** clears `deleted_at` so the job reappears in active lists.
- **Force-delete** removes every storage object the job owns (photos, job-files, photo reports, contracts, expense receipts) and then deletes the row — FK `ON DELETE CASCADE` handles every job-related table.
- **Lazy purge**: `GET /api/jobs/trash` first hard-deletes anything trashed >30 days ago, then returns what remains.
- **Permission**: hard role check (`admin` or `office_staff` only). Crew members never see the affordances or hit the API.

## Decisions baked in (matching the chat answers)

| Question | Answer | Where |
|---|---|---|
| Where does the Trash UI live? | (A) Filter pill on `/jobs` | [src/app/jobs/page.tsx](src/app/jobs/page.tsx) |
| Permission gating | Admin or office staff only | [src/lib/jobs/auth.ts](src/lib/jobs/auth.ts) |
| Auto-purge mechanism | (B) Lazy on view | [src/app/api/jobs/trash/route.ts](src/app/api/jobs/trash/route.ts) |
| Photo cleanup location | Inlined Next.js route handler with service-role client | [src/lib/jobs/purge.ts](src/lib/jobs/purge.ts) |
| Cascade scope | All files/photos/related rows; contacts kept | FK CASCADE + storage purge across 5 buckets |
| Activity log | Skipped | n/a |

## Schema

[supabase/migration-build66-soft-delete-jobs.sql](supabase/migration-build66-soft-delete-jobs.sql) adds `jobs.deleted_at timestamptz` and a composite index on `(organization_id, deleted_at)`.

## ⚠️ Deploy order

**Run the migration in Supabase BEFORE merging this PR.** Without the `deleted_at` column, every existing jobs query (the jobs page, the dashboard, anywhere the new `.is("deleted_at", null)` filter is applied) will 500.

```sql
ALTER TABLE jobs ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
CREATE INDEX IF NOT EXISTS idx_jobs_org_deleted_at ON jobs (organization_id, deleted_at);
```

## Files

- New: migration; `src/lib/jobs/{auth,purge}.ts`; four API routes (`/api/jobs/[id]/delete`, `/api/jobs/[id]/restore`, `/api/jobs/[id]` DELETE, `/api/jobs/trash` GET)
- Modified: `src/lib/types.ts` (add `deleted_at`); `src/app/jobs/page.tsx` (filter + Trash pill + restore/purge row); `src/app/page.tsx` (dashboard filters out trashed); `src/components/job-detail.tsx` (trash banner + Move-to-trash button, both gated)

## Test plan

### Schema (run on prod first)
- [ ] Migration applies cleanly: `\d jobs` shows the new column and index

### Permission gating
- [ ] As **crew_member**: no Trash filter pill on `/jobs`; no Trash icon on job detail; `POST /api/jobs/[id]/delete` returns 403
- [ ] As **office_staff**: Trash pill visible; Move-to-trash works; Restore works; Delete-forever works
- [ ] As **admin**: same as office_staff

### Active list behavior
- [ ] Trashed jobs disappear from `/jobs` (default filter "All") and from dashboard stats / recent jobs
- [ ] Active jobs still appear normally
- [ ] Stat-card counts (Active, Emergencies, Pending Invoice, This Month) decrement when a job is trashed

### Trash list
- [ ] After clicking "Trash" pill, only trashed jobs appear, sorted by deletion time (most recent first)
- [ ] Each row shows `N days until permanent deletion` (or "Auto-purges today" at day 30)
- [ ] Restore button moves the job back to the active list and increments stats accordingly
- [ ] Delete-forever asks for confirmation, then removes the row and shows toast
- [ ] Verify in Supabase that the photos/files/contracts/reports/receipts buckets no longer contain the job's objects after Delete-forever
- [ ] Verify cascade: child rows in `job_activities`, `invoices`, `payments`, `expenses`, `contracts`, `photo_reports`, `job_files`, `photos`, `job_adjusters`, `payment_requests`, `job_emails`, `job_custom_fields`, `jarvis_conversations` are all gone after force-delete

### Lazy purge
- [ ] Manually backdate a row's `deleted_at` to >30 days ago in Supabase, then GET `/api/jobs/trash` — the row is purged and the response includes `autoPurged: 1`

### Job detail
- [ ] Active job: Move-to-trash button (gated) sits next to the status select; clicking → confirm → toast → redirect to `/jobs`
- [ ] Trashed job (e.g. via direct URL): banner shows "In trash · Moved on …" with a Restore button (gated)

### Cross-tenant safety
- [ ] As an admin in org A, attempt to call `DELETE /api/jobs/<id-in-org-B>` — should fail (RLS blocks the SELECT/DELETE)

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)