### PR TITLE
Request Context: build the wrapper + convert expenses routes (tracer #79)

### DIFF
--- a/src/app/api/expenses/[id]/receipt-url/route.ts
+++ b/src/app/api/expenses/[id]/receipt-url/route.ts
@@ -1,18 +1,17 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+// Logged-in only (no permission key) — matches the route's prior behavior.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const service = ctx.serviceClient!;
+    const { data: expense } = await service.from("expenses").select("receipt_path").eq("id", id).maybeSingle<{ receipt_path: string | null }>();
+    if (!expense?.receipt_path) return NextResponse.json({ error: "No receipt" }, { status: 404 });
 
-  const { id } = await params;
-  const service = createServiceClient();
-  const { data: expense } = await service.from("expenses").select("receipt_path").eq("id", id).maybeSingle();
-  if (!expense?.receipt_path) return NextResponse.json({ error: "No receipt" }, { status: 404 });
-
-  const { data, error } = await service.storage.from("receipts").createSignedUrl(expense.receipt_path, 600);
-  if (error || !data) return NextResponse.json({ error: error?.message ?? "Failed" }, { status: 500 });
-  return NextResponse.json({ url: data.signedUrl, expiresAt: new Date(Date.now() + 600 * 1000).toISOString() });
-}
+    const { data, error } = await service.storage.from("receipts").createSignedUrl(expense.receipt_path, 600);
+    if (error || !data) return NextResponse.json({ error: error?.message ?? "Failed" }, { status: 500 });
+    return NextResponse.json({ url: data.signedUrl, expiresAt: new Date(Date.now() + 600 * 1000).toISOString() });
+  },
+);

--- a/src/app/api/expenses/[id]/route.test.ts
+++ b/src/app/api/expenses/[id]/route.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function callerIs(role: string, grants: string[] = []) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role, grants }),
+    }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("DELETE /api/expenses/[id] (converted to withRequestContext)", () => {
+  it("returns 403 when a non-admin lacks the log_expenses permission", async () => {
+    callerIs("member", []);
+    const service = fakeServiceClient({});
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("exp-1"));
+
+    expect(res.status).toBe(403);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 404 when the expense is not in the caller's active organization", async () => {
+    callerIs("admin");
+    const service = fakeServiceClient({
+      tables: {
+        expenses: [
+          { id: "exp-1", organization_id: "other-org", submitted_by: "user-1" },
+        ],
+      },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("exp-1"));
+
+    expect(res.status).toBe(404);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 403 when a non-admin tries to delete an expense they did not submit", async () => {
+    callerIs("member", ["log_expenses"]);
+    const service = fakeServiceClient({
+      tables: {
+        expenses: [
+          {
+            id: "exp-1",
+            organization_id: "org-1",
+            submitted_by: "someone-else",
+            receipt_path: null,
+            thumbnail_path: null,
+            activity_id: null,
+          },
+        ],
+      },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("exp-1"));
+
+    expect(res.status).toBe(403);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("deletes an expense the caller submitted and cleans up its storage objects", async () => {
+    callerIs("member", ["log_expenses"]);
+    const service = fakeServiceClient({
+      tables: {
+        expenses: [
+          {
+            id: "exp-1",
+            organization_id: "org-1",
+            submitted_by: "user-1",
+            receipt_path: "org-1/receipts/exp-1.jpg",
+            thumbnail_path: "org-1/thumbs/exp-1.jpg",
+            activity_id: "act-1",
+          },
+        ],
+      },
+      rpcResults: {
+        delete_expense_cascade: {
+          data: {
+            receipt_path: "org-1/receipts/exp-1.jpg",
+            thumbnail_path: "org-1/thumbs/exp-1.jpg",
+          },
+        },
+      },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("exp-1"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    expect(service.rpcCalls).toEqual([
+      { name: "delete_expense_cascade", args: { p_expense_id: "exp-1" } },
+    ]);
+    expect(service.storageRemovals).toEqual([
+      {
+        bucket: "receipts",
+        paths: ["org-1/receipts/exp-1.jpg", "org-1/thumbs/exp-1.jpg"],
+      },
+    ]);
+  });
+
+  it("lets an admin delete an expense submitted by another user", async () => {
+    callerIs("admin");
+    const service = fakeServiceClient({
+      tables: {
+        expenses: [
+          {
+            id: "exp-1",
+            organization_id: "org-1",
+            submitted_by: "someone-else",
+            receipt_path: null,
+            thumbnail_path: null,
+            activity_id: null,
+          },
+        ],
+      },
+      rpcResults: { delete_expense_cascade: { data: {} } },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(new Request("http://test"), paramsFor("exp-1"));
+
+    expect(res.status).toBe(200);
+    expect(service.rpcCalls).toHaveLength(1);
+  });
+});

--- a/src/app/api/expenses/[id]/route.ts
+++ b/src/app/api/expenses/[id]/route.ts
@@ -1,93 +1,97 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  withRequestContext,
+  type RequestContext,
+} from "@/lib/request-context/with-request-context";
 
-async function getCallerAndExpense(id: string) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { ok: false as const, status: 401, error: "Not authenticated" };
-
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data: membership } = await supabase
-    .from("user_organizations")
-    .select("id, role")
-    .eq("user_id", user.id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string; role: string }>();
-
-  const service = createServiceClient();
-  const { data: expense } = await service.from("expenses")
+// Editing or deleting an expense needs the `log_expenses` permission
+// (admins auto-pass) — enforced by the wrapper. Beyond that, a non-admin
+// may only touch their *own* expense; that ownership rule is route-specific
+// business logic and stays here. The expense row is loaded with the Service
+// client and scoped to the Active Organization.
+async function loadExpenseForCaller(ctx: RequestContext, id: string) {
+  const service = ctx.serviceClient!;
+  const { data: expense } = await service
+    .from("expenses")
     .select("id, submitted_by, receipt_path, thumbnail_path, activity_id")
     .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (!expense) return { ok: false as const, status: 404, error: "Expense not found" };
-
-  const isAdmin = membership?.role === "admin";
-  const isSubmitter = expense.submitted_by === user.id;
-  if (!isAdmin && !isSubmitter) return { ok: false as const, status: 403, error: "Permission denied" };
-
-  // Also require log_expenses (defence in depth — submitters were granted this by role, but double check).
-  if (!isAdmin) {
-    const { data: perm } = await supabase
-      .from("user_organization_permissions")
-      .select("granted")
-      .eq("user_organization_id", membership?.id ?? "")
-      .eq("permission_key", "log_expenses")
-      .maybeSingle();
-    if (!perm?.granted) return { ok: false as const, status: 403, error: "Permission denied" };
+    .eq("organization_id", ctx.orgId)
+    .maybeSingle<{
+      id: string;
+      submitted_by: string;
+      receipt_path: string | null;
+      thumbnail_path: string | null;
+      activity_id: string | null;
+    }>();
+  if (!expense) {
+    return { ok: false as const, status: 404, error: "Expense not found" };
   }
 
-  return { ok: true as const, user, expense, service };
-}
-
-export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const caller = await getCallerAndExpense(id);
-  if (!caller.ok) return NextResponse.json({ error: caller.error }, { status: caller.status });
-
-  const body = await request.json();
-  const { error } = await caller.service.rpc("update_expense", {
-    p_expense_id: id,
-    p_vendor_id: body.vendor_id,
-    p_vendor_name: body.vendor_name,
-    p_category_id: body.category_id,
-    p_amount: body.amount,
-    p_expense_date: body.expense_date,
-    p_payment_method: body.payment_method,
-    p_description: body.description,
-    p_receipt_path: body.receipt_path,
-    p_thumbnail_path: body.thumbnail_path,
-  });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  // If the photo was replaced, delete the old objects (caller provides the previous paths as query params).
-  const { searchParams } = new URL(request.url);
-  const oldReceipt = searchParams.get("old_receipt");
-  const oldThumb = searchParams.get("old_thumb");
-  const toRemove = [oldReceipt, oldThumb].filter((p): p is string => Boolean(p)
-    && p !== body.receipt_path && p !== body.thumbnail_path);
-  if (toRemove.length) await caller.service.storage.from("receipts").remove(toRemove);
-
-  return NextResponse.json({ success: true });
-}
-
-export async function DELETE(_request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const caller = await getCallerAndExpense(id);
-  if (!caller.ok) return NextResponse.json({ error: caller.error }, { status: caller.status });
-
-  const { data, error } = await caller.service.rpc("delete_expense_cascade", { p_expense_id: id });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  // Storage cleanup — best effort; orphans are acceptable per spec.
-  const row = Array.isArray(data) ? data[0] : data;
-  const paths = [row?.receipt_path, row?.thumbnail_path].filter((p): p is string => Boolean(p));
-  if (paths.length) {
-    const { error: rmErr } = await caller.service.storage.from("receipts").remove(paths);
-    if (rmErr) console.warn("receipts cleanup failed after expense delete", { id, paths, rmErr });
+  const isAdmin = ctx.role === "admin";
+  const isSubmitter = expense.submitted_by === ctx.userId;
+  if (!isAdmin && !isSubmitter) {
+    return { ok: false as const, status: 403, error: "Permission denied" };
   }
 
-  return NextResponse.json({ success: true });
+  return { ok: true as const, expense, service };
 }
+
+export const PATCH = withRequestContext(
+  { permission: "log_expenses", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const caller = await loadExpenseForCaller(ctx, id);
+    if (!caller.ok) {
+      return NextResponse.json({ error: caller.error }, { status: caller.status });
+    }
+
+    const body = await request.json();
+    const { error } = await caller.service.rpc("update_expense", {
+      p_expense_id: id,
+      p_vendor_id: body.vendor_id,
+      p_vendor_name: body.vendor_name,
+      p_category_id: body.category_id,
+      p_amount: body.amount,
+      p_expense_date: body.expense_date,
+      p_payment_method: body.payment_method,
+      p_description: body.description,
+      p_receipt_path: body.receipt_path,
+      p_thumbnail_path: body.thumbnail_path,
+    });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    // If the photo was replaced, delete the old objects (caller provides the previous paths as query params).
+    const { searchParams } = new URL(request.url);
+    const oldReceipt = searchParams.get("old_receipt");
+    const oldThumb = searchParams.get("old_thumb");
+    const toRemove = [oldReceipt, oldThumb].filter((p): p is string => Boolean(p)
+      && p !== body.receipt_path && p !== body.thumbnail_path);
+    if (toRemove.length) await caller.service.storage.from("receipts").remove(toRemove);
+
+    return NextResponse.json({ success: true });
+  },
+);
+
+export const DELETE = withRequestContext(
+  { permission: "log_expenses", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const caller = await loadExpenseForCaller(ctx, id);
+    if (!caller.ok) {
+      return NextResponse.json({ error: caller.error }, { status: caller.status });
+    }
+
+    const { data, error } = await caller.service.rpc("delete_expense_cascade", { p_expense_id: id });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    // Storage cleanup — best effort; orphans are acceptable per spec.
+    const row = Array.isArray(data) ? data[0] : data;
+    const paths = [row?.receipt_path, row?.thumbnail_path].filter((p): p is string => Boolean(p));
+    if (paths.length) {
+      const { error: rmErr } = await caller.service.storage.from("receipts").remove(paths);
+      if (rmErr) console.warn("receipts cleanup failed after expense delete", { id, paths, rmErr });
+    }
+
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/expenses/[id]/thumbnail-url/route.ts
+++ b/src/app/api/expenses/[id]/thumbnail-url/route.ts
@@ -1,18 +1,17 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+// Logged-in only (no permission key) — matches the route's prior behavior.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const service = ctx.serviceClient!;
+    const { data: expense } = await service.from("expenses").select("thumbnail_path").eq("id", id).maybeSingle<{ thumbnail_path: string | null }>();
+    if (!expense?.thumbnail_path) return NextResponse.json({ error: "No thumbnail" }, { status: 404 });
 
-  const { id } = await params;
-  const service = createServiceClient();
-  const { data: expense } = await service.from("expenses").select("thumbnail_path").eq("id", id).maybeSingle();
-  if (!expense?.thumbnail_path) return NextResponse.json({ error: "No thumbnail" }, { status: 404 });
-
-  const { data, error } = await service.storage.from("receipts").createSignedUrl(expense.thumbnail_path, 600);
-  if (error || !data) return NextResponse.json({ error: error?.message ?? "Failed" }, { status: 500 });
-  return NextResponse.json({ url: data.signedUrl, expiresAt: new Date(Date.now() + 600 * 1000).toISOString() });
-}
+    const { data, error } = await service.storage.from("receipts").createSignedUrl(expense.thumbnail_path, 600);
+    if (error || !data) return NextResponse.json({ error: error?.message ?? "Failed" }, { status: 500 });
+    return NextResponse.json({ url: data.signedUrl, expiresAt: new Date(Date.now() + 600 * 1000).toISOString() });
+  },
+);

--- a/src/app/api/expenses/__test-utils__/request-context-fakes.ts
+++ b/src/app/api/expenses/__test-utils__/request-context-fakes.ts
@@ -1,0 +1,146 @@
+// Supabase fakes for the converted `expenses` route tests. The routes now
+// run through `withRequestContext`, so a route test exercises two clients:
+//
+//   * the User client — what the wrapper authenticates against and what
+//     the POST route reads `user_profiles` from;
+//   * the Service client — what the route bodies read/write expenses with.
+//
+// Both are table-row fakes covering only the query surface these routes
+// actually use: select / eq / order / maybeSingle / awaited-list, plus rpc
+// and storage on the Service client.
+
+type Row = Record<string, unknown>;
+
+export interface SelectBuilder {
+  select(cols?: string): SelectBuilder;
+  eq(col: string, val: unknown): SelectBuilder;
+  order(col: string, opts?: unknown): SelectBuilder;
+  maybeSingle<T = Row>(): Promise<{ data: T | null; error: null }>;
+  then(resolve: (v: { data: Row[]; error: null }) => unknown): unknown;
+}
+
+function selectBuilder(rows: Row[]): SelectBuilder {
+  let filtered = [...rows];
+  const builder: SelectBuilder = {
+    select() {
+      return builder;
+    },
+    eq(col, val) {
+      filtered = filtered.filter((r) => r[col] === val);
+      return builder;
+    },
+    order() {
+      return builder;
+    },
+    async maybeSingle<T = Row>() {
+      return { data: (filtered[0] ?? null) as T | null, error: null };
+    },
+    then(resolve) {
+      return resolve({ data: filtered, error: null });
+    },
+  };
+  return builder;
+}
+
+// A fake User client. `tables` seeds whatever the wrapper or route reads:
+// `user_organizations` (membership), `user_organization_permissions`
+// (grants), and `user_profiles` for the POST route.
+export function fakeUserClient(opts: {
+  user: { id: string } | null;
+  tables?: Record<string, Row[]>;
+}) {
+  const tables = opts.tables ?? {};
+  return {
+    auth: {
+      async getUser() {
+        return { data: { user: opts.user }, error: null };
+      },
+    },
+    from(table: string) {
+      return selectBuilder(tables[table] ?? []);
+    },
+  };
+}
+
+// Convenience: build the `tables` map for a caller who is a member of the
+// active organization with a given role and set of granted permissions.
+export function memberTables(opts: {
+  userId: string;
+  membershipId?: string;
+  orgId?: string;
+  role: string;
+  grants?: string[];
+  profile?: { full_name: string } | null;
+}): Record<string, Row[]> {
+  const membershipId = opts.membershipId ?? "m-1";
+  const orgId = opts.orgId ?? "org-1";
+  const tables: Record<string, Row[]> = {
+    user_organizations: [
+      {
+        id: membershipId,
+        role: opts.role,
+        user_id: opts.userId,
+        organization_id: orgId,
+      },
+    ],
+    user_organization_permissions: (opts.grants ?? []).map((permission_key) => ({
+      user_organization_id: membershipId,
+      permission_key,
+      granted: true,
+    })),
+  };
+  if (opts.profile !== undefined) {
+    tables.user_profiles =
+      opts.profile === null ? [] : [{ id: opts.userId, ...opts.profile }];
+  }
+  return tables;
+}
+
+interface RpcResult {
+  data?: unknown;
+  error?: { message: string } | null;
+}
+
+export interface ServiceFake {
+  client: unknown;
+  rpcCalls: { name: string; args: unknown }[];
+  storageRemovals: { bucket: string; paths: string[] }[];
+}
+
+// A fake Service client: table reads, rpc (recorded), and storage
+// remove / createSignedUrl.
+export function fakeServiceClient(opts: {
+  tables?: Record<string, Row[]>;
+  rpcResults?: Record<string, RpcResult>;
+}): ServiceFake {
+  const tables = opts.tables ?? {};
+  const rpcCalls: { name: string; args: unknown }[] = [];
+  const storageRemovals: { bucket: string; paths: string[] }[] = [];
+  const client = {
+    from(table: string) {
+      return selectBuilder(tables[table] ?? []);
+    },
+    async rpc(name: string, args: unknown) {
+      rpcCalls.push({ name, args });
+      const result = opts.rpcResults?.[name];
+      return { data: result?.data ?? null, error: result?.error ?? null };
+    },
+    storage: {
+      from(bucket: string) {
+        return {
+          async remove(paths: string[]) {
+            storageRemovals.push({ bucket, paths });
+            return { data: paths.map((name) => ({ name })), error: null };
+          },
+          async createSignedUrl(path: string) {
+            return {
+              data: { signedUrl: `https://signed.test/${path}` },
+              error: null,
+            };
+          },
+        };
+      },
+    },
+  };
+  return { client, rpcCalls, storageRemovals };
+}

--- a/src/app/api/expenses/by-activity/[activityId]/route.ts
+++ b/src/app/api/expenses/by-activity/[activityId]/route.ts
@@ -1,23 +1,21 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function GET(_request: Request, { params }: { params: Promise<{ activityId: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-
-  const { activityId } = await params;
-  const service = createServiceClient();
-  const { data, error } = await service.from("expenses")
-    .select(`
-      *,
-      vendor:vendors!vendor_id(id, name, vendor_type),
-      category:expense_categories!category_id(id, name, display_label, bg_color, text_color, icon)
-    `)
-    .eq("activity_id", activityId)
-    .maybeSingle();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(data);
-}
+// Logged-in only (no permission key) — matches the route's prior behavior.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ activityId: string }> }) => {
+    const { activityId } = await params;
+    const { data, error } = await ctx.serviceClient!.from("expenses")
+      .select(`
+        *,
+        vendor:vendors!vendor_id(id, name, vendor_type),
+        category:expense_categories!category_id(id, name, display_label, bg_color, text_color, icon)
+      `)
+      .eq("activity_id", activityId)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/expenses/by-job/[jobId]/route.test.ts
+++ b/src/app/api/expenses/by-job/[jobId]/route.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function paramsFor(jobId: string) {
+  return { params: Promise.resolve({ jobId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/expenses/by-job/[jobId] (converted to withRequestContext)", () => {
+  it("returns 401 when unauthenticated — no permission required, but logged-in is", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({}).client as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the job's expenses for any logged-in caller, even one with no permission grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: {
+          expenses: [
+            { id: "exp-1", job_id: "job-1" },
+            { id: "exp-2", job_id: "job-1" },
+            { id: "exp-3", job_id: "job-2" },
+          ],
+        },
+      }).client as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.map((e: { id: string }) => e.id)).toEqual(["exp-1", "exp-2"]);
+  });
+});

--- a/src/app/api/expenses/by-job/[jobId]/route.ts
+++ b/src/app/api/expenses/by-job/[jobId]/route.ts
@@ -1,23 +1,24 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function GET(_request: Request, { params }: { params: Promise<{ jobId: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-
-  const { jobId } = await params;
-  const service = createServiceClient();
-  const { data, error } = await service.from("expenses")
-    .select(`
-      *,
-      vendor:vendors!vendor_id(id, name, vendor_type),
-      category:expense_categories!category_id(id, name, display_label, bg_color, text_color, icon)
-    `)
-    .eq("job_id", jobId)
-    .order("expense_date", { ascending: false })
-    .order("created_at", { ascending: false });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+// Logged-in only (no permission key) — matches the route's prior behavior.
+// Reads expenses with the Service client; org-scoping of this query is a
+// known pre-existing gap, tracked for the #86 ungated-endpoint follow-up
+// and intentionally not changed by this conversion.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ jobId: string }> }) => {
+    const { jobId } = await params;
+    const { data, error } = await ctx.serviceClient!.from("expenses")
+      .select(`
+        *,
+        vendor:vendors!vendor_id(id, name, vendor_type),
+        category:expense_categories!category_id(id, name, display_label, bg_color, text_color, icon)
+      `)
+      .eq("job_id", jobId)
+      .order("expense_date", { ascending: false })
+      .order("created_at", { ascending: false });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/expenses/route.test.ts
+++ b/src/app/api/expenses/route.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+  type ServiceFake,
+} from "./__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+const validBody = {
+  job_id: "job-1",
+  vendor_id: null,
+  vendor_name: "Acme Supply",
+  category_id: "cat-1",
+  amount: 125.5,
+  expense_date: "2026-05-16",
+  payment_method: "business_card",
+  description: null,
+  receipt_path: null,
+  thumbnail_path: null,
+};
+
+function postRequest(body: unknown) {
+  return new Request("http://test/api/expenses", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+function useServiceFake(rpcResults?: Record<string, { data?: unknown }>): ServiceFake {
+  const service = fakeServiceClient({ rpcResults });
+  vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+  return service;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/expenses (converted to withRequestContext)", () => {
+  it("returns 401 and never reaches the create RPC when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const service = useServiceFake();
+
+    const res = await POST(postRequest(validBody), noParams);
+
+    expect(res.status).toBe(401);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 403 when a non-admin lacks the log_expenses permission", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    const service = useServiceFake();
+
+    const res = await POST(postRequest(validBody), noParams);
+
+    expect(res.status).toBe(403);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 403 'Profile not found' when the caller has no user_profiles row", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", profile: null }),
+      }) as never,
+    );
+    const service = useServiceFake();
+
+    const res = await POST(postRequest(validBody), noParams);
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Profile not found" });
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "admin",
+          profile: { full_name: "Dana Lee" },
+        }),
+      }) as never,
+    );
+    const service = useServiceFake();
+
+    const res = await POST(postRequest({ ...validBody, job_id: "" }), noParams);
+
+    expect(res.status).toBe(400);
+    expect(service.rpcCalls).toHaveLength(0);
+  });
+
+  it("creates the expense, passing the caller's id and full_name to the RPC", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["log_expenses"],
+          profile: { full_name: "Dana Lee" },
+        }),
+      }) as never,
+    );
+    const service = useServiceFake({
+      create_expense_with_activity: { data: "expense-9" },
+    });
+
+    const res = await POST(postRequest(validBody), noParams);
+
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({ id: "expense-9" });
+    expect(service.rpcCalls).toHaveLength(1);
+    expect(service.rpcCalls[0].name).toBe("create_expense_with_activity");
+    expect(service.rpcCalls[0].args).toMatchObject({
+      p_submitted_by: "user-1",
+      p_submitter_name: "Dana Lee",
+      p_job_id: "job-1",
+    });
+  });
+});

--- a/src/app/api/expenses/route.ts
+++ b/src/app/api/expenses/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 interface CreatePayload {
   job_id: string;
@@ -16,68 +14,52 @@ interface CreatePayload {
   thumbnail_path: string | null;
 }
 
-async function requireLogExpenses() {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { ok: false as const, response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
+// Logging an expense needs the `log_expenses` permission (admins auto-pass)
+// and the Service client to call the create RPC. The Request Context does
+// not carry the user's `full_name` — no other endpoint needs it — so this
+// route keeps its own small `user_profiles` lookup, preserving the
+// "Profile not found" 403 the inline gate used to return.
+export const POST = withRequestContext(
+  { permission: "log_expenses", serviceClient: true },
+  async (request, ctx) => {
+    const { data: profile } = await ctx.supabase
+      .from("user_profiles")
+      .select("full_name")
+      .eq("id", ctx.userId)
+      .maybeSingle<{ full_name: string }>();
+    if (!profile) {
+      return NextResponse.json({ error: "Profile not found" }, { status: 403 });
+    }
 
-  const { data: profile } = await supabase.from("user_profiles").select("full_name").eq("id", user.id).maybeSingle();
-  if (!profile) return { ok: false as const, response: NextResponse.json({ error: "Profile not found" }, { status: 403 }) };
+    const body = (await request.json()) as CreatePayload;
+    if (!body.job_id || !body.category_id || !body.vendor_name || typeof body.amount !== "number") {
+      return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+    }
 
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data: membership } = await supabase
-    .from("user_organizations")
-    .select("id, role")
-    .eq("user_id", user.id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string; role: string }>();
+    const ALLOWED_PAYMENT_METHODS = ["business_card", "business_ach", "cash", "personal_reimburse", "other"];
+    if (!ALLOWED_PAYMENT_METHODS.includes(body.payment_method)) {
+      return NextResponse.json({ error: "Invalid payment_method" }, { status: 400 });
+    }
+    if (typeof body.expense_date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(body.expense_date) || Number.isNaN(new Date(body.expense_date).getTime())) {
+      return NextResponse.json({ error: "Invalid expense_date (must be YYYY-MM-DD)" }, { status: 400 });
+    }
 
-  if (membership?.role === "admin") return { ok: true as const, userId: user.id, fullName: profile.full_name, role: membership.role };
-  if (!membership) return { ok: false as const, response: NextResponse.json({ error: "Permission denied" }, { status: 403 }) };
+    const { data, error } = await ctx.serviceClient!.rpc("create_expense_with_activity", {
+      p_job_id: body.job_id,
+      p_vendor_id: body.vendor_id,
+      p_vendor_name: body.vendor_name,
+      p_category_id: body.category_id,
+      p_amount: body.amount,
+      p_expense_date: body.expense_date,
+      p_payment_method: body.payment_method,
+      p_description: body.description,
+      p_receipt_path: body.receipt_path,
+      p_thumbnail_path: body.thumbnail_path,
+      p_submitted_by: ctx.userId,
+      p_submitter_name: profile.full_name,
+    });
 
-  const { data: perm } = await supabase
-    .from("user_organization_permissions")
-    .select("granted")
-    .eq("user_organization_id", membership.id)
-    .eq("permission_key", "log_expenses")
-    .maybeSingle();
-  if (perm?.granted) return { ok: true as const, userId: user.id, fullName: profile.full_name, role: membership.role };
-  return { ok: false as const, response: NextResponse.json({ error: "Permission denied" }, { status: 403 }) };
-}
-
-export async function POST(request: Request) {
-  const auth = await requireLogExpenses();
-  if (!auth.ok) return auth.response;
-
-  const body = (await request.json()) as CreatePayload;
-  if (!body.job_id || !body.category_id || !body.vendor_name || typeof body.amount !== "number") {
-    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
-  }
-
-  const ALLOWED_PAYMENT_METHODS = ["business_card", "business_ach", "cash", "personal_reimburse", "other"];
-  if (!ALLOWED_PAYMENT_METHODS.includes(body.payment_method)) {
-    return NextResponse.json({ error: "Invalid payment_method" }, { status: 400 });
-  }
-  if (typeof body.expense_date !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(body.expense_date) || Number.isNaN(new Date(body.expense_date).getTime())) {
-    return NextResponse.json({ error: "Invalid expense_date (must be YYYY-MM-DD)" }, { status: 400 });
-  }
-
-  const service = createServiceClient();
-  const { data, error } = await service.rpc("create_expense_with_activity", {
-    p_job_id: body.job_id,
-    p_vendor_id: body.vendor_id,
-    p_vendor_name: body.vendor_name,
-    p_category_id: body.category_id,
-    p_amount: body.amount,
-    p_expense_date: body.expense_date,
-    p_payment_method: body.payment_method,
-    p_description: body.description,
-    p_receipt_path: body.receipt_path,
-    p_thumbnail_path: body.thumbnail_path,
-    p_submitted_by: auth.userId,
-    p_submitter_name: auth.fullName,
-  });
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ id: data }, { status: 201 });
-}
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ id: data }, { status: 201 });
+  },
+);

--- a/src/lib/request-context/evaluate-permission-rule.test.ts
+++ b/src/lib/request-context/evaluate-permission-rule.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluatePermissionRule,
+  type PermissionFacts,
+} from "./evaluate-permission-rule";
+
+// The four caller archetypes the acceptance criteria names, each crossed
+// against every rule shape below.
+const admin: PermissionFacts = { role: "admin", grantedPermissions: [] };
+const adminWithGrants: PermissionFacts = {
+  role: "admin",
+  grantedPermissions: ["view_invoices"],
+};
+function member(grants: string[]): PermissionFacts {
+  return { role: "member", grantedPermissions: grants };
+}
+const nonMember: PermissionFacts = { role: null, grantedPermissions: [] };
+
+describe("evaluatePermissionRule", () => {
+  describe("single-permission rule", () => {
+    const rule = { permission: "view_invoices" };
+
+    it("allows an admin even without the grant", () => {
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("allows a non-admin who holds the grant", () => {
+      expect(evaluatePermissionRule(rule, member(["view_invoices"]))).toBe(true);
+    });
+
+    it("denies a non-admin who lacks the grant", () => {
+      expect(evaluatePermissionRule(rule, member(["view_estimates"]))).toBe(
+        false,
+      );
+    });
+
+    it("denies a non-member (no role, no grants)", () => {
+      expect(evaluatePermissionRule(rule, nonMember)).toBe(false);
+    });
+  });
+
+  describe("multi-permission rule", () => {
+    const rule = { permission: ["view_estimates", "view_invoices"] };
+
+    it("allows an admin even without any of the grants", () => {
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("allows a non-admin who holds one of the keys", () => {
+      expect(evaluatePermissionRule(rule, member(["view_invoices"]))).toBe(true);
+    });
+
+    it("allows a non-admin who holds the other key", () => {
+      expect(evaluatePermissionRule(rule, member(["view_estimates"]))).toBe(
+        true,
+      );
+    });
+
+    it("denies a non-admin who holds none of the keys", () => {
+      expect(evaluatePermissionRule(rule, member(["log_expenses"]))).toBe(
+        false,
+      );
+    });
+
+    it("denies a non-member", () => {
+      expect(evaluatePermissionRule(rule, nonMember)).toBe(false);
+    });
+  });
+
+  describe("adminOnly rule", () => {
+    const rule = { adminOnly: true };
+
+    it("allows an admin", () => {
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("denies a non-admin even if they hold permission grants", () => {
+      expect(
+        evaluatePermissionRule(rule, member(["view_invoices", "log_expenses"])),
+      ).toBe(false);
+    });
+
+    it("denies a non-member", () => {
+      expect(evaluatePermissionRule(rule, nonMember)).toBe(false);
+    });
+  });
+
+  describe("empty rule (logged-in only)", () => {
+    const rule = {};
+
+    it("allows an admin", () => {
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("allows a non-admin with no grants", () => {
+      expect(evaluatePermissionRule(rule, member([]))).toBe(true);
+    });
+
+    it("allows a caller with no membership in the active organization", () => {
+      expect(evaluatePermissionRule(rule, nonMember)).toBe(true);
+    });
+  });
+
+  describe("rule-shape edge cases", () => {
+    it("enforces adminOnly when a rule mistakenly sets both adminOnly and permission", () => {
+      const rule = { adminOnly: true, permission: "view_invoices" };
+      expect(evaluatePermissionRule(rule, member(["view_invoices"]))).toBe(
+        false,
+      );
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("denies a non-admin for an empty permission array, still admits an admin", () => {
+      const rule = { permission: [] };
+      expect(evaluatePermissionRule(rule, member(["view_invoices"]))).toBe(
+        false,
+      );
+      expect(evaluatePermissionRule(rule, adminWithGrants)).toBe(true);
+    });
+  });
+});

--- a/src/lib/request-context/evaluate-permission-rule.ts
+++ b/src/lib/request-context/evaluate-permission-rule.ts
@@ -1,0 +1,61 @@
+// The single home of the access-control policy. A pure function: no I/O,
+// no Supabase, no HTTP. Given a permission rule and the facts about a
+// caller, it answers one question — is this caller allowed in?
+//
+// It is deliberately ignorant of authentication (the 401 case) and of the
+// Service-client opt-in. Those are I/O and plumbing concerns owned by
+// `withRequestContext`. This module only encodes the role/permission policy
+// that the four old route gates (requirePermission, requireAnyPermission,
+// requireAdmin, requireViewAccounting) and the inline requireLogExpenses
+// each re-implemented by hand.
+
+// The policy half of a Request Context rule. `withRequestContext` accepts
+// this plus a `serviceClient` flag; that flag never reaches this function
+// because it is not a policy question.
+export interface PermissionRule {
+  // Caller must hold this permission key, or any one of these keys. Admins
+  // always pass a `permission` rule without holding the key.
+  permission?: string | string[];
+  // Caller must have the `admin` role. No permission key substitutes.
+  adminOnly?: boolean;
+}
+
+// What the caller is, as resolved from the active organization. `role` is
+// null when the caller has no membership in the active organization;
+// `grantedPermissions` is then empty.
+export interface PermissionFacts {
+  role: string | null;
+  grantedPermissions: string[];
+}
+
+/**
+ * Decides whether a caller satisfies a permission rule.
+ *
+ * - `adminOnly` passes only for role `admin`.
+ * - `permission` (single key or array) passes if the caller is `admin` OR
+ *   holds at least one of the keys.
+ * - An empty rule (`{}` — logged-in only) always passes; the caller having
+ *   reached this function means authentication already succeeded.
+ *
+ * `adminOnly` and `permission` are meant to be mutually exclusive; if both
+ * are set, `adminOnly` is enforced (the stricter of the two).
+ */
+export function evaluatePermissionRule(
+  rule: PermissionRule,
+  facts: PermissionFacts,
+): boolean {
+  if (rule.adminOnly) {
+    return facts.role === "admin";
+  }
+
+  if (rule.permission !== undefined) {
+    if (facts.role === "admin") return true;
+    const keys = Array.isArray(rule.permission)
+      ? rule.permission
+      : [rule.permission];
+    return keys.some((key) => facts.grantedPermissions.includes(key));
+  }
+
+  // Empty rule: authentication alone is enough.
+  return true;
+}

--- a/src/lib/request-context/with-request-context.test.ts
+++ b/src/lib/request-context/with-request-context.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { withRequestContext, type RequestContext } from "./with-request-context";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+
+// A fake User client covering exactly the surface the wrapper touches:
+// auth.getUser, the `user_organizations` membership lookup (maybeSingle),
+// and the `user_organization_permissions` grants lookup (awaited list).
+function fakeUserClient(opts: {
+  user: { id: string } | null;
+  membership?: { id: string; role: string } | null;
+  grants?: string[];
+}) {
+  const membership = opts.membership ?? null;
+  const grants = opts.grants ?? [];
+  return {
+    auth: {
+      async getUser() {
+        return { data: { user: opts.user }, error: null };
+      },
+    },
+    from() {
+      const builder = {
+        select() {
+          return builder;
+        },
+        eq() {
+          return builder;
+        },
+        async maybeSingle() {
+          return { data: membership, error: null };
+        },
+        then(
+          resolve: (v: {
+            data: { permission_key: string }[];
+            error: null;
+          }) => unknown,
+        ) {
+          return resolve({
+            data: grants.map((permission_key) => ({ permission_key })),
+            error: null,
+          });
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+const SERVICE_SENTINEL = { __service: true };
+
+function paramsContext<T>(params: T) {
+  return { params: Promise.resolve(params) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(createServiceClient).mockReturnValue(SERVICE_SENTINEL as never);
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("withRequestContext", () => {
+  it("returns 401 and never invokes the handler when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const handler = vi.fn();
+
+    const route = withRequestContext({ permission: "log_expenses" }, handler);
+    const res = await route(new Request("http://test"), paramsContext({}));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Not authenticated" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 and never invokes the handler when the rule is not satisfied", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "member" },
+        grants: ["view_invoices"],
+      }) as never,
+    );
+    const handler = vi.fn();
+
+    const route = withRequestContext({ permission: "log_expenses" }, handler);
+    const res = await route(new Request("http://test"), paramsContext({}));
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Permission denied" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when an authenticated caller has no membership in the active organization", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" }, membership: null }) as never,
+    );
+    const handler = vi.fn();
+
+    const route = withRequestContext({ adminOnly: true }, handler);
+    const res = await route(new Request("http://test"), paramsContext({}));
+
+    expect(res.status).toBe(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("invokes the handler with a Request Context carrying userId, orgId and role", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "member" },
+        grants: ["log_expenses"],
+      }) as never,
+    );
+    let received: RequestContext | undefined;
+    const handler = vi.fn((_req: Request, ctx: RequestContext) => {
+      received = ctx;
+      return new Response("ok");
+    });
+
+    const route = withRequestContext({ permission: "log_expenses" }, handler);
+    const res = await route(new Request("http://test"), paramsContext({}));
+
+    expect(res.status).toBe(200);
+    expect(received?.userId).toBe("user-1");
+    expect(received?.orgId).toBe("org-1");
+    expect(received?.role).toBe("member");
+  });
+
+  it("admits an admin against a permission rule they hold no grant for", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "admin-1" },
+        membership: { id: "m-1", role: "admin" },
+        grants: [],
+      }) as never,
+    );
+    const handler = vi.fn(() => new Response("ok"));
+
+    const route = withRequestContext({ permission: "log_expenses" }, handler);
+    const res = await route(new Request("http://test"), paramsContext({}));
+
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("omits the Service client from the context unless the rule opts in", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "admin" },
+      }) as never,
+    );
+    let received: RequestContext | undefined;
+    const handler = vi.fn((_req: Request, ctx: RequestContext) => {
+      received = ctx;
+      return new Response("ok");
+    });
+
+    const route = withRequestContext({}, handler);
+    await route(new Request("http://test"), paramsContext({}));
+
+    expect(received?.serviceClient).toBeUndefined();
+    expect(createServiceClient).not.toHaveBeenCalled();
+  });
+
+  it("includes the Service client when the rule sets serviceClient: true", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "admin" },
+      }) as never,
+    );
+    let received: RequestContext | undefined;
+    const handler = vi.fn((_req: Request, ctx: RequestContext) => {
+      received = ctx;
+      return new Response("ok");
+    });
+
+    const route = withRequestContext({ serviceClient: true }, handler);
+    await route(new Request("http://test"), paramsContext({}));
+
+    expect(received?.serviceClient).toBe(SERVICE_SENTINEL);
+  });
+
+  it("passes the Next.js route segment context through to the handler untouched", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "admin" },
+      }) as never,
+    );
+    let receivedParams: unknown;
+    const handler = vi.fn(
+      async (
+        _req: Request,
+        _ctx: RequestContext,
+        routeContext: { params: Promise<{ id: string }> },
+      ) => {
+        receivedParams = await routeContext.params;
+        return new Response("ok");
+      },
+    );
+
+    const route = withRequestContext<{ id: string }>({}, handler);
+    await route(new Request("http://test"), paramsContext({ id: "exp-9" }));
+
+    expect(receivedParams).toEqual({ id: "exp-9" });
+  });
+});

--- a/src/lib/request-context/with-request-context.ts
+++ b/src/lib/request-context/with-request-context.ts
@@ -1,0 +1,134 @@
+// `withRequestContext` — the one wrapper every authenticated API endpoint
+// routes through. An endpoint no longer *starts with* a check; it *hands
+// itself to* this wrapper together with a one-line rule. The wrapper runs
+// the check first, and on denial sends the rejection so the endpoint's own
+// code never runs — the "stop on denial" step is structural, not a line of
+// code anyone can forget.
+//
+// It performs all the I/O the old route gates each hand-rolled: resolve the
+// user, resolve the Active Organization from the JWT claim, fetch the
+// caller's membership role and permission grants. The allow/deny *policy*
+// itself lives in the pure `evaluatePermissionRule`.
+//
+// See CONTEXT.md for Organization / Active Organization / Request Context /
+// User client / Service client.
+
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  evaluatePermissionRule,
+  type PermissionRule,
+} from "./evaluate-permission-rule";
+
+// The rule handed to the wrapper: the access-control policy plus the one
+// piece of plumbing the policy does not care about — whether the Request
+// Context should also carry the Service client.
+//
+//   { permission: "view_invoices" }                  needs that permission
+//   { permission: ["view_estimates", "view_invoices"] }  needs any one
+//   { adminOnly: true }                               admin role required
+//   {} / omitted                                      logged-in only
+//   { serviceClient: true }                           combinable with any
+export interface RequestContextRule extends PermissionRule {
+  serviceClient?: boolean;
+}
+
+// Handed to the route handler once the rule has passed. `supabase` is the
+// User client (row-level security enforced — the database itself prevents
+// cross-Organization reads). `serviceClient` is present only when the rule
+// opted in. `orgId` / `role` are null only for a logged-in-only (`{}`) rule
+// whose caller has no membership in the Active Organization; any rule that
+// names a permission or admin guarantees both are non-null on success.
+export interface RequestContext {
+  userId: string;
+  orgId: string | null;
+  role: string | null;
+  supabase: SupabaseClient;
+  serviceClient?: SupabaseClient;
+}
+
+type RouteSegmentContext<TParams> = { params: Promise<TParams> };
+
+// A route handler written against this module: it receives the request, the
+// resolved Request Context, and the Next.js route-segment context (dynamic
+// `params`) passed through untouched.
+export type ContextualRouteHandler<TParams> = (
+  request: Request,
+  context: RequestContext,
+  routeContext: RouteSegmentContext<TParams>,
+) => Promise<Response> | Response;
+
+const REJECT_UNAUTHENTICATED = { error: "Not authenticated" };
+const REJECT_FORBIDDEN = { error: "Permission denied" };
+
+/**
+ * Wraps an API route handler with authentication, Active-Organization
+ * resolution, and a permission check.
+ *
+ * On an unauthenticated request the wrapper returns 401 and the handler
+ * never runs; on a request that fails the rule it returns 403 and the
+ * handler never runs. Otherwise the handler is invoked with a Request
+ * Context and the Next.js route params untouched.
+ *
+ * `TParams` is inferred from the handler's third argument — annotate it
+ * (`{ params }: { params: Promise<{ id: string }> }`) on dynamic routes.
+ */
+export function withRequestContext<TParams = Record<string, never>>(
+  rule: RequestContextRule,
+  handler: ContextualRouteHandler<TParams>,
+): (
+  request: Request,
+  routeContext: RouteSegmentContext<TParams>,
+) => Promise<Response> {
+  return async (request, routeContext) => {
+    const supabase = await createServerSupabaseClient();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json(REJECT_UNAUTHENTICATED, { status: 401 });
+    }
+
+    const orgId = await getActiveOrganizationId(supabase);
+
+    const { data: membership } = await supabase
+      .from("user_organizations")
+      .select("id, role")
+      .eq("user_id", user.id)
+      .eq("organization_id", orgId)
+      .maybeSingle<{ id: string; role: string }>();
+
+    let grantedPermissions: string[] = [];
+    if (membership) {
+      const { data: grants } = await supabase
+        .from("user_organization_permissions")
+        .select("permission_key")
+        .eq("user_organization_id", membership.id)
+        .eq("granted", true);
+      grantedPermissions = ((grants ?? []) as { permission_key: string }[]).map(
+        (g) => g.permission_key,
+      );
+    }
+
+    const role = membership?.role ?? null;
+    if (!evaluatePermissionRule(rule, { role, grantedPermissions })) {
+      return NextResponse.json(REJECT_FORBIDDEN, { status: 403 });
+    }
+
+    const context: RequestContext = {
+      userId: user.id,
+      orgId,
+      role,
+      supabase,
+    };
+    if (rule.serviceClient) {
+      context.serviceClient = createServiceClient();
+    }
+
+    return handler(request, context, routeContext);
+  };
+}


### PR DESCRIPTION
## Summary

Tracer-bullet slice for the **Request Context** architecture (PRD #78). Builds the one authenticated-request module that the four hand-rolled route gates will collapse into, and proves it end to end by converting the `expenses` endpoints.

Closes #79. Unblocks #80–#85.

## New modules — `src/lib/request-context/`

- **`evaluate-permission-rule`** — the pure access-control policy, no I/O. Given a rule and a caller's facts (role, granted permission keys), returns allow/deny. `adminOnly` → admin role only; `permission` (single or array) → admin OR holds a key; empty rule → logged-in only.
- **`withRequestContext`** — the wrapper. Resolves the user, the Active Organization from the JWT claim, membership role, and all granted permission keys; defers the decision to `evaluate-permission-rule`; on denial returns a standardized 401/403 so **the handler never runs**. On success hands the handler a Request Context `{ userId, orgId, role, supabase }`, adding the Service client only on `{ serviceClient: true }`. Next.js route params pass through untouched.

## Converted endpoints

The inline `requireLogExpenses` re-implementation is removed; all six `expenses` routes go through the wrapper:

| Route | Rule |
|---|---|
| `POST /api/expenses` | `{ permission: "log_expenses", serviceClient: true }` — keeps its own `user_profiles` lookup for `full_name`, preserving the `Profile not found` 403 |
| `PATCH`/`DELETE /api/expenses/[id]` | same rule; the submitter-or-admin **ownership** check stays as route business logic |
| `GET` `by-job` / `by-activity` / `[id]/thumbnail-url` / `[id]/receipt-url` | `{ serviceClient: true }` (logged-in only), matching prior behavior |

## Review notes

- **Rejection wording standardized** here (`Not authenticated` / `Permission denied`) — the four old gates disagreed (`forbidden` / `admin only` / `Profile not found`).
- The four old gates are **left in place**; their deletion is #86. Old and new coexist.
- `{}` (logged-in-only) routes now run 2 extra queries to populate `orgId`/`role` in the context — auth-lookup perf is explicitly out of scope per the PRD.
- The four `by-*`/`*-url` GETs read expenses via the Service client **without org-scoping** — a pre-existing data-scoping gap, untouched here and flagged in a code comment for the #86 ungated-endpoint follow-up.

## Testing

- 17 pure-function cases, 8 wrapper cases, 12 converted-route cases (static / dynamic / logged-in-only).
- Typecheck clean — including Next 16's route validator. The only `tsc` error is the pre-existing, unrelated `sync-folder-incremental.test.ts` TS2322.
- Lint clean on the changed surface. Full suite green — 218 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)