### PR TITLE
request-context: convert jobs + payments + payment-requests routes (#83)

### DIFF
--- a/src/app/api/__test-utils__/request-context-fakes.ts
+++ b/src/app/api/__test-utils__/request-context-fakes.ts
@@ -1,0 +1,156 @@
+// Supabase fakes for the converted `jobs` / `payments` / `payment-requests`
+// route tests (#83). These routes now run through `withRequestContext`, so a
+// route test exercises two clients:
+//
+//   * the User client — what the wrapper authenticates against (and what the
+//     logged-in-only routes query directly);
+//   * the Service client — what permission-gated route bodies read/write with.
+//
+// Both are table-row fakes covering the query surface these routes use:
+// select / eq / in / not / is / lt / or / order / limit / maybeSingle /
+// single / awaited-list, plus update / insert / delete (recorded, no-op on
+// the seeded rows) and storage.
+
+type Row = Record<string, unknown>;
+
+type Awaitable = {
+  maybeSingle<T = Row>(): Promise<{ data: T | null; error: null }>;
+  single<T = Row>(): Promise<{ data: T | null; error: null }>;
+  then(resolve: (v: { data: Row[]; error: null }) => unknown): unknown;
+};
+
+// One builder type for both reads and mutations: every filter and mutation
+// method returns the builder; `eq` / `in` actually filter so list and
+// maybeSingle reads stay meaningful; the rest are no-ops.
+export interface QueryBuilder extends Awaitable {
+  select(cols?: string): QueryBuilder;
+  insert(payload?: unknown): QueryBuilder;
+  update(payload?: unknown): QueryBuilder;
+  delete(): QueryBuilder;
+  upsert(payload?: unknown, opts?: unknown): QueryBuilder;
+  eq(col: string, val: unknown): QueryBuilder;
+  in(col: string, vals: unknown[]): QueryBuilder;
+  not(...args: unknown[]): QueryBuilder;
+  is(...args: unknown[]): QueryBuilder;
+  lt(...args: unknown[]): QueryBuilder;
+  gt(...args: unknown[]): QueryBuilder;
+  or(...args: unknown[]): QueryBuilder;
+  order(...args: unknown[]): QueryBuilder;
+  limit(...args: unknown[]): QueryBuilder;
+}
+
+function queryBuilder(rows: Row[]): QueryBuilder {
+  let filtered = [...rows];
+  const passthrough = () => builder;
+  const builder: QueryBuilder = {
+    select: passthrough,
+    insert: passthrough,
+    update: passthrough,
+    delete: passthrough,
+    upsert: passthrough,
+    eq(col, val) {
+      filtered = filtered.filter((r) => r[col] === val);
+      return builder;
+    },
+    in(col, vals) {
+      filtered = filtered.filter((r) => vals.includes(r[col]));
+      return builder;
+    },
+    not: passthrough,
+    is: passthrough,
+    lt: passthrough,
+    gt: passthrough,
+    or: passthrough,
+    order: passthrough,
+    limit: passthrough,
+    async maybeSingle<T = Row>() {
+      return { data: (filtered[0] ?? null) as T | null, error: null };
+    },
+    async single<T = Row>() {
+      return { data: (filtered[0] ?? null) as T | null, error: null };
+    },
+    then(resolve) {
+      return resolve({ data: filtered, error: null });
+    },
+  };
+  return builder;
+}
+
+// A fake User client. `tables` seeds whatever the wrapper or route reads:
+// `user_organizations` (membership), `user_organization_permissions`
+// (grants), and any table a logged-in-only route queries directly.
+export function fakeUserClient(opts: {
+  user: { id: string } | null;
+  tables?: Record<string, Row[]>;
+}) {
+  const tables = opts.tables ?? {};
+  return {
+    auth: {
+      async getUser() {
+        return { data: { user: opts.user }, error: null };
+      },
+    },
+    from(table: string) {
+      return queryBuilder(tables[table] ?? []);
+    },
+  };
+}
+
+// Convenience: build the `tables` map for a caller who is a member of the
+// active organization with a given role and set of granted permissions.
+// Pass extra route-queried tables via `extraTables`.
+export function memberTables(opts: {
+  userId: string;
+  membershipId?: string;
+  orgId?: string;
+  role: string;
+  grants?: string[];
+  extraTables?: Record<string, Row[]>;
+}): Record<string, Row[]> {
+  const membershipId = opts.membershipId ?? "m-1";
+  const orgId = opts.orgId ?? "org-1";
+  return {
+    user_organizations: [
+      {
+        id: membershipId,
+        role: opts.role,
+        user_id: opts.userId,
+        organization_id: orgId,
+      },
+    ],
+    user_organization_permissions: (opts.grants ?? []).map((permission_key) => ({
+      user_organization_id: membershipId,
+      permission_key,
+      granted: true,
+    })),
+    ...(opts.extraTables ?? {}),
+  };
+}
+
+// A fake Service client: table reads/writes plus storage remove /
+// createSignedUrl.
+export function fakeServiceClient(opts: {
+  tables?: Record<string, Row[]>;
+} = {}) {
+  const tables = opts.tables ?? {};
+  return {
+    from(table: string) {
+      return queryBuilder(tables[table] ?? []);
+    },
+    storage: {
+      from() {
+        return {
+          async remove(paths: string[]) {
+            return { data: paths.map((name) => ({ name })), error: null };
+          },
+          async createSignedUrl(path: string) {
+            return {
+              data: { signedUrl: `https://signed.test/${path}` },
+              error: null,
+            };
+          },
+        };
+      },
+    },
+  };
+}

--- a/src/app/api/jobs/[id]/contact-email/route.ts
+++ b/src/app/api/jobs/[id]/contact-email/route.ts
@@ -1,50 +1,46 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/jobs/[id]/contact-email
 // Returns the linked contact's email + display name. Used by the payment
 // request modal to prefill the Recipient field; callers may override.
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "record_payments");
-  if (!gate.ok) return gate.response;
+// Needs `record_payments` (admins auto-pass) and the Service client to
+// read the job + contact regardless of RLS.
+export const GET = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const supabase = ctx.serviceClient!;
 
-  const { id } = await params;
-  const supabase = createServiceClient();
+    const { data: job, error: jobErr } = await supabase
+      .from("jobs")
+      .select("contact_id")
+      .eq("id", id)
+      .maybeSingle<{ contact_id: string | null }>();
+    if (jobErr) return NextResponse.json({ error: jobErr.message }, { status: 500 });
+    if (!job) return NextResponse.json({ error: "job_not_found" }, { status: 404 });
 
-  const { data: job, error: jobErr } = await supabase
-    .from("jobs")
-    .select("contact_id")
-    .eq("id", id)
-    .maybeSingle<{ contact_id: string | null }>();
-  if (jobErr) return NextResponse.json({ error: jobErr.message }, { status: 500 });
-  if (!job) return NextResponse.json({ error: "job_not_found" }, { status: 404 });
+    if (!job.contact_id) {
+      return NextResponse.json({ email: null, name: null });
+    }
 
-  if (!job.contact_id) {
-    return NextResponse.json({ email: null, name: null });
-  }
+    const { data: contact } = await supabase
+      .from("contacts")
+      .select("email, first_name, last_name")
+      .eq("id", job.contact_id)
+      .maybeSingle<{
+        email: string | null;
+        first_name: string | null;
+        last_name: string | null;
+      }>();
 
-  const { data: contact } = await supabase
-    .from("contacts")
-    .select("email, first_name, last_name")
-    .eq("id", job.contact_id)
-    .maybeSingle<{
-      email: string | null;
-      first_name: string | null;
-      last_name: string | null;
-    }>();
+    const email = contact?.email ?? null;
+    const name =
+      [contact?.first_name, contact?.last_name]
+        .filter(Boolean)
+        .join(" ")
+        .trim() || null;
 
-  const email = contact?.email ?? null;
-  const name =
-    [contact?.first_name, contact?.last_name]
-      .filter(Boolean)
-      .join(" ")
-      .trim() || null;
-
-  return NextResponse.json({ email, name });
-}
+    return NextResponse.json({ email, name });
+  },
+);

--- a/src/app/api/jobs/[id]/delete/route.test.ts
+++ b/src/app/api/jobs/[id]/delete/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// Soft-delete carried the `requireJobsDelete` gate (admin OR office_staff);
+// it now rides on the `roles` rule. These tests pin that 1:1 mapping.
+describe("POST /api/jobs/[id]/delete (converted to withRequestContext, roles rule)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member role, even one holding permission grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["log_expenses", "view_billing"],
+        }),
+      }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows an office_staff caller", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "office_staff" }),
+      }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("allows an admin caller", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin" }),
+      }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1"));
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/jobs/[id]/delete/route.ts
+++ b/src/app/api/jobs/[id]/delete/route.ts
@@ -5,25 +5,21 @@
 // /api/jobs/trash.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requireJobsDelete } from "@/lib/jobs/auth";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireJobsDelete(supabase);
-  if (!gate.ok) return gate.response;
+export const POST = withRequestContext(
+  { roles: ["admin", "office_staff"] },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const { error } = await supabase
-    .from("jobs")
-    .update({ deleted_at: new Date().toISOString() })
-    .eq("id", id)
-    .is("deleted_at", null);
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({ ok: true });
-}
+    const { error } = await ctx.supabase
+      .from("jobs")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", id)
+      .is("deleted_at", null);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/jobs/[id]/files/[fileId]/route.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/route.ts
@@ -1,84 +1,91 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // PATCH /api/jobs/[id]/files/[fileId] — rename
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string; fileId: string }> }
-) {
-  const { fileId } = await params;
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const PATCH = withRequestContext(
+  {},
+  async (
+    request,
+    ctx,
+    { params }: { params: Promise<{ id: string; fileId: string }> },
+  ) => {
+    const { fileId } = await params;
 
-  const body = await request.json().catch(() => null);
-  const rawFilename = typeof body?.filename === "string" ? body.filename : "";
-  const filename = rawFilename.trim();
+    const body = await request.json().catch(() => null);
+    const rawFilename = typeof body?.filename === "string" ? body.filename : "";
+    const filename = rawFilename.trim();
 
-  if (!filename) {
-    return NextResponse.json({ error: "Filename is required" }, { status: 400 });
-  }
-  if (filename.length > 255) {
-    return NextResponse.json(
-      { error: "Filename must be 255 characters or fewer" },
-      { status: 400 }
-    );
-  }
+    if (!filename) {
+      return NextResponse.json({ error: "Filename is required" }, { status: 400 });
+    }
+    if (filename.length > 255) {
+      return NextResponse.json(
+        { error: "Filename must be 255 characters or fewer" },
+        { status: 400 }
+      );
+    }
 
-  const supabase = await createServerSupabaseClient();
+    const { data, error } = await ctx.supabase
+      .from("job_files")
+      .update({ filename })
+      .eq("id", fileId)
+      .select()
+      .single();
 
-  const { data, error } = await supabase
-    .from("job_files")
-    .update({ filename })
-    .eq("id", fileId)
-    .select()
-    .single();
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json(data);
-}
+    return NextResponse.json(data);
+  },
+);
 
 // DELETE /api/jobs/[id]/files/[fileId] — delete storage object, then row
-export async function DELETE(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string; fileId: string }> }
-) {
-  const { fileId } = await params;
-  const supabase = await createServerSupabaseClient();
+export const DELETE = withRequestContext(
+  {},
+  async (
+    _request,
+    ctx,
+    { params }: { params: Promise<{ id: string; fileId: string }> },
+  ) => {
+    const { fileId } = await params;
+    const supabase = ctx.supabase;
 
-  // 1. Look up storage_path
-  const { data: row, error: lookupError } = await supabase
-    .from("job_files")
-    .select("storage_path")
-    .eq("id", fileId)
-    .single();
+    // 1. Look up storage_path
+    const { data: row, error: lookupError } = await supabase
+      .from("job_files")
+      .select("storage_path")
+      .eq("id", fileId)
+      .single();
 
-  if (lookupError || !row) {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
-  }
+    if (lookupError || !row) {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
 
-  // 2. Delete storage object first
-  const { error: storageError } = await supabase.storage
-    .from("job-files")
-    .remove([row.storage_path]);
+    // 2. Delete storage object first
+    const { error: storageError } = await supabase.storage
+      .from("job-files")
+      .remove([row.storage_path]);
 
-  if (storageError) {
-    return NextResponse.json(
-      { error: `Storage delete failed: ${storageError.message}` },
-      { status: 500 }
-    );
-  }
+    if (storageError) {
+      return NextResponse.json(
+        { error: `Storage delete failed: ${storageError.message}` },
+        { status: 500 }
+      );
+    }
 
-  // 3. Delete row (if this fails, the object is already gone — acceptable;
-  //    the next list fetch will still show the row and user can retry)
-  const { error: deleteError } = await supabase
-    .from("job_files")
-    .delete()
-    .eq("id", fileId);
+    // 3. Delete row (if this fails, the object is already gone — acceptable;
+    //    the next list fetch will still show the row and user can retry)
+    const { error: deleteError } = await supabase
+      .from("job_files")
+      .delete()
+      .eq("id", fileId);
 
-  if (deleteError) {
-    return NextResponse.json({ error: deleteError.message }, { status: 500 });
-  }
+    if (deleteError) {
+      return NextResponse.json({ error: deleteError.message }, { status: 500 });
+    }
 
-  return NextResponse.json({ ok: true });
-}
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/jobs/[id]/files/[fileId]/url/route.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/url/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/jobs/[id]/files/[fileId]/url — short-lived signed URL
 // Returns { url: string, expiresAt: string }
@@ -8,34 +8,39 @@ import { createServerSupabaseClient } from "@/lib/supabase-server";
 // an <a download> link on the client. Do NOT pass the `download` option
 // to createSignedUrl — that forces Content-Disposition: attachment and
 // breaks iframe preview.
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string; fileId: string }> }
-) {
-  const { fileId } = await params;
-  const supabase = await createServerSupabaseClient();
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const GET = withRequestContext(
+  {},
+  async (
+    _request,
+    ctx,
+    { params }: { params: Promise<{ id: string; fileId: string }> },
+  ) => {
+    const { fileId } = await params;
+    const supabase = ctx.supabase;
 
-  const { data: row, error: lookupError } = await supabase
-    .from("job_files")
-    .select("storage_path")
-    .eq("id", fileId)
-    .single();
+    const { data: row, error: lookupError } = await supabase
+      .from("job_files")
+      .select("storage_path")
+      .eq("id", fileId)
+      .single();
 
-  if (lookupError || !row) {
-    return NextResponse.json({ error: "File not found" }, { status: 404 });
-  }
+    if (lookupError || !row) {
+      return NextResponse.json({ error: "File not found" }, { status: 404 });
+    }
 
-  const { data, error } = await supabase.storage
-    .from("job-files")
-    .createSignedUrl(row.storage_path, 600);
+    const { data, error } = await supabase.storage
+      .from("job-files")
+      .createSignedUrl(row.storage_path, 600);
 
-  if (error || !data) {
-    return NextResponse.json(
-      { error: error?.message || "Failed to create signed URL" },
-      { status: 500 }
-    );
-  }
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message || "Failed to create signed URL" },
+        { status: 500 }
+      );
+    }
 
-  const expiresAt = new Date(Date.now() + 600 * 1000).toISOString();
-  return NextResponse.json({ url: data.signedUrl, expiresAt });
-}
+    const expiresAt = new Date(Date.now() + 600 * 1000).toISOString();
+    return NextResponse.json({ url: data.signedUrl, expiresAt });
+  },
+);

--- a/src/app/api/jobs/[id]/files/route.ts
+++ b/src/app/api/jobs/[id]/files/route.ts
@@ -1,100 +1,99 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { randomUUID } from "crypto";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 
 // GET /api/jobs/[id]/files — list files for a job (scoped to active org).
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id: jobId } = await params;
-  const supabase = await createServerSupabaseClient();
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const GET = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: jobId } = await params;
 
-  const { data, error } = await supabase
-    .from("job_files")
-    .select("*")
-    .eq("organization_id", await getActiveOrganizationId(supabase))
-    .eq("job_id", jobId)
-    .order("created_at", { ascending: false });
+    const { data, error } = await ctx.supabase
+      .from("job_files")
+      .select("*")
+      .eq("organization_id", ctx.orgId)
+      .eq("job_id", jobId)
+      .order("created_at", { ascending: false });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  return NextResponse.json(data ?? []);
-}
+    return NextResponse.json(data ?? []);
+  },
+);
 
 // POST /api/jobs/[id]/files — upload one or more files
 // Returns { succeeded: JobFile[], failed: { filename: string, error: string }[] }
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id: jobId } = await params;
-  const formData = await request.formData();
-  const files = formData.getAll("file") as File[];
+export const POST = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: jobId } = await params;
+    const formData = await request.formData();
+    const files = formData.getAll("file") as File[];
 
-  if (files.length === 0) {
-    return NextResponse.json({ error: "No files provided" }, { status: 400 });
-  }
-
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const succeeded: unknown[] = [];
-  const failed: { filename: string; error: string }[] = [];
-
-  for (const file of files) {
-    try {
-      const uuid = randomUUID();
-      // Org-prefixed path to match the post-18a rename layout.
-      const storagePath = `${orgId}/${jobId}/${uuid}-${file.name}`;
-
-      const arrayBuffer = await file.arrayBuffer();
-      const { error: uploadError } = await supabase.storage
-        .from("job-files")
-        .upload(storagePath, arrayBuffer, {
-          contentType: file.type || "application/octet-stream",
-          upsert: false,
-        });
-
-      if (uploadError) {
-        failed.push({ filename: file.name, error: uploadError.message });
-        continue;
-      }
-
-      const { data: row, error: insertError } = await supabase
-        .from("job_files")
-        .insert({
-          organization_id: orgId,
-          job_id: jobId,
-          filename: file.name,
-          storage_path: storagePath,
-          size_bytes: file.size,
-          mime_type: file.type || "application/octet-stream",
-        })
-        .select()
-        .single();
-
-      if (insertError) {
-        // Roll back the storage upload so we don't orphan the object
-        await supabase.storage.from("job-files").remove([storagePath]);
-        failed.push({ filename: file.name, error: insertError.message });
-        continue;
-      }
-
-      succeeded.push(row);
-    } catch (e) {
-      failed.push({
-        filename: file.name,
-        error: e instanceof Error ? e.message : "Unknown error",
-      });
+    if (files.length === 0) {
+      return NextResponse.json({ error: "No files provided" }, { status: 400 });
     }
-  }
 
-  // 200 = all good, 207 = partial, 500 = all failed
-  const status =
-    failed.length === 0 ? 200 : succeeded.length === 0 ? 500 : 207;
+    const supabase = ctx.supabase;
+    const orgId = ctx.orgId;
+    const succeeded: unknown[] = [];
+    const failed: { filename: string; error: string }[] = [];
 
-  return NextResponse.json({ succeeded, failed }, { status });
-}
+    for (const file of files) {
+      try {
+        const uuid = randomUUID();
+        // Org-prefixed path to match the post-18a rename layout.
+        const storagePath = `${orgId}/${jobId}/${uuid}-${file.name}`;
+
+        const arrayBuffer = await file.arrayBuffer();
+        const { error: uploadError } = await supabase.storage
+          .from("job-files")
+          .upload(storagePath, arrayBuffer, {
+            contentType: file.type || "application/octet-stream",
+            upsert: false,
+          });
+
+        if (uploadError) {
+          failed.push({ filename: file.name, error: uploadError.message });
+          continue;
+        }
+
+        const { data: row, error: insertError } = await supabase
+          .from("job_files")
+          .insert({
+            organization_id: orgId,
+            job_id: jobId,
+            filename: file.name,
+            storage_path: storagePath,
+            size_bytes: file.size,
+            mime_type: file.type || "application/octet-stream",
+          })
+          .select()
+          .single();
+
+        if (insertError) {
+          // Roll back the storage upload so we don't orphan the object
+          await supabase.storage.from("job-files").remove([storagePath]);
+          failed.push({ filename: file.name, error: insertError.message });
+          continue;
+        }
+
+        succeeded.push(row);
+      } catch (e) {
+        failed.push({
+          filename: file.name,
+          error: e instanceof Error ? e.message : "Unknown error",
+        });
+      }
+    }
+
+    // 200 = all good, 207 = partial, 500 = all failed
+    const status =
+      failed.length === 0 ? 200 : succeeded.length === 0 ? 500 : 207;
+
+    return NextResponse.json({ succeeded, failed }, { status });
+  },
+);

--- a/src/app/api/jobs/[id]/photos/bulk-tag/route.ts
+++ b/src/app/api/jobs/[id]/photos/bulk-tag/route.ts
@@ -1,49 +1,51 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id: jobId } = await params;
-  const { photoIds, tagIds, action } = await request.json() as {
-    photoIds: string[];
-    tagIds: string[];
-    action: "add" | "remove";
-  };
+// POST /api/jobs/[id]/photos/bulk-tag — add/remove tags on selected photos.
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const POST = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: jobId } = await params;
+    const { photoIds, tagIds, action } = await request.json() as {
+      photoIds: string[];
+      tagIds: string[];
+      action: "add" | "remove";
+    };
 
-  if (!photoIds?.length || !tagIds?.length || !action) {
-    return NextResponse.json({ error: "Missing photoIds, tagIds, or action" }, { status: 400 });
-  }
+    if (!photoIds?.length || !tagIds?.length || !action) {
+      return NextResponse.json({ error: "Missing photoIds, tagIds, or action" }, { status: 400 });
+    }
 
-  const supabase = await createServerSupabaseClient();
+    const supabase = ctx.supabase;
 
-  const { data: photos } = await supabase
-    .from("photos")
-    .select("id")
-    .eq("job_id", jobId)
-    .in("id", photoIds);
+    const { data: photos } = await supabase
+      .from("photos")
+      .select("id")
+      .eq("job_id", jobId)
+      .in("id", photoIds);
 
-  const validIds = (photos || []).map((p) => p.id);
+    const validIds = (photos || []).map((p) => p.id);
 
-  if (action === "add") {
-    const rows = validIds.flatMap((photoId) =>
-      tagIds.map((tagId) => ({ photo_id: photoId, tag_id: tagId }))
-    );
-    const { error } = await supabase
-      .from("photo_tag_assignments")
-      .upsert(rows, { onConflict: "photo_id,tag_id", ignoreDuplicates: true });
+    if (action === "add") {
+      const rows = validIds.flatMap((photoId) =>
+        tagIds.map((tagId) => ({ photo_id: photoId, tag_id: tagId }))
+      );
+      const { error } = await supabase
+        .from("photo_tag_assignments")
+        .upsert(rows, { onConflict: "photo_id,tag_id", ignoreDuplicates: true });
 
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  } else {
-    const { error } = await supabase
-      .from("photo_tag_assignments")
-      .delete()
-      .in("photo_id", validIds)
-      .in("tag_id", tagIds);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    } else {
+      const { error } = await supabase
+        .from("photo_tag_assignments")
+        .delete()
+        .in("photo_id", validIds)
+        .in("tag_id", tagIds);
 
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  return NextResponse.json({ updated: validIds.length });
-}
+    return NextResponse.json({ updated: validIds.length });
+  },
+);

--- a/src/app/api/jobs/[id]/photos/bulk/route.ts
+++ b/src/app/api/jobs/[id]/photos/bulk/route.ts
@@ -1,54 +1,56 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id: jobId } = await params;
-  const { photoIds } = await request.json() as { photoIds: string[] };
+// DELETE /api/jobs/[id]/photos/bulk — bulk-delete photos.
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const DELETE = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: jobId } = await params;
+    const { photoIds } = await request.json() as { photoIds: string[] };
 
-  if (!photoIds || photoIds.length === 0) {
-    return NextResponse.json({ error: "No photo IDs provided" }, { status: 400 });
-  }
+    if (!photoIds || photoIds.length === 0) {
+      return NextResponse.json({ error: "No photo IDs provided" }, { status: 400 });
+    }
 
-  const supabase = await createServerSupabaseClient();
+    const supabase = ctx.supabase;
 
-  const { data: photos, error: fetchError } = await supabase
-    .from("photos")
-    .select("id, storage_path, annotated_path, thumbnail_path")
-    .eq("job_id", jobId)
-    .in("id", photoIds);
+    const { data: photos, error: fetchError } = await supabase
+      .from("photos")
+      .select("id, storage_path, annotated_path, thumbnail_path")
+      .eq("job_id", jobId)
+      .in("id", photoIds);
 
-  if (fetchError) {
-    return NextResponse.json({ error: fetchError.message }, { status: 500 });
-  }
+    if (fetchError) {
+      return NextResponse.json({ error: fetchError.message }, { status: 500 });
+    }
 
-  if (!photos || photos.length === 0) {
-    return NextResponse.json({ error: "No matching photos found" }, { status: 404 });
-  }
+    if (!photos || photos.length === 0) {
+      return NextResponse.json({ error: "No matching photos found" }, { status: 404 });
+    }
 
-  const storagePaths: string[] = [];
-  for (const photo of photos) {
-    storagePaths.push(photo.storage_path);
-    if (photo.annotated_path) storagePaths.push(photo.annotated_path);
-    if (photo.thumbnail_path) storagePaths.push(photo.thumbnail_path);
-    const ext = photo.storage_path.split(".").pop();
-    const basePath = photo.storage_path.replace(`.${ext}`, "");
-    storagePaths.push(`${basePath}-original.${ext}`);
-  }
+    const storagePaths: string[] = [];
+    for (const photo of photos) {
+      storagePaths.push(photo.storage_path);
+      if (photo.annotated_path) storagePaths.push(photo.annotated_path);
+      if (photo.thumbnail_path) storagePaths.push(photo.thumbnail_path);
+      const ext = photo.storage_path.split(".").pop();
+      const basePath = photo.storage_path.replace(`.${ext}`, "");
+      storagePaths.push(`${basePath}-original.${ext}`);
+    }
 
-  await supabase.storage.from("photos").remove(storagePaths);
+    await supabase.storage.from("photos").remove(storagePaths);
 
-  const { error: deleteError } = await supabase
-    .from("photos")
-    .delete()
-    .eq("job_id", jobId)
-    .in("id", photoIds);
+    const { error: deleteError } = await supabase
+      .from("photos")
+      .delete()
+      .eq("job_id", jobId)
+      .in("id", photoIds);
 
-  if (deleteError) {
-    return NextResponse.json({ error: deleteError.message }, { status: 500 });
-  }
+    if (deleteError) {
+      return NextResponse.json({ error: deleteError.message }, { status: 500 });
+    }
 
-  return NextResponse.json({ deleted: photos.length });
-}
+    return NextResponse.json({ deleted: photos.length });
+  },
+);

--- a/src/app/api/jobs/[id]/photos/download/route.ts
+++ b/src/app/api/jobs/[id]/photos/download/route.ts
@@ -1,41 +1,43 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id: jobId } = await params;
-  const { photoIds } = await request.json() as { photoIds: string[] };
+// POST /api/jobs/[id]/photos/download — signed URLs for selected photos.
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const POST = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: jobId } = await params;
+    const { photoIds } = await request.json() as { photoIds: string[] };
 
-  if (!photoIds || photoIds.length === 0) {
-    return NextResponse.json({ error: "No photo IDs provided" }, { status: 400 });
-  }
+    if (!photoIds || photoIds.length === 0) {
+      return NextResponse.json({ error: "No photo IDs provided" }, { status: 400 });
+    }
 
-  const supabase = await createServerSupabaseClient();
+    const supabase = ctx.supabase;
 
-  const { data: photos, error } = await supabase
-    .from("photos")
-    .select("id, storage_path, caption")
-    .eq("job_id", jobId)
-    .in("id", photoIds);
+    const { data: photos, error } = await supabase
+      .from("photos")
+      .select("id, storage_path, caption")
+      .eq("job_id", jobId)
+      .in("id", photoIds);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!photos?.length) return NextResponse.json({ error: "No matching photos" }, { status: 404 });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!photos?.length) return NextResponse.json({ error: "No matching photos" }, { status: 404 });
 
-  const urls = await Promise.all(
-    photos.map(async (photo) => {
-      const { data } = await supabase.storage
-        .from("photos")
-        .createSignedUrl(photo.storage_path, 3600);
-      return {
-        id: photo.id,
-        url: data?.signedUrl || null,
-        filename: photo.storage_path.split("/").pop() || "photo.jpg",
-        caption: photo.caption,
-      };
-    })
-  );
+    const urls = await Promise.all(
+      photos.map(async (photo) => {
+        const { data } = await supabase.storage
+          .from("photos")
+          .createSignedUrl(photo.storage_path, 3600);
+        return {
+          id: photo.id,
+          url: data?.signedUrl || null,
+          filename: photo.storage_path.split("/").pop() || "photo.jpg",
+          caption: photo.caption,
+        };
+      })
+    );
 
-  return NextResponse.json({ urls: urls.filter((u) => u.url !== null) });
-}
+    return NextResponse.json({ urls: urls.filter((u) => u.url !== null) });
+  },
+);

--- a/src/app/api/jobs/[id]/restore/route.ts
+++ b/src/app/api/jobs/[id]/restore/route.ts
@@ -3,24 +3,20 @@
 // no-op.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requireJobsDelete } from "@/lib/jobs/auth";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireJobsDelete(supabase);
-  if (!gate.ok) return gate.response;
+export const POST = withRequestContext(
+  { roles: ["admin", "office_staff"] },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const { error } = await supabase
-    .from("jobs")
-    .update({ deleted_at: null })
-    .eq("id", id);
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({ ok: true });
-}
+    const { error } = await ctx.supabase
+      .from("jobs")
+      .update({ deleted_at: null })
+      .eq("id", id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -2,30 +2,27 @@
 // Removes every storage object the job owns (photos, job files, photo
 // reports, contracts, expense receipts) then deletes the jobs row, which
 // cascades to all child tables with FK ON DELETE CASCADE. Restricted to
-// admin/office_staff per the same gate as soft-delete.
+// admin/office_staff per the same rule as soft-delete.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requireJobsDelete } from "@/lib/jobs/auth";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { purgeJobStorage } from "@/lib/jobs/purge";
 
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireJobsDelete(supabase);
-  if (!gate.ok) return gate.response;
+export const DELETE = withRequestContext(
+  { roles: ["admin", "office_staff"] },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const supabase = ctx.supabase;
 
-  const { storageRemoved, storageErrors } = await purgeJobStorage(supabase, id);
+    const { storageRemoved, storageErrors } = await purgeJobStorage(supabase, id);
 
-  const { error: deleteError } = await supabase.from("jobs").delete().eq("id", id);
-  if (deleteError) {
-    return NextResponse.json(
-      { error: deleteError.message, storageRemoved, storageErrors },
-      { status: 500 },
-    );
-  }
-  return NextResponse.json({ ok: true, storageRemoved, storageErrors });
-}
+    const { error: deleteError } = await supabase.from("jobs").delete().eq("id", id);
+    if (deleteError) {
+      return NextResponse.json(
+        { error: deleteError.message, storageRemoved, storageErrors },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json({ ok: true, storageRemoved, storageErrors });
+  },
+);

--- a/src/app/api/jobs/search/route.test.ts
+++ b/src/app/api/jobs/search/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// Job search was previously ungated (RLS-only); it is now logged-in only.
+describe("GET /api/jobs/search (converted to withRequestContext, logged-in only)", () => {
+  it("returns 401 when unauthenticated — no permission required, but logged-in is", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/jobs/search"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns jobs for any logged-in caller, even one with no permission grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: [],
+          extraTables: {
+            jobs: [
+              { id: "job-1", job_number: "1001", property_address: "1 Main St" },
+              { id: "job-2", job_number: "1002", property_address: "2 Oak Ave" },
+            ],
+          },
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/jobs/search"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobs.map((j: { id: string }) => j.id)).toEqual([
+      "job-1",
+      "job-2",
+    ]);
+  });
+});

--- a/src/app/api/jobs/search/route.ts
+++ b/src/app/api/jobs/search/route.ts
@@ -1,15 +1,14 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/jobs/search?q=...&limit=10
-export async function GET(request: NextRequest) {
+// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+export const GET = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const q = (searchParams.get("q") || "").replace(/[%,.*()]/g, "");
   const limit = Math.min(Math.max(parseInt(searchParams.get("limit") || "10") || 10, 1), 50);
 
-  const supabase = await createServerSupabaseClient();
-
-  let query = supabase
+  let query = ctx.supabase
     .from("jobs")
     .select("id, job_number, property_address")
     .not("status", "eq", "cancelled")
@@ -29,4 +28,4 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json({ jobs: data || [] });
-}
+});

--- a/src/app/api/jobs/trash/route.ts
+++ b/src/app/api/jobs/trash/route.ts
@@ -2,60 +2,60 @@
 // auto-purging anything that has been trashed for more than 30 days
 // (lazy purge, per the design decision in #33).
 //
-// Auth: same gate as /api/jobs/[id]/delete — admin or office_staff only.
+// Auth: same rule as /api/jobs/[id]/delete — admin or office_staff only.
 // Crew members never see the trash UI, so this endpoint should only be
 // hit by callers that already have the right role; we still enforce it
 // defensively.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requireJobsDelete } from "@/lib/jobs/auth";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { purgeJobStorage } from "@/lib/jobs/purge";
 
 const RETENTION_DAYS = 30;
 
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireJobsDelete(supabase);
-  if (!gate.ok) return gate.response;
+export const GET = withRequestContext(
+  { roles: ["admin", "office_staff"] },
+  async (_request, ctx) => {
+    const supabase = ctx.supabase;
 
-  // 1. Find anything past the 30-day window in the caller's org.
-  // RLS scopes this to the active organization, so we only see and only
-  // touch rows the caller is allowed to manage.
-  const cutoffIso = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
-  const { data: expired } = await supabase
-    .from("jobs")
-    .select("id")
-    .not("deleted_at", "is", null)
-    .lt("deleted_at", cutoffIso);
+    // 1. Find anything past the 30-day window in the caller's org.
+    // RLS scopes this to the active organization, so we only see and only
+    // touch rows the caller is allowed to manage.
+    const cutoffIso = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    const { data: expired } = await supabase
+      .from("jobs")
+      .select("id")
+      .not("deleted_at", "is", null)
+      .lt("deleted_at", cutoffIso);
 
-  // 2. For each expired row: clear storage, then hard-delete (cascade
-  // takes the rest). One job at a time so a single failure doesn't strand
-  // the others. Storage errors are logged on the response but do not
-  // block the SQL delete — orphan storage objects are recoverable, but
-  // a half-deleted job row in the trash is not.
-  const purgeFailures: { jobId: string; storageErrors: string[] }[] = [];
-  for (const row of expired ?? []) {
-    const { storageErrors } = await purgeJobStorage(supabase, row.id);
-    if (storageErrors.length > 0) {
-      purgeFailures.push({ jobId: row.id, storageErrors });
+    // 2. For each expired row: clear storage, then hard-delete (cascade
+    // takes the rest). One job at a time so a single failure doesn't strand
+    // the others. Storage errors are logged on the response but do not
+    // block the SQL delete — orphan storage objects are recoverable, but
+    // a half-deleted job row in the trash is not.
+    const purgeFailures: { jobId: string; storageErrors: string[] }[] = [];
+    for (const row of expired ?? []) {
+      const { storageErrors } = await purgeJobStorage(supabase, row.id);
+      if (storageErrors.length > 0) {
+        purgeFailures.push({ jobId: row.id, storageErrors });
+      }
+      await supabase.from("jobs").delete().eq("id", row.id);
     }
-    await supabase.from("jobs").delete().eq("id", row.id);
-  }
 
-  // 3. List what's left in the trash.
-  const { data: trashed, error } = await supabase
-    .from("jobs")
-    .select("*, contact:contacts!contact_id(*)")
-    .not("deleted_at", "is", null)
-    .order("deleted_at", { ascending: false });
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({
-    jobs: trashed ?? [],
-    autoPurged: expired?.length ?? 0,
-    purgeFailures,
-    retentionDays: RETENTION_DAYS,
-  });
-}
+    // 3. List what's left in the trash.
+    const { data: trashed, error } = await supabase
+      .from("jobs")
+      .select("*, contact:contacts!contact_id(*)")
+      .not("deleted_at", "is", null)
+      .order("deleted_at", { ascending: false });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({
+      jobs: trashed ?? [],
+      autoPurged: expired?.length ?? 0,
+      purgeFailures,
+      retentionDays: RETENTION_DAYS,
+    });
+  },
+);

--- a/src/app/api/payment-requests/[id]/receipt-url/route.ts
+++ b/src/app/api/payment-requests/[id]/receipt-url/route.ts
@@ -1,37 +1,32 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 export const runtime = "nodejs";
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const authSupabase = await createServerSupabaseClient();
-  const gate = await requirePermission(authSupabase, "view_billing");
-  if (!gate.ok) return gate.response;
-  const { id } = await params;
+export const GET = withRequestContext(
+  { permission: "view_billing", serviceClient: true },
+  async (_req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const supabase = createServiceClient();
-  const { data: pr } = await supabase
-    .from("payment_requests")
-    .select("receipt_pdf_path")
-    .eq("id", id)
-    .maybeSingle<{ receipt_pdf_path: string | null }>();
-  if (!pr?.receipt_pdf_path) {
-    return NextResponse.json({ error: "no receipt PDF" }, { status: 404 });
-  }
+    const supabase = ctx.serviceClient!;
+    const { data: pr } = await supabase
+      .from("payment_requests")
+      .select("receipt_pdf_path")
+      .eq("id", id)
+      .maybeSingle<{ receipt_pdf_path: string | null }>();
+    if (!pr?.receipt_pdf_path) {
+      return NextResponse.json({ error: "no receipt PDF" }, { status: 404 });
+    }
 
-  const { data, error } = await supabase.storage
-    .from("receipts")
-    .createSignedUrl(pr.receipt_pdf_path, 300);
-  if (error || !data) {
-    return NextResponse.json(
-      { error: error?.message ?? "signed URL failed" },
-      { status: 500 },
-    );
-  }
-  return NextResponse.json({ url: data.signedUrl });
-}
+    const { data, error } = await supabase.storage
+      .from("receipts")
+      .createSignedUrl(pr.receipt_pdf_path, 300);
+    if (error || !data) {
+      return NextResponse.json(
+        { error: error?.message ?? "signed URL failed" },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json({ url: data.signedUrl });
+  },
+);

--- a/src/app/api/payment-requests/[id]/refund/route.ts
+++ b/src/app/api/payment-requests/[id]/refund/route.ts
@@ -1,7 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { getStripeClient } from "@/lib/stripe";
 import type { PaymentRow } from "@/lib/payments/types";
 
@@ -14,157 +12,150 @@ interface Body {
   notify_customer?: boolean;
 }
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const authSupabase = await createServerSupabaseClient();
-  const gate = await requirePermission(authSupabase, "record_payments");
-  if (!gate.ok) return gate.response;
+export const POST = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id: paymentRequestId } = await params;
 
-  const { id: paymentRequestId } = await params;
+    const body = (await req.json().catch(() => null)) as Body | null;
+    if (!body || typeof body.amount !== "number" || body.amount <= 0) {
+      return NextResponse.json(
+        { error: "amount must be a positive number" },
+        { status: 400 },
+      );
+    }
 
-  const body = (await req.json().catch(() => null)) as Body | null;
-  if (!body || typeof body.amount !== "number" || body.amount <= 0) {
-    return NextResponse.json(
-      { error: "amount must be a positive number" },
-      { status: 400 },
+    const serviceSupabase = ctx.serviceClient!;
+
+    // Find the most recent stripe payment row linked to this request.
+    const { data: payment, error: payErr } = await serviceSupabase
+      .from("payments")
+      .select("id, organization_id, amount, status, stripe_charge_id, payment_request_id")
+      .eq("payment_request_id", paymentRequestId)
+      .eq("source", "stripe")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<
+        Pick<
+          PaymentRow,
+          | "id"
+          | "organization_id"
+          | "amount"
+          | "status"
+          | "stripe_charge_id"
+          | "payment_request_id"
+        >
+      >();
+    if (payErr || !payment) {
+      return NextResponse.json(
+        { error: "no Stripe payment found on this request" },
+        { status: 404 },
+      );
+    }
+    if (!payment.stripe_charge_id) {
+      return NextResponse.json(
+        { error: "payment has no stripe_charge_id — cannot refund" },
+        { status: 400 },
+      );
+    }
+
+    // Validate amount against remaining refundable
+    const { data: prevRefunds } = await serviceSupabase
+      .from("refunds")
+      .select("amount, status")
+      .eq("payment_id", payment.id)
+      .in("status", ["pending", "succeeded"]);
+    const refundedSoFar = (prevRefunds ?? []).reduce(
+      (s: number, r: { amount: number }) => s + Number(r.amount),
+      0,
     );
-  }
+    const remaining = Number(payment.amount) - refundedSoFar;
+    if (body.amount - remaining > 0.01) {
+      return NextResponse.json(
+        {
+          error: `refund exceeds remaining refundable ($${remaining.toFixed(2)})`,
+        },
+        { status: 400 },
+      );
+    }
 
-  const serviceSupabase = createServiceClient();
+    // Guard against double-click: if there's already a pending refund on
+    // this payment, return it without creating a new Stripe refund.
+    const { data: existingPending } = await serviceSupabase
+      .from("refunds")
+      .select("id, stripe_refund_id, status")
+      .eq("payment_id", payment.id)
+      .eq("status", "pending")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<{
+        id: string;
+        stripe_refund_id: string | null;
+        status: string;
+      }>();
+    if (existingPending) {
+      return NextResponse.json({
+        refund_id: existingPending.id,
+        status: "pending",
+        stripe_refund_id: existingPending.stripe_refund_id,
+        note: "existing pending refund reused",
+      });
+    }
 
-  // Find the most recent stripe payment row linked to this request.
-  const { data: payment, error: payErr } = await serviceSupabase
-    .from("payments")
-    .select("id, organization_id, amount, status, stripe_charge_id, payment_request_id")
-    .eq("payment_request_id", paymentRequestId)
-    .eq("source", "stripe")
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle<
-      Pick<
-        PaymentRow,
-        | "id"
-        | "organization_id"
-        | "amount"
-        | "status"
-        | "stripe_charge_id"
-        | "payment_request_id"
-      >
-    >();
-  if (payErr || !payment) {
-    return NextResponse.json(
-      { error: "no Stripe payment found on this request" },
-      { status: 404 },
-    );
-  }
-  if (!payment.stripe_charge_id) {
-    return NextResponse.json(
-      { error: "payment has no stripe_charge_id — cannot refund" },
-      { status: 400 },
-    );
-  }
+    // The acting user for refunded_by — resolved by the wrapper.
+    const refundedBy = ctx.userId;
 
-  // Validate amount against remaining refundable
-  const { data: prevRefunds } = await serviceSupabase
-    .from("refunds")
-    .select("amount, status")
-    .eq("payment_id", payment.id)
-    .in("status", ["pending", "succeeded"]);
-  const refundedSoFar = (prevRefunds ?? []).reduce(
-    (s: number, r: { amount: number }) => s + Number(r.amount),
-    0,
-  );
-  const remaining = Number(payment.amount) - refundedSoFar;
-  if (body.amount - remaining > 0.01) {
-    return NextResponse.json(
-      {
-        error: `refund exceeds remaining refundable ($${remaining.toFixed(2)})`,
-      },
-      { status: 400 },
-    );
-  }
-
-  // Guard against double-click: if there's already a pending refund on
-  // this payment, return it without creating a new Stripe refund.
-  const { data: existingPending } = await serviceSupabase
-    .from("refunds")
-    .select("id, stripe_refund_id, status")
-    .eq("payment_id", payment.id)
-    .eq("status", "pending")
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle<{
-      id: string;
-      stripe_refund_id: string | null;
-      status: string;
-    }>();
-  if (existingPending) {
-    return NextResponse.json({
-      refund_id: existingPending.id,
-      status: "pending",
-      stripe_refund_id: existingPending.stripe_refund_id,
-      note: "existing pending refund reused",
-    });
-  }
-
-  // Find the acting user for refunded_by
-  const {
-    data: { user },
-  } = await authSupabase.auth.getUser();
-  const refundedBy = user?.id ?? null;
-
-  // Create pending refund row FIRST so we have an ID to send to Stripe metadata.
-  const { data: refundRow, error: rfErr } = await serviceSupabase
-    .from("refunds")
-    .insert({
-      payment_id: payment.id,
-      payment_request_id: paymentRequestId,
-      amount: body.amount,
-      reason: body.reason ?? null,
-      include_reason_in_customer_email:
-        body.include_reason_in_customer_email ?? false,
-      notify_customer: body.notify_customer ?? true,
-      refunded_by: refundedBy,
-      status: "pending",
-    })
-    .select("id")
-    .maybeSingle<{ id: string }>();
-  if (rfErr || !refundRow) {
-    return NextResponse.json(
-      { error: `failed to create refund row: ${rfErr?.message ?? ""}` },
-      { status: 500 },
-    );
-  }
-
-  // Call Stripe. Scope the stripe connection to the payment's org.
-  const { client: stripe } = await getStripeClient(payment.organization_id);
-  try {
-    const stripeRefund = await stripe.refunds.create({
-      charge: payment.stripe_charge_id,
-      amount: Math.round(body.amount * 100),
-      reason: "requested_by_customer",
-      metadata: {
-        refund_id: refundRow.id,
+    // Create pending refund row FIRST so we have an ID to send to Stripe metadata.
+    const { data: refundRow, error: rfErr } = await serviceSupabase
+      .from("refunds")
+      .insert({
+        payment_id: payment.id,
         payment_request_id: paymentRequestId,
-      },
-    });
-    await serviceSupabase
-      .from("refunds")
-      .update({ stripe_refund_id: stripeRefund.id })
-      .eq("id", refundRow.id);
-    return NextResponse.json({
-      refund_id: refundRow.id,
-      status: "pending",
-      stripe_refund_id: stripeRefund.id,
-    });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    await serviceSupabase
-      .from("refunds")
-      .update({ status: "failed", failure_reason: msg })
-      .eq("id", refundRow.id);
-    return NextResponse.json({ error: msg }, { status: 500 });
-  }
-}
+        amount: body.amount,
+        reason: body.reason ?? null,
+        include_reason_in_customer_email:
+          body.include_reason_in_customer_email ?? false,
+        notify_customer: body.notify_customer ?? true,
+        refunded_by: refundedBy,
+        status: "pending",
+      })
+      .select("id")
+      .maybeSingle<{ id: string }>();
+    if (rfErr || !refundRow) {
+      return NextResponse.json(
+        { error: `failed to create refund row: ${rfErr?.message ?? ""}` },
+        { status: 500 },
+      );
+    }
+
+    // Call Stripe. Scope the stripe connection to the payment's org.
+    const { client: stripe } = await getStripeClient(payment.organization_id);
+    try {
+      const stripeRefund = await stripe.refunds.create({
+        charge: payment.stripe_charge_id,
+        amount: Math.round(body.amount * 100),
+        reason: "requested_by_customer",
+        metadata: {
+          refund_id: refundRow.id,
+          payment_request_id: paymentRequestId,
+        },
+      });
+      await serviceSupabase
+        .from("refunds")
+        .update({ stripe_refund_id: stripeRefund.id })
+        .eq("id", refundRow.id);
+      return NextResponse.json({
+        refund_id: refundRow.id,
+        status: "pending",
+        stripe_refund_id: stripeRefund.id,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await serviceSupabase
+        .from("refunds")
+        .update({ status: "failed", failure_reason: msg })
+        .eq("id", refundRow.id);
+      return NextResponse.json({ error: msg }, { status: 500 });
+    }
+  },
+);

--- a/src/app/api/payment-requests/[id]/refundable/route.ts
+++ b/src/app/api/payment-requests/[id]/refundable/route.ts
@@ -1,40 +1,35 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 export const runtime = "nodejs";
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const authSupabase = await createServerSupabaseClient();
-  const gate = await requirePermission(authSupabase, "view_billing");
-  if (!gate.ok) return gate.response;
-  const { id } = await params;
+export const GET = withRequestContext(
+  { permission: "view_billing", serviceClient: true },
+  async (_req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const supabase = createServiceClient();
-  const { data: payment } = await supabase
-    .from("payments")
-    .select("id, amount")
-    .eq("payment_request_id", id)
-    .eq("source", "stripe")
-    .order("created_at", { ascending: false })
-    .limit(1)
-    .maybeSingle<{ id: string; amount: number }>();
-  if (!payment) {
-    return NextResponse.json({ error: "no Stripe payment" }, { status: 404 });
-  }
-  const { data: refunds } = await supabase
-    .from("refunds")
-    .select("amount, status")
-    .eq("payment_id", payment.id)
-    .in("status", ["pending", "succeeded"]);
-  const refundedSum = (refunds ?? []).reduce(
-    (s: number, r: { amount: number }) => s + Number(r.amount),
-    0,
-  );
-  const remaining = Number(payment.amount) - refundedSum;
-  return NextResponse.json({ remaining, payment_id: payment.id });
-}
+    const supabase = ctx.serviceClient!;
+    const { data: payment } = await supabase
+      .from("payments")
+      .select("id, amount")
+      .eq("payment_request_id", id)
+      .eq("source", "stripe")
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle<{ id: string; amount: number }>();
+    if (!payment) {
+      return NextResponse.json({ error: "no Stripe payment" }, { status: 404 });
+    }
+    const { data: refunds } = await supabase
+      .from("refunds")
+      .select("amount, status")
+      .eq("payment_id", payment.id)
+      .in("status", ["pending", "succeeded"]);
+    const refundedSum = (refunds ?? []).reduce(
+      (s: number, r: { amount: number }) => s + Number(r.amount),
+      0,
+    );
+    const remaining = Number(payment.amount) - refundedSum;
+    return NextResponse.json({ remaining, payment_id: payment.id });
+  },
+);

--- a/src/app/api/payment-requests/[id]/route.test.ts
+++ b/src/app/api/payment-requests/[id]/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({
+      tables: {
+        payment_requests: [{ id: "pr-1", title: "Deposit", amount: 500 }],
+      },
+    }) as never,
+  );
+});
+
+// payment-requests/[id] GET carried `requirePermission("view_billing")`;
+// it now rides on the `permission` rule (admins auto-pass).
+describe("GET /api/payment-requests/[id] (converted to withRequestContext, view_billing)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("pr-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member who lacks view_billing", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["log_expenses"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("pr-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the payment request for a member who holds view_billing", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["view_billing"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("pr-1"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.payment_request.id).toBe("pr-1");
+  });
+
+  it("allows an admin even without the grant", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("pr-1"));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when the payment request does not exist", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "admin",
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("does-not-exist"));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/payment-requests/[id]/route.ts
+++ b/src/app/api/payment-requests/[id]/route.ts
@@ -1,24 +1,17 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "view_billing");
-  if (!gate.ok) return gate.response;
-
-  const { id } = await params;
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("payment_requests")
-    .select("*")
-    .eq("id", id)
-    .maybeSingle();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) return NextResponse.json({ error: "not_found" }, { status: 404 });
-  return NextResponse.json({ payment_request: data });
-}
+export const GET = withRequestContext(
+  { permission: "view_billing", serviceClient: true },
+  async (_req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { data, error } = await ctx.serviceClient!
+      .from("payment_requests")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) return NextResponse.json({ error: "not_found" }, { status: 404 });
+    return NextResponse.json({ payment_request: data });
+  },
+);

--- a/src/app/api/payment-requests/[id]/send/route.ts
+++ b/src/app/api/payment-requests/[id]/send/route.ts
@@ -1,46 +1,40 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { sendPaymentRequestEmail } from "@/lib/payment-emails";
 
-export async function POST(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "record_payments");
-  if (!gate.ok) return gate.response;
-
-  const { id } = await params;
-  const supabase = createServiceClient();
-  const { data: pr, error } = await supabase
-    .from("payment_requests")
-    .select("id, status")
-    .eq("id", id)
-    .maybeSingle<{ id: string; status: string }>();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!pr) return NextResponse.json({ error: "not_found" }, { status: 404 });
-  if (pr.status !== "draft") {
-    return NextResponse.json(
-      { error: `cannot_send_from_status_${pr.status}` },
-      { status: 400 },
-    );
-  }
-
-  try {
-    const sent = await sendPaymentRequestEmail(id);
-    const { data: updated } = await supabase
+export const POST = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (_req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const supabase = ctx.serviceClient!;
+    const { data: pr, error } = await supabase
       .from("payment_requests")
-      .select("*")
+      .select("id, status")
       .eq("id", id)
-      .maybeSingle();
-    return NextResponse.json({ payment_request: updated, message_id: sent.messageId });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return NextResponse.json(
-      { error: `send_failed: ${msg}` },
-      { status: 502 },
-    );
-  }
-}
+      .maybeSingle<{ id: string; status: string }>();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!pr) return NextResponse.json({ error: "not_found" }, { status: 404 });
+    if (pr.status !== "draft") {
+      return NextResponse.json(
+        { error: `cannot_send_from_status_${pr.status}` },
+        { status: 400 },
+      );
+    }
+
+    try {
+      const sent = await sendPaymentRequestEmail(id);
+      const { data: updated } = await supabase
+        .from("payment_requests")
+        .select("*")
+        .eq("id", id)
+        .maybeSingle();
+      return NextResponse.json({ payment_request: updated, message_id: sent.messageId });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return NextResponse.json(
+        { error: `send_failed: ${msg}` },
+        { status: 502 },
+      );
+    }
+  },
+);

--- a/src/app/api/payment-requests/[id]/void/route.ts
+++ b/src/app/api/payment-requests/[id]/void/route.ts
@@ -1,96 +1,90 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { getStripeClient } from "@/lib/stripe";
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "record_payments");
-  if (!gate.ok) return gate.response;
+export const POST = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (req, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = (await req.json().catch(() => ({}))) as { reason?: string };
 
-  const { id } = await params;
-  const body = (await req.json().catch(() => ({}))) as { reason?: string };
-
-  const supabase = createServiceClient();
-  const { data: pr, error } = await supabase
-    .from("payment_requests")
-    .select("*")
-    .eq("id", id)
-    .maybeSingle();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!pr) return NextResponse.json({ error: "not_found" }, { status: 404 });
-  if (pr.status === "paid") {
-    return NextResponse.json({ error: "cannot_void_paid" }, { status: 400 });
-  }
-  if (pr.status === "voided") {
-    return NextResponse.json({ payment_request: pr });
-  }
-
-  if (pr.stripe_checkout_session_id) {
-    try {
-      const { client } = await getStripeClient(pr.organization_id);
-      await client.checkout.sessions.expire(pr.stripe_checkout_session_id);
-    } catch {
-      // Session may already be expired or Stripe may be temporarily unreachable.
-      // Proceed with the DB-side void anyway — the session is best-effort cleanup.
+    const supabase = ctx.serviceClient!;
+    const { data: pr, error } = await supabase
+      .from("payment_requests")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!pr) return NextResponse.json({ error: "not_found" }, { status: 404 });
+    if (pr.status === "paid") {
+      return NextResponse.json({ error: "cannot_void_paid" }, { status: 400 });
     }
-  }
+    if (pr.status === "voided") {
+      return NextResponse.json({ payment_request: pr });
+    }
 
-  const { data: updated, error: updErr } = await supabase
-    .from("payment_requests")
-    .update({
-      status: "voided",
-      voided_at: new Date().toISOString(),
-      voided_by: gate.userId,
-      void_reason: body.reason ?? null,
-    })
-    .eq("id", id)
-    .select("*")
-    .maybeSingle();
-  if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
+    if (pr.stripe_checkout_session_id) {
+      try {
+        const { client } = await getStripeClient(pr.organization_id);
+        await client.checkout.sessions.expire(pr.stripe_checkout_session_id);
+      } catch {
+        // Session may already be expired or Stripe may be temporarily unreachable.
+        // Proceed with the DB-side void anyway — the session is best-effort cleanup.
+      }
+    }
 
-  // Recompute parent flags.
-  const { data: remainingForJob } = await supabase
-    .from("payment_requests")
-    .select("id, status")
-    .eq("job_id", pr.job_id)
-    .in("status", ["draft", "sent", "viewed"]);
-  const jobStillPending = (remainingForJob ?? []).length > 0;
-  const { error: jobFlagErr } = await supabase
-    .from("jobs")
-    .update({ has_pending_payment_request: jobStillPending })
-    .eq("id", pr.job_id);
-  if (jobFlagErr) {
-    console.error("[payment-requests/void] failed to recompute jobs flag:", {
-      job_id: pr.job_id,
-      payment_request_id: id,
-      error: jobFlagErr.message,
-    });
-  }
+    const { data: updated, error: updErr } = await supabase
+      .from("payment_requests")
+      .update({
+        status: "voided",
+        voided_at: new Date().toISOString(),
+        voided_by: ctx.userId,
+        void_reason: body.reason ?? null,
+      })
+      .eq("id", id)
+      .select("*")
+      .maybeSingle();
+    if (updErr) return NextResponse.json({ error: updErr.message }, { status: 500 });
 
-  if (pr.invoice_id) {
-    const { data: remainingForInvoice } = await supabase
+    // Recompute parent flags.
+    const { data: remainingForJob } = await supabase
       .from("payment_requests")
       .select("id, status")
-      .eq("invoice_id", pr.invoice_id)
-      .not("status", "in", "(voided,expired,failed,refunded)");
-    const invoiceStillLinked = (remainingForInvoice ?? []).length > 0;
-    const { error: invFlagErr } = await supabase
-      .from("invoices")
-      .update({ has_payment_request: invoiceStillLinked })
-      .eq("id", pr.invoice_id);
-    if (invFlagErr) {
-      console.error("[payment-requests/void] failed to recompute invoices flag:", {
-        invoice_id: pr.invoice_id,
+      .eq("job_id", pr.job_id)
+      .in("status", ["draft", "sent", "viewed"]);
+    const jobStillPending = (remainingForJob ?? []).length > 0;
+    const { error: jobFlagErr } = await supabase
+      .from("jobs")
+      .update({ has_pending_payment_request: jobStillPending })
+      .eq("id", pr.job_id);
+    if (jobFlagErr) {
+      console.error("[payment-requests/void] failed to recompute jobs flag:", {
+        job_id: pr.job_id,
         payment_request_id: id,
-        error: invFlagErr.message,
+        error: jobFlagErr.message,
       });
     }
-  }
 
-  return NextResponse.json({ payment_request: updated });
-}
+    if (pr.invoice_id) {
+      const { data: remainingForInvoice } = await supabase
+        .from("payment_requests")
+        .select("id, status")
+        .eq("invoice_id", pr.invoice_id)
+        .not("status", "in", "(voided,expired,failed,refunded)");
+      const invoiceStillLinked = (remainingForInvoice ?? []).length > 0;
+      const { error: invFlagErr } = await supabase
+        .from("invoices")
+        .update({ has_payment_request: invoiceStillLinked })
+        .eq("id", pr.invoice_id);
+      if (invFlagErr) {
+        console.error("[payment-requests/void] failed to recompute invoices flag:", {
+          invoice_id: pr.invoice_id,
+          payment_request_id: id,
+          error: invFlagErr.message,
+        });
+      }
+    }
+
+    return NextResponse.json({ payment_request: updated });
+  },
+);

--- a/src/app/api/payment-requests/route.ts
+++ b/src/app/api/payment-requests/route.ts
@@ -1,10 +1,7 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { getStripeClient, StripeNotConnectedError } from "@/lib/stripe";
 import { generatePaymentLinkToken } from "@/lib/payment-link-tokens";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 
 interface CreateBody {
   job_id: string;
@@ -27,165 +24,155 @@ function addDays(date: Date, days: number): Date {
   return d;
 }
 
-export async function POST(req: NextRequest) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "record_payments");
-  if (!gate.ok) return gate.response;
+export const POST = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (req, ctx) => {
+    const body = (await req.json()) as CreateBody;
 
-  const body = (await req.json()) as CreateBody;
-
-  if (!body.job_id || !body.title || typeof body.amount !== "number" || body.amount <= 0) {
-    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
-  }
-  const validTypes: CreateBody["request_type"][] = ["invoice", "deposit", "retainer", "partial"];
-  if (!validTypes.includes(body.request_type)) {
-    return NextResponse.json({ error: "invalid_request_type" }, { status: 400 });
-  }
-
-  // Amount must be representable as whole cents (2 decimal places at most).
-  const scaled = Math.round(body.amount * 100);
-  if (Math.abs(scaled / 100 - body.amount) > 1e-9) {
-    return NextResponse.json({ error: "amount_precision" }, { status: 400 });
-  }
-
-  const orgId = await getActiveOrganizationId(auth);
-  if (!orgId) {
-    return NextResponse.json({ error: "no_active_organization" }, { status: 401 });
-  }
-
-  let stripeCtx: Awaited<ReturnType<typeof getStripeClient>>;
-  try {
-    stripeCtx = await getStripeClient(orgId);
-  } catch (e) {
-    if (e instanceof StripeNotConnectedError) {
-      return NextResponse.json({ error: "stripe_not_connected" }, { status: 400 });
+    if (!body.job_id || !body.title || typeof body.amount !== "number" || body.amount <= 0) {
+      return NextResponse.json({ error: "invalid_body" }, { status: 400 });
     }
-    throw e;
-  }
-  const { client: stripe, connection } = stripeCtx;
-
-  const supabase = createServiceClient();
-
-  const { data: job, error: jobErr } = await supabase
-    .from("jobs")
-    .select("id, contact_id, job_number")
-    .eq("id", body.job_id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (jobErr || !job) return NextResponse.json({ error: "job_not_found" }, { status: 404 });
-
-  let customerEmail: string | null = null;
-  let customerName: string | null = null;
-  if (job.contact_id) {
-    const { data: contact } = await supabase
-      .from("contacts")
-      .select("email, first_name, last_name")
-      .eq("id", job.contact_id)
-      .maybeSingle();
-    if (contact) {
-      customerEmail = contact.email ?? null;
-      customerName = [contact.first_name, contact.last_name].filter(Boolean).join(" ") || null;
+    const validTypes: CreateBody["request_type"][] = ["invoice", "deposit", "retainer", "partial"];
+    if (!validTypes.includes(body.request_type)) {
+      return NextResponse.json({ error: "invalid_request_type" }, { status: 400 });
     }
-  }
 
-  // Caller-supplied override wins over the contact lookup. Lets the user
-  // send a payment request to a different address without editing the
-  // contact record.
-  if (typeof body.payer_email === "string") {
-    const trimmed = body.payer_email.trim();
-    if (trimmed) {
-      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
-        return NextResponse.json({ error: "invalid_payer_email" }, { status: 400 });
+    // Amount must be representable as whole cents (2 decimal places at most).
+    const scaled = Math.round(body.amount * 100);
+    if (Math.abs(scaled / 100 - body.amount) > 1e-9) {
+      return NextResponse.json({ error: "amount_precision" }, { status: 400 });
+    }
+
+    const orgId = ctx.orgId;
+    if (!orgId) {
+      return NextResponse.json({ error: "no_active_organization" }, { status: 401 });
+    }
+
+    let stripeCtx: Awaited<ReturnType<typeof getStripeClient>>;
+    try {
+      stripeCtx = await getStripeClient(orgId);
+    } catch (e) {
+      if (e instanceof StripeNotConnectedError) {
+        return NextResponse.json({ error: "stripe_not_connected" }, { status: 400 });
       }
-      customerEmail = trimmed;
+      throw e;
     }
-  }
-  if (typeof body.payer_name === "string") {
-    customerName = body.payer_name.trim() || customerName;
-  }
+    const { client: stripe, connection } = stripeCtx;
 
-  if (body.invoice_id) {
-    const { data: invoice } = await supabase
-      .from("invoices")
-      .select("id, job_id, total_amount")
-      .eq("id", body.invoice_id)
+    const supabase = ctx.serviceClient!;
+
+    const { data: job, error: jobErr } = await supabase
+      .from("jobs")
+      .select("id, contact_id, job_number")
+      .eq("id", body.job_id)
+      .eq("organization_id", orgId)
       .maybeSingle();
-    if (!invoice) return NextResponse.json({ error: "invoice_not_found" }, { status: 404 });
-    if (invoice.job_id !== body.job_id) {
-      return NextResponse.json({ error: "invoice_job_mismatch" }, { status: 400 });
+    if (jobErr || !job) return NextResponse.json({ error: "job_not_found" }, { status: 404 });
+
+    let customerEmail: string | null = null;
+    let customerName: string | null = null;
+    if (job.contact_id) {
+      const { data: contact } = await supabase
+        .from("contacts")
+        .select("email, first_name, last_name")
+        .eq("id", job.contact_id)
+        .maybeSingle();
+      if (contact) {
+        customerEmail = contact.email ?? null;
+        customerName = [contact.first_name, contact.last_name].filter(Boolean).join(" ") || null;
+      }
     }
-    const { data: payments } = await supabase
-      .from("payments")
-      .select("amount, status")
-      .eq("invoice_id", body.invoice_id);
-    const paid = (payments ?? [])
-      .filter((p) => p.status === "received")
-      .reduce((acc: number, p: { amount: number }) => acc + Number(p.amount), 0);
-    const balance = Number(invoice.total_amount) - paid;
-    if (body.amount > balance + 0.005) {
-      return NextResponse.json({ error: "amount_exceeds_balance" }, { status: 400 });
+
+    // Caller-supplied override wins over the contact lookup. Lets the user
+    // send a payment request to a different address without editing the
+    // contact record.
+    if (typeof body.payer_email === "string") {
+      const trimmed = body.payer_email.trim();
+      if (trimmed) {
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+          return NextResponse.json({ error: "invalid_payer_email" }, { status: 400 });
+        }
+        customerEmail = trimmed;
+      }
     }
-  }
+    if (typeof body.payer_name === "string") {
+      customerName = body.payer_name.trim() || customerName;
+    }
 
-  let allowCard = body.allow_card ?? connection.card_enabled;
-  const allowAch = body.allow_ach ?? connection.ach_enabled;
-  if (
-    connection.ach_preferred_threshold != null &&
-    body.amount >= Number(connection.ach_preferred_threshold) &&
-    connection.ach_enabled
-  ) {
-    allowCard = false;
-  }
-  if (!allowCard && !allowAch) {
-    return NextResponse.json({ error: "no_payment_methods_available" }, { status: 400 });
-  }
+    if (body.invoice_id) {
+      const { data: invoice } = await supabase
+        .from("invoices")
+        .select("id, job_id, total_amount")
+        .eq("id", body.invoice_id)
+        .maybeSingle();
+      if (!invoice) return NextResponse.json({ error: "invoice_not_found" }, { status: 404 });
+      if (invoice.job_id !== body.job_id) {
+        return NextResponse.json({ error: "invoice_job_mismatch" }, { status: 400 });
+      }
+      const { data: payments } = await supabase
+        .from("payments")
+        .select("amount, status")
+        .eq("invoice_id", body.invoice_id);
+      const paid = (payments ?? [])
+        .filter((p) => p.status === "received")
+        .reduce((acc: number, p: { amount: number }) => acc + Number(p.amount), 0);
+      const balance = Number(invoice.total_amount) - paid;
+      if (body.amount > balance + 0.005) {
+        return NextResponse.json({ error: "amount_exceeds_balance" }, { status: 400 });
+      }
+    }
 
-  const paymentMethodTypes: ("card" | "us_bank_account")[] = [];
-  if (allowCard && connection.card_enabled) paymentMethodTypes.push("card");
-  if (allowAch && connection.ach_enabled) paymentMethodTypes.push("us_bank_account");
+    let allowCard = body.allow_card ?? connection.card_enabled;
+    const allowAch = body.allow_ach ?? connection.ach_enabled;
+    if (
+      connection.ach_preferred_threshold != null &&
+      body.amount >= Number(connection.ach_preferred_threshold) &&
+      connection.ach_enabled
+    ) {
+      allowCard = false;
+    }
+    if (!allowCard && !allowAch) {
+      return NextResponse.json({ error: "no_payment_methods_available" }, { status: 400 });
+    }
 
-  const paymentRequestId = crypto.randomUUID();
-  const expiryDays = body.link_expiry_days ?? DEFAULT_EXPIRY_DAYS;
-  const linkExpiresAt = addDays(new Date(), expiryDays);
+    const paymentMethodTypes: ("card" | "us_bank_account")[] = [];
+    if (allowCard && connection.card_enabled) paymentMethodTypes.push("card");
+    if (allowAch && connection.ach_enabled) paymentMethodTypes.push("us_bank_account");
 
-  // Stripe Checkout Sessions expire at most 24 hours after creation. Our
-  // payment link token may outlive the session — in Build 17b, /pay/[token]
-  // will regenerate a fresh session when a valid token arrives after the
-  // session has expired. Here we cap at 23.5h to stay safely under Stripe's
-  // limit. Do NOT raise this cap without addressing the Stripe API contract.
-  const STRIPE_SESSION_MAX_MS = 23.5 * 60 * 60 * 1000;
-  const stripeSessionExpiresAt = new Date(
-    Math.min(linkExpiresAt.getTime(), Date.now() + STRIPE_SESSION_MAX_MS),
-  );
+    const paymentRequestId = crypto.randomUUID();
+    const expiryDays = body.link_expiry_days ?? DEFAULT_EXPIRY_DAYS;
+    const linkExpiresAt = addDays(new Date(), expiryDays);
 
-  const token = generatePaymentLinkToken({
-    paymentRequestId,
-    jobId: body.job_id,
-    expiresAt: linkExpiresAt,
-  });
+    // Stripe Checkout Sessions expire at most 24 hours after creation. Our
+    // payment link token may outlive the session — in Build 17b, /pay/[token]
+    // will regenerate a fresh session when a valid token arrives after the
+    // session has expired. Here we cap at 23.5h to stay safely under Stripe's
+    // limit. Do NOT raise this cap without addressing the Stripe API contract.
+    const STRIPE_SESSION_MAX_MS = 23.5 * 60 * 60 * 1000;
+    const stripeSessionExpiresAt = new Date(
+      Math.min(linkExpiresAt.getTime(), Date.now() + STRIPE_SESSION_MAX_MS),
+    );
 
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
-  const session = await stripe.checkout.sessions.create({
-    mode: "payment",
-    payment_method_types: paymentMethodTypes,
-    line_items: [
-      {
-        quantity: 1,
-        price_data: {
-          currency: "usd",
-          product_data: { name: body.title },
-          unit_amount: Math.round(body.amount * 100),
+    const token = generatePaymentLinkToken({
+      paymentRequestId,
+      jobId: body.job_id,
+      expiresAt: linkExpiresAt,
+    });
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL!;
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      payment_method_types: paymentMethodTypes,
+      line_items: [
+        {
+          quantity: 1,
+          price_data: {
+            currency: "usd",
+            product_data: { name: body.title },
+            unit_amount: Math.round(body.amount * 100),
+          },
         },
-      },
-    ],
-    metadata: {
-      organization_id: orgId,
-      payment_request_id: paymentRequestId,
-      job_id: body.job_id,
-      invoice_id: body.invoice_id ?? "",
-      request_type: body.request_type,
-    },
-    payment_intent_data: {
+      ],
       metadata: {
         organization_id: orgId,
         payment_request_id: paymentRequestId,
@@ -193,91 +180,98 @@ export async function POST(req: NextRequest) {
         invoice_id: body.invoice_id ?? "",
         request_type: body.request_type,
       },
-      statement_descriptor_suffix:
-        connection.default_statement_descriptor?.slice(0, 22) || undefined,
-      // 17c — intentionally NOT setting receipt_email. Our webhook handler
-      // sends a branded receipt email with a PDF attached. To prevent
-      // Stripe from also sending its default receipt, disable the
-      // "Successful payments" email in Stripe Dashboard → Settings →
-      // Emails (applies account-wide).
-    },
-    customer_email: customerEmail ?? undefined,
-    success_url: `${appUrl}/pay/${token}/success`,
-    cancel_url: `${appUrl}/pay/${token}`,
-    expires_at: Math.floor(stripeSessionExpiresAt.getTime() / 1000),
-  });
+      payment_intent_data: {
+        metadata: {
+          organization_id: orgId,
+          payment_request_id: paymentRequestId,
+          job_id: body.job_id,
+          invoice_id: body.invoice_id ?? "",
+          request_type: body.request_type,
+        },
+        statement_descriptor_suffix:
+          connection.default_statement_descriptor?.slice(0, 22) || undefined,
+        // 17c — intentionally NOT setting receipt_email. Our webhook handler
+        // sends a branded receipt email with a PDF attached. To prevent
+        // Stripe from also sending its default receipt, disable the
+        // "Successful payments" email in Stripe Dashboard → Settings →
+        // Emails (applies account-wide).
+      },
+      customer_email: customerEmail ?? undefined,
+      success_url: `${appUrl}/pay/${token}/success`,
+      cancel_url: `${appUrl}/pay/${token}`,
+      expires_at: Math.floor(stripeSessionExpiresAt.getTime() / 1000),
+    });
 
-  const { data: inserted, error: insertErr } = await supabase
-    .from("payment_requests")
-    .insert({
-      organization_id: orgId,
-      id: paymentRequestId,
-      job_id: body.job_id,
-      invoice_id: body.invoice_id ?? null,
-      request_type: body.request_type,
-      title: body.title,
-      amount: body.amount,
-      status: "draft",
-      stripe_checkout_session_id: session.id,
-      link_token: token,
-      link_expires_at: linkExpiresAt.toISOString(),
-      payer_email: customerEmail,
-      payer_name: customerName,
-      sent_by: gate.userId,
-    })
-    .select("*")
-    .maybeSingle();
-  if (insertErr) {
-    try {
-      await stripe.checkout.sessions.expire(session.id);
-    } catch {
-      /* best-effort cleanup */
+    const { data: inserted, error: insertErr } = await supabase
+      .from("payment_requests")
+      .insert({
+        organization_id: orgId,
+        id: paymentRequestId,
+        job_id: body.job_id,
+        invoice_id: body.invoice_id ?? null,
+        request_type: body.request_type,
+        title: body.title,
+        amount: body.amount,
+        status: "draft",
+        stripe_checkout_session_id: session.id,
+        link_token: token,
+        link_expires_at: linkExpiresAt.toISOString(),
+        payer_email: customerEmail,
+        payer_name: customerName,
+        sent_by: ctx.userId,
+      })
+      .select("*")
+      .maybeSingle();
+    if (insertErr) {
+      try {
+        await stripe.checkout.sessions.expire(session.id);
+      } catch {
+        /* best-effort cleanup */
+      }
+      return NextResponse.json({ error: insertErr.message }, { status: 500 });
     }
-    return NextResponse.json({ error: insertErr.message }, { status: 500 });
-  }
 
-  const { error: jobFlagErr } = await supabase
-    .from("jobs")
-    .update({ has_pending_payment_request: true })
-    .eq("id", body.job_id);
-  if (jobFlagErr) {
-    console.error(
-      "[payment-requests] failed to set jobs.has_pending_payment_request:",
-      { job_id: body.job_id, payment_request_id: paymentRequestId, error: jobFlagErr.message },
-    );
-  }
-  if (body.invoice_id) {
-    const { error: invFlagErr } = await supabase
-      .from("invoices")
-      .update({ has_payment_request: true })
-      .eq("id", body.invoice_id);
-    if (invFlagErr) {
+    const { error: jobFlagErr } = await supabase
+      .from("jobs")
+      .update({ has_pending_payment_request: true })
+      .eq("id", body.job_id);
+    if (jobFlagErr) {
       console.error(
-        "[payment-requests] failed to set invoices.has_payment_request:",
-        { invoice_id: body.invoice_id, payment_request_id: paymentRequestId, error: invFlagErr.message },
+        "[payment-requests] failed to set jobs.has_pending_payment_request:",
+        { job_id: body.job_id, payment_request_id: paymentRequestId, error: jobFlagErr.message },
       );
     }
-  }
+    if (body.invoice_id) {
+      const { error: invFlagErr } = await supabase
+        .from("invoices")
+        .update({ has_payment_request: true })
+        .eq("id", body.invoice_id);
+      if (invFlagErr) {
+        console.error(
+          "[payment-requests] failed to set invoices.has_payment_request:",
+          { invoice_id: body.invoice_id, payment_request_id: paymentRequestId, error: invFlagErr.message },
+        );
+      }
+    }
 
-  return NextResponse.json({ payment_request: inserted });
-}
+    return NextResponse.json({ payment_request: inserted });
+  },
+);
 
-export async function GET(req: NextRequest) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "view_billing");
-  if (!gate.ok) return gate.response;
+export const GET = withRequestContext(
+  { permission: "view_billing", serviceClient: true },
+  async (req, ctx) => {
+    const url = new URL(req.url);
+    const jobId = url.searchParams.get("job_id");
+    if (!jobId) return NextResponse.json({ error: "job_id_required" }, { status: 400 });
 
-  const url = new URL(req.url);
-  const jobId = url.searchParams.get("job_id");
-  if (!jobId) return NextResponse.json({ error: "job_id_required" }, { status: 400 });
-
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("payment_requests")
-    .select("*")
-    .eq("organization_id", await getActiveOrganizationId(auth))
-    .eq("job_id", jobId)
-    .order("created_at", { ascending: false });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ payment_requests: data });
-}
+    const { data, error } = await ctx.serviceClient!
+      .from("payment_requests")
+      .select("*")
+      .eq("organization_id", ctx.orgId)
+      .eq("job_id", jobId)
+      .order("created_at", { ascending: false });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ payment_requests: data });
+  },
+);

--- a/src/app/api/payments/[id]/retry-qb-sync/route.ts
+++ b/src/app/api/payments/[id]/retry-qb-sync/route.ts
@@ -1,45 +1,39 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { syncPaymentToQb } from "@/lib/qb/sync/stripe-payment-bridge";
-import { createServiceClient } from "@/lib/supabase-api";
 
 export const runtime = "nodejs";
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const authSupabase = await createServerSupabaseClient();
-  const gate = await requirePermission(authSupabase, "record_payments");
-  if (!gate.ok) return gate.response;
-  const { id } = await params;
+export const POST = withRequestContext(
+  { permission: "record_payments", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const supabase = ctx.serviceClient!;
 
-  const supabase = createServiceClient();
-
-  // Mark pending before attempting, so the UI badge flips quickly.
-  await supabase
-    .from("payments")
-    .update({
-      quickbooks_sync_status: "pending",
-      quickbooks_sync_attempted_at: new Date().toISOString(),
-      quickbooks_sync_error: null,
-    })
-    .eq("id", id);
-
-  try {
-    await syncPaymentToQb(id);
-    return NextResponse.json({ ok: true, status: "synced" });
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    // Mark pending before attempting, so the UI badge flips quickly.
     await supabase
       .from("payments")
       .update({
-        quickbooks_sync_status: "failed",
-        quickbooks_sync_error: msg,
+        quickbooks_sync_status: "pending",
         quickbooks_sync_attempted_at: new Date().toISOString(),
+        quickbooks_sync_error: null,
       })
       .eq("id", id);
-    return NextResponse.json({ error: msg, status: "failed" }, { status: 500 });
-  }
-}
+
+    try {
+      await syncPaymentToQb(id);
+      return NextResponse.json({ ok: true, status: "synced" });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      await supabase
+        .from("payments")
+        .update({
+          quickbooks_sync_status: "failed",
+          quickbooks_sync_error: msg,
+          quickbooks_sync_attempted_at: new Date().toISOString(),
+        })
+        .eq("id", id);
+      return NextResponse.json({ error: msg, status: "failed" }, { status: 500 });
+    }
+  },
+);

--- a/src/app/api/payments/[id]/route.ts
+++ b/src/app/api/payments/[id]/route.ts
@@ -2,8 +2,7 @@
 // DELETE /api/payments/[id]   — delete. Trigger captures snapshot before delete.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 interface PatchBody {
   amount?: number;
@@ -16,50 +15,40 @@ interface PatchBody {
   status?: "received" | "pending" | "due";
 }
 
-export async function PATCH(
-  request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+export const PATCH = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = (await request.json().catch(() => null)) as PatchBody | null;
+    if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
 
-  const { id } = await context.params;
-  const body = (await request.json().catch(() => null)) as PatchBody | null;
-  if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
+    const patch: Record<string, unknown> = {};
+    if (typeof body.amount === "number") patch.amount = body.amount;
+    if (typeof body.method === "string") patch.method = body.method;
+    if (typeof body.source === "string") patch.source = body.source;
+    if (body.receivedDate !== undefined) patch.received_date = body.receivedDate;
+    if (body.referenceNumber !== undefined) patch.reference_number = body.referenceNumber;
+    if (body.payerName !== undefined) patch.payer_name = body.payerName;
+    if (body.notes !== undefined) patch.notes = body.notes;
+    if (body.status) patch.status = body.status;
 
-  const patch: Record<string, unknown> = {};
-  if (typeof body.amount === "number") patch.amount = body.amount;
-  if (typeof body.method === "string") patch.method = body.method;
-  if (typeof body.source === "string") patch.source = body.source;
-  if (body.receivedDate !== undefined) patch.received_date = body.receivedDate;
-  if (body.referenceNumber !== undefined) patch.reference_number = body.referenceNumber;
-  if (body.payerName !== undefined) patch.payer_name = body.payerName;
-  if (body.notes !== undefined) patch.notes = body.notes;
-  if (body.status) patch.status = body.status;
+    const { data, error } = await ctx.serviceClient!
+      .from("payments")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);
 
-  const service = createServiceClient();
-  const { data, error } = await service
-    .from("payments")
-    .update(patch)
-    .eq("id", id)
-    .select()
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
-
-export async function DELETE(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-
-  const { id } = await context.params;
-  const service = createServiceClient();
-  const { error } = await service.from("payments").delete().eq("id", id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ ok: true });
-}
+export const DELETE = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { error } = await ctx.serviceClient!.from("payments").delete().eq("id", id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -2,9 +2,7 @@
 // POST /api/payments                       — record a payment.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 interface CreatePaymentBody {
   jobId: string;
@@ -18,19 +16,17 @@ interface CreatePaymentBody {
   notes?: string | null;
 }
 
-export async function GET(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-
+// Listing payments is logged-in only; the User client's RLS scopes rows to
+// the active organization.
+export const GET = withRequestContext({}, async (request, ctx) => {
   const url = new URL(request.url);
   const invoiceId = url.searchParams.get("invoiceId");
   const jobId = url.searchParams.get("jobId");
 
-  let query = supabase
+  let query = ctx.supabase
     .from("payments")
     .select("*")
-    .eq("organization_id", await getActiveOrganizationId(supabase))
+    .eq("organization_id", ctx.orgId)
     .order("received_date", { ascending: false, nullsFirst: false })
     .order("created_at", { ascending: false });
   if (invoiceId) query = query.eq("invoice_id", invoiceId);
@@ -39,52 +35,53 @@ export async function GET(request: Request) {
   const { data, error } = await query;
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ rows: data ?? [] });
-}
+});
 
-export async function POST(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-
-  const body = (await request.json().catch(() => null)) as CreatePaymentBody | null;
-  if (!body?.jobId || !body?.source || !body?.method || !body.amount) {
-    return NextResponse.json({ error: "jobId, source, method, amount required" }, { status: 400 });
-  }
-
-  const orgId = await getActiveOrganizationId(supabase);
-  const service = createServiceClient();
-  if (body.invoiceId) {
-    const { data: inv } = await service
-      .from("invoices")
-      .select("status")
-      .eq("id", body.invoiceId)
-      .eq("organization_id", orgId)
-      .maybeSingle<{ status: string }>();
-    if (inv?.status === "draft") {
-      return NextResponse.json(
-        { error: "Cannot record a payment on a draft invoice. Send or mark it sent first." },
-        { status: 400 },
-      );
+// Recording a payment is logged-in only; it writes with the Service client
+// so the insert and the draft-invoice guard bypass RLS.
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as CreatePaymentBody | null;
+    if (!body?.jobId || !body?.source || !body?.method || !body.amount) {
+      return NextResponse.json({ error: "jobId, source, method, amount required" }, { status: 400 });
     }
-  }
 
-  const { data, error } = await service
-    .from("payments")
-    .insert({
-      organization_id: orgId,
-      job_id: body.jobId,
-      invoice_id: body.invoiceId ?? null,
-      source: body.source,
-      method: body.method,
-      amount: body.amount,
-      reference_number: body.referenceNumber ?? null,
-      payer_name: body.payerName ?? null,
-      received_date: body.receivedDate ?? new Date().toISOString(),
-      notes: body.notes ?? null,
-      status: "received",
-    })
-    .select()
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+    const orgId = ctx.orgId;
+    const service = ctx.serviceClient!;
+    if (body.invoiceId) {
+      const { data: inv } = await service
+        .from("invoices")
+        .select("status")
+        .eq("id", body.invoiceId)
+        .eq("organization_id", orgId)
+        .maybeSingle<{ status: string }>();
+      if (inv?.status === "draft") {
+        return NextResponse.json(
+          { error: "Cannot record a payment on a draft invoice. Send or mark it sent first." },
+          { status: 400 },
+        );
+      }
+    }
+
+    const { data, error } = await service
+      .from("payments")
+      .insert({
+        organization_id: orgId,
+        job_id: body.jobId,
+        invoice_id: body.invoiceId ?? null,
+        source: body.source,
+        method: body.method,
+        amount: body.amount,
+        reference_number: body.referenceNumber ?? null,
+        payer_name: body.payerName ?? null,
+        received_date: body.receivedDate ?? new Date().toISOString(),
+        notes: body.notes ?? null,
+        status: "received",
+      })
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/lib/request-context/evaluate-permission-rule.test.ts
+++ b/src/lib/request-context/evaluate-permission-rule.test.ts
@@ -101,6 +101,38 @@ describe("evaluatePermissionRule", () => {
     });
   });
 
+  describe("roles rule", () => {
+    // The job-delete gate: admin OR office_staff, no permission grant
+    // substitutes.
+    const rule = { roles: ["admin", "office_staff"] };
+
+    it("allows an admin (admin is listed explicitly)", () => {
+      expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("allows a non-admin whose role is in the list", () => {
+      expect(
+        evaluatePermissionRule(rule, { role: "office_staff", grantedPermissions: [] }),
+      ).toBe(true);
+    });
+
+    it("denies a role not in the list, even with permission grants", () => {
+      expect(
+        evaluatePermissionRule(rule, member(["view_invoices", "log_expenses"])),
+      ).toBe(false);
+    });
+
+    it("denies a non-member (null role)", () => {
+      expect(evaluatePermissionRule(rule, nonMember)).toBe(false);
+    });
+
+    it("does not auto-pass an admin when admin is absent from the list", () => {
+      expect(evaluatePermissionRule({ roles: ["office_staff"] }, admin)).toBe(
+        false,
+      );
+    });
+  });
+
   describe("rule-shape edge cases", () => {
     it("enforces adminOnly when a rule mistakenly sets both adminOnly and permission", () => {
       const rule = { adminOnly: true, permission: "view_invoices" };
@@ -108,6 +140,11 @@ describe("evaluatePermissionRule", () => {
         false,
       );
       expect(evaluatePermissionRule(rule, admin)).toBe(true);
+    });
+
+    it("denies a non-member for an empty roles list", () => {
+      expect(evaluatePermissionRule({ roles: [] }, admin)).toBe(false);
+      expect(evaluatePermissionRule({ roles: [] }, nonMember)).toBe(false);
     });
 
     it("denies a non-admin for an empty permission array, still admits an admin", () => {

--- a/src/lib/request-context/evaluate-permission-rule.ts
+++ b/src/lib/request-context/evaluate-permission-rule.ts
@@ -5,9 +5,9 @@
 // It is deliberately ignorant of authentication (the 401 case) and of the
 // Service-client opt-in. Those are I/O and plumbing concerns owned by
 // `withRequestContext`. This module only encodes the role/permission policy
-// that the four old route gates (requirePermission, requireAnyPermission,
-// requireAdmin, requireViewAccounting) and the inline requireLogExpenses
-// each re-implemented by hand.
+// that the old route gates (requirePermission, requireAnyPermission,
+// requireAdmin, requireViewAccounting, requireJobsDelete) and the inline
+// requireLogExpenses each re-implemented by hand.
 
 // The policy half of a Request Context rule. `withRequestContext` accepts
 // this plus a `serviceClient` flag; that flag never reaches this function
@@ -18,6 +18,11 @@ export interface PermissionRule {
   permission?: string | string[];
   // Caller must have the `admin` role. No permission key substitutes.
   adminOnly?: boolean;
+  // Caller's role must be one of these. Unlike `permission`, admin does NOT
+  // auto-pass — include "admin" in the list when admins should be allowed.
+  // This is the form for hard role checks that no permission grant can
+  // substitute for, e.g. the job-delete gate's `["admin", "office_staff"]`.
+  roles?: string[];
 }
 
 // What the caller is, as resolved from the active organization. `role` is
@@ -34,11 +39,14 @@ export interface PermissionFacts {
  * - `adminOnly` passes only for role `admin`.
  * - `permission` (single key or array) passes if the caller is `admin` OR
  *   holds at least one of the keys.
+ * - `roles` passes only if the caller's role is in the list — admin gets no
+ *   automatic pass, so admins must be listed explicitly.
  * - An empty rule (`{}` — logged-in only) always passes; the caller having
  *   reached this function means authentication already succeeded.
  *
- * `adminOnly` and `permission` are meant to be mutually exclusive; if both
- * are set, `adminOnly` is enforced (the stricter of the two).
+ * `adminOnly`, `permission`, and `roles` are meant to be mutually exclusive;
+ * if more than one is set, the earlier in this list wins (the strictest is
+ * `adminOnly`).
  */
 export function evaluatePermissionRule(
   rule: PermissionRule,
@@ -54,6 +62,10 @@ export function evaluatePermissionRule(
       ? rule.permission
       : [rule.permission];
     return keys.some((key) => facts.grantedPermissions.includes(key));
+  }
+
+  if (rule.roles !== undefined) {
+    return facts.role !== null && rule.roles.includes(facts.role);
   }
 
   // Empty rule: authentication alone is enough.


### PR DESCRIPTION
## What this does

Converts all 22 `jobs`, `payments`, and `payment-requests` API routes to the `withRequestContext` wrapper built in #79, and removes the inline gates they each carried. Closes #83.

## The `roles` rule

The job soft-delete / restore / trash / hard-delete routes used a **fifth** gate — `requireJobsDelete` (`src/lib/jobs/auth.ts`) — enforcing **"role is `admin` OR `office_staff`"**. The #79 rule shape (`adminOnly` / `permission`) could not express this 1:1, so `evaluatePermissionRule` gains a `roles` rule: a hard role-set check with **no admin auto-pass** (admins must be listed). `requireJobsDelete` maps to `{ roles: ["admin", "office_staff"] }`.

## Behavior-preserving conversion

- **Gated → 1:1 rule.** `requirePermission("record_payments" | "view_billing")` → `{ permission: … }`; `requireJobsDelete` → `{ roles: ["admin","office_staff"] }`.
- **Previously ungated → logged-in only.** `jobs/search`, `jobs/[id]/files*`, `jobs/[id]/photos/*` were RLS-only; now wrapped `{}`. No access change for logged-in callers; unauthenticated callers now get a 401 (same as the #79 expenses GETs). Noted for the #86 ungated-endpoint list.
- **Service-client routes** opt in via `serviceClient: true`.
- Rejection vocabulary standardizes to `Not authenticated` (401) / `Permission denied` (403), per #79.

## Notes

- `requireJobsDelete` is no longer imported by any route; `canDeleteJobs` (its client-side mirror) is untouched.
- No public payment-link or `CRON_SECRET` endpoints fall in this batch.
- `payment-requests/[id]/refund` previously read `refunded_by` from `authSupabase.auth.getUser()` (could be `null`); it now uses `ctx.userId`, which is always present — the route already required a permission, so a user was always authenticated.

## Verification

- Typecheck clean on the changed surface (the only `tsc` error in the repo is the pre-existing, unrelated `sync-folder-incremental.test.ts` `TS2322`).
- Lint clean on the changed surface.
- Full suite **235 tests / 34 files** green — adds 6 `roles` policy unit tests and 11 converted-route tests (a `roles` route, a logged-in-only route, a permission-gated route) behind a shared `src/app/api/__test-utils__/request-context-fakes.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)