### PR TITLE
contracts: permanently delete contract templates (#76)

### DIFF
--- a/src/app/api/settings/contract-templates/[id]/permanent/route.test.ts
+++ b/src/app/api/settings/contract-templates/[id]/permanent/route.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions-api", () => ({
+  requirePermission: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { requirePermission } from "@/lib/permissions-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { makeSupabaseFake } from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function grantPermission() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
+  vi.mocked(requirePermission).mockResolvedValue({ ok: true, userId: "user-1" });
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+}
+
+function denyPermission() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
+  vi.mocked(requirePermission).mockResolvedValue({
+    ok: false,
+    response: NextResponse.json({ error: "forbidden" }, { status: 403 }),
+  });
+}
+
+describe("DELETE /api/settings/contract-templates/[id]/permanent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the caller lacks manage_contract_templates", async () => {
+    denyPermission();
+    const service = makeSupabaseFake();
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(403);
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 404 when the template is not in the active organization", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "other-org", pdf_storage_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(404);
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 409 with the blocker list when a `sent` contract references the template", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: "org-1/templates/tpl-1.pdf" },
+    ]);
+    service.seed("contracts", [
+      { id: "c-sent", template_id: "tpl-1", status: "sent" },
+      { id: "c-draft", template_id: "tpl-1", status: "draft" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("blocked");
+    expect(body.blockers).toEqual([{ contractId: "c-sent", status: "sent" }]);
+    // The advisory check short-circuits before the RPC.
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 409 when a `viewed` contract references the template", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: null },
+    ]);
+    service.seed("contracts", [
+      { id: "c-viewed", template_id: "tpl-1", status: "viewed" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(409);
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("deletes a template with only draft + terminal references: calls the RPC and removes the PDF", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: "org-1/templates/tpl-1.pdf" },
+    ]);
+    service.seed("contracts", [
+      { id: "c-draft", template_id: "tpl-1", status: "draft" },
+      { id: "c-signed", template_id: "tpl-1", status: "signed" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+
+    expect(service.state.rpcCalls).toEqual([
+      {
+        name: "hard_delete_contract_template",
+        args: { p_template_id: "tpl-1", p_org_id: "org-1" },
+      },
+    ]);
+    expect(service.state.storageRemovals).toEqual([
+      { bucket: "contract-pdfs", paths: ["org-1/templates/tpl-1.pdf"] },
+    ]);
+  });
+
+  it("deletes a template with no contracts referencing it", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(200);
+    expect(service.state.rpcCalls).toHaveLength(1);
+    // No pdf_storage_path → no storage removal attempted.
+    expect(service.state.storageRemovals).toHaveLength(0);
+  });
+
+  it("still returns 200 when the best-effort storage cleanup fails", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: "org-1/templates/tpl-1.pdf" },
+    ]);
+    service.setError("storage.contract-pdfs.remove", { message: "object not found" });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(200);
+    expect(service.state.rpcCalls).toHaveLength(1);
+  });
+
+  it("returns 409 when the RPC's authoritative re-check loses a race (template_delete_blocked)", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: null },
+    ]);
+    service.setError("rpc.hard_delete_contract_template", {
+      message: "template_delete_blocked: 1 contract(s) referencing template tpl-1 are still awaiting signature",
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe("blocked");
+  });
+
+  it("returns 500 when the RPC fails for an unrecognized reason", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1", pdf_storage_path: null },
+    ]);
+    service.setError("rpc.hard_delete_contract_template", {
+      message: "deadlock detected",
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/settings/contract-templates/[id]/permanent/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/permanent/route.ts
@@ -1,0 +1,98 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { requirePermission } from "@/lib/permissions-api";
+import { apiDbError } from "@/lib/api-errors";
+import {
+  evaluateTemplateDeletion,
+  type ReferencingContract,
+} from "@/lib/contracts/template-deletion-eligibility";
+
+// DELETE /api/settings/contract-templates/[id]/permanent
+//
+// Permanently removes a contract template and its uploaded PDF (issue #76).
+// Distinct from DELETE /api/settings/contract-templates/[id], which is a soft
+// archive (is_active=false) and still backs the "Archive" action.
+//
+// Gated by `manage_contract_templates` and scoped to the active organization,
+// matching POST / PATCH / duplicate.
+//
+// The advisory eligibility check below feeds a 409 with the blocker list when
+// a customer is mid-signing. The hard_delete_contract_template RPC re-checks
+// the same rule inside its transaction — it is the authoritative gate against
+// a contract that flips to `sent` between the dialog opening and the confirm.
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const authClient = await createServerSupabaseClient();
+  const gate = await requirePermission(authClient, "manage_contract_templates");
+  if (!gate.ok) return gate.response;
+  const orgId = await getActiveOrganizationId(authClient);
+
+  const supabase = createServiceClient();
+
+  const { data: template, error: loadErr } = await supabase
+    .from("contract_templates")
+    .select("id, pdf_storage_path")
+    .eq("id", id)
+    .eq("organization_id", orgId)
+    .maybeSingle<{ id: string; pdf_storage_path: string | null }>();
+  if (loadErr) return apiDbError(loadErr.message, "DELETE template/permanent select");
+  if (!template) {
+    return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  }
+
+  const { data: refs, error: refsErr } = await supabase
+    .from("contracts")
+    .select("id, status")
+    .eq("template_id", id);
+  if (refsErr) {
+    return apiDbError(refsErr.message, "DELETE template/permanent contracts select");
+  }
+
+  const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
+  if (!eligibility.deletable) {
+    return NextResponse.json(
+      {
+        error: "blocked",
+        blockers: eligibility.blockers.map((b) => ({
+          contractId: b.id,
+          status: b.status,
+        })),
+      },
+      { status: 409 },
+    );
+  }
+
+  const { error: rpcErr } = await supabase.rpc("hard_delete_contract_template", {
+    p_template_id: id,
+    p_org_id: orgId,
+  });
+  if (rpcErr) {
+    // The RPC's authoritative re-check lost a race: a contract became
+    // `sent` / `viewed` after our advisory check passed.
+    if (rpcErr.message.includes("template_delete_blocked")) {
+      return NextResponse.json({ error: "blocked", blockers: [] }, { status: 409 });
+    }
+    return apiDbError(rpcErr.message, "DELETE template/permanent rpc");
+  }
+
+  // Best-effort storage cleanup. A failed storage delete must not fail the
+  // request — the template row is already gone and an orphaned file is
+  // harmless (per the #76 PRD).
+  if (template.pdf_storage_path) {
+    const { error: storageErr } = await supabase.storage
+      .from("contract-pdfs")
+      .remove([template.pdf_storage_path]);
+    if (storageErr) {
+      console.warn(
+        `[template-permanent-delete] storage cleanup failed for ${template.pdf_storage_path}: ${storageErr.message}`,
+      );
+    }
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/settings/contract-templates/[id]/usage/route.test.ts
+++ b/src/app/api/settings/contract-templates/[id]/usage/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+vi.mock("@/lib/permissions-api", () => ({
+  requirePermission: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { requirePermission } from "@/lib/permissions-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { makeSupabaseFake } from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function grantPermission() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
+  vi.mocked(requirePermission).mockResolvedValue({ ok: true, userId: "user-1" });
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+}
+
+function denyPermission() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
+  vi.mocked(requirePermission).mockResolvedValue({
+    ok: false,
+    response: NextResponse.json({ error: "forbidden" }, { status: 403 }),
+  });
+}
+
+describe("GET /api/settings/contract-templates/[id]/usage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the caller lacks manage_contract_templates", async () => {
+    denyPermission();
+    const service = makeSupabaseFake();
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await GET(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when the template is not in the active organization", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "other-org" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await GET(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns empty blockers and zero draftCount for an unreferenced template", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await GET(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ blockers: [], draftCount: 0 });
+  });
+
+  it("returns the blocker list and draft count for a mixed set of referencing contracts", async () => {
+    grantPermission();
+    const service = makeSupabaseFake();
+    service.seed("contract_templates", [
+      { id: "tpl-1", organization_id: "org-1" },
+    ]);
+    service.seed("contracts", [
+      { id: "c-sent", template_id: "tpl-1", status: "sent" },
+      { id: "c-viewed", template_id: "tpl-1", status: "viewed" },
+      { id: "c-draft-1", template_id: "tpl-1", status: "draft" },
+      { id: "c-draft-2", template_id: "tpl-1", status: "draft" },
+      { id: "c-signed", template_id: "tpl-1", status: "signed" },
+      { id: "c-other", template_id: "tpl-2", status: "sent" },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await GET(new Request("http://test"), paramsFor("tpl-1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      blockers: [
+        { contractId: "c-sent", status: "sent" },
+        { contractId: "c-viewed", status: "viewed" },
+      ],
+      draftCount: 2,
+    });
+  });
+});

--- a/src/app/api/settings/contract-templates/[id]/usage/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/usage/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { requirePermission } from "@/lib/permissions-api";
+import { apiDbError } from "@/lib/api-errors";
+import {
+  evaluateTemplateDeletion,
+  type ReferencingContract,
+} from "@/lib/contracts/template-deletion-eligibility";
+
+// GET /api/settings/contract-templates/[id]/usage
+//
+// Advisory endpoint for the permanent-delete UI (issue #76). Returns the
+// referencing-contract picture the templates-list dialog needs to choose
+// between the confirm dialog and the block dialog:
+//   * `blockers`   — contracts still awaiting signature (`sent` / `viewed`);
+//                    non-empty means the delete is currently blocked.
+//   * `draftCount` — unsent draft contracts that would cascade-delete.
+//
+// Advisory only: the hard_delete_contract_template RPC remains the source of
+// truth and re-checks at delete time. Gated by `manage_contract_templates`
+// and scoped to the active organization, matching the permanent-delete route.
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const authClient = await createServerSupabaseClient();
+  const gate = await requirePermission(authClient, "manage_contract_templates");
+  if (!gate.ok) return gate.response;
+  const orgId = await getActiveOrganizationId(authClient);
+
+  const supabase = createServiceClient();
+
+  const { data: template, error: loadErr } = await supabase
+    .from("contract_templates")
+    .select("id")
+    .eq("id", id)
+    .eq("organization_id", orgId)
+    .maybeSingle<{ id: string }>();
+  if (loadErr) return apiDbError(loadErr.message, "GET template/usage select");
+  if (!template) {
+    return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  }
+
+  const { data: refs, error: refsErr } = await supabase
+    .from("contracts")
+    .select("id, status")
+    .eq("template_id", id);
+  if (refsErr) {
+    return apiDbError(refsErr.message, "GET template/usage contracts select");
+  }
+
+  const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
+  return NextResponse.json({
+    blockers: eligibility.blockers.map((b) => ({
+      contractId: b.id,
+      status: b.status,
+    })),
+    draftCount: eligibility.draftIds.length,
+  });
+}

--- a/src/app/settings/contract-templates/page.tsx
+++ b/src/app/settings/contract-templates/page.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   Lock,
   MoreHorizontal,
+  Trash2,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useAuth } from "@/lib/auth-context";
@@ -23,6 +24,23 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+// Usage picture from GET …/[id]/usage, used to choose between the block
+// dialog (a customer is mid-signing) and the confirm dialog (#76).
+interface DeleteDialogState {
+  template: ContractTemplateListItem;
+  blockers: { contractId: string; status: string }[];
+  draftCount: number;
+}
 
 export default function ContractTemplatesPage() {
   const { hasPermission, loading: authLoading } = useAuth();
@@ -31,6 +49,8 @@ export default function ContractTemplatesPage() {
 
   const [templates, setTemplates] = useState<ContractTemplateListItem[] | null>(null);
   const [creating, setCreating] = useState(false);
+  const [deleteDialog, setDeleteDialog] = useState<DeleteDialogState | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const refresh = useCallback(async () => {
     const res = await fetch("/api/settings/contract-templates");
@@ -119,6 +139,52 @@ export default function ContractTemplatesPage() {
     if (!res.ok) {
       toast.error("Failed to update");
       refresh();
+    }
+  }
+
+  // Permanent delete (#76). Step one: ask the usage endpoint whether a
+  // customer is mid-signing, then open the block or confirm dialog.
+  async function handleDeletePermanently(t: ContractTemplateListItem) {
+    const res = await fetch(`/api/settings/contract-templates/${t.id}/usage`);
+    if (!res.ok) {
+      toast.error("Failed to check template usage");
+      return;
+    }
+    const usage = (await res.json()) as {
+      blockers: { contractId: string; status: string }[];
+      draftCount: number;
+    };
+    setDeleteDialog({
+      template: t,
+      blockers: usage.blockers,
+      draftCount: usage.draftCount,
+    });
+  }
+
+  // Step two: the user confirmed. The RPC re-checks eligibility, so a 409
+  // here means a contract became mid-signing since the dialog opened.
+  async function confirmDelete() {
+    if (!deleteDialog) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(
+        `/api/settings/contract-templates/${deleteDialog.template.id}/permanent`,
+        { method: "DELETE" },
+      );
+      if (res.ok) {
+        toast.success("Template permanently deleted");
+        setDeleteDialog(null);
+        refresh();
+      } else if (res.status === 409) {
+        toast.error(
+          "Can't delete — a customer is mid-signing a contract from this template",
+        );
+        setDeleteDialog(null);
+      } else {
+        toast.error("Failed to delete template");
+      }
+    } finally {
+      setDeleting(false);
     }
   }
 
@@ -277,6 +343,12 @@ export default function ContractTemplatesPage() {
                             </>
                           )}
                         </DropdownMenuItem>
+                        <DropdownMenuItem
+                          variant="destructive"
+                          onClick={() => handleDeletePermanently(t)}
+                        >
+                          <Trash2 size={14} /> Delete permanently
+                        </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </td>
@@ -286,6 +358,75 @@ export default function ContractTemplatesPage() {
           </table>
         </div>
       )}
+
+      {/* Permanent-delete confirm / block dialog (#76) */}
+      <Dialog
+        open={deleteDialog !== null}
+        onOpenChange={(open) => {
+          if (!open && !deleting) setDeleteDialog(null);
+        }}
+      >
+        <DialogContent>
+          {deleteDialog && deleteDialog.blockers.length > 0 ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Can&apos;t delete this template</DialogTitle>
+                <DialogDescription>
+                  {deleteDialog.blockers.length} contract
+                  {deleteDialog.blockers.length === 1 ? " is" : "s are"} still
+                  awaiting signature from a customer. Once they are signed,
+                  expired, or voided you can permanently delete &ldquo;
+                  {deleteDialog.template.name}&rdquo;.
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setDeleteDialog(null)}>
+                  Close
+                </Button>
+              </DialogFooter>
+            </>
+          ) : deleteDialog ? (
+            <>
+              <DialogHeader>
+                <DialogTitle>Delete template permanently?</DialogTitle>
+                <DialogDescription>
+                  This permanently removes &ldquo;{deleteDialog.template.name}
+                  &rdquo; and its uploaded PDF. This cannot be undone.
+                  {deleteDialog.draftCount > 0 ? (
+                    <>
+                      {" "}
+                      {deleteDialog.draftCount} unsent draft contract
+                      {deleteDialog.draftCount === 1 ? "" : "s"} built from this
+                      template will also be deleted.
+                    </>
+                  ) : null}
+                </DialogDescription>
+              </DialogHeader>
+              <DialogFooter>
+                <Button
+                  variant="outline"
+                  onClick={() => setDeleteDialog(null)}
+                  disabled={deleting}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={confirmDelete}
+                  disabled={deleting}
+                >
+                  {deleting ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Trash2 size={16} />
+                  )}
+                  Delete permanently
+                </Button>
+              </DialogFooter>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/contracts/contract-signer-view.tsx
+++ b/src/components/contracts/contract-signer-view.tsx
@@ -33,6 +33,18 @@ export default function ContractSignerView({ view, signToken, inPerson, onSigned
   // The signer can't toggle these — they render as a locked input.
   const prefilledInputs = view.contract.customer_inputs ?? {};
 
+  // A null template means the source template was hard-deleted (#76). That
+  // only happens for already-`signed` contracts, which the sign page renders
+  // via its SignedShell — this signing component is never reached for them.
+  // The guard keeps the type honest for the degraded view shape.
+  if (!view.template) {
+    return (
+      <div className="p-8 text-muted-foreground">
+        This contract is no longer available for signing.
+      </div>
+    );
+  }
+
   const myFields = view.template.overlay_fields.filter(
     (f) => f.type !== "signature" || f.signerOrder === view.signer.signer_order,
   );

--- a/src/lib/contracts/build-public-signing-view.test.ts
+++ b/src/lib/contracts/build-public-signing-view.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./resolve-merge-values", () => ({
+  resolveMergeValues: vi.fn(async () => ({})),
+}));
+
+import { buildPublicSigningViewForContract } from "./build-public-signing-view";
+import { makeSupabaseFake } from "./__test-utils__/supabase-fake";
+
+// #76 graceful degradation: a `signed` contract is its own stamped PDF and
+// survives the permanent deletion of its source template. The FK ON DELETE
+// SET NULL nulls contracts.template_id; buildPublicSigningView must then
+// build a usable view from the contract's signed_pdf_path instead of
+// erroring with template_not_found.
+
+function seedSigner(service: ReturnType<typeof makeSupabaseFake>, contractId: string) {
+  service.seed("contract_signers", [
+    {
+      id: "signer-1",
+      contract_id: contractId,
+      signer_order: 1,
+      name: "Jane Customer",
+      role_label: "Customer",
+      signed_at: "2026-05-10T00:00:00Z",
+    },
+  ]);
+}
+
+describe("buildPublicSigningViewForContract — deleted-template degradation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds a view backed by signed_pdf_path for a signed contract whose template was deleted", async () => {
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      {
+        id: "c-1",
+        organization_id: "org-1",
+        job_id: "job-1",
+        template_id: null, // FK nulled by the template hard-delete
+        title: "Roof Replacement Agreement",
+        status: "signed",
+        signed_at: "2026-05-10T00:00:00Z",
+        signed_pdf_path: "org-1/contracts/c-1/signed.pdf",
+        filled_content_html: "",
+        customer_inputs: null,
+        link_token: null,
+        link_expires_at: null,
+      },
+    ]);
+    seedSigner(service, "c-1");
+
+    const result = await buildPublicSigningViewForContract(
+      service.client as never,
+      "c-1",
+      "signer-1",
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.view.template).toBeNull();
+    expect(result.view.contract.signed_pdf_path).toBe("org-1/contracts/c-1/signed.pdf");
+    expect(result.view.contract.status).toBe("signed");
+    // The contract template was never consulted — template_id is null.
+    expect(service.state.selectFromCalls).not.toContain("contract_templates");
+  });
+
+  it("still errors with template_not_found for an in-flight contract whose template is missing", async () => {
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      {
+        id: "c-2",
+        organization_id: "org-1",
+        job_id: "job-1",
+        template_id: "tpl-gone",
+        title: "Pending Agreement",
+        status: "viewed",
+        signed_at: null,
+        signed_pdf_path: null,
+        filled_content_html: "",
+        customer_inputs: null,
+        link_token: null,
+        link_expires_at: null,
+      },
+    ]);
+    seedSigner(service, "c-2");
+
+    const result = await buildPublicSigningViewForContract(
+      service.client as never,
+      "c-2",
+      "signer-1",
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toBe("template_not_found");
+  });
+});

--- a/src/lib/contracts/build-public-signing-view.ts
+++ b/src/lib/contracts/build-public-signing-view.ts
@@ -32,7 +32,9 @@ export type BuildViewResult =
 interface LoadedBundle {
   contract: Contract & { link_token: string | null };
   signer: ContractSigner;
-  template: ContractTemplate;
+  // Null when a `signed` contract's source template was permanently deleted
+  // (#76). buildViewFromBundle degrades to the contract's stamped PDF.
+  template: ContractTemplate | null;
   allSigners: { id: string; signer_order: 1 | 2; signed_at: string | null }[];
   companyMap: Map<string, string | null>;
 }
@@ -51,6 +53,22 @@ async function loadCompanyMap(
   );
 }
 
+// Loads a contract's source template, tolerating a null template_id (#76:
+// the FK is nulled when the template is hard-deleted) and a missing row.
+// Returns null in both cases; callers decide whether that is fatal.
+async function loadTemplate(
+  supabase: SupabaseClient,
+  templateId: string | null,
+): Promise<ContractTemplate | null> {
+  if (!templateId) return null;
+  const { data } = await supabase
+    .from("contract_templates")
+    .select("*")
+    .eq("id", templateId)
+    .maybeSingle<ContractTemplate>();
+  return data ?? null;
+}
+
 async function buildViewFromBundle(
   supabase: SupabaseClient,
   bundle: LoadedBundle,
@@ -58,7 +76,7 @@ async function buildViewFromBundle(
   const { contract, signer, template, allSigners, companyMap } = bundle;
 
   let pdfUrl: string | null = null;
-  if (template.pdf_storage_path) {
+  if (template?.pdf_storage_path) {
     const { data: signed } = await supabase.storage
       .from("contract-pdfs")
       .createSignedUrl(template.pdf_storage_path, 600);
@@ -77,19 +95,25 @@ async function buildViewFromBundle(
       link_expires_at: contract.link_expires_at,
       signed_at: contract.signed_at,
       signed_pdf_path: contract.signed_pdf_path,
-      legacy_html: template.pdf_storage_path
-        ? null
-        : (contract.filled_content_html ?? null),
+      // A deleted-template (#76) signed contract serves its stamped
+      // signed_pdf_path, never legacy HTML.
+      legacy_html: template
+        ? template.pdf_storage_path
+          ? null
+          : (contract.filled_content_html ?? null)
+        : null,
       customer_inputs: contract.customer_inputs ?? null,
     },
-    template: {
-      id: template.id,
-      pdf_url: pdfUrl,
-      pdf_pages: template.pdf_pages,
-      overlay_fields: template.overlay_fields,
-      signer_count: template.signer_count,
-      signer_role_label: template.signer_role_label,
-    },
+    template: template
+      ? {
+          id: template.id,
+          pdf_url: pdfUrl,
+          pdf_pages: template.pdf_pages,
+          overlay_fields: template.overlay_fields,
+          signer_count: template.signer_count,
+          signer_role_label: template.signer_role_label,
+        }
+      : null,
     resolved_merge_values: resolved,
     signer: {
       id: signer.id,
@@ -163,12 +187,13 @@ export async function buildPublicSigningViewByToken(
     .maybeSingle<ContractSigner>();
   if (!signer) return { ok: false, error: "signer_not_found" };
 
-  const { data: template } = await supabase
-    .from("contract_templates")
-    .select("*")
-    .eq("id", contract.template_id)
-    .maybeSingle<ContractTemplate>();
-  if (!template) return { ok: false, error: "template_not_found" };
+  const template = await loadTemplate(supabase, contract.template_id);
+  // Graceful degradation (#76): a `signed` contract is its own stamped PDF
+  // and survives its template's deletion. Any other status still needs the
+  // template to render a signable view.
+  if (!template && contract.status !== "signed") {
+    return { ok: false, error: "template_not_found" };
+  }
 
   const { data: allSigners } = await supabase
     .from("contract_signers")
@@ -217,12 +242,11 @@ export async function buildPublicSigningViewForContract(
     .maybeSingle<ContractSigner>();
   if (!signer) return { ok: false, error: "signer_not_found" };
 
-  const { data: template } = await supabase
-    .from("contract_templates")
-    .select("*")
-    .eq("id", contract.template_id)
-    .maybeSingle<ContractTemplate>();
-  if (!template) return { ok: false, error: "template_not_found" };
+  const template = await loadTemplate(supabase, contract.template_id);
+  // Graceful degradation (#76) — see buildPublicSigningViewByToken.
+  if (!template && contract.status !== "signed") {
+    return { ok: false, error: "template_not_found" };
+  }
 
   const { data: allSigners } = await supabase
     .from("contract_signers")

--- a/src/lib/contracts/template-deletion-eligibility.test.ts
+++ b/src/lib/contracts/template-deletion-eligibility.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateTemplateDeletion,
+  type ReferencingContract,
+} from "./template-deletion-eligibility";
+
+function ref(id: string, status: ReferencingContract["status"]): ReferencingContract {
+  return { id, status };
+}
+
+describe("evaluateTemplateDeletion", () => {
+  it("is deletable when no contracts reference the template", () => {
+    const result = evaluateTemplateDeletion([]);
+    expect(result).toEqual({ deletable: true, blockers: [], draftIds: [] });
+  });
+
+  it("blocks deletion when a `sent` contract references the template", () => {
+    const result = evaluateTemplateDeletion([ref("c-1", "sent")]);
+    expect(result.deletable).toBe(false);
+    expect(result.blockers).toEqual([ref("c-1", "sent")]);
+    expect(result.draftIds).toEqual([]);
+  });
+
+  it("blocks deletion when a `viewed` contract references the template", () => {
+    const result = evaluateTemplateDeletion([ref("c-1", "viewed")]);
+    expect(result.deletable).toBe(false);
+    expect(result.blockers).toEqual([ref("c-1", "viewed")]);
+  });
+
+  it("collects `draft` contracts into draftIds without blocking", () => {
+    const result = evaluateTemplateDeletion([
+      ref("d-1", "draft"),
+      ref("d-2", "draft"),
+    ]);
+    expect(result.deletable).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.draftIds).toEqual(["d-1", "d-2"]);
+  });
+
+  it("treats `signed` contracts as deletable-through (retained, not a blocker, not a draft)", () => {
+    const result = evaluateTemplateDeletion([ref("s-1", "signed")]);
+    expect(result).toEqual({ deletable: true, blockers: [], draftIds: [] });
+  });
+
+  it("treats `expired` contracts as deletable-through", () => {
+    const result = evaluateTemplateDeletion([ref("e-1", "expired")]);
+    expect(result).toEqual({ deletable: true, blockers: [], draftIds: [] });
+  });
+
+  it("treats `voided` contracts as deletable-through", () => {
+    const result = evaluateTemplateDeletion([ref("v-1", "voided")]);
+    expect(result).toEqual({ deletable: true, blockers: [], draftIds: [] });
+  });
+
+  it("resolves a mixed set: blockers listed, drafts collected, terminals ignored", () => {
+    const result = evaluateTemplateDeletion([
+      ref("sent-1", "sent"),
+      ref("viewed-1", "viewed"),
+      ref("draft-1", "draft"),
+      ref("draft-2", "draft"),
+      ref("signed-1", "signed"),
+      ref("expired-1", "expired"),
+      ref("voided-1", "voided"),
+    ]);
+    expect(result.deletable).toBe(false);
+    expect(result.blockers).toEqual([
+      ref("sent-1", "sent"),
+      ref("viewed-1", "viewed"),
+    ]);
+    expect(result.draftIds).toEqual(["draft-1", "draft-2"]);
+  });
+
+  it("is deletable when only drafts and terminal contracts reference the template", () => {
+    const result = evaluateTemplateDeletion([
+      ref("draft-1", "draft"),
+      ref("signed-1", "signed"),
+      ref("voided-1", "voided"),
+    ]);
+    expect(result.deletable).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.draftIds).toEqual(["draft-1"]);
+  });
+
+  it("preserves blocker order as given by the caller", () => {
+    const result = evaluateTemplateDeletion([
+      ref("b-2", "viewed"),
+      ref("b-1", "sent"),
+    ]);
+    expect(result.blockers.map((b) => b.id)).toEqual(["b-2", "b-1"]);
+  });
+});

--- a/src/lib/contracts/template-deletion-eligibility.ts
+++ b/src/lib/contracts/template-deletion-eligibility.ts
@@ -1,0 +1,46 @@
+import type { ContractStatus } from "./types";
+
+// The deep module behind issue #76's permanent-delete feature: it is the
+// single place the "may this contract template be hard-deleted?" rule
+// lives. Pure — no DB, no I/O. The usage endpoint feeds it the referencing
+// contracts to drive the confirm/block dialog; the hard_delete RPC encodes
+// the same rule in SQL as the authoritative gate.
+
+export interface ReferencingContract {
+  id: string;
+  status: ContractStatus;
+}
+
+export interface TemplateDeletionEligibility {
+  // false when at least one referencing contract is mid-signing.
+  deletable: boolean;
+  // Contracts that block the delete — `sent` / `viewed` (a customer is
+  // currently mid-signing). Empty when deletable.
+  blockers: ReferencingContract[];
+  // Ids of `draft` referencing contracts. These cascade-delete with the
+  // template; the confirm dialog discloses the count.
+  draftIds: string[];
+}
+
+// A signed contract is already its own stamped PDF, so a *history* of use
+// never protects a template — only work-in-progress does. Deletion is
+// refused in exactly one situation: a referencing contract is `sent` or
+// `viewed` (a customer is mid-signing). `draft` contracts cascade-delete;
+// `signed` / `expired` / `voided` contracts are retained (their template_id
+// is nulled by the FK ON DELETE SET NULL).
+export function evaluateTemplateDeletion(
+  referencingContracts: ReferencingContract[],
+): TemplateDeletionEligibility {
+  const blockers = referencingContracts.filter(
+    (c) => c.status === "sent" || c.status === "viewed",
+  );
+  const draftIds = referencingContracts
+    .filter((c) => c.status === "draft")
+    .map((c) => c.id);
+
+  return {
+    deletable: blockers.length === 0,
+    blockers,
+    draftIds,
+  };
+}

--- a/src/lib/contracts/types.ts
+++ b/src/lib/contracts/types.ts
@@ -101,7 +101,9 @@ export interface Contract {
   id: string;
   organization_id: string;
   job_id: string;
-  template_id: string;
+  // Nullable since #76: hard-deleting a contract template nulls this column
+  // (FK ON DELETE SET NULL) on surviving signed / expired / voided contracts.
+  template_id: string | null;
   template_version: number;
   title: string;
   status: ContractStatus;
@@ -232,6 +234,9 @@ export interface PublicSigningView {
     // can see what will be stamped without being able to change it.
     customer_inputs: Record<string, string | boolean> | null;
   };
+  // Null since #76 when a `signed` contract's source template has been
+  // permanently deleted — the view degrades to the contract's own stamped
+  // signed_pdf_path. Always present for an in-flight (signable) contract.
   template: {
     id: string;
     pdf_url: string | null;          // signed URL of source template PDF
@@ -239,7 +244,7 @@ export interface PublicSigningView {
     overlay_fields: OverlayField[];
     signer_count: 1 | 2;
     signer_role_label: string;
-  };
+  } | null;
   resolved_merge_values: Record<string, string>;
   signer: {
     id: string;

--- a/supabase/migration-build76-hard-delete-template-rpc.sql
+++ b/supabase/migration-build76-hard-delete-template-rpc.sql
@@ -1,0 +1,83 @@
+-- build76 (issue #76): add `hard_delete_contract_template(p_template_id uuid,
+-- p_org_id uuid)` RPC.
+--
+-- Backs the new DELETE /api/settings/contract-templates/[id]/permanent route.
+-- Permanently removes a contract template that an org admin no longer needs.
+--
+-- This RPC is the *authoritative* eligibility gate. The route runs an
+-- advisory pre-check (the GET …/usage endpoint + the pure
+-- `evaluateTemplateDeletion` module) to drive the confirm/block dialog, but
+-- the RPC re-checks at delete time inside the transaction so a contract that
+-- flips to `sent` between the dialog opening and the confirm cannot slip
+-- through.
+--
+-- Eligibility rule (mirror of src/lib/contracts/template-deletion-eligibility.ts):
+--   * `sent` / `viewed` referencing contract  -> BLOCK (RAISE).
+--   * `draft` referencing contract            -> cascade-deleted here.
+--   * `signed` / `expired` / `voided`         -> retained; the FK
+--       contracts_template_id_fkey ON DELETE SET NULL (build76 FK migration)
+--       nulls their template_id when the template row is deleted.
+--
+-- Cascade semantics from build33 / build68a:
+--   contract_signers.contract_id -> ON DELETE CASCADE
+--   contract_events.contract_id  -> ON DELETE CASCADE
+-- so deleting a draft contract removes its signers + events in one statement.
+-- No contract_events are written for the deleted drafts — by definition the
+-- event log goes away with the contract (matches delete_contract / build68a).
+--
+-- The blocked path RAISEs with the recognizable token `template_delete_blocked`
+-- in the message; the route handler matches that token to return HTTP 409
+-- (anything else is a 500). The whole function runs in one transaction, so a
+-- RAISE aborts before any draft is deleted.
+--
+-- p_org_id scopes both the template load and the final delete: a caller can
+-- never delete a template outside its own organization. Referencing contracts
+-- are matched by template_id alone — a contract always shares its template's
+-- organization, so no separate org filter is needed on the contracts side.
+
+CREATE OR REPLACE FUNCTION public.hard_delete_contract_template(
+  p_template_id uuid,
+  p_org_id uuid
+)
+ RETURNS void
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_template_id uuid;
+  v_blockers integer;
+BEGIN
+  SELECT id INTO v_template_id
+    FROM public.contract_templates
+    WHERE id = p_template_id AND organization_id = p_org_id;
+  IF v_template_id IS NULL THEN
+    RAISE EXCEPTION 'hard_delete_contract_template: template % not found in organization %', p_template_id, p_org_id;
+  END IF;
+
+  -- Authoritative re-check: refuse the delete while a customer is mid-signing.
+  SELECT count(*) INTO v_blockers
+    FROM public.contracts
+    WHERE template_id = p_template_id
+      AND status IN ('sent', 'viewed');
+  IF v_blockers > 0 THEN
+    RAISE EXCEPTION 'template_delete_blocked: % contract(s) referencing template % are still awaiting signature', v_blockers, p_template_id;
+  END IF;
+
+  -- Unsent drafts cascade-delete with the template (their signers + events
+  -- go via the build33 ON DELETE CASCADE foreign keys).
+  DELETE FROM public.contracts
+    WHERE template_id = p_template_id
+      AND status = 'draft';
+
+  -- Delete the template row. The FK ON DELETE SET NULL nulls template_id on
+  -- the surviving terminal (signed / expired / voided) contracts.
+  DELETE FROM public.contract_templates
+    WHERE id = p_template_id AND organization_id = p_org_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'hard_delete_contract_template: template % vanished mid-delete', p_template_id;
+  END IF;
+END;
+$function$;
+
+-- ROLLBACK ---
+-- DROP FUNCTION public.hard_delete_contract_template(uuid, uuid);

--- a/supabase/migration-build76-template-id-nullable-fk.sql
+++ b/supabase/migration-build76-template-id-nullable-fk.sql
@@ -1,0 +1,46 @@
+-- build76 (issue #76): make contracts.template_id nullable and change its
+-- foreign key to ON DELETE SET NULL.
+--
+-- Backs the new "Permanently delete contract templates" feature. A signed
+-- contract is already saved as its own stamped PDF (contracts.signed_pdf_path)
+-- and no longer depends on its source template. When an org admin hard-deletes
+-- a template, surviving terminal contracts (signed / expired / voided) must be
+-- retained — they keep their row, their stamped PDF stays downloadable, and a
+-- signed contract's original signing link still serves the document.
+--
+-- The build33 inline definition was:
+--   template_id uuid NOT NULL REFERENCES contract_templates(id)
+-- which auto-named the FK `contracts_template_id_fkey` with NO ACTION on
+-- delete — deleting a referenced template would FK-error. This migration:
+--   * drops NOT NULL so a surviving contract can have a null template_id;
+--   * recreates the FK with ON DELETE SET NULL so the delete nulls the
+--     column on terminal contracts instead of failing.
+--
+-- The hard_delete_contract_template RPC (build76 RPC migration) deletes
+-- `draft` referencing contracts outright and is the authoritative gate that
+-- refuses the delete while a `sent` / `viewed` contract still references the
+-- template. By the time the template row is deleted, the only contracts that
+-- still point at it are terminal, and the FK SET NULL clears their column.
+
+ALTER TABLE public.contracts
+  ALTER COLUMN template_id DROP NOT NULL;
+
+ALTER TABLE public.contracts
+  DROP CONSTRAINT contracts_template_id_fkey;
+
+ALTER TABLE public.contracts
+  ADD CONSTRAINT contracts_template_id_fkey
+    FOREIGN KEY (template_id) REFERENCES public.contract_templates(id)
+    ON DELETE SET NULL;
+
+-- ROLLBACK ---
+-- ALTER TABLE public.contracts
+--   DROP CONSTRAINT contracts_template_id_fkey;
+--
+-- ALTER TABLE public.contracts
+--   ADD CONSTRAINT contracts_template_id_fkey
+--     FOREIGN KEY (template_id) REFERENCES public.contract_templates(id);
+--
+-- -- Only re-add NOT NULL if no contract rows have a null template_id:
+-- ALTER TABLE public.contracts
+--   ALTER COLUMN template_id SET NOT NULL;


### PR DESCRIPTION
## Summary

Adds a **Delete permanently** action to the Contract Templates list (`⋯` menu), hard-removing a template and its uploaded PDF. The existing soft-archive `DELETE` is unchanged and still backs "Archive".

A signed contract is already its own stamped PDF, so a *history* of use never protects a template — only work-in-progress does. Deletion is refused in exactly one case: a customer is mid-signing a contract built from the template (`sent`/`viewed` status).

Behaviour by referencing-contract status:
- **`sent`/`viewed`** — blocks the delete (block dialog lists the count).
- **`draft`** — cascade-deleted with the template (confirm dialog discloses the count).
- **`signed`/`expired`/`voided`** — retained; `template_id` is nulled. A signed contract's original signing link still serves its stamped PDF.

## What's included

- **FK migration** — `contracts.template_id` nullable, `contracts_template_id_fkey` recreated as `ON DELETE SET NULL`.
- **`hard_delete_contract_template` RPC** — authoritative eligibility gate, re-checks at delete time inside the transaction.
- **`template-deletion-eligibility`** — pure deep module holding the rule, built TDD.
- **Routes** — `DELETE …/[id]/permanent` and `GET …/[id]/usage`, both gated by `manage_contract_templates` and org-scoped; best-effort storage cleanup of the template PDF.
- **Signing-view degradation** — `build-public-signing-view.ts` builds a view from `signed_pdf_path` for a signed contract whose template is gone; `Contract.template_id` and `PublicSigningView.template` are now nullable.
- **UI** — confirm/block dialogs, success/error toasts, list refresh.

## Migrations

Both build76 migrations have been applied to AAA prod (`rzzprgidqbnqcdupmpfe`) and verified — `template_id` nullable, FK `ON DELETE SET NULL`, RPC present.

## Testing

25 new tests (eligibility module, both routes, signing-view degradation). Full suite **181/181 green**; typecheck and lint clean.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)