### PR TITLE
feat(contracts): zoom controls in PDF template editor

### DIFF
--- a/src/components/contracts/pdf-canvas.tsx
+++ b/src/components/contracts/pdf-canvas.tsx
@@ -12,6 +12,7 @@ interface Props {
   pdfPages: PdfPage[];
   overlayFields: OverlayField[];
   scale?: number;
+  zoom?: number;
   renderOverlay: (args: {
     page: PdfPage;
     fields: OverlayField[];
@@ -29,6 +30,7 @@ export default function PdfCanvas({
   pdfPages,
   overlayFields,
   scale: maxScale = 1.5,
+  zoom = 1,
   renderOverlay,
   onPageDrop,
 }: Props) {
@@ -55,7 +57,7 @@ export default function PdfCanvas({
     containerWidth > 0
       ? Math.max(0.25, (containerWidth - HORIZONTAL_GUTTER_PX) / maxPageWidthPt)
       : maxScale;
-  const scale = Math.min(maxScale, fitScale);
+  const scale = Math.min(maxScale, fitScale) * zoom;
 
   return (
     <div ref={containerRef} className="flex flex-col items-center gap-6 py-6">

--- a/src/components/contracts/template-pdf-editor.tsx
+++ b/src/components/contracts/template-pdf-editor.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { toast } from "sonner";
+import { Minus, Plus } from "lucide-react";
 import TemplatePdfUploadZone from "./template-pdf-upload-zone";
 import PdfCanvas from "./pdf-canvas";
 import OverlayFieldChip from "./overlay-field-chip";
@@ -10,6 +11,10 @@ import FieldPalette from "./field-palette";
 import FieldInspector from "./field-inspector";
 import { MERGE_FIELDS } from "@/lib/contracts/merge-fields";
 import type { ContractTemplate, OverlayField, OverlayFieldType } from "@/lib/contracts/types";
+
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 0.25;
 
 interface Props {
   initial: ContractTemplate;
@@ -29,6 +34,7 @@ export default function TemplatePdfEditor({ initial }: Props) {
   const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [savingState, setSavingState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [zoom, setZoom] = useState(1);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dirtyRef = useRef(false);
 
@@ -207,19 +213,48 @@ export default function TemplatePdfEditor({ initial }: Props) {
             {savingState === "error" && "Save error"}
             {savingState === "idle" && "—"}
           </span>
-          <a
-            href={`/api/settings/contract-templates/${template.id}/preview`}
-            target="_blank"
-            rel="noopener"
-            className="text-xs text-[var(--brand-primary)] hover:underline"
-          >
-            Preview ↗
-          </a>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                aria-label="Zoom out"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setZoom((z) => Math.max(ZOOM_MIN, +(z - ZOOM_STEP).toFixed(2)));
+                }}
+                disabled={zoom <= ZOOM_MIN}
+                className="rounded border border-border p-1 text-muted-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Minus size={14} />
+              </button>
+              <button
+                type="button"
+                aria-label="Zoom in"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setZoom((z) => Math.min(ZOOM_MAX, +(z + ZOOM_STEP).toFixed(2)));
+                }}
+                disabled={zoom >= ZOOM_MAX}
+                className="rounded border border-border p-1 text-muted-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <Plus size={14} />
+              </button>
+            </div>
+            <a
+              href={`/api/settings/contract-templates/${template.id}/preview`}
+              target="_blank"
+              rel="noopener"
+              className="text-xs text-[var(--brand-primary)] hover:underline"
+            >
+              Preview ↗
+            </a>
+          </div>
         </div>
         <PdfCanvas
           pdfUrl={pdfUrl}
           pdfPages={template.pdf_pages}
           overlayFields={template.overlay_fields}
+          zoom={zoom}
           onPageDrop={onPageDrop}
           renderOverlay={({ page, fields, scale }) => (
             <>


### PR DESCRIPTION
## Summary

- Adds `-` / `+` zoom buttons to the contract template editor toolbar (next to "Preview ↗"), driving a `userZoom` state with range 0.5x–3x, step 0.25x.
- `<PdfCanvas>` accepts an optional `zoom` prop that multiplies the existing fit-to-width scale. Drop math and `<OverlayFieldChip>` already use `scale`, so chip positions stay correct at any zoom level.
- Buttons disable at min/max; clicks `stopPropagation` so they don't trigger the parent's deselect handler.

## Test plan

- [ ] Open `/settings/contract-templates/<id>/edit` for a template with overlay fields placed
- [ ] Click `+` repeatedly — page renders larger, chips remain on the same PDF locations relative to the page
- [ ] Click `-` past the fit-to-width baseline — page renders smaller
- [ ] Drop a new field at zoom != 1 — verify it lands at the cursor position and persists at the right PDF coordinate
- [ ] Confirm `+` disables at 3x and `-` disables at 0.5x

🤖 Generated with [Claude Code](https://claude.com/claude-code)