### PR TITLE
form-builder: id-immutability + usage warnings + delete-block (#69)

### DIFF
--- a/src/app/api/settings/intake-form/restore/route.ts
+++ b/src/app/api/settings/intake-form/restore/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { findBlockedRemovals } from "@/lib/contracts/form-config-removal-guard";
+import type { FormConfig } from "@/lib/types";
 
 // POST /api/settings/intake-form/restore — copy an older version forward as a new row.
 // Never mutates or deletes prior versions.
@@ -30,7 +32,7 @@ export async function POST(request: Request) {
 
   const { data: latest, error: latestErr } = await supabase
     .from("form_config")
-    .select("version")
+    .select("version, config")
     .eq("organization_id", orgId)
     .order("version", { ascending: false })
     .limit(1)
@@ -38,6 +40,24 @@ export async function POST(request: Request) {
 
   if (latestErr) {
     return NextResponse.json({ error: latestErr.message }, { status: 500 });
+  }
+
+  // Restoring an older version effectively removes any fields that exist on
+  // the current latest version but are absent from the target. Block the
+  // restore if any of those removed fields are referenced by contract
+  // templates.
+  const priorConfig: FormConfig | null = latest?.config ?? null;
+  try {
+    const blocked = await findBlockedRemovals(supabase, priorConfig, target.config);
+    if (blocked.length > 0) {
+      return NextResponse.json(
+        { error: "field_referenced_by_templates", blocked },
+        { status: 409 },
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Reference check failed";
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 
   const nextVersion = (latest?.version ?? 0) + 1;

--- a/src/app/api/settings/intake-form/route.ts
+++ b/src/app/api/settings/intake-form/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { findBlockedRemovals } from "@/lib/contracts/form-config-removal-guard";
+import type { FormConfig } from "@/lib/types";
 
 // GET /api/settings/intake-form — fetch latest form config for the active org.
 export async function GET() {
@@ -28,14 +30,33 @@ export async function POST(request: Request) {
   const supabase = await createServerSupabaseClient();
   const orgId = await getActiveOrganizationId(supabase);
 
-  // Get current max version for this org
+  // Get current latest version + config for this org
   const { data: current } = await supabase
     .from("form_config")
-    .select("version")
+    .select("version, config")
     .eq("organization_id", orgId)
     .order("version", { ascending: false })
     .limit(1)
     .maybeSingle();
+
+  const priorConfig: FormConfig | null = current?.config ?? null;
+
+  // Block deletes that would orphan contract-template merge references.
+  try {
+    const blocked = await findBlockedRemovals(supabase, priorConfig, config);
+    if (blocked.length > 0) {
+      return NextResponse.json(
+        {
+          error: "field_referenced_by_templates",
+          blocked,
+        },
+        { status: 409 },
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Reference check failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
 
   const nextVersion = (current?.version ?? 0) + 1;
 

--- a/src/app/api/settings/intake-form/usage/route.ts
+++ b/src/app/api/settings/intake-form/usage/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { findReferencingTemplates } from "@/lib/contracts/template-reference-lookup";
+import type { FormConfig } from "@/lib/types";
+
+// GET /api/settings/intake-form/usage
+// Returns { usage: { [slug]: [{ id, name, is_active }] } } for every slug
+// derived from the active org's latest form_config (slug = merge_field_slug ?? id).
+export async function GET() {
+  const supabase = await createServerSupabaseClient();
+  const orgId = await getActiveOrganizationId(supabase);
+
+  const { data: cfgRow, error: cfgErr } = await supabase
+    .from("form_config")
+    .select("config")
+    .eq("organization_id", orgId)
+    .order("version", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (cfgErr) return NextResponse.json({ error: cfgErr.message }, { status: 500 });
+
+  const config: FormConfig = cfgRow?.config ?? { sections: [] };
+  const slugs = new Set<string>();
+  for (const section of config.sections) {
+    for (const field of section.fields) {
+      slugs.add(field.merge_field_slug ?? field.id);
+    }
+  }
+
+  if (slugs.size === 0) return NextResponse.json({ usage: {} });
+
+  try {
+    const usage = await findReferencingTemplates(supabase, [...slugs]);
+    return NextResponse.json({ usage });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "lookup failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/settings/intake-form/page.tsx
+++ b/src/app/settings/intake-form/page.tsx
@@ -1,19 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Palette } from "@/components/form-builder/palette";
 import { Canvas, type ViewMode } from "@/components/form-builder/canvas";
 import { Inspector } from "@/components/form-builder/inspector";
 import { VersionPill } from "@/components/form-builder/version-pill";
 import { useFormConfig } from "@/components/form-builder/use-form-config";
+import { UsageProvider, useUsageRefetch } from "@/components/form-builder/usage-context";
 import { FIELD_PRESETS } from "@/lib/intake-form-presets";
 import type { FormField } from "@/lib/types";
 
 export default function IntakeFormBuilderPage() {
+  return (
+    <UsageProvider>
+      <IntakeFormBuilderInner />
+    </UsageProvider>
+  );
+}
+
+function IntakeFormBuilderInner() {
   const { config, setConfig, loading, status, saveNow } = useFormConfig();
   const [selectedFieldId, setSelectedFieldId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>("edit");
   const isTesting = viewMode === "test";
+  const refetchUsage = useUsageRefetch();
+  const prevStatusKindRef = useRef(status.kind);
+  useEffect(() => {
+    if (prevStatusKindRef.current === "saving" && status.kind === "idle") {
+      refetchUsage();
+    }
+    prevStatusKindRef.current = status.kind;
+  }, [status.kind, refetchUsage]);
 
   function refresh() {
     window.location.reload();

--- a/src/app/settings/payments/payment-email-template-field.tsx
+++ b/src/app/settings/payments/payment-email-template-field.tsx
@@ -161,6 +161,7 @@ function groupBySection(registry: MergeFieldDefinition[]): SectionGroup[] {
   const order: string[] = [];
   const byName = new Map<string, { name: string; label: string }[]>();
   for (const f of registry) {
+    if (f.hidden) continue;
     if (!byName.has(f.section)) {
       order.push(f.section);
       byName.set(f.section, []);

--- a/src/components/contracts/email-template-field.tsx
+++ b/src/components/contracts/email-template-field.tsx
@@ -153,6 +153,7 @@ function groupBySection(registry: MergeFieldDefinition[]): SectionGroup[] {
   const order: string[] = [];
   const byName = new Map<string, { name: string; label: string }[]>();
   for (const f of registry) {
+    if (f.hidden) continue;
     if (!byName.has(f.section)) {
       order.push(f.section);
       byName.set(f.section, []);

--- a/src/components/contracts/field-inspector.tsx
+++ b/src/components/contracts/field-inspector.tsx
@@ -18,6 +18,7 @@ function groupBySection(
   const sections: string[] = [];
   const map = new Map<string, MergeFieldDefinition[]>();
   for (const def of registry) {
+    if (def.hidden) continue;
     if (!map.has(def.section)) {
       sections.push(def.section);
       map.set(def.section, []);

--- a/src/components/contracts/template-pdf-editor.tsx
+++ b/src/components/contracts/template-pdf-editor.tsx
@@ -160,7 +160,10 @@ export default function TemplatePdfEditor({ initial }: Props) {
       if (type === "label") newField.labelText = "Label";
       // Default merge fields to the first known name so the validator passes on first drop.
       // Authors change it in the inspector.
-      if (type === "merge") newField.mergeFieldName = mergeRegistry[0]?.slug ?? "";
+      if (type === "merge") {
+        newField.mergeFieldName =
+          mergeRegistry.find((r) => !r.hidden)?.slug ?? "";
+      }
       markDirty((prev) => ({ ...prev, overlay_fields: [...prev.overlay_fields, newField] }));
       setSelectedFieldId(id);
     },

--- a/src/components/form-builder/canvas-field.tsx
+++ b/src/components/form-builder/canvas-field.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { GripVertical, Eye, EyeOff, Copy, Trash2, Lock } from "lucide-react";
+import { GripVertical, Eye, EyeOff, Copy, Trash2, Lock, FileText, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { FormField } from "@/lib/types";
+import { useFieldUsage } from "./usage-context";
 
 export function CanvasField({
   field,
@@ -12,6 +14,7 @@ export function CanvasField({
   onSelect,
   onToggleRequired,
   onToggleVisibility,
+  onHide,
   onDuplicate,
   onDelete,
 }: {
@@ -20,9 +23,25 @@ export function CanvasField({
   onSelect: () => void;
   onToggleRequired: () => void;
   onToggleVisibility: () => void;
+  onHide: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
 }) {
+  const slug = field.merge_field_slug ?? field.id;
+  const usage = useFieldUsage(slug);
+  const usageCount = usage.length;
+  const [showUsageList, setShowUsageList] = useState(false);
+  const [showDeleteBlock, setShowDeleteBlock] = useState(false);
+  const isVisible = field.visible !== false;
+
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.stopPropagation();
+    if (usageCount > 0) {
+      setShowDeleteBlock(true);
+      return;
+    }
+    onDelete();
+  }
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: field.id, data: { type: "field", fieldId: field.id } });
 
@@ -58,7 +77,7 @@ export function CanvasField({
         </button>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1.5 mb-1">
+          <div className="flex items-center gap-1.5 mb-1 flex-wrap">
             <label className="text-sm font-medium text-foreground">{field.label}</label>
             <button
               onClick={(e) => {
@@ -76,10 +95,38 @@ export function CanvasField({
               {field.required ? "Required" : "Optional"}
             </button>
             {isDefault && <Lock size={10} className="text-muted-foreground/40" />}
+            {usageCount > 0 && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowUsageList((v) => !v);
+                }}
+                className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-700 dark:text-blue-300 hover:bg-blue-500/20 transition-colors"
+                title={`Used by ${usageCount} contract template${usageCount === 1 ? "" : "s"}`}
+              >
+                <FileText size={10} />
+                Used by {usageCount}
+              </button>
+            )}
           </div>
           <FieldPreview field={field} />
           {field.help_text && (
             <p className="text-[11px] text-muted-foreground mt-1">{field.help_text}</p>
+          )}
+          {showUsageList && usageCount > 0 && (
+            <ul
+              onClick={(e) => e.stopPropagation()}
+              className="mt-2 rounded-md border border-border bg-muted/40 px-2 py-1.5 text-[11px] space-y-0.5"
+            >
+              {usage.map((t) => (
+                <li key={t.id} className="text-foreground">
+                  {t.name}
+                  {!t.is_active && (
+                    <span className="ml-1 text-muted-foreground italic">(inactive)</span>
+                  )}
+                </li>
+              ))}
+            </ul>
           )}
         </div>
 
@@ -106,10 +153,7 @@ export function CanvasField({
           </button>
           {!isDefault && (
             <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete();
-              }}
+              onClick={handleDeleteClick}
               className="p-1.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10"
               aria-label="Delete field"
             >
@@ -118,6 +162,69 @@ export function CanvasField({
           )}
         </div>
       </div>
+
+      {showDeleteBlock && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+          onClick={(e) => {
+            e.stopPropagation();
+            setShowDeleteBlock(false);
+          }}
+        >
+          <div
+            className="bg-card border border-border rounded-xl shadow-xl max-w-md w-full p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-start gap-3 mb-3">
+              <AlertTriangle size={20} className="text-destructive shrink-0 mt-0.5" />
+              <div>
+                <h4 className="text-sm font-semibold text-foreground">
+                  Can&apos;t delete &quot;{field.label}&quot;
+                </h4>
+                <p className="text-xs text-muted-foreground mt-1">
+                  This field is referenced by {usageCount} contract template
+                  {usageCount === 1 ? "" : "s"}. Deleting it would break the
+                  merge field on those templates.
+                </p>
+              </div>
+            </div>
+            <ul className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs space-y-1 max-h-40 overflow-y-auto mb-4">
+              {usage.map((t) => (
+                <li key={t.id} className="text-foreground">
+                  {t.name}
+                  {!t.is_active && (
+                    <span className="ml-1 text-muted-foreground italic">(inactive)</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <p className="text-xs text-muted-foreground mb-3">
+              Either remove this merge field from the templates above first, or
+              hide the field instead. Hidden fields stay in the registry so
+              existing contracts keep resolving.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowDeleteBlock(false)}
+                className="px-3 h-9 rounded-lg text-sm font-medium border border-border text-muted-foreground hover:bg-muted"
+              >
+                Cancel
+              </button>
+              {isVisible && (
+                <button
+                  onClick={() => {
+                    onHide();
+                    setShowDeleteBlock(false);
+                  }}
+                  className="px-3 h-9 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-all"
+                >
+                  Hide instead
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/form-builder/canvas-section.tsx
+++ b/src/components/form-builder/canvas-section.tsx
@@ -150,6 +150,7 @@ export function CanvasSection({
               onToggleVisibility={() =>
                 onUpdateField(field.id, { visible: field.visible === false })
               }
+              onHide={() => onUpdateField(field.id, { visible: false })}
               onDuplicate={() => onDuplicateField(field.id)}
               onDelete={() => onDeleteField(field.id)}
             />

--- a/src/components/form-builder/inspector.tsx
+++ b/src/components/form-builder/inspector.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import { Input } from "@/components/ui/input";
-import { X, Lock } from "lucide-react";
+import { X, Lock, AlertTriangle } from "lucide-react";
 import type { FormField } from "@/lib/types";
+import { useFieldUsage } from "./usage-context";
 
 const FIELD_TYPES: { value: FormField["type"]; label: string }[] = [
   { value: "text", label: "Text" },
@@ -78,6 +79,25 @@ export function Inspector({
   const isDefault = !!field.is_default;
   const hasOptions = field.type === "select" || field.type === "pill";
   const [newOption, setNewOption] = useState("");
+  const slug = field.merge_field_slug ?? field.id;
+  const usage = useFieldUsage(slug);
+  const [pendingMapsTo, setPendingMapsTo] = useState<string | null>(null);
+
+  function handleMapsToChange(rawValue: string) {
+    const newValue = rawValue || "";
+    if ((field.maps_to ?? "") === newValue) return;
+    if (usage.length > 0) {
+      setPendingMapsTo(newValue);
+      return;
+    }
+    onUpdate({ maps_to: newValue || undefined });
+  }
+
+  function confirmMapsTo() {
+    if (pendingMapsTo === null) return;
+    onUpdate({ maps_to: pendingMapsTo || undefined });
+    setPendingMapsTo(null);
+  }
 
   function addOption() {
     if (!newOption.trim()) return;
@@ -133,6 +153,21 @@ export function Inspector({
             value={field.label}
             onChange={(e) => onUpdate({ label: e.target.value })}
             className="h-9"
+          />
+        </div>
+
+        <div>
+          <label
+            className="text-xs font-medium text-muted-foreground mb-1 flex items-center gap-1"
+            title="Field ID is fixed after first save. Renaming would orphan downstream merge-field references on contract templates."
+          >
+            Field ID <Lock size={10} className="text-muted-foreground/60" />
+          </label>
+          <Input
+            value={field.merge_field_slug ?? field.id}
+            readOnly
+            disabled
+            className="h-9 font-mono text-xs cursor-not-allowed opacity-70"
           />
         </div>
 
@@ -258,7 +293,7 @@ export function Inspector({
           <label className="block text-xs font-medium text-muted-foreground mb-1">Maps to</label>
           <select
             value={field.maps_to || ""}
-            onChange={(e) => onUpdate({ maps_to: e.target.value || undefined })}
+            onChange={(e) => handleMapsToChange(e.target.value)}
             className="w-full h-9 rounded-lg border border-border bg-card px-2 text-sm text-foreground"
           >
             <option value="">— Custom field —</option>
@@ -275,6 +310,51 @@ export function Inspector({
           </p>
         </div>
       </div>
+
+      {pendingMapsTo !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div className="bg-card border border-border rounded-xl shadow-xl max-w-md w-full p-5">
+            <div className="flex items-start gap-3 mb-3">
+              <AlertTriangle size={20} className="text-amber-500 shrink-0 mt-0.5" />
+              <div>
+                <h4 className="text-sm font-semibold text-foreground">
+                  Change &quot;Maps to&quot; for a referenced field?
+                </h4>
+                <p className="text-xs text-muted-foreground mt-1">
+                  &quot;{field.label}&quot; is used by {usage.length} contract template
+                  {usage.length === 1 ? "" : "s"}. Re-routing it changes which
+                  column delivers the value when these templates resolve their
+                  merge fields.
+                </p>
+              </div>
+            </div>
+            <ul className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs space-y-1 max-h-40 overflow-y-auto mb-4">
+              {usage.map((t) => (
+                <li key={t.id} className="text-foreground">
+                  {t.name}
+                  {!t.is_active && (
+                    <span className="ml-1 text-muted-foreground italic">(inactive)</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setPendingMapsTo(null)}
+                className="px-3 h-9 rounded-lg text-sm font-medium border border-border text-muted-foreground hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmMapsTo}
+                className="px-3 h-9 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-all"
+              >
+                Change anyway
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/components/form-builder/usage-context.tsx
+++ b/src/components/form-builder/usage-context.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import type { TemplateRef } from "@/lib/contracts/template-reference-lookup";
+
+type UsageMap = Record<string, TemplateRef[]>;
+
+interface UsageContextValue {
+  usage: UsageMap;
+  loading: boolean;
+  refetch: () => Promise<void>;
+}
+
+const UsageContext = createContext<UsageContextValue | null>(null);
+
+export function UsageProvider({ children }: { children: React.ReactNode }) {
+  const [usage, setUsage] = useState<UsageMap>({});
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(async () => {
+    try {
+      const res = await fetch("/api/settings/intake-form/usage");
+      if (!res.ok) {
+        setUsage({});
+        return;
+      }
+      const data = await res.json();
+      setUsage(data.usage ?? {});
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return (
+    <UsageContext.Provider value={{ usage, loading, refetch }}>
+      {children}
+    </UsageContext.Provider>
+  );
+}
+
+export function useFieldUsage(slug: string): TemplateRef[] {
+  const ctx = useContext(UsageContext);
+  if (!ctx) return [];
+  return ctx.usage[slug] ?? [];
+}
+
+export function useUsageRefetch(): () => Promise<void> {
+  const ctx = useContext(UsageContext);
+  return ctx?.refetch ?? (async () => {});
+}

--- a/src/components/form-builder/use-form-config.ts
+++ b/src/components/form-builder/use-form-config.ts
@@ -54,6 +54,21 @@ export function useFormConfig() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ config: next }),
       });
+      if (res.status === 409) {
+        const body = await res.json().catch(() => null);
+        const blocked: { label: string; references: { name: string }[] }[] =
+          body?.blocked ?? [];
+        const names = blocked
+          .flatMap((b) => b.references.map((r) => r.name))
+          .filter((v, i, arr) => arr.indexOf(v) === i);
+        const fieldList = blocked.map((b) => `"${b.label}"`).join(", ");
+        toast.error(
+          `Can't remove ${fieldList || "field"} — referenced by: ${names.join(", ")}. Refreshing.`,
+        );
+        setStatus({ kind: "error", message: "field_referenced_by_templates" });
+        window.location.reload();
+        return;
+      }
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
       lastSavedRef.current = JSON.stringify(next);

--- a/src/lib/contracts/form-config-removal-guard.test.ts
+++ b/src/lib/contracts/form-config-removal-guard.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import type { FormConfig } from "@/lib/types";
+import { diffRemovedFields, fieldSlug } from "./form-config-removal-guard";
+
+function cfg(fields: { id: string; merge_field_slug?: string }[]): FormConfig {
+  return {
+    sections: [
+      {
+        id: "s1",
+        title: "S",
+        visible: true,
+        fields: fields.map((f) => ({
+          id: f.id,
+          type: "text",
+          label: f.id,
+          visible: true,
+          ...(f.merge_field_slug ? { merge_field_slug: f.merge_field_slug } : {}),
+        })),
+      },
+    ],
+  };
+}
+
+describe("diffRemovedFields", () => {
+  it("returns empty when prior is null (first save)", () => {
+    expect(diffRemovedFields(null, cfg([{ id: "a" }]))).toEqual([]);
+  });
+
+  it("returns fields whose ids are not in next config", () => {
+    const prior = cfg([{ id: "a" }, { id: "b" }, { id: "c" }]);
+    const next = cfg([{ id: "a" }, { id: "c" }]);
+    const removed = diffRemovedFields(prior, next);
+    expect(removed.map((f) => f.id)).toEqual(["b"]);
+  });
+
+  it("returns empty when next is a superset (pure additions)", () => {
+    const prior = cfg([{ id: "a" }]);
+    const next = cfg([{ id: "a" }, { id: "b" }]);
+    expect(diffRemovedFields(prior, next)).toEqual([]);
+  });
+
+  it("detects removal across sections", () => {
+    const prior: FormConfig = {
+      sections: [
+        {
+          id: "s1",
+          title: "S1",
+          visible: true,
+          fields: [{ id: "a", type: "text", label: "A", visible: true }],
+        },
+        {
+          id: "s2",
+          title: "S2",
+          visible: true,
+          fields: [{ id: "b", type: "text", label: "B", visible: true }],
+        },
+      ],
+    };
+    const next: FormConfig = {
+      sections: [
+        {
+          id: "s1",
+          title: "S1",
+          visible: true,
+          fields: [{ id: "a", type: "text", label: "A", visible: true }],
+        },
+      ],
+    };
+    expect(diffRemovedFields(prior, next).map((f) => f.id)).toEqual(["b"]);
+  });
+});
+
+describe("fieldSlug", () => {
+  it("returns merge_field_slug when set", () => {
+    expect(
+      fieldSlug({
+        id: "first_name",
+        type: "text",
+        label: "First",
+        merge_field_slug: "customer_first_name",
+      }),
+    ).toBe("customer_first_name");
+  });
+
+  it("falls back to id when merge_field_slug is unset", () => {
+    expect(fieldSlug({ id: "first_name", type: "text", label: "First" })).toBe(
+      "first_name",
+    );
+  });
+});

--- a/src/lib/contracts/form-config-removal-guard.ts
+++ b/src/lib/contracts/form-config-removal-guard.ts
@@ -1,0 +1,62 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { FormConfig, FormField } from "@/lib/types";
+import {
+  findReferencingTemplates,
+  type TemplateRef,
+} from "./template-reference-lookup";
+
+export interface BlockedRemoval {
+  field_id: string;
+  slug: string;
+  label: string;
+  references: TemplateRef[];
+}
+
+export function diffRemovedFields(
+  prior: FormConfig | null,
+  next: FormConfig,
+): FormField[] {
+  if (!prior) return [];
+  const nextIds = new Set<string>();
+  for (const s of next.sections) {
+    for (const f of s.fields) nextIds.add(f.id);
+  }
+  const removed: FormField[] = [];
+  for (const s of prior.sections) {
+    for (const f of s.fields) {
+      if (!nextIds.has(f.id)) removed.push(f);
+    }
+  }
+  return removed;
+}
+
+export function fieldSlug(field: FormField): string {
+  return field.merge_field_slug ?? field.id;
+}
+
+export async function findBlockedRemovals(
+  supabase: SupabaseClient,
+  prior: FormConfig | null,
+  next: FormConfig,
+): Promise<BlockedRemoval[]> {
+  const removed = diffRemovedFields(prior, next);
+  if (removed.length === 0) return [];
+
+  const slugs = [...new Set(removed.map(fieldSlug))];
+  const usage = await findReferencingTemplates(supabase, slugs);
+
+  const blocked: BlockedRemoval[] = [];
+  for (const field of removed) {
+    const slug = fieldSlug(field);
+    const refs = usage[slug] ?? [];
+    if (refs.length > 0) {
+      blocked.push({
+        field_id: field.id,
+        slug,
+        label: field.label,
+        references: refs,
+      });
+    }
+  }
+  return blocked;
+}

--- a/src/lib/contracts/merge-field-registry.test.ts
+++ b/src/lib/contracts/merge-field-registry.test.ts
@@ -146,7 +146,7 @@ describe("buildMergeFieldRegistry", () => {
     });
   });
 
-  it("excludes fields where visible is false", () => {
+  it("keeps fields where visible is false but marks them hidden", () => {
     const formConfig: FormConfig = {
       sections: [
         {
@@ -175,10 +175,13 @@ describe("buildMergeFieldRegistry", () => {
 
     const registry = buildMergeFieldRegistry(formConfig, []);
 
-    expect(registry.map((r) => r.slug)).toEqual(["first_name"]);
+    expect(registry.map((r) => ({ slug: r.slug, hidden: r.hidden ?? false }))).toEqual([
+      { slug: "first_name", hidden: false },
+      { slug: "middle_name", hidden: true },
+    ]);
   });
 
-  it("excludes fields from sections where visible is false", () => {
+  it("marks fields in hidden sections as hidden but keeps them in the registry", () => {
     const formConfig: FormConfig = {
       sections: [
         {
@@ -200,7 +203,15 @@ describe("buildMergeFieldRegistry", () => {
 
     const registry = buildMergeFieldRegistry(formConfig, []);
 
-    expect(registry).toEqual([]);
+    expect(registry).toEqual([
+      {
+        slug: "secret",
+        label: "Secret",
+        section: "Hidden",
+        source: { kind: "maps_to", column: "job.secret" },
+        hidden: true,
+      },
+    ]);
   });
 
   it("carries pill options through with their labels", () => {

--- a/src/lib/contracts/merge-field-registry.ts
+++ b/src/lib/contracts/merge-field-registry.ts
@@ -11,6 +11,11 @@ export interface MergeFieldDefinition {
   section: string;
   source: MergeFieldSource;
   options?: { value: string; label: string }[];
+  // Set when the source form_config field (or its section) is hidden.
+  // Hidden entries stay in the registry so existing contracts referencing
+  // their slug continue to resolve from job_custom_fields. Picker UIs
+  // should filter these out when authoring new templates.
+  hidden?: boolean;
 }
 
 export function buildMergeFieldRegistry(
@@ -19,9 +24,9 @@ export function buildMergeFieldRegistry(
 ): MergeFieldDefinition[] {
   const out: MergeFieldDefinition[] = [];
   for (const section of formConfig.sections) {
-    if (section.visible === false) continue;
+    const sectionHidden = section.visible === false;
     for (const field of section.fields) {
-      if (field.visible === false) continue;
+      const fieldHidden = sectionHidden || field.visible === false;
       const slug = field.merge_field_slug ?? field.id;
       const source: MergeFieldSource = field.maps_to
         ? { kind: "maps_to", column: field.maps_to }
@@ -35,6 +40,7 @@ export function buildMergeFieldRegistry(
       if (field.options) {
         entry.options = field.options.map((o) => ({ value: o.value, label: o.label }));
       }
+      if (fieldHidden) entry.hidden = true;
       out.push(entry);
     }
   }

--- a/src/lib/contracts/template-reference-lookup.test.ts
+++ b/src/lib/contracts/template-reference-lookup.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import type { OverlayField } from "./types";
+import {
+  extractReferencedSlugs,
+  buildReferenceIndex,
+  type TemplateRow,
+} from "./template-reference-lookup";
+
+function mergeField(id: string, slug: string): OverlayField {
+  return {
+    id,
+    type: "merge",
+    page: 1,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 20,
+    fontSize: 11,
+    mergeFieldName: slug,
+  };
+}
+
+function signatureField(id: string): OverlayField {
+  return {
+    id,
+    type: "signature",
+    page: 1,
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 30,
+    fontSize: 11,
+    signerOrder: 1,
+  };
+}
+
+describe("extractReferencedSlugs", () => {
+  it("returns slugs only for merge-type fields", () => {
+    const fields: OverlayField[] = [
+      mergeField("a", "customer_first_name"),
+      signatureField("b"),
+      mergeField("c", "property_address"),
+    ];
+    expect([...extractReferencedSlugs(fields)].sort()).toEqual([
+      "customer_first_name",
+      "property_address",
+    ]);
+  });
+
+  it("dedupes repeated slugs within a single template", () => {
+    const fields: OverlayField[] = [
+      mergeField("a", "customer_first_name"),
+      mergeField("b", "customer_first_name"),
+    ];
+    expect([...extractReferencedSlugs(fields)]).toEqual(["customer_first_name"]);
+  });
+
+  it("ignores merge fields with empty mergeFieldName", () => {
+    const fields: OverlayField[] = [
+      { ...mergeField("a", ""), mergeFieldName: "" },
+    ];
+    expect(extractReferencedSlugs(fields).size).toBe(0);
+  });
+
+  it("returns empty set for empty input", () => {
+    expect(extractReferencedSlugs([]).size).toBe(0);
+  });
+});
+
+describe("buildReferenceIndex", () => {
+  it("maps each requested slug to templates that reference it", () => {
+    const templates: TemplateRow[] = [
+      {
+        id: "t1",
+        name: "Work Authorization",
+        is_active: true,
+        overlay_fields: [mergeField("a", "customer_first_name")],
+      },
+      {
+        id: "t2",
+        name: "Service Agreement",
+        is_active: true,
+        overlay_fields: [
+          mergeField("a", "customer_first_name"),
+          mergeField("b", "property_address"),
+        ],
+      },
+      {
+        id: "t3",
+        name: "Old Template",
+        is_active: false,
+        overlay_fields: [mergeField("a", "claim_number")],
+      },
+    ];
+
+    const idx = buildReferenceIndex(templates, [
+      "customer_first_name",
+      "property_address",
+      "unused_slug",
+    ]);
+
+    expect(idx["customer_first_name"]).toEqual([
+      { id: "t1", name: "Work Authorization", is_active: true },
+      { id: "t2", name: "Service Agreement", is_active: true },
+    ]);
+    expect(idx["property_address"]).toEqual([
+      { id: "t2", name: "Service Agreement", is_active: true },
+    ]);
+    expect(idx["unused_slug"]).toEqual([]);
+  });
+
+  it("returns is_active flag so UI can distinguish inactive templates", () => {
+    const templates: TemplateRow[] = [
+      {
+        id: "t1",
+        name: "Inactive Old",
+        is_active: false,
+        overlay_fields: [mergeField("a", "customer_first_name")],
+      },
+    ];
+    const idx = buildReferenceIndex(templates, ["customer_first_name"]);
+    expect(idx["customer_first_name"]).toEqual([
+      { id: "t1", name: "Inactive Old", is_active: false },
+    ]);
+  });
+
+  it("never lists the same template twice for one slug even when referenced multiple times", () => {
+    const templates: TemplateRow[] = [
+      {
+        id: "t1",
+        name: "Repeat",
+        is_active: true,
+        overlay_fields: [
+          mergeField("a", "customer_first_name"),
+          mergeField("b", "customer_first_name"),
+        ],
+      },
+    ];
+    const idx = buildReferenceIndex(templates, ["customer_first_name"]);
+    expect(idx["customer_first_name"]).toHaveLength(1);
+  });
+
+  it("handles templates with null overlay_fields", () => {
+    const templates: TemplateRow[] = [
+      { id: "t1", name: "Empty", is_active: true, overlay_fields: null },
+    ];
+    const idx = buildReferenceIndex(templates, ["customer_first_name"]);
+    expect(idx["customer_first_name"]).toEqual([]);
+  });
+
+  it("returns empty object when slugs list is empty (no work to do)", () => {
+    const templates: TemplateRow[] = [
+      {
+        id: "t1",
+        name: "Anything",
+        is_active: true,
+        overlay_fields: [mergeField("a", "customer_first_name")],
+      },
+    ];
+    const idx = buildReferenceIndex(templates, []);
+    expect(idx).toEqual({});
+  });
+});

--- a/src/lib/contracts/template-reference-lookup.ts
+++ b/src/lib/contracts/template-reference-lookup.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { OverlayField } from "./types";
+
+export interface TemplateRef {
+  id: string;
+  name: string;
+  is_active: boolean;
+}
+
+export function extractReferencedSlugs(overlayFields: OverlayField[]): Set<string> {
+  const slugs = new Set<string>();
+  for (const f of overlayFields) {
+    if (f.type === "merge" && f.mergeFieldName) {
+      slugs.add(f.mergeFieldName);
+    }
+  }
+  return slugs;
+}
+
+export type TemplateRow = {
+  id: string;
+  name: string;
+  is_active: boolean;
+  overlay_fields: OverlayField[] | null;
+};
+
+export function buildReferenceIndex(
+  templates: TemplateRow[],
+  slugs: string[],
+): Record<string, TemplateRef[]> {
+  const wanted = new Set(slugs);
+  const out: Record<string, TemplateRef[]> = {};
+  for (const slug of slugs) out[slug] = [];
+
+  for (const t of templates) {
+    const fields = t.overlay_fields ?? [];
+    const referenced = extractReferencedSlugs(fields);
+    for (const slug of referenced) {
+      if (!wanted.has(slug)) continue;
+      const list = out[slug];
+      if (list.some((r) => r.id === t.id)) continue;
+      list.push({ id: t.id, name: t.name, is_active: t.is_active });
+    }
+  }
+  return out;
+}
+
+export async function findReferencingTemplates(
+  supabase: SupabaseClient,
+  slugs: string[],
+): Promise<Record<string, TemplateRef[]>> {
+  if (slugs.length === 0) return {};
+
+  const { data, error } = await supabase
+    .from("contract_templates")
+    .select("id, name, is_active, overlay_fields");
+
+  if (error) throw new Error(error.message);
+
+  return buildReferenceIndex((data ?? []) as TemplateRow[], slugs);
+}


### PR DESCRIPTION
## Summary

Slice #69 of [#65](https://github.com/ericdaniels22/Nookleus/issues/65) (contracts builder). Protects existing contract and email templates from silent breakage when an intake form field is renamed, redirected, or deleted.

- **TemplateReferenceLookup module** (\`src/lib/contracts/template-reference-lookup.ts\`): pure \`extractReferencedSlugs(overlay_fields)\` + RLS-scoped \`findReferencingTemplates(supabase, slugs)\` returning \`{ slug: [{ id, name, is_active }] }\`.
- **Server guards** in \`POST /api/settings/intake-form\` and \`/api/settings/intake-form/restore\`: 409 when a removed field's slug is referenced by any contract_template, with a structured \`blocked\` list in the response.
- **New endpoint** \`GET /api/settings/intake-form/usage\`: returns the same map for every slug derived from the active org's latest form_config.
- **Form-builder UI:**
  - Inspector shows the Field ID as a read-only input with a lock-icon tooltip explaining it's fixed after first save.
  - "Used by N" badge on each canvas field row; clicking expands the list of referencing templates (inactive ones marked).
  - \`maps_to\` change on a referenced field triggers a confirm modal listing templates; cancel reverts the select.
  - Delete on a referenced field is blocked client-side with a modal listing templates and a "Hide instead" CTA that flips \`visible:false\`. 409 responses are surfaced as toast + page reload as defense-in-depth against races.
- **\`buildMergeFieldRegistry\` now keeps hidden fields** with \`hidden:true\` so existing contracts continue resolving from \`job_custom_fields\` (AC6 strict reading). Picker consumers — \`field-inspector\`, \`email-template-field\`, \`payment-email-template-field\` — and \`template-pdf-editor\`'s default pick filter on \`r.hidden\` so authors can't pick hidden fields for new fields.

## Files

19 changed, +774 / -19. Three new modules + one new route + one new context + one new test file + edits to 13 existing files.

## Tests

\`npx vitest run\` → 138/138 green (123 baseline + 15 new: 9 for \`template-reference-lookup\`, 6 for \`form-config-removal-guard\`).
\`npx tsc --noEmit\` clean on changed surface; pre-existing \`src/lib/email/sync-folder-incremental.test.ts:246\` error from #64 remains (flagged in earlier handoffs).
\`npm run build\` ✓ Compiled, new route \`/api/settings/intake-form/usage\` registered.

## Test plan (AC1–AC6)

- [ ] AC1 — POST to \`/api/settings/intake-form\` with a payload that omits a prior referenced field's id returns 409 with \`{ error: "field_referenced_by_templates", blocked: [...] }\`
- [ ] AC2 — In the builder inspector, the Field ID input is \`readOnly disabled\` with a tooltip
- [ ] AC3 — Each form_config field row in the canvas shows a "Used by N" badge when N > 0; clicking expands the list of templates
- [ ] AC4 — Changing a referenced field's \`maps_to\` in the inspector shows a confirm modal listing affected templates; cancel reverts, confirm proceeds
- [ ] AC5 — Clicking the trash icon on a referenced field opens a blocking modal with "Cancel" and "Hide instead"; "Hide instead" flips \`visible:false\` (autosave succeeds without warning)
- [ ] AC6 — Hiding a referenced field succeeds; opening the existing contract still resolves the slug from \`job_custom_fields\` (no "unresolved" placeholder)

🤖 Generated with [Claude Code](https://claude.com/claude-code)