### PR TITLE
Request Context: convert settings endpoints (#84)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -1,0 +1,112 @@
+# Request Context — ungated-endpoint list
+
+Running list of API endpoints that the Request Context conversion slices
+(#80–#85) wrapped **logged-in-only** (`withRequestContext({}, …)`) because
+they had **no permission gate at all** before the conversion.
+
+The conversion is behavior-preserving by design (PRD #78): an endpoint with
+no prior gate is wrapped logged-in-only, which matches its prior behavior —
+it is **not** tightened here. This document is the deliverable that turns
+"endpoints with no check" into a tracked, triageable list. **Tightening any
+of these is a separate follow-up** — see #86, which publishes the final
+version of this list.
+
+Each slice appends its feature area below as it lands.
+
+---
+
+## #79 — expenses (tracer)
+
+All wrapped `{ serviceClient: true }` (logged-in-only; Service client opt-in):
+
+- `GET /api/expenses/by-job/[jobId]`
+- `GET /api/expenses/by-activity/[activityId]`
+- `GET /api/expenses/[id]/thumbnail-url`
+- `GET /api/expenses/[id]/receipt-url`
+
+The four `by-*` / `*-url` GETs additionally read expenses with the Service
+client **without org-scoping** — a pre-existing data-scoping gap, flagged in
+code comments for the triage follow-up.
+
+---
+
+## #84 — settings
+
+`settings` is the area PRD #78 calls out as most likely to contain real
+access-control gaps. The conversion wrapped 35 previously-ungated endpoints
+logged-in-only. Grouped by sub-area:
+
+### ⚠️ users — highest-priority triage
+
+These mutate org membership, roles, profiles, and permission grants with
+**no permission gate**. They should almost certainly require an admin /
+`access_settings`-class permission. Flagged for urgent triage.
+
+- `GET /api/settings/users` — lists all members of the active org
+- `POST /api/settings/users` — invites a new user, sets role + permissions
+- `PATCH /api/settings/users/[id]` — edits a profile, role, and active/ban state
+- `GET /api/settings/users/[id]/permissions` — reads a member's permission grants
+- `PUT /api/settings/users/[id]/permissions` — **rewrites a member's permission grants**
+
+### contract-templates
+
+- `GET /api/settings/contract-templates` — list templates
+- `GET /api/settings/contract-templates/[id]` — read one template (also **not org-scoped**)
+- `DELETE /api/settings/contract-templates/[id]` — soft-archive (`is_active=false`); also **lacks an organization filter** — any logged-in user can archive any org's template by id
+- `GET /api/settings/contract-templates/[id]/pdf` — short-lived signed URL for the template PDF
+- `GET /api/settings/contract-templates/jobs` — recent-jobs picker for the preview modal
+- `POST /api/settings/contract-templates/preview` — merge-field-resolved HTML preview
+
+### intake-form
+
+- `GET /api/settings/intake-form` — latest form config
+- `POST /api/settings/intake-form` — save a new form-config version
+- `GET /api/settings/intake-form/custom-fields` — per-job custom field values
+- `POST /api/settings/intake-form/restore` — restore an older form-config version
+- `GET /api/settings/intake-form/usage` — template references of form fields
+- `GET /api/settings/intake-form/versions` — version history
+
+### company / appearance / branding
+
+- `GET /api/settings/company` · `PUT /api/settings/company` — company settings key/value store
+- `GET /api/settings/appearance` · `PUT /api/settings/appearance` — brand colors
+- `POST /api/settings/company/logo` — upload the company logo
+
+### catalogs (statuses / damage-types)
+
+- `GET`, `POST`, `PUT`, `DELETE /api/settings/statuses` — job-status catalog
+- `GET`, `POST`, `PUT`, `DELETE /api/settings/damage-types` — damage-type catalog
+
+### email
+
+- `GET /api/settings/contract-email` · `PATCH /api/settings/contract-email` — contract email settings
+- `GET /api/settings/signatures` · `PUT /api/settings/signatures` — per-account email signatures
+
+### data export
+
+- `GET /api/settings/export` — CSV export of jobs / contacts / payments / invoices / emails / activities
+
+### nav
+
+- `GET /api/settings/nav-order` — admin-configured nav order (read)
+
+---
+
+## #84 — settings: notes (not in the list above)
+
+A few `settings` endpoints are **not** counted as previously-ungated, with
+the reasoning recorded here so the triage follow-up has the full picture:
+
+- `PUT /api/settings/nav-order` — had an inline admin check that accepts
+  admin in **any** org the caller belongs to (nav_items is product-level).
+  `withRequestContext`'s `adminOnly` rule only checks the Active
+  Organization, so this route is wrapped `{}` and **keeps the any-org admin
+  check as its own business logic**. Still gated — not ungated.
+- `GET /api/settings/expense-categories`, `GET /api/settings/vendors` — each
+  had an explicit inline `getUser()` 401 check, i.e. were already
+  logged-in-only. Wrapped `{}` / `{ serviceClient: true }`; no change.
+- `GET /api/settings/contract-templates/[id]/preview` — was gated on
+  `manage_contract_templates` but, by design, fell back to any logged-in
+  member of the active org (it is opened from send-contract / sign-in-person
+  modals). Its effective policy was always "logged-in", so it is wrapped
+  `{}`. The route renders only sample data, no contract PII.

--- a/src/app/api/settings/__test-utils__/request-context-fakes.ts
+++ b/src/app/api/settings/__test-utils__/request-context-fakes.ts
@@ -1,0 +1,90 @@
+// Supabase fakes for the converted `settings` route tests. The routes now
+// run through `withRequestContext`, so a route test exercises the User
+// client the wrapper authenticates against — `createServerSupabaseClient`.
+//
+// The wrapper reads, in order: `auth.getUser()`, the caller's
+// `user_organizations` membership (id + role), then the granted
+// `user_organization_permissions` keys. `fakeUserClient` + `memberTables`
+// cover exactly that surface; route bodies that use the Service client are
+// faked separately (e.g. with `makeSupabaseFake`).
+
+type Row = Record<string, unknown>;
+
+export interface SelectBuilder {
+  select(cols?: string): SelectBuilder;
+  eq(col: string, val: unknown): SelectBuilder;
+  order(col: string, opts?: unknown): SelectBuilder;
+  maybeSingle<T = Row>(): Promise<{ data: T | null; error: null }>;
+  then(resolve: (v: { data: Row[]; error: null }) => unknown): unknown;
+}
+
+function selectBuilder(rows: Row[]): SelectBuilder {
+  let filtered = [...rows];
+  const builder: SelectBuilder = {
+    select() {
+      return builder;
+    },
+    eq(col, val) {
+      filtered = filtered.filter((r) => r[col] === val);
+      return builder;
+    },
+    order() {
+      return builder;
+    },
+    async maybeSingle<T = Row>() {
+      return { data: (filtered[0] ?? null) as T | null, error: null };
+    },
+    then(resolve) {
+      return resolve({ data: filtered, error: null });
+    },
+  };
+  return builder;
+}
+
+// A fake User client. `tables` seeds whatever the wrapper reads:
+// `user_organizations` (membership) and `user_organization_permissions`
+// (grants).
+export function fakeUserClient(opts: {
+  user: { id: string } | null;
+  tables?: Record<string, Row[]>;
+}) {
+  const tables = opts.tables ?? {};
+  return {
+    auth: {
+      async getUser() {
+        return { data: { user: opts.user }, error: null };
+      },
+    },
+    from(table: string) {
+      return selectBuilder(tables[table] ?? []);
+    },
+  };
+}
+
+// Convenience: build the `tables` map for a caller who is a member of the
+// active organization with a given role and set of granted permissions.
+export function memberTables(opts: {
+  userId: string;
+  membershipId?: string;
+  orgId?: string;
+  role: string;
+  grants?: string[];
+}): Record<string, Row[]> {
+  const membershipId = opts.membershipId ?? "m-1";
+  const orgId = opts.orgId ?? "org-1";
+  return {
+    user_organizations: [
+      {
+        id: membershipId,
+        role: opts.role,
+        user_id: opts.userId,
+        organization_id: orgId,
+      },
+    ],
+    user_organization_permissions: (opts.grants ?? []).map((permission_key) => ({
+      user_organization_id: membershipId,
+      permission_key,
+      granted: true,
+    })),
+  };
+}

--- a/src/app/api/settings/accounting/checklist/route.ts
+++ b/src/app/api/settings/accounting/checklist/route.ts
@@ -3,106 +3,105 @@
 // PATCH /api/settings/accounting/checklist — toggles the manual flags
 //                                              (cpa_cleanup_confirmed,
 //                                              dry_run_review_confirmed).
+//
+// Both methods are admin-only and read/write the qb_* tables with the
+// Service client (the admin-only RLS policies need not resolve auth.uid()).
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requireAdmin } from "@/lib/qb/auth";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import type { QbConnectionRow, QbMappingRow } from "@/lib/qb/types";
 
 const KNOWN_PAYMENT_METHODS = ["check", "ach", "venmo_zelle", "cash", "credit_card"];
 
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireAdmin(supabase);
-  if (!gate.ok) return gate.response;
+export const GET = withRequestContext(
+  { adminOnly: true, serviceClient: true },
+  async (_request, ctx) => {
+    const service = ctx.serviceClient!;
+    const { data: conn } = await service
+      .from("qb_connection")
+      .select("*")
+      .eq("is_active", true)
+      .maybeSingle<QbConnectionRow>();
+    if (!conn) return NextResponse.json({ items: [] });
 
-  const service = createServiceClient();
-  const { data: conn } = await service
-    .from("qb_connection")
-    .select("*")
-    .eq("is_active", true)
-    .maybeSingle<QbConnectionRow>();
-  if (!conn) return NextResponse.json({ items: [] });
+    const { data: mappings } = await service
+      .from("qb_mappings")
+      .select("id, type, platform_value, qb_entity_id, qb_entity_name, created_at, updated_at");
+    const all = (mappings ?? []) as QbMappingRow[];
 
-  const { data: mappings } = await service
-    .from("qb_mappings")
-    .select("id, type, platform_value, qb_entity_id, qb_entity_name, created_at, updated_at");
-  const all = (mappings ?? []) as QbMappingRow[];
+    const { data: damageTypes } = await service.from("damage_types").select("id");
+    const damageTypeCount = damageTypes?.length ?? 0;
+    const damageMapped = all.filter((m) => m.type === "damage_type").length;
+    const methodMapped = all.filter((m) => m.type === "payment_method").length;
 
-  const { data: damageTypes } = await service.from("damage_types").select("id");
-  const damageTypeCount = damageTypes?.length ?? 0;
-  const damageMapped = all.filter((m) => m.type === "damage_type").length;
-  const methodMapped = all.filter((m) => m.type === "payment_method").length;
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const setupTs = conn.setup_completed_at ? Date.parse(conn.setup_completed_at) : null;
+    const dryRunOld = !!(conn.dry_run_mode && setupTs !== null && setupTs <= sevenDaysAgo);
 
-  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-  const setupTs = conn.setup_completed_at ? Date.parse(conn.setup_completed_at) : null;
-  const dryRunOld = !!(conn.dry_run_mode && setupTs !== null && setupTs <= sevenDaysAgo);
+    return NextResponse.json({
+      items: [
+        {
+          key: "cpa_cleanup_confirmed",
+          label: "CPA has completed QB cleanup",
+          checked: conn.cpa_cleanup_confirmed,
+          manual: true,
+        },
+        {
+          key: "damage_mappings",
+          label: "Damage type → class mappings complete",
+          checked: damageMapped > 0 && damageMapped >= damageTypeCount,
+          manual: false,
+        },
+        {
+          key: "method_mappings",
+          label: "Payment method → deposit account mappings complete",
+          checked: methodMapped >= KNOWN_PAYMENT_METHODS.length,
+          manual: false,
+        },
+        {
+          key: "dry_run_7_days",
+          label: "Dry run active for 7+ days",
+          checked: dryRunOld,
+          manual: false,
+        },
+        {
+          key: "dry_run_review_confirmed",
+          label: "Would-have-synced log reviewed",
+          checked: conn.dry_run_review_confirmed,
+          manual: true,
+        },
+      ],
+    });
+  },
+);
 
-  return NextResponse.json({
-    items: [
-      {
-        key: "cpa_cleanup_confirmed",
-        label: "CPA has completed QB cleanup",
-        checked: conn.cpa_cleanup_confirmed,
-        manual: true,
-      },
-      {
-        key: "damage_mappings",
-        label: "Damage type → class mappings complete",
-        checked: damageMapped > 0 && damageMapped >= damageTypeCount,
-        manual: false,
-      },
-      {
-        key: "method_mappings",
-        label: "Payment method → deposit account mappings complete",
-        checked: methodMapped >= KNOWN_PAYMENT_METHODS.length,
-        manual: false,
-      },
-      {
-        key: "dry_run_7_days",
-        label: "Dry run active for 7+ days",
-        checked: dryRunOld,
-        manual: false,
-      },
-      {
-        key: "dry_run_review_confirmed",
-        label: "Would-have-synced log reviewed",
-        checked: conn.dry_run_review_confirmed,
-        manual: true,
-      },
-    ],
-  });
-}
+export const PATCH = withRequestContext(
+  { adminOnly: true, serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as {
+      cpa_cleanup_confirmed?: boolean;
+      dry_run_review_confirmed?: boolean;
+    } | null;
+    if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
 
-export async function PATCH(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const gate = await requireAdmin(supabase);
-  if (!gate.ok) return gate.response;
+    const service = ctx.serviceClient!;
+    const patch: Record<string, unknown> = {};
+    if (typeof body.cpa_cleanup_confirmed === "boolean") {
+      patch.cpa_cleanup_confirmed = body.cpa_cleanup_confirmed;
+    }
+    if (typeof body.dry_run_review_confirmed === "boolean") {
+      patch.dry_run_review_confirmed = body.dry_run_review_confirmed;
+    }
 
-  const body = (await request.json().catch(() => null)) as {
-    cpa_cleanup_confirmed?: boolean;
-    dry_run_review_confirmed?: boolean;
-  } | null;
-  if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
+    const { data: conn } = await service
+      .from("qb_connection")
+      .select("id")
+      .eq("is_active", true)
+      .maybeSingle<{ id: string }>();
+    if (!conn) return NextResponse.json({ error: "no active connection" }, { status: 404 });
 
-  const service = createServiceClient();
-  const patch: Record<string, unknown> = {};
-  if (typeof body.cpa_cleanup_confirmed === "boolean") {
-    patch.cpa_cleanup_confirmed = body.cpa_cleanup_confirmed;
-  }
-  if (typeof body.dry_run_review_confirmed === "boolean") {
-    patch.dry_run_review_confirmed = body.dry_run_review_confirmed;
-  }
-
-  const { data: conn } = await service
-    .from("qb_connection")
-    .select("id")
-    .eq("is_active", true)
-    .maybeSingle<{ id: string }>();
-  if (!conn) return NextResponse.json({ error: "no active connection" }, { status: 404 });
-
-  const { error } = await service.from("qb_connection").update(patch).eq("id", conn.id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ ok: true });
-}
+    const { error } = await service.from("qb_connection").update(patch).eq("id", conn.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/settings/appearance/route.ts
+++ b/src/app/api/settings/appearance/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 const APPEARANCE_KEYS = ["brand_primary", "brand_secondary", "brand_accent"];
 
-// GET /api/settings/appearance — fetch brand color settings
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// GET /api/settings/appearance — fetch brand color settings.
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("company_settings")
     .select("key, value")
     .in("key", APPEARANCE_KEYS);
@@ -21,16 +21,16 @@ export async function GET() {
   }
 
   return NextResponse.json(settings);
-}
+});
 
-// PUT /api/settings/appearance — save brand color settings
-export async function PUT(request: Request) {
+// PUT /api/settings/appearance — save brand color settings.
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PUT = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
-  const supabase = await createServerSupabaseClient();
 
   for (const key of APPEARANCE_KEYS) {
     if (key in body) {
-      const { error } = await supabase
+      const { error } = await ctx.supabase
         .from("company_settings")
         .upsert(
           { key, value: String(body[key] || ""), updated_at: new Date().toISOString() },
@@ -47,4 +47,4 @@ export async function PUT(request: Request) {
   }
 
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/company/logo/route.ts
+++ b/src/app/api/settings/company/logo/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/svg+xml", "image/webp"];
 const MAX_SIZE = 2 * 1024 * 1024; // 2MB
 
 // POST /api/settings/company/logo — upload company logo (org-prefixed path).
-export async function POST(request: Request) {
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const POST = withRequestContext({}, async (request, ctx) => {
   const formData = await request.formData();
   const file = formData.get("file") as File | null;
 
@@ -28,11 +28,10 @@ export async function POST(request: Request) {
     );
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   // Delete old logo if exists (scoped to org)
-  const { data: existing } = await supabase
+  const { data: existing } = await ctx.supabase
     .from("company_settings")
     .select("value")
     .eq("organization_id", orgId)
@@ -40,7 +39,7 @@ export async function POST(request: Request) {
     .maybeSingle();
 
   if (existing?.value) {
-    await supabase.storage.from("company-assets").remove([existing.value]);
+    await ctx.supabase.storage.from("company-assets").remove([existing.value]);
   }
 
   // Upload new logo at {org_id}/logo/{timestamp}-rand.ext
@@ -48,7 +47,7 @@ export async function POST(request: Request) {
   const fileName = `${orgId}/logo/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
   const buffer = Buffer.from(await file.arrayBuffer());
 
-  const { error: uploadError } = await supabase.storage
+  const { error: uploadError } = await ctx.supabase.storage
     .from("company-assets")
     .upload(fileName, buffer, {
       contentType: file.type,
@@ -63,7 +62,7 @@ export async function POST(request: Request) {
   }
 
   // Save path to company_settings
-  await supabase
+  await ctx.supabase
     .from("company_settings")
     .upsert(
       { organization_id: orgId, key: "logo_path", value: fileName, updated_at: new Date().toISOString() },
@@ -75,4 +74,4 @@ export async function POST(request: Request) {
   const publicUrl = `${supabaseUrl}/storage/v1/object/public/company-assets/${fileName}`;
 
   return NextResponse.json({ path: fileName, url: publicUrl });
-}
+});

--- a/src/app/api/settings/company/route.ts
+++ b/src/app/api/settings/company/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/company — fetch all company settings for the active org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("company_settings")
     .select("key, value")
-    .eq("organization_id", await getActiveOrganizationId(supabase));
+    .eq("organization_id", ctx.orgId);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
@@ -20,20 +19,20 @@ export async function GET() {
   }
 
   return NextResponse.json(settings);
-}
+});
 
 // PUT /api/settings/company — upsert company settings for the active org.
-export async function PUT(request: Request) {
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PUT = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   const entries = Object.entries(body).filter(
     ([key]) => typeof key === "string" && key.length > 0
   );
 
   for (const [key, value] of entries) {
-    const { error } = await supabase
+    const { error } = await ctx.supabase
       .from("company_settings")
       .upsert(
         { organization_id: orgId, key, value: String(value ?? ""), updated_at: new Date().toISOString() },
@@ -49,4 +48,4 @@ export async function PUT(request: Request) {
   }
 
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/contract-email/route.ts
+++ b/src/app/api/settings/contract-email/route.ts
@@ -1,23 +1,24 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import type { ContractEmailProvider, ContractEmailSettings } from "@/lib/contracts/types";
 
 // The table is effectively a singleton — seeded with one row in the
 // build33 migration. If it somehow goes missing we surface a clear error
 // rather than inserting a new row silently.
-async function getSettings() {
-  const supabase = await createServerSupabaseClient();
+async function getSettings(supabase: SupabaseClient) {
   const { data, error } = await supabase
     .from("contract_email_settings")
     .select("*")
     .limit(1)
     .maybeSingle<ContractEmailSettings>();
-  return { supabase, data, error };
+  return { data, error };
 }
 
 // GET /api/settings/contract-email
-export async function GET() {
-  const { data, error } = await getSettings();
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await getSettings(ctx.supabase);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   if (!data) {
     return NextResponse.json(
@@ -26,16 +27,17 @@ export async function GET() {
     );
   }
   return NextResponse.json(data);
-}
+});
 
 // PATCH /api/settings/contract-email
-export async function PATCH(request: Request) {
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PATCH = withRequestContext({}, async (request, ctx) => {
   const body = (await request.json().catch(() => null)) as Partial<ContractEmailSettings> | null;
   if (!body) {
     return NextResponse.json({ error: "Body must be a JSON object" }, { status: 400 });
   }
 
-  const { supabase, data: current, error: fetchErr } = await getSettings();
+  const { data: current, error: fetchErr } = await getSettings(ctx.supabase);
   if (fetchErr) return NextResponse.json({ error: fetchErr.message }, { status: 500 });
   if (!current) {
     return NextResponse.json(
@@ -93,7 +95,7 @@ export async function PATCH(request: Request) {
     );
   }
 
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("contract_email_settings")
     .update(patch)
     .eq("id", current.id)
@@ -101,4 +103,4 @@ export async function PATCH(request: Request) {
     .single();
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data);
-}
+});

--- a/src/app/api/settings/contract-templates/[id]/duplicate/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/duplicate/route.ts
@@ -1,70 +1,63 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 
 // POST /api/settings/contract-templates/[id]/duplicate
-export async function POST(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requirePermission(supabase, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const orgId = await getActiveOrganizationId(supabase);
+export const POST = withRequestContext(
+  { permission: "manage_contract_templates", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const { data: source, error: fetchErr } = await supabase
-    .from("contract_templates")
-    .select("*")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (fetchErr) return apiDbError(fetchErr.message, "POST duplicate select");
-  if (!source) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    const { data: source, error: fetchErr } = await ctx.supabase
+      .from("contract_templates")
+      .select("*")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle();
+    if (fetchErr) return apiDbError(fetchErr.message, "POST duplicate select");
+    if (!source) return NextResponse.json({ error: "Template not found" }, { status: 404 });
 
-  // Insert the copy with overlay_fields preserved but pdf_storage_path
-  // initially null — copied below post-insert so the path can include the
-  // new row's id.
-  const { data: inserted, error: insertErr } = await supabase
-    .from("contract_templates")
-    .insert({
-      organization_id: orgId,
-      name: `${source.name} (Copy)`,
-      description: source.description,
-      pdf_storage_path: null,
-      pdf_page_count: source.pdf_page_count,
-      pdf_pages: source.pdf_pages,
-      overlay_fields: source.overlay_fields,
-      signer_count: source.signer_count,
-      signer_role_label: source.signer_role_label,
-      is_active: false,
-      version: 1,
-      created_by: gate.userId,
-    })
-    .select()
-    .single();
-  if (insertErr) return apiDbError(insertErr.message, "POST duplicate insert");
+    // Insert the copy with overlay_fields preserved but pdf_storage_path
+    // initially null — copied below post-insert so the path can include the
+    // new row's id.
+    const { data: inserted, error: insertErr } = await ctx.supabase
+      .from("contract_templates")
+      .insert({
+        organization_id: orgId,
+        name: `${source.name} (Copy)`,
+        description: source.description,
+        pdf_storage_path: null,
+        pdf_page_count: source.pdf_page_count,
+        pdf_pages: source.pdf_pages,
+        overlay_fields: source.overlay_fields,
+        signer_count: source.signer_count,
+        signer_role_label: source.signer_role_label,
+        is_active: false,
+        version: 1,
+        created_by: ctx.userId,
+      })
+      .select()
+      .single();
+    if (insertErr) return apiDbError(insertErr.message, "POST duplicate insert");
 
-  // Copy the source PDF in Storage if present, then patch pdf_storage_path.
-  if (source.pdf_storage_path) {
-    const newPath = `${orgId}/templates/${inserted.id}.pdf`;
-    const service = createServiceClient();
-    const { error: copyErr } = await service.storage
-      .from("contract-pdfs")
-      .copy(source.pdf_storage_path, newPath);
-    if (!copyErr) {
-      await supabase
-        .from("contract_templates")
-        .update({ pdf_storage_path: newPath })
-        .eq("id", inserted.id);
-      inserted.pdf_storage_path = newPath;
+    // Copy the source PDF in Storage if present, then patch pdf_storage_path.
+    if (source.pdf_storage_path) {
+      const newPath = `${orgId}/templates/${inserted.id}.pdf`;
+      const { error: copyErr } = await ctx.serviceClient!.storage
+        .from("contract-pdfs")
+        .copy(source.pdf_storage_path, newPath);
+      if (!copyErr) {
+        await ctx.supabase
+          .from("contract_templates")
+          .update({ pdf_storage_path: newPath })
+          .eq("id", inserted.id);
+        inserted.pdf_storage_path = newPath;
+      }
+      // If copy fails (e.g. source PDF missing), keep the row but with
+      // pdf_storage_path=null. The user will need to re-upload.
     }
-    // If copy fails (e.g. source PDF missing), keep the row but with
-    // pdf_storage_path=null. The user will need to re-upload.
-  }
 
-  return NextResponse.json(inserted, { status: 201 });
-}
+    return NextResponse.json(inserted, { status: 201 });
+  },
+);

--- a/src/app/api/settings/contract-templates/[id]/pdf/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/pdf/route.ts
@@ -1,110 +1,103 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { PDFDocument } from "pdf-lib";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
-import { createServiceClient } from "@/lib/supabase-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 
 const MAX_BYTES = 10 * 1024 * 1024;
 
-export async function POST(
-  req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requirePermission(supabase, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const orgId = await getActiveOrganizationId(supabase);
+export const POST = withRequestContext(
+  { permission: "manage_contract_templates", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const formData = await req.formData();
-  const file = formData.get("pdf");
-  if (!(file instanceof File)) {
-    return NextResponse.json({ error: "missing_file" }, { status: 400 });
-  }
-  if (file.size > MAX_BYTES) {
-    return NextResponse.json({ error: "file_too_large", max_bytes: MAX_BYTES }, { status: 413 });
-  }
-  if (file.type !== "application/pdf") {
-    return NextResponse.json({ error: "invalid_content_type" }, { status: 400 });
-  }
+    const formData = await request.formData();
+    const file = formData.get("pdf");
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "missing_file" }, { status: 400 });
+    }
+    if (file.size > MAX_BYTES) {
+      return NextResponse.json({ error: "file_too_large", max_bytes: MAX_BYTES }, { status: 413 });
+    }
+    if (file.type !== "application/pdf") {
+      return NextResponse.json({ error: "invalid_content_type" }, { status: 400 });
+    }
 
-  const bytes = new Uint8Array(await file.arrayBuffer());
+    const bytes = new Uint8Array(await file.arrayBuffer());
 
-  let pageCount: number;
-  let pdfPages: { page: number; width_pt: number; height_pt: number }[];
-  try {
-    const doc = await PDFDocument.load(bytes);
-    pageCount = doc.getPageCount();
-    pdfPages = Array.from({ length: pageCount }, (_, i) => {
-      const p = doc.getPage(i);
-      return { page: i + 1, width_pt: p.getWidth(), height_pt: p.getHeight() };
-    });
-  } catch (err) {
-    return NextResponse.json({ error: "pdf_parse_failed", detail: String(err) }, { status: 400 });
-  }
+    let pageCount: number;
+    let pdfPages: { page: number; width_pt: number; height_pt: number }[];
+    try {
+      const doc = await PDFDocument.load(bytes);
+      pageCount = doc.getPageCount();
+      pdfPages = Array.from({ length: pageCount }, (_, i) => {
+        const p = doc.getPage(i);
+        return { page: i + 1, width_pt: p.getWidth(), height_pt: p.getHeight() };
+      });
+    } catch (err) {
+      return NextResponse.json({ error: "pdf_parse_failed", detail: String(err) }, { status: 400 });
+    }
 
-  // Verify the row exists and belongs to this org. Capture current version
-  // so we can bump it atomically.
-  const { data: existing, error: selectErr } = await supabase
-    .from("contract_templates")
-    .select("id, version")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (selectErr) return apiDbError(selectErr.message, "POST template/[id]/pdf select");
-  if (!existing) return NextResponse.json({ error: "not_found" }, { status: 404 });
+    // Verify the row exists and belongs to this org. Capture current version
+    // so we can bump it atomically.
+    const { data: existing, error: selectErr } = await ctx.supabase
+      .from("contract_templates")
+      .select("id, version")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle();
+    if (selectErr) return apiDbError(selectErr.message, "POST template/[id]/pdf select");
+    if (!existing) return NextResponse.json({ error: "not_found" }, { status: 404 });
 
-  const path = `${orgId}/templates/${id}.pdf`;
-  const service = createServiceClient();
-  const { error: uploadErr } = await service.storage
-    .from("contract-pdfs")
-    .upload(path, bytes, { contentType: "application/pdf", upsert: true });
-  if (uploadErr) return apiDbError(uploadErr.message, "POST template/[id]/pdf upload");
+    const path = `${orgId}/templates/${id}.pdf`;
+    const { error: uploadErr } = await ctx.serviceClient!.storage
+      .from("contract-pdfs")
+      .upload(path, bytes, { contentType: "application/pdf", upsert: true });
+    if (uploadErr) return apiDbError(uploadErr.message, "POST template/[id]/pdf upload");
 
-  // Replacing the source PDF clears overlay_fields (positions are tied to the
-  // old PDF's pages). Bump version application-side, mirroring the existing
-  // PATCH route.
-  const { data: updated, error: updateErr } = await supabase
-    .from("contract_templates")
-    .update({
-      pdf_storage_path: path,
-      pdf_page_count: pageCount,
-      pdf_pages: pdfPages,
-      overlay_fields: [],
-      version: (existing.version ?? 1) + 1,
-    })
-    .eq("id", id)
-    .select()
-    .single();
-  if (updateErr) return apiDbError(updateErr.message, "POST template/[id]/pdf update");
+    // Replacing the source PDF clears overlay_fields (positions are tied to the
+    // old PDF's pages). Bump version application-side, mirroring the existing
+    // PATCH route.
+    const { data: updated, error: updateErr } = await ctx.supabase
+      .from("contract_templates")
+      .update({
+        pdf_storage_path: path,
+        pdf_page_count: pageCount,
+        pdf_pages: pdfPages,
+        overlay_fields: [],
+        version: (existing.version ?? 1) + 1,
+      })
+      .eq("id", id)
+      .select()
+      .single();
+    if (updateErr) return apiDbError(updateErr.message, "POST template/[id]/pdf update");
 
-  return NextResponse.json({ template: updated });
-}
+    return NextResponse.json({ template: updated });
+  },
+);
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+// GET /api/settings/contract-templates/[id]/pdf — short-lived signed URL.
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const { data: tpl, error } = await supabase
-    .from("contract_templates")
-    .select("pdf_storage_path")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (error) return apiDbError(error.message, "GET template/[id]/pdf select");
-  if (!tpl?.pdf_storage_path) return NextResponse.json({ error: "no_pdf" }, { status: 404 });
+    const { data: tpl, error } = await ctx.supabase
+      .from("contract_templates")
+      .select("pdf_storage_path")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle();
+    if (error) return apiDbError(error.message, "GET template/[id]/pdf select");
+    if (!tpl?.pdf_storage_path) return NextResponse.json({ error: "no_pdf" }, { status: 404 });
 
-  const service = createServiceClient();
-  const { data: signed, error: signErr } = await service.storage
-    .from("contract-pdfs")
-    .createSignedUrl(tpl.pdf_storage_path, 60);
-  if (signErr || !signed) return apiDbError(signErr?.message ?? "sign_failed", "GET template/[id]/pdf sign");
+    const { data: signed, error: signErr } = await ctx.serviceClient!.storage
+      .from("contract-pdfs")
+      .createSignedUrl(tpl.pdf_storage_path, 60);
+    if (signErr || !signed) return apiDbError(signErr?.message ?? "sign_failed", "GET template/[id]/pdf sign");
 
-  return NextResponse.json({ url: signed.signedUrl });
-}
+    return NextResponse.json({ url: signed.signedUrl });
+  },
+);

--- a/src/app/api/settings/contract-templates/[id]/permanent/route.test.ts
+++ b/src/app/api/settings/contract-templates/[id]/permanent/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextResponse } from "next/server";
 
 vi.mock("@/lib/supabase-server", () => ({
   createServerSupabaseClient: vi.fn(),
@@ -9,10 +8,6 @@ vi.mock("@/lib/supabase-api", () => ({
   createServiceClient: vi.fn(),
 }));
 
-vi.mock("@/lib/permissions-api", () => ({
-  requirePermission: vi.fn(),
-}));
-
 vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
@@ -20,26 +15,43 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 import { DELETE } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { makeSupabaseFake } from "@/lib/contracts/__test-utils__/supabase-fake";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
 
 function paramsFor(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
+// The route now runs through `withRequestContext`: the wrapper authenticates
+// against the User client and the route body reads/writes with the Service
+// client. `grantPermission` makes the caller a member holding
+// `manage_contract_templates`; `denyPermission` a member holding nothing.
 function grantPermission() {
-  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
-  vi.mocked(requirePermission).mockResolvedValue({ ok: true, userId: "user-1" });
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["manage_contract_templates"],
+      }),
+    }) as never,
+  );
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 }
 
 function denyPermission() {
-  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
-  vi.mocked(requirePermission).mockResolvedValue({
-    ok: false,
-    response: NextResponse.json({ error: "forbidden" }, { status: 403 }),
-  });
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+    }) as never,
+  );
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 }
 
 describe("DELETE /api/settings/contract-templates/[id]/permanent", () => {

--- a/src/app/api/settings/contract-templates/[id]/permanent/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/permanent/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import {
   evaluateTemplateDeletion,
@@ -22,77 +19,74 @@ import {
 // a customer is mid-signing. The hard_delete_contract_template RPC re-checks
 // the same rule inside its transaction — it is the authoritative gate against
 // a contract that flips to `sent` between the dialog opening and the confirm.
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const authClient = await createServerSupabaseClient();
-  const gate = await requirePermission(authClient, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const orgId = await getActiveOrganizationId(authClient);
+export const DELETE = withRequestContext(
+  { permission: "manage_contract_templates", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const supabase = createServiceClient();
+    const supabase = ctx.serviceClient!;
 
-  const { data: template, error: loadErr } = await supabase
-    .from("contract_templates")
-    .select("id, pdf_storage_path")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string; pdf_storage_path: string | null }>();
-  if (loadErr) return apiDbError(loadErr.message, "DELETE template/permanent select");
-  if (!template) {
-    return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  }
-
-  const { data: refs, error: refsErr } = await supabase
-    .from("contracts")
-    .select("id, status")
-    .eq("template_id", id);
-  if (refsErr) {
-    return apiDbError(refsErr.message, "DELETE template/permanent contracts select");
-  }
-
-  const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
-  if (!eligibility.deletable) {
-    return NextResponse.json(
-      {
-        error: "blocked",
-        blockers: eligibility.blockers.map((b) => ({
-          contractId: b.id,
-          status: b.status,
-        })),
-      },
-      { status: 409 },
-    );
-  }
-
-  const { error: rpcErr } = await supabase.rpc("hard_delete_contract_template", {
-    p_template_id: id,
-    p_org_id: orgId,
-  });
-  if (rpcErr) {
-    // The RPC's authoritative re-check lost a race: a contract became
-    // `sent` / `viewed` after our advisory check passed.
-    if (rpcErr.message.includes("template_delete_blocked")) {
-      return NextResponse.json({ error: "blocked", blockers: [] }, { status: 409 });
+    const { data: template, error: loadErr } = await supabase
+      .from("contract_templates")
+      .select("id, pdf_storage_path")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle<{ id: string; pdf_storage_path: string | null }>();
+    if (loadErr) return apiDbError(loadErr.message, "DELETE template/permanent select");
+    if (!template) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
     }
-    return apiDbError(rpcErr.message, "DELETE template/permanent rpc");
-  }
 
-  // Best-effort storage cleanup. A failed storage delete must not fail the
-  // request — the template row is already gone and an orphaned file is
-  // harmless (per the #76 PRD).
-  if (template.pdf_storage_path) {
-    const { error: storageErr } = await supabase.storage
-      .from("contract-pdfs")
-      .remove([template.pdf_storage_path]);
-    if (storageErr) {
-      console.warn(
-        `[template-permanent-delete] storage cleanup failed for ${template.pdf_storage_path}: ${storageErr.message}`,
+    const { data: refs, error: refsErr } = await supabase
+      .from("contracts")
+      .select("id, status")
+      .eq("template_id", id);
+    if (refsErr) {
+      return apiDbError(refsErr.message, "DELETE template/permanent contracts select");
+    }
+
+    const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
+    if (!eligibility.deletable) {
+      return NextResponse.json(
+        {
+          error: "blocked",
+          blockers: eligibility.blockers.map((b) => ({
+            contractId: b.id,
+            status: b.status,
+          })),
+        },
+        { status: 409 },
       );
     }
-  }
 
-  return NextResponse.json({ success: true });
-}
+    const { error: rpcErr } = await supabase.rpc("hard_delete_contract_template", {
+      p_template_id: id,
+      p_org_id: orgId,
+    });
+    if (rpcErr) {
+      // The RPC's authoritative re-check lost a race: a contract became
+      // `sent` / `viewed` after our advisory check passed.
+      if (rpcErr.message.includes("template_delete_blocked")) {
+        return NextResponse.json({ error: "blocked", blockers: [] }, { status: 409 });
+      }
+      return apiDbError(rpcErr.message, "DELETE template/permanent rpc");
+    }
+
+    // Best-effort storage cleanup. A failed storage delete must not fail the
+    // request — the template row is already gone and an orphaned file is
+    // harmless (per the #76 PRD).
+    if (template.pdf_storage_path) {
+      const { error: storageErr } = await supabase.storage
+        .from("contract-pdfs")
+        .remove([template.pdf_storage_path]);
+      if (storageErr) {
+        console.warn(
+          `[template-permanent-delete] storage cleanup failed for ${template.pdf_storage_path}: ${storageErr.message}`,
+        );
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/contract-templates/[id]/preview/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/preview/route.ts
@@ -1,8 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
-import { createServiceClient } from "@/lib/supabase-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import { stampPdf } from "@/lib/contracts/stamp-pdf";
 import type { OverlayField, PdfPage } from "@/lib/contracts/types";
@@ -35,97 +32,76 @@ const SAMPLE_MERGE_VALUES: Record<string, string> = {
   company_license: "TX-LIC-1234",
 };
 
-export async function GET(
-  _req: NextRequest,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  // Permission gate: template authors (manage_contract_templates) clearly
-  // need preview access, but Task 26 also wired this route up to
-  // <PreviewContractModal>, which is opened from the send-contract and
-  // sign-in-person modals. Users in those flows can SEND contracts but
-  // may not have template-management. The send/in-person POSTs gate on
-  // authenticated session + org membership only (no permission key), so
-  // we match that bar as a fallback. The preview only renders sample data
-  // (no contract-specific PII), so this matches the actual data sensitivity.
-  const gate = await requirePermission(supabase, "manage_contract_templates");
-  if (!gate.ok) {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-    if (!user) {
-      return NextResponse.json({ error: "not authenticated" }, { status: 401 });
+// Logged-in only. This route previously gated on `manage_contract_templates`
+// but, by design, fell back to any logged-in member of the active org: it is
+// opened from the send-contract and sign-in-person modals, whose own POSTs
+// gate on session + org membership alone. The preview only renders sample
+// data (no contract-specific PII), so the effective policy was always
+// "logged-in" — that is the equivalent rule here.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
+
+    const { data: tpl, error } = await ctx.supabase
+      .from("contract_templates")
+      .select("id, pdf_storage_path, pdf_pages, overlay_fields, signer_count")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle();
+    if (error) return apiDbError(error.message, "GET preview select");
+    if (!tpl?.pdf_storage_path) return NextResponse.json({ error: "no_pdf" }, { status: 404 });
+
+    // Layer the org's actual company info over the sample so the preview
+    // shows real branding when present.
+    const { data: orgRow } = await ctx.supabase
+      .from("organizations")
+      .select("name")
+      .eq("id", orgId)
+      .maybeSingle();
+    const sample: Record<string, string> = { ...SAMPLE_MERGE_VALUES };
+    if (orgRow?.name) sample.company_name = orgRow.name;
+
+    // Sample customer inputs: each input field gets a placeholder; checkboxes ticked.
+    const overlayFields = (tpl.overlay_fields ?? []) as OverlayField[];
+    const customerInputs: Record<string, string | boolean> = {};
+    for (const f of overlayFields) {
+      if (f.type === "input" && f.inputKey) {
+        customerInputs[f.inputKey] = f.inputLabel ? `Sample ${f.inputLabel}` : "Sample input";
+      }
+      if (f.type === "checkbox" && f.inputKey) customerInputs[f.inputKey] = true;
     }
-    const fallbackOrgId = await getActiveOrganizationId(supabase);
-    const { data: membership } = await supabase
-      .from("user_organizations")
-      .select("id")
-      .eq("user_id", user.id)
-      .eq("organization_id", fallbackOrgId)
-      .maybeSingle<{ id: string }>();
-    if (!membership) return gate.response;
-  }
-  const orgId = await getActiveOrganizationId(supabase);
 
-  const { data: tpl, error } = await supabase
-    .from("contract_templates")
-    .select("id, pdf_storage_path, pdf_pages, overlay_fields, signer_count")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (error) return apiDbError(error.message, "GET preview select");
-  if (!tpl?.pdf_storage_path) return NextResponse.json({ error: "no_pdf" }, { status: 404 });
+    const { data: blob, error: dlErr } = await ctx.serviceClient!.storage
+      .from("contract-pdfs")
+      .download(tpl.pdf_storage_path);
+    if (dlErr || !blob) return apiDbError(dlErr?.message ?? "download_failed", "GET preview download");
+    const sourceBytes = new Uint8Array(await blob.arrayBuffer());
 
-  // Layer the org's actual company info over the sample so the preview
-  // shows real branding when present.
-  const { data: orgRow } = await supabase
-    .from("organizations")
-    .select("name")
-    .eq("id", orgId)
-    .maybeSingle();
-  const sample: Record<string, string> = { ...SAMPLE_MERGE_VALUES };
-  if (orgRow?.name) sample.company_name = orgRow.name;
-
-  // Sample customer inputs: each input field gets a placeholder; checkboxes ticked.
-  const overlayFields = (tpl.overlay_fields ?? []) as OverlayField[];
-  const customerInputs: Record<string, string | boolean> = {};
-  for (const f of overlayFields) {
-    if (f.type === "input" && f.inputKey) {
-      customerInputs[f.inputKey] = f.inputLabel ? `Sample ${f.inputLabel}` : "Sample input";
+    let stampedBytes: Uint8Array;
+    try {
+      stampedBytes = await stampPdf({
+        sourcePdfBytes: sourceBytes,
+        pdfPages: (tpl.pdf_pages ?? []) as PdfPage[],
+        overlayFields,
+        resolvedMergeValues: sample,
+        customerInputs,
+        signatureDataUrls: {},
+        signerOrderById: {},
+        signedAt: new Date(),
+      });
+    } catch (err) {
+      return apiDbError(String(err), "GET preview stamp");
     }
-    if (f.type === "checkbox" && f.inputKey) customerInputs[f.inputKey] = true;
-  }
 
-  const service = createServiceClient();
-  const { data: blob, error: dlErr } = await service.storage
-    .from("contract-pdfs")
-    .download(tpl.pdf_storage_path);
-  if (dlErr || !blob) return apiDbError(dlErr?.message ?? "download_failed", "GET preview download");
-  const sourceBytes = new Uint8Array(await blob.arrayBuffer());
-
-  let stampedBytes: Uint8Array;
-  try {
-    stampedBytes = await stampPdf({
-      sourcePdfBytes: sourceBytes,
-      pdfPages: (tpl.pdf_pages ?? []) as PdfPage[],
-      overlayFields,
-      resolvedMergeValues: sample,
-      customerInputs,
-      signatureDataUrls: {},
-      signerOrderById: {},
-      signedAt: new Date(),
+    return new NextResponse(Buffer.from(stampedBytes), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": "inline; filename=\"preview.pdf\"",
+        "Cache-Control": "no-store",
+      },
     });
-  } catch (err) {
-    return apiDbError(String(err), "GET preview stamp");
-  }
-
-  return new NextResponse(Buffer.from(stampedBytes), {
-    status: 200,
-    headers: {
-      "Content-Type": "application/pdf",
-      "Content-Disposition": "inline; filename=\"preview.pdf\"",
-      "Cache-Control": "no-store",
-    },
-  });
-}
+  },
+);

--- a/src/app/api/settings/contract-templates/[id]/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import type { OverlayField, PdfPage } from "@/lib/contracts/types";
 import { validateOverlayFields } from "@/lib/contracts/overlay-validation";
@@ -10,127 +8,127 @@ import { SYSTEM_MERGE_FIELDS } from "@/lib/contracts/merge-fields";
 import type { FormConfig } from "@/lib/types";
 
 // GET /api/settings/contract-templates/[id]
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
-    .from("contract_templates")
-    .select("*")
-    .eq("id", id)
-    .maybeSingle();
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { data, error } = await ctx.supabase
+      .from("contract_templates")
+      .select("*")
+      .eq("id", id)
+      .maybeSingle();
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  return NextResponse.json(data);
-}
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    return NextResponse.json(data);
+  },
+);
 
 // PATCH /api/settings/contract-templates/[id] — auto-save handler.
 // 409 stale-check via the version column (mirrors 67a auto-save).
 // overlay_fields validated server-side.
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const gate = await requirePermission(supabase, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const orgId = await getActiveOrganizationId(supabase);
+export const PATCH = withRequestContext(
+  { permission: "manage_contract_templates" },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const body = await request.json().catch(() => ({}));
+    const body = await request.json().catch(() => ({}));
 
-  // Fetch existing for stale-check + validation context.
-  const { data: existing, error: fetchErr } = await supabase
-    .from("contract_templates")
-    .select("id, version, pdf_pages, signer_count")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (fetchErr) return apiDbError(fetchErr.message, "PATCH template/[id] select");
-  if (!existing) return NextResponse.json({ error: "Template not found" }, { status: 404 });
-
-  // 409 stale-check.
-  const incomingVersion = Number(body.version);
-  if (Number.isFinite(incomingVersion) && incomingVersion !== existing.version) {
-    return NextResponse.json({ error: "stale", current: existing.version }, { status: 409 });
-  }
-
-  const update: Partial<{
-    name: string;
-    description: string | null;
-    signer_count: 1 | 2;
-    signer_role_label: string;
-    overlay_fields: OverlayField[];
-    is_active: boolean;
-    version: number;
-  }> = {};
-
-  if (typeof body.name === "string") update.name = body.name.trim().slice(0, 120);
-  if (body.description === null || typeof body.description === "string") {
-    update.description = body.description;
-  }
-  if (body.signer_count === 1 || body.signer_count === 2) {
-    update.signer_count = body.signer_count;
-  }
-  if (typeof body.signer_role_label === "string") {
-    update.signer_role_label = body.signer_role_label.slice(0, 120);
-  }
-  if (Array.isArray(body.overlay_fields)) {
-    const { data: form } = await supabase
-      .from("form_config")
-      .select("config")
+    // Fetch existing for stale-check + validation context.
+    const { data: existing, error: fetchErr } = await ctx.supabase
+      .from("contract_templates")
+      .select("id, version, pdf_pages, signer_count")
+      .eq("id", id)
       .eq("organization_id", orgId)
-      .order("version", { ascending: false })
-      .limit(1)
-      .maybeSingle<{ config: FormConfig }>();
-    const formConfig: FormConfig = form?.config ?? { sections: [] };
-    const registry = buildMergeFieldRegistry(formConfig, SYSTEM_MERGE_FIELDS);
-    const knownMergeNames = new Set(registry.map((r) => r.slug));
+      .maybeSingle();
+    if (fetchErr) return apiDbError(fetchErr.message, "PATCH template/[id] select");
+    if (!existing) return NextResponse.json({ error: "Template not found" }, { status: 404 });
 
-    const errs = validateOverlayFields(
-      body.overlay_fields as OverlayField[],
-      (existing.pdf_pages ?? null) as PdfPage[] | null,
-      (update.signer_count ?? existing.signer_count) as 1 | 2,
-      knownMergeNames,
-    );
-    if (errs.length) {
-      return NextResponse.json({ error: "invalid_overlay_fields", details: errs }, { status: 400 });
+    // 409 stale-check.
+    const incomingVersion = Number(body.version);
+    if (Number.isFinite(incomingVersion) && incomingVersion !== existing.version) {
+      return NextResponse.json({ error: "stale", current: existing.version }, { status: 409 });
     }
-    update.overlay_fields = body.overlay_fields as OverlayField[];
-  }
-  if (typeof body.is_active === "boolean") update.is_active = body.is_active;
 
-  // Bump version on every successful save (overlay positions, name, etc.).
-  update.version = (existing.version ?? 1) + 1;
+    const update: Partial<{
+      name: string;
+      description: string | null;
+      signer_count: 1 | 2;
+      signer_role_label: string;
+      overlay_fields: OverlayField[];
+      is_active: boolean;
+      version: number;
+    }> = {};
 
-  const { data, error } = await supabase
-    .from("contract_templates")
-    .update(update)
-    .eq("id", id)
-    .select()
-    .single();
-  if (error) return apiDbError(error.message, "PATCH template/[id] update");
+    if (typeof body.name === "string") update.name = body.name.trim().slice(0, 120);
+    if (body.description === null || typeof body.description === "string") {
+      update.description = body.description;
+    }
+    if (body.signer_count === 1 || body.signer_count === 2) {
+      update.signer_count = body.signer_count;
+    }
+    if (typeof body.signer_role_label === "string") {
+      update.signer_role_label = body.signer_role_label.slice(0, 120);
+    }
+    if (Array.isArray(body.overlay_fields)) {
+      const { data: form } = await ctx.supabase
+        .from("form_config")
+        .select("config")
+        .eq("organization_id", orgId)
+        .order("version", { ascending: false })
+        .limit(1)
+        .maybeSingle<{ config: FormConfig }>();
+      const formConfig: FormConfig = form?.config ?? { sections: [] };
+      const registry = buildMergeFieldRegistry(formConfig, SYSTEM_MERGE_FIELDS);
+      const knownMergeNames = new Set(registry.map((r) => r.slug));
 
-  return NextResponse.json(data);
-}
+      const errs = validateOverlayFields(
+        body.overlay_fields as OverlayField[],
+        (existing.pdf_pages ?? null) as PdfPage[] | null,
+        (update.signer_count ?? existing.signer_count) as 1 | 2,
+        knownMergeNames,
+      );
+      if (errs.length) {
+        return NextResponse.json({ error: "invalid_overlay_fields", details: errs }, { status: 400 });
+      }
+      update.overlay_fields = body.overlay_fields as OverlayField[];
+    }
+    if (typeof body.is_active === "boolean") update.is_active = body.is_active;
+
+    // Bump version on every successful save (overlay positions, name, etc.).
+    update.version = (existing.version ?? 1) + 1;
+
+    const { data, error } = await ctx.supabase
+      .from("contract_templates")
+      .update(update)
+      .eq("id", id)
+      .select()
+      .single();
+    if (error) return apiDbError(error.message, "PATCH template/[id] update");
+
+    return NextResponse.json(data);
+  },
+);
 
 // DELETE /api/settings/contract-templates/[id] — soft archive by flipping
 // is_active=false. Templates are never hard-deleted because signed contracts
 // in Build 15b will reference them historically.
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
-  const { error } = await supabase
-    .from("contract_templates")
-    .update({ is_active: false })
-    .eq("id", id);
+//
+// Logged-in only — previously ungated, and also lacking an organization
+// filter. Recorded for the #78 ungated-endpoint list; tightening (a
+// permission key + org scoping) is the separate triage follow-up.
+export const DELETE = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { error } = await ctx.supabase
+      .from("contract_templates")
+      .update({ is_active: false })
+      .eq("id", id);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ success: true });
-}
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/contract-templates/[id]/usage/route.test.ts
+++ b/src/app/api/settings/contract-templates/[id]/usage/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextResponse } from "next/server";
 
 vi.mock("@/lib/supabase-server", () => ({
   createServerSupabaseClient: vi.fn(),
@@ -9,10 +8,6 @@ vi.mock("@/lib/supabase-api", () => ({
   createServiceClient: vi.fn(),
 }));
 
-vi.mock("@/lib/permissions-api", () => ({
-  requirePermission: vi.fn(),
-}));
-
 vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
@@ -20,26 +15,41 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 import { GET } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { makeSupabaseFake } from "@/lib/contracts/__test-utils__/supabase-fake";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
 
 function paramsFor(id: string) {
   return { params: Promise.resolve({ id }) };
 }
 
+// The route now runs through `withRequestContext`: the wrapper authenticates
+// against the User client and the route body reads with the Service client.
 function grantPermission() {
-  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
-  vi.mocked(requirePermission).mockResolvedValue({ ok: true, userId: "user-1" });
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["manage_contract_templates"],
+      }),
+    }) as never,
+  );
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 }
 
 function denyPermission() {
-  vi.mocked(createServerSupabaseClient).mockResolvedValue({} as never);
-  vi.mocked(requirePermission).mockResolvedValue({
-    ok: false,
-    response: NextResponse.json({ error: "forbidden" }, { status: 403 }),
-  });
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+    }) as never,
+  );
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 }
 
 describe("GET /api/settings/contract-templates/[id]/usage", () => {

--- a/src/app/api/settings/contract-templates/[id]/usage/route.ts
+++ b/src/app/api/settings/contract-templates/[id]/usage/route.ts
@@ -1,8 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import {
   evaluateTemplateDeletion,
@@ -21,43 +18,40 @@ import {
 // Advisory only: the hard_delete_contract_template RPC remains the source of
 // truth and re-checks at delete time. Gated by `manage_contract_templates`
 // and scoped to the active organization, matching the permanent-delete route.
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> },
-) {
-  const { id } = await params;
-  const authClient = await createServerSupabaseClient();
-  const gate = await requirePermission(authClient, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const orgId = await getActiveOrganizationId(authClient);
+export const GET = withRequestContext(
+  { permission: "manage_contract_templates", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const orgId = ctx.orgId;
 
-  const supabase = createServiceClient();
+    const supabase = ctx.serviceClient!;
 
-  const { data: template, error: loadErr } = await supabase
-    .from("contract_templates")
-    .select("id")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string }>();
-  if (loadErr) return apiDbError(loadErr.message, "GET template/usage select");
-  if (!template) {
-    return NextResponse.json({ error: "Template not found" }, { status: 404 });
-  }
+    const { data: template, error: loadErr } = await supabase
+      .from("contract_templates")
+      .select("id")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .maybeSingle<{ id: string }>();
+    if (loadErr) return apiDbError(loadErr.message, "GET template/usage select");
+    if (!template) {
+      return NextResponse.json({ error: "Template not found" }, { status: 404 });
+    }
 
-  const { data: refs, error: refsErr } = await supabase
-    .from("contracts")
-    .select("id, status")
-    .eq("template_id", id);
-  if (refsErr) {
-    return apiDbError(refsErr.message, "GET template/usage contracts select");
-  }
+    const { data: refs, error: refsErr } = await supabase
+      .from("contracts")
+      .select("id, status")
+      .eq("template_id", id);
+    if (refsErr) {
+      return apiDbError(refsErr.message, "GET template/usage contracts select");
+    }
 
-  const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
-  return NextResponse.json({
-    blockers: eligibility.blockers.map((b) => ({
-      contractId: b.id,
-      status: b.status,
-    })),
-    draftCount: eligibility.draftIds.length,
-  });
-}
+    const eligibility = evaluateTemplateDeletion((refs ?? []) as ReferencingContract[]);
+    return NextResponse.json({
+      blockers: eligibility.blockers.map((b) => ({
+        contractId: b.id,
+        status: b.status,
+      })),
+      draftCount: eligibility.draftIds.length,
+    });
+  },
+);

--- a/src/app/api/settings/contract-templates/jobs/route.ts
+++ b/src/app/api/settings/contract-templates/jobs/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/contract-templates/jobs
 // Minimal job list used to populate the Preview modal's job picker.
 // Returns the 25 most recent jobs with their job_number + customer name
 // so the author can eyeball which job the preview is rendering against.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("jobs")
     .select("id, job_number, property_address, created_at, contact:contacts!contact_id(first_name, last_name)")
     .order("created_at", { ascending: false })
@@ -38,4 +39,4 @@ export async function GET() {
   });
 
   return NextResponse.json(options);
-}
+});

--- a/src/app/api/settings/contract-templates/preview/route.ts
+++ b/src/app/api/settings/contract-templates/preview/route.ts
@@ -1,12 +1,14 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { resolveMergeFields } from "@/lib/contracts/merge-fields";
 
 // POST /api/settings/contract-templates/preview
 // Body: { jobId: string, contentHtml: string }
 // Returns the merge-field-resolved HTML plus the list of fields that
 // had no data on that job so the modal can flag them to the author.
-export async function POST(request: Request) {
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const POST = withRequestContext({}, async (request, ctx) => {
   const body = await request.json().catch(() => null);
   if (!body || typeof body.jobId !== "string" || typeof body.contentHtml !== "string") {
     return NextResponse.json(
@@ -15,7 +17,6 @@ export async function POST(request: Request) {
     );
   }
 
-  const supabase = await createServerSupabaseClient();
-  const result = await resolveMergeFields(supabase, body.contentHtml, body.jobId);
+  const result = await resolveMergeFields(ctx.supabase, body.contentHtml, body.jobId);
   return NextResponse.json(result);
-}
+});

--- a/src/app/api/settings/contract-templates/route.ts
+++ b/src/app/api/settings/contract-templates/route.ts
@@ -1,73 +1,69 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { requirePermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 
 // GET /api/settings/contract-templates — list templates for the active org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("contract_templates")
     .select(
       "id, name, description, pdf_page_count, signer_count, is_active, updated_at",
     )
-    .eq("organization_id", await getActiveOrganizationId(supabase))
+    .eq("organization_id", ctx.orgId)
     .order("updated_at", { ascending: false });
 
   if (error) return apiDbError(error.message, "GET /api/settings/contract-templates");
   return NextResponse.json(data ?? []);
-}
+});
 
 // POST /api/settings/contract-templates — create a new blank template scoped to the active org.
-export async function POST(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const gate = await requirePermission(supabase, "manage_contract_templates");
-  if (!gate.ok) return gate.response;
-  const userId = gate.userId;
+export const POST = withRequestContext(
+  { permission: "manage_contract_templates" },
+  async (request, ctx) => {
+    const body = await request.json().catch(() => ({}));
+    const requestedName: string = (body?.name || "Untitled Template").toString().slice(0, 120);
+    const orgId = ctx.orgId;
 
-  const body = await request.json().catch(() => ({}));
-  const requestedName: string = (body?.name || "Untitled Template").toString().slice(0, 120);
-  const orgId = await getActiveOrganizationId(supabase);
-
-  // Derive a unique name per the (organization_id, name) unique index from
-  // build46. If "Foo" is taken, try "Foo (2)", "Foo (3)", … up to 999.
-  const { data: existingRows } = await supabase
-    .from("contract_templates")
-    .select("name")
-    .eq("organization_id", orgId)
-    .ilike("name", `${requestedName}%`);
-  const taken = new Set((existingRows ?? []).map((r) => r.name));
-  let name = requestedName;
-  if (taken.has(requestedName)) {
-    for (let n = 2; n < 1000; n++) {
-      const candidate = `${requestedName} (${n})`.slice(0, 120);
-      if (!taken.has(candidate)) {
-        name = candidate;
-        break;
+    // Derive a unique name per the (organization_id, name) unique index from
+    // build46. If "Foo" is taken, try "Foo (2)", "Foo (3)", … up to 999.
+    const { data: existingRows } = await ctx.supabase
+      .from("contract_templates")
+      .select("name")
+      .eq("organization_id", orgId)
+      .ilike("name", `${requestedName}%`);
+    const taken = new Set((existingRows ?? []).map((r) => r.name));
+    let name = requestedName;
+    if (taken.has(requestedName)) {
+      for (let n = 2; n < 1000; n++) {
+        const candidate = `${requestedName} (${n})`.slice(0, 120);
+        if (!taken.has(candidate)) {
+          name = candidate;
+          break;
+        }
       }
     }
-  }
 
-  const { data, error } = await supabase
-    .from("contract_templates")
-    .insert({
-      organization_id: orgId,
-      name,
-      description: body?.description ?? null,
-      pdf_storage_path: null,
-      pdf_page_count: null,
-      pdf_pages: null,
-      overlay_fields: [],
-      signer_count: body.signer_count === 2 ? 2 : 1,
-      signer_role_label: body.signer_role_label ?? "Customer",
-      is_active: false,
-      version: 1,
-      created_by: userId,
-    })
-    .select()
-    .single();
+    const { data, error } = await ctx.supabase
+      .from("contract_templates")
+      .insert({
+        organization_id: orgId,
+        name,
+        description: body?.description ?? null,
+        pdf_storage_path: null,
+        pdf_page_count: null,
+        pdf_pages: null,
+        overlay_fields: [],
+        signer_count: body.signer_count === 2 ? 2 : 1,
+        signer_role_label: body.signer_role_label ?? "Customer",
+        is_active: false,
+        version: 1,
+        created_by: ctx.userId,
+      })
+      .select()
+      .single();
 
-  if (error) return apiDbError(error.message, "POST /api/settings/contract-templates insert");
-  return NextResponse.json(data, { status: 201 });
-}
+    if (error) return apiDbError(error.message, "POST /api/settings/contract-templates insert");
+    return NextResponse.json(data, { status: 201 });
+  },
+);

--- a/src/app/api/settings/damage-types/route.ts
+++ b/src/app/api/settings/damage-types/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// All four methods are logged-in only — previously ungated (recorded for the
+// #78 ungated-endpoint list).
 
 // GET /api/settings/damage-types — NULL-org defaults plus this org's rows.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data, error } = await supabase
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const orgId = ctx.orgId;
+  const { data, error } = await ctx.supabase
     .from("damage_types")
     .select("*")
     .or(`organization_id.is.null,organization_id.eq.${orgId}`)
@@ -14,10 +15,10 @@ export async function GET() {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data);
-}
+});
 
 // POST /api/settings/damage-types — create new (always org-owned) type.
-export async function POST(request: Request) {
+export const POST = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
   const { name, display_label, bg_color, text_color, icon } = body;
 
@@ -25,10 +26,9 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "name and display_label are required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
-  const { data: existing } = await supabase
+  const { data: existing } = await ctx.supabase
     .from("damage_types")
     .select("sort_order")
     .or(`organization_id.is.null,organization_id.eq.${orgId}`)
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
 
   const nextOrder = (existing?.[0]?.sort_order ?? 0) + 1;
 
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("damage_types")
     .insert({
       organization_id: orgId,
@@ -60,17 +60,16 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json(data, { status: 201 });
-}
+});
 
 // PUT /api/settings/damage-types — bulk update, active-org rows only.
-export async function PUT(request: Request) {
+export const PUT = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   if (Array.isArray(body)) {
     for (const item of body) {
-      const { error } = await supabase
+      const { error } = await ctx.supabase
         .from("damage_types")
         .update({
           display_label: item.display_label,
@@ -88,7 +87,7 @@ export async function PUT(request: Request) {
   }
 
   const { id, display_label, bg_color, text_color, icon, sort_order } = body;
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("damage_types")
     .update({ display_label, bg_color, text_color, icon, sort_order })
     .eq("id", id)
@@ -96,18 +95,17 @@ export async function PUT(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ success: true });
-}
+});
 
 // DELETE /api/settings/damage-types?id=xxx
-export async function DELETE(request: Request) {
+export const DELETE = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const id = searchParams.get("id");
   if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
-  const { data: dtype } = await supabase
+  const { data: dtype } = await ctx.supabase
     .from("damage_types")
     .select("is_default, name, organization_id")
     .eq("id", id)
@@ -117,7 +115,7 @@ export async function DELETE(request: Request) {
     return NextResponse.json({ error: "Default damage types cannot be deleted" }, { status: 403 });
   }
 
-  const { count } = await supabase
+  const { count } = await ctx.supabase
     .from("jobs")
     .select("*", { count: "exact", head: true })
     .eq("organization_id", orgId)
@@ -130,11 +128,11 @@ export async function DELETE(request: Request) {
     );
   }
 
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("damage_types")
     .delete()
     .eq("id", id)
     .eq("organization_id", orgId);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/expense-categories/route.ts
+++ b/src/app/api/settings/expense-categories/route.ts
@@ -1,133 +1,124 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET — list, any authenticated user. Bucket-D semantics: NULL-org rows are
 // Nookleus-provided defaults visible to every tenant; org-scoped rows are
 // visible only to members of that org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-
-  const orgId = await getActiveOrganizationId(supabase);
-  const service = createServiceClient();
-  const { data, error } = await service
-    .from("expense_categories")
-    .select("*")
-    .or(`organization_id.is.null,organization_id.eq.${orgId}`)
-    .order("sort_order");
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx) => {
+    const { data, error } = await ctx
+      .serviceClient!.from("expense_categories")
+      .select("*")
+      .or(`organization_id.is.null,organization_id.eq.${ctx.orgId}`)
+      .order("sort_order");
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);
 
 // POST — create custom category (always org-owned).
-export async function POST(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_expense_categories");
-  if (!guard.ok) return guard.response;
-
-  const body = await request.json();
-  const { name, display_label, bg_color, text_color, icon } = body as {
-    name?: string; display_label?: string; bg_color?: string; text_color?: string; icon?: string;
-  };
-  if (!name || !display_label) {
-    return NextResponse.json({ error: "name and display_label are required" }, { status: 400 });
-  }
-
-  const orgId = await getActiveOrganizationId(supabase);
-  const service = createServiceClient();
-  const { data: existing } = await service
-    .from("expense_categories")
-    .select("sort_order")
-    .or(`organization_id.is.null,organization_id.eq.${orgId}`)
-    .order("sort_order", { ascending: false })
-    .limit(1);
-  const nextOrder = (existing?.[0]?.sort_order ?? 0) + 1;
-
-  const { data, error } = await service.from("expense_categories").insert({
-    organization_id: orgId,
-    name: name.toLowerCase().replace(/\s+/g, "_"),
-    display_label,
-    bg_color: bg_color || "#F1EFE8",
-    text_color: text_color || "#5F5E5A",
-    icon: icon || null,
-    sort_order: nextOrder,
-    is_default: false,
-  }).select().single();
-
-  if (error) {
-    if (error.message.includes("duplicate")) {
-      return NextResponse.json({ error: "A category with that name already exists" }, { status: 409 });
+export const POST = withRequestContext(
+  { permission: "manage_expense_categories", serviceClient: true },
+  async (request, ctx) => {
+    const body = await request.json();
+    const { name, display_label, bg_color, text_color, icon } = body as {
+      name?: string; display_label?: string; bg_color?: string; text_color?: string; icon?: string;
+    };
+    if (!name || !display_label) {
+      return NextResponse.json({ error: "name and display_label are required" }, { status: 400 });
     }
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json(data, { status: 201 });
-}
+
+    const orgId = ctx.orgId;
+    const service = ctx.serviceClient!;
+    const { data: existing } = await service
+      .from("expense_categories")
+      .select("sort_order")
+      .or(`organization_id.is.null,organization_id.eq.${orgId}`)
+      .order("sort_order", { ascending: false })
+      .limit(1);
+    const nextOrder = (existing?.[0]?.sort_order ?? 0) + 1;
+
+    const { data, error } = await service.from("expense_categories").insert({
+      organization_id: orgId,
+      name: name.toLowerCase().replace(/\s+/g, "_"),
+      display_label,
+      bg_color: bg_color || "#F1EFE8",
+      text_color: text_color || "#5F5E5A",
+      icon: icon || null,
+      sort_order: nextOrder,
+      is_default: false,
+    }).select().single();
+
+    if (error) {
+      if (error.message.includes("duplicate")) {
+        return NextResponse.json({ error: "A category with that name already exists" }, { status: 409 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data, { status: 201 });
+  },
+);
 
 // PUT — bulk update (rename/recolor/reorder). Scoped to the active org so
 // a tenant can't mutate another org's rows; Nookleus-default rows (NULL
 // org) are immutable from this endpoint.
-export async function PUT(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_expense_categories");
-  if (!guard.ok) return guard.response;
+export const PUT = withRequestContext(
+  { permission: "manage_expense_categories", serviceClient: true },
+  async (request, ctx) => {
+    const body = await request.json();
+    const service = ctx.serviceClient!;
+    const orgId = ctx.orgId;
 
-  const body = await request.json();
-  const service = createServiceClient();
-  const orgId = await getActiveOrganizationId(supabase);
-
-  const items = Array.isArray(body) ? body : [body];
-  for (const item of items) {
-    const { error } = await service.from("expense_categories").update({
-      display_label: item.display_label,
-      bg_color: item.bg_color,
-      text_color: item.text_color,
-      icon: item.icon,
-      sort_order: item.sort_order,
-    }).eq("id", item.id).eq("organization_id", orgId);
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({ success: true });
-}
+    const items = Array.isArray(body) ? body : [body];
+    for (const item of items) {
+      const { error } = await service.from("expense_categories").update({
+        display_label: item.display_label,
+        bg_color: item.bg_color,
+        text_color: item.text_color,
+        icon: item.icon,
+        sort_order: item.sort_order,
+      }).eq("id", item.id).eq("organization_id", orgId);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  },
+);
 
 // DELETE — custom categories only (not defaults), and not if any expense references it.
-export async function DELETE(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_expense_categories");
-  if (!guard.ok) return guard.response;
+export const DELETE = withRequestContext(
+  { permission: "manage_expense_categories", serviceClient: true },
+  async (request, ctx) => {
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get("id");
+    if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
 
-  const { searchParams } = new URL(request.url);
-  const id = searchParams.get("id");
-  if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
+    const service = ctx.serviceClient!;
+    const orgId = ctx.orgId;
+    const { data: cat } = await service
+      .from("expense_categories")
+      .select("is_default, organization_id")
+      .eq("id", id)
+      .single();
+    if (cat?.is_default || cat?.organization_id === null) {
+      return NextResponse.json({ error: "Default categories cannot be deleted" }, { status: 403 });
+    }
 
-  const service = createServiceClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data: cat } = await service
-    .from("expense_categories")
-    .select("is_default, organization_id")
-    .eq("id", id)
-    .single();
-  if (cat?.is_default || cat?.organization_id === null) {
-    return NextResponse.json({ error: "Default categories cannot be deleted" }, { status: 403 });
-  }
+    const { count } = await service
+      .from("expenses")
+      .select("*", { count: "exact", head: true })
+      .eq("category_id", id)
+      .eq("organization_id", orgId);
+    if (count && count > 0) {
+      return NextResponse.json({ error: `Cannot delete — ${count} expense(s) use this category` }, { status: 409 });
+    }
 
-  const { count } = await service
-    .from("expenses")
-    .select("*", { count: "exact", head: true })
-    .eq("category_id", id)
-    .eq("organization_id", orgId);
-  if (count && count > 0) {
-    return NextResponse.json({ error: `Cannot delete — ${count} expense(s) use this category` }, { status: 409 });
-  }
-
-  const { error } = await service
-    .from("expense_categories")
-    .delete()
-    .eq("id", id)
-    .eq("organization_id", orgId);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ success: true });
-}
+    const { error } = await service
+      .from("expense_categories")
+      .delete()
+      .eq("id", id)
+      .eq("organization_id", orgId);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/export/route.ts
+++ b/src/app/api/settings/export/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 function toCsv(data: Record<string, unknown>[]): string {
   if (data.length === 0) return "";
@@ -17,48 +17,48 @@ function toCsv(data: Record<string, unknown>[]): string {
 }
 
 // GET /api/settings/export?type=jobs&startDate=...&endDate=...
-export async function GET(request: NextRequest) {
-  const type = request.nextUrl.searchParams.get("type");
-  const startDate = request.nextUrl.searchParams.get("startDate");
-  const endDate = request.nextUrl.searchParams.get("endDate");
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (request, ctx) => {
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get("type");
+  const startDate = searchParams.get("startDate");
+  const endDate = searchParams.get("endDate");
 
   if (!type) {
     return NextResponse.json({ error: "type is required" }, { status: 400 });
   }
-
-  const supabase = await createServerSupabaseClient();
 
   let query;
   let filename: string;
 
   switch (type) {
     case "jobs": {
-      query = supabase.from("jobs").select("job_number, status, urgency, damage_type, damage_source, property_address, property_type, property_sqft, affected_areas, insurance_company, claim_number, created_at");
+      query = ctx.supabase.from("jobs").select("job_number, status, urgency, damage_type, damage_source, property_address, property_type, property_sqft, affected_areas, insurance_company, claim_number, created_at");
       filename = "jobs.csv";
       break;
     }
     case "contacts": {
-      query = supabase.from("contacts").select("first_name, last_name, phone, email, role, company, notes, created_at");
+      query = ctx.supabase.from("contacts").select("first_name, last_name, phone, email, role, company, notes, created_at");
       filename = "contacts.csv";
       break;
     }
     case "payments": {
-      query = supabase.from("payments").select("job_id, source, method, amount, reference_number, payer_name, status, notes, received_date, created_at");
+      query = ctx.supabase.from("payments").select("job_id, source, method, amount, reference_number, payer_name, status, notes, received_date, created_at");
       filename = "payments.csv";
       break;
     }
     case "invoices": {
-      query = supabase.from("invoices").select("invoice_number, job_id, total_amount, status, issued_date, notes, created_at");
+      query = ctx.supabase.from("invoices").select("invoice_number, job_id, total_amount, status, issued_date, notes, created_at");
       filename = "invoices.csv";
       break;
     }
     case "emails": {
-      query = supabase.from("emails").select("folder, from_address, from_name, subject, snippet, is_read, has_attachments, matched_by, received_at");
+      query = ctx.supabase.from("emails").select("folder, from_address, from_name, subject, snippet, is_read, has_attachments, matched_by, received_at");
       filename = "emails.csv";
       break;
     }
     case "activities": {
-      query = supabase.from("job_activities").select("job_id, activity_type, title, description, author, created_at");
+      query = ctx.supabase.from("job_activities").select("job_id, activity_type, title, description, author, created_at");
       filename = "activities.csv";
       break;
     }
@@ -83,4 +83,4 @@ export async function GET(request: NextRequest) {
       "Content-Disposition": `attachment; filename="${filename}"`,
     },
   });
-}
+});

--- a/src/app/api/settings/intake-form/custom-fields/route.ts
+++ b/src/app/api/settings/intake-form/custom-fields/route.ts
@@ -1,17 +1,17 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/intake-form/custom-fields?jobId=xxx
-export async function GET(request: NextRequest) {
-  const jobId = request.nextUrl.searchParams.get("jobId");
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (request, ctx) => {
+  const jobId = new URL(request.url).searchParams.get("jobId");
   if (!jobId) return NextResponse.json({ error: "jobId required" }, { status: 400 });
 
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("job_custom_fields")
     .select("*")
     .eq("job_id", jobId);
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data || []);
-}
+});

--- a/src/app/api/settings/intake-form/restore/route.ts
+++ b/src/app/api/settings/intake-form/restore/route.ts
@@ -1,22 +1,21 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { findBlockedRemovals } from "@/lib/contracts/form-config-removal-guard";
 import type { FormConfig } from "@/lib/types";
 
 // POST /api/settings/intake-form/restore — copy an older version forward as a new row.
 // Never mutates or deletes prior versions.
-export async function POST(request: Request) {
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const POST = withRequestContext({}, async (request, ctx) => {
   const body = await request.json().catch(() => ({}));
   const targetVersion = Number(body?.version);
   if (!Number.isFinite(targetVersion) || targetVersion < 1) {
     return NextResponse.json({ error: "Invalid version" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
-  const { data: target, error: fetchErr } = await supabase
+  const { data: target, error: fetchErr } = await ctx.supabase
     .from("form_config")
     .select("config")
     .eq("organization_id", orgId)
@@ -30,7 +29,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const { data: latest, error: latestErr } = await supabase
+  const { data: latest, error: latestErr } = await ctx.supabase
     .from("form_config")
     .select("version, config")
     .eq("organization_id", orgId)
@@ -48,7 +47,7 @@ export async function POST(request: Request) {
   // templates.
   const priorConfig: FormConfig | null = latest?.config ?? null;
   try {
-    const blocked = await findBlockedRemovals(supabase, priorConfig, target.config);
+    const blocked = await findBlockedRemovals(ctx.supabase, priorConfig, target.config);
     if (blocked.length > 0) {
       return NextResponse.json(
         { error: "field_referenced_by_templates", blocked },
@@ -62,7 +61,7 @@ export async function POST(request: Request) {
 
   const nextVersion = (latest?.version ?? 0) + 1;
 
-  const { error: insertErr } = await supabase
+  const { error: insertErr } = await ctx.supabase
     .from("form_config")
     .insert({
       organization_id: orgId,
@@ -79,4 +78,4 @@ export async function POST(request: Request) {
     version: nextVersion,
     config: target.config,
   });
-}
+});

--- a/src/app/api/settings/intake-form/route.ts
+++ b/src/app/api/settings/intake-form/route.ts
@@ -1,37 +1,36 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { findBlockedRemovals } from "@/lib/contracts/form-config-removal-guard";
 import type { FormConfig } from "@/lib/types";
 
 // GET /api/settings/intake-form — fetch latest form config for the active org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("form_config")
     .select("*")
-    .eq("organization_id", await getActiveOrganizationId(supabase))
+    .eq("organization_id", ctx.orgId)
     .order("version", { ascending: false })
     .limit(1)
     .maybeSingle();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data || { config: { sections: [] }, version: 0 });
-}
+});
 
 // POST /api/settings/intake-form — save new version (org-scoped).
-export async function POST(request: Request) {
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const POST = withRequestContext({}, async (request, ctx) => {
   const { config } = await request.json();
 
   if (!config || !config.sections) {
     return NextResponse.json({ error: "Invalid config" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   // Get current latest version + config for this org
-  const { data: current } = await supabase
+  const { data: current } = await ctx.supabase
     .from("form_config")
     .select("version, config")
     .eq("organization_id", orgId)
@@ -43,7 +42,7 @@ export async function POST(request: Request) {
 
   // Block deletes that would orphan contract-template merge references.
   try {
-    const blocked = await findBlockedRemovals(supabase, priorConfig, config);
+    const blocked = await findBlockedRemovals(ctx.supabase, priorConfig, config);
     if (blocked.length > 0) {
       return NextResponse.json(
         {
@@ -60,7 +59,7 @@ export async function POST(request: Request) {
 
   const nextVersion = (current?.version ?? 0) + 1;
 
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("form_config")
     .insert({
       organization_id: orgId,
@@ -73,4 +72,4 @@ export async function POST(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data, { status: 201 });
-}
+});

--- a/src/app/api/settings/intake-form/usage/route.ts
+++ b/src/app/api/settings/intake-form/usage/route.ts
@@ -1,17 +1,16 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { findReferencingTemplates } from "@/lib/contracts/template-reference-lookup";
 import type { FormConfig } from "@/lib/types";
 
 // GET /api/settings/intake-form/usage
 // Returns { usage: { [slug]: [{ id, name, is_active }] } } for every slug
 // derived from the active org's latest form_config (slug = merge_field_slug ?? id).
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const orgId = ctx.orgId;
 
-  const { data: cfgRow, error: cfgErr } = await supabase
+  const { data: cfgRow, error: cfgErr } = await ctx.supabase
     .from("form_config")
     .select("config")
     .eq("organization_id", orgId)
@@ -32,10 +31,10 @@ export async function GET() {
   if (slugs.size === 0) return NextResponse.json({ usage: {} });
 
   try {
-    const usage = await findReferencingTemplates(supabase, [...slugs]);
+    const usage = await findReferencingTemplates(ctx.supabase, [...slugs]);
     return NextResponse.json({ usage });
   } catch (err) {
     const message = err instanceof Error ? err.message : "lookup failed";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-}
+});

--- a/src/app/api/settings/intake-form/versions/route.ts
+++ b/src/app/api/settings/intake-form/versions/route.ts
@@ -1,16 +1,13 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/intake-form/versions — last 20 versions for the active org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-
-  const { data, error } = await supabase
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("form_config")
     .select("version, created_by, created_at")
-    .eq("organization_id", orgId)
+    .eq("organization_id", ctx.orgId)
     .order("version", { ascending: false })
     .limit(20);
 
@@ -19,4 +16,4 @@ export async function GET() {
   }
 
   return NextResponse.json({ versions: data ?? [] });
-}
+});

--- a/src/app/api/settings/invoice-email/route.ts
+++ b/src/app/api/settings/invoice-email/route.ts
@@ -1,85 +1,82 @@
 // GET /api/settings/invoice-email   — returns the singleton row.
 // PATCH /api/settings/invoice-email — updates allowed fields.
 //
-// Auth: admin required. DB access uses the service client so the admin-only
+// Auth: admin required. DB access uses the Service client so the admin-only
 // RLS policy on invoice_email_settings doesn't need to resolve auth.uid().
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requireAdmin } from "@/lib/qb/auth";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import type { InvoiceEmailProvider, InvoiceEmailSettings } from "@/lib/qb/types";
 
-async function getSettings() {
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
+async function getSettings(service: SupabaseClient) {
+  const { data, error } = await service
     .from("invoice_email_settings")
     .select("*")
     .limit(1)
     .maybeSingle<InvoiceEmailSettings>();
-  return { supabase, data, error };
+  return { data, error };
 }
 
-export async function GET() {
-  const auth = await createServerSupabaseClient();
-  const gate = await requireAdmin(auth);
-  if (!gate.ok) return gate.response;
-
-  const { data, error } = await getSettings();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) {
-    return NextResponse.json(
-      { error: "invoice_email_settings row missing — did the build38 migration run?" },
-      { status: 500 },
-    );
-  }
-  return NextResponse.json(data);
-}
-
-export async function PATCH(request: Request) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requireAdmin(auth);
-  if (!gate.ok) return gate.response;
-
-  const body = (await request.json().catch(() => null)) as Partial<InvoiceEmailSettings> | null;
-  if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
-
-  const { supabase, data: current } = await getSettings();
-  if (!current) return NextResponse.json({ error: "settings missing" }, { status: 500 });
-
-  const patch: Partial<InvoiceEmailSettings> = {};
-  const strFields: Array<keyof InvoiceEmailSettings> = [
-    "send_from_email",
-    "send_from_name",
-    "reply_to_email",
-    "subject_template",
-    "body_template",
-  ];
-  for (const f of strFields) {
-    if (body[f] === null || typeof body[f] === "string") {
-      (patch as Record<string, unknown>)[f] = body[f] || null;
+export const GET = withRequestContext(
+  { adminOnly: true, serviceClient: true },
+  async (_request, ctx) => {
+    const { data, error } = await getSettings(ctx.serviceClient!);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) {
+      return NextResponse.json(
+        { error: "invoice_email_settings row missing — did the build38 migration run?" },
+        { status: 500 },
+      );
     }
-  }
-  if (body.provider === "resend" || body.provider === "email_account") {
-    patch.provider = body.provider as InvoiceEmailProvider;
-  }
-  if (body.email_account_id === null || typeof body.email_account_id === "string") {
-    patch.email_account_id = body.email_account_id || null;
-  }
+    return NextResponse.json(data);
+  },
+);
 
-  if (patch.provider === "email_account" && !patch.email_account_id && !current.email_account_id) {
-    return NextResponse.json(
-      { error: "Select an email account before switching provider to email_account" },
-      { status: 400 },
-    );
-  }
+export const PATCH = withRequestContext(
+  { adminOnly: true, serviceClient: true },
+  async (request, ctx) => {
+    const service = ctx.serviceClient!;
+    const body = (await request.json().catch(() => null)) as Partial<InvoiceEmailSettings> | null;
+    if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
 
-  const { data, error } = await supabase
-    .from("invoice_email_settings")
-    .update(patch)
-    .eq("id", current.id)
-    .select()
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+    const { data: current } = await getSettings(service);
+    if (!current) return NextResponse.json({ error: "settings missing" }, { status: 500 });
+
+    const patch: Partial<InvoiceEmailSettings> = {};
+    const strFields: Array<keyof InvoiceEmailSettings> = [
+      "send_from_email",
+      "send_from_name",
+      "reply_to_email",
+      "subject_template",
+      "body_template",
+    ];
+    for (const f of strFields) {
+      if (body[f] === null || typeof body[f] === "string") {
+        (patch as Record<string, unknown>)[f] = body[f] || null;
+      }
+    }
+    if (body.provider === "resend" || body.provider === "email_account") {
+      patch.provider = body.provider as InvoiceEmailProvider;
+    }
+    if (body.email_account_id === null || typeof body.email_account_id === "string") {
+      patch.email_account_id = body.email_account_id || null;
+    }
+
+    if (patch.provider === "email_account" && !patch.email_account_id && !current.email_account_id) {
+      return NextResponse.json(
+        { error: "Select an email account before switching provider to email_account" },
+        { status: 400 },
+      );
+    }
+
+    const { data, error } = await service
+      .from("invoice_email_settings")
+      .update(patch)
+      .eq("id", current.id)
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/settings/nav-order/route.ts
+++ b/src/app/api/settings/nav-order/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/nav-order — returns the admin-configured order.
 // Any signed-in user can read (RLS enforces this).
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("nav_items")
     .select("href, sort_order")
     .order("sort_order");
@@ -14,29 +14,24 @@ export async function GET() {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
   return NextResponse.json(data ?? []);
-}
+});
 
 // PUT /api/settings/nav-order — admin-only. Body: { order: string[] }
 // where `order` is an array of hrefs in the desired display order.
 // Upserts each href with sort_order = index + 1.
-export async function PUT(request: Request) {
-  const supabase = await createServerSupabaseClient();
-
-  // Auth check
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) {
-    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
-  }
-
+//
+// nav_items is a product-level table, so the admin check accepts admin in
+// ANY org the caller belongs to — not just the Active Organization. The
+// wrapper's `adminOnly` rule only checks the Active Organization, so this
+// route stays logged-in-only at the wrapper and keeps the any-org admin
+// check as its own business logic (matching the build48 RLS policy).
+export const PUT = withRequestContext({}, async (request, ctx) => {
   // Admin check (defense-in-depth; RLS also enforces this). nav_items is a
-  // product-level table, so we accept admin in ANY org the user belongs to
-  // (the same check the updated build48 policy uses).
-  const { data: anyAdminMembership } = await supabase
+  // product-level table, so we accept admin in ANY org the user belongs to.
+  const { data: anyAdminMembership } = await ctx.supabase
     .from("user_organizations")
     .select("id")
-    .eq("user_id", user.id)
+    .eq("user_id", ctx.userId)
     .eq("role", "admin")
     .limit(1)
     .maybeSingle<{ id: string }>();
@@ -78,7 +73,7 @@ export async function PUT(request: Request) {
     sort_order: i + 1,
   }));
 
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("nav_items")
     .upsert(rows, { onConflict: "href" });
 
@@ -86,4 +81,4 @@ export async function PUT(request: Request) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/payment-email/route.ts
+++ b/src/app/api/settings/payment-email/route.ts
@@ -1,158 +1,160 @@
+// GET /api/settings/payment-email   — returns the singleton row.
+// PATCH /api/settings/payment-email — updates allowed fields.
+//
+// Auth: the `access_settings` permission. DB access uses the Service client.
+
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import type {
   PaymentEmailProvider,
   PaymentEmailSettings,
 } from "@/lib/payments/types";
 
-async function getSettings() {
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
+async function getSettings(service: SupabaseClient) {
+  const { data, error } = await service
     .from("payment_email_settings")
     .select("*")
     .limit(1)
     .maybeSingle<PaymentEmailSettings>();
-  return { supabase, data, error };
+  return { data, error };
 }
 
-export async function GET() {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
-
-  const { data, error } = await getSettings();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  if (!data) {
-    return NextResponse.json(
-      { error: "payment_email_settings row missing — did the build40 migration run?" },
-      { status: 500 },
-    );
-  }
-  return NextResponse.json(data);
-}
-
-export async function PATCH(request: Request) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
-
-  const body = (await request.json().catch(() => null)) as
-    | Partial<PaymentEmailSettings>
-    | null;
-  if (!body) {
-    return NextResponse.json(
-      { error: "Body must be a JSON object" },
-      { status: 400 },
-    );
-  }
-
-  const { supabase, data: current, error: fetchErr } = await getSettings();
-  if (fetchErr)
-    return NextResponse.json({ error: fetchErr.message }, { status: 500 });
-  if (!current) {
-    return NextResponse.json(
-      { error: "payment_email_settings row missing — did the build40 migration run?" },
-      { status: 500 },
-    );
-  }
-
-  const patch: Partial<PaymentEmailSettings> = {};
-  const stringFields: Array<keyof PaymentEmailSettings> = [
-    "send_from_email",
-    "send_from_name",
-    "payment_request_subject_template",
-    "payment_request_body_template",
-    "payment_reminder_subject_template",
-    "payment_reminder_body_template",
-    "payment_receipt_subject_template",
-    "payment_receipt_body_template",
-    "refund_confirmation_subject_template",
-    "refund_confirmation_body_template",
-    "payment_received_internal_subject_template",
-    "payment_received_internal_body_template",
-    "payment_failed_internal_subject_template",
-    "payment_failed_internal_body_template",
-    "refund_issued_internal_subject_template",
-    "refund_issued_internal_body_template",
-    // Build 67c2 — estimate + invoice send templates
-    "estimate_send_subject_template",
-    "estimate_send_body_template",
-    "invoice_send_subject_template",
-    "invoice_send_body_template",
-  ];
-  for (const f of stringFields) {
-    const v = body[f];
-    if (typeof v === "string") {
-      if (v.length > 5000) {
-        return NextResponse.json(
-          { error: `${f} exceeds 5000 char limit` },
-          { status: 400 },
-        );
-      }
-      (patch as Record<string, unknown>)[f] = v;
-    }
-  }
-  if (
-    body.internal_notification_to_email === null ||
-    typeof body.internal_notification_to_email === "string"
-  ) {
-    patch.internal_notification_to_email =
-      body.internal_notification_to_email || null;
-  }
-  if (body.reply_to_email === null || typeof body.reply_to_email === "string") {
-    patch.reply_to_email = body.reply_to_email || null;
-  }
-  if (body.provider === "resend" || body.provider === "email_account") {
-    patch.provider = body.provider as PaymentEmailProvider;
-  }
-  if (
-    body.email_account_id === null ||
-    typeof body.email_account_id === "string"
-  ) {
-    patch.email_account_id = body.email_account_id || null;
-  }
-  if (Array.isArray(body.reminder_day_offsets)) {
-    const offsets = body.reminder_day_offsets
-      .map((n) => Number(n))
-      .filter((n) => Number.isFinite(n) && n > 0 && n <= 60);
-    patch.reminder_day_offsets = offsets;
-  }
-  if (typeof body.default_link_expiry_days === "number") {
-    const d = Math.round(body.default_link_expiry_days);
-    if (d < 1 || d > 30) {
+export const GET = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (_request, ctx) => {
+    const { data, error } = await getSettings(ctx.serviceClient!);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    if (!data) {
       return NextResponse.json(
-        { error: "default_link_expiry_days must be between 1 and 30" },
+        { error: "payment_email_settings row missing — did the build40 migration run?" },
+        { status: 500 },
+      );
+    }
+    return NextResponse.json(data);
+  },
+);
+
+export const PATCH = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (request, ctx) => {
+    const service = ctx.serviceClient!;
+    const body = (await request.json().catch(() => null)) as
+      | Partial<PaymentEmailSettings>
+      | null;
+    if (!body) {
+      return NextResponse.json(
+        { error: "Body must be a JSON object" },
         { status: 400 },
       );
     }
-    patch.default_link_expiry_days = d;
-  }
-  if (body.fee_disclosure_text === null || typeof body.fee_disclosure_text === "string") {
-    patch.fee_disclosure_text = body.fee_disclosure_text || null;
-  }
 
-  if (
-    patch.provider === "email_account" &&
-    !patch.email_account_id &&
-    !current.email_account_id
-  ) {
-    return NextResponse.json(
-      {
-        error:
-          "Select an email account before switching provider to email_account",
-      },
-      { status: 400 },
-    );
-  }
+    const { data: current, error: fetchErr } = await getSettings(service);
+    if (fetchErr)
+      return NextResponse.json({ error: fetchErr.message }, { status: 500 });
+    if (!current) {
+      return NextResponse.json(
+        { error: "payment_email_settings row missing — did the build40 migration run?" },
+        { status: 500 },
+      );
+    }
 
-  const { data, error } = await supabase
-    .from("payment_email_settings")
-    .update(patch)
-    .eq("id", current.id)
-    .select()
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+    const patch: Partial<PaymentEmailSettings> = {};
+    const stringFields: Array<keyof PaymentEmailSettings> = [
+      "send_from_email",
+      "send_from_name",
+      "payment_request_subject_template",
+      "payment_request_body_template",
+      "payment_reminder_subject_template",
+      "payment_reminder_body_template",
+      "payment_receipt_subject_template",
+      "payment_receipt_body_template",
+      "refund_confirmation_subject_template",
+      "refund_confirmation_body_template",
+      "payment_received_internal_subject_template",
+      "payment_received_internal_body_template",
+      "payment_failed_internal_subject_template",
+      "payment_failed_internal_body_template",
+      "refund_issued_internal_subject_template",
+      "refund_issued_internal_body_template",
+      // Build 67c2 — estimate + invoice send templates
+      "estimate_send_subject_template",
+      "estimate_send_body_template",
+      "invoice_send_subject_template",
+      "invoice_send_body_template",
+    ];
+    for (const f of stringFields) {
+      const v = body[f];
+      if (typeof v === "string") {
+        if (v.length > 5000) {
+          return NextResponse.json(
+            { error: `${f} exceeds 5000 char limit` },
+            { status: 400 },
+          );
+        }
+        (patch as Record<string, unknown>)[f] = v;
+      }
+    }
+    if (
+      body.internal_notification_to_email === null ||
+      typeof body.internal_notification_to_email === "string"
+    ) {
+      patch.internal_notification_to_email =
+        body.internal_notification_to_email || null;
+    }
+    if (body.reply_to_email === null || typeof body.reply_to_email === "string") {
+      patch.reply_to_email = body.reply_to_email || null;
+    }
+    if (body.provider === "resend" || body.provider === "email_account") {
+      patch.provider = body.provider as PaymentEmailProvider;
+    }
+    if (
+      body.email_account_id === null ||
+      typeof body.email_account_id === "string"
+    ) {
+      patch.email_account_id = body.email_account_id || null;
+    }
+    if (Array.isArray(body.reminder_day_offsets)) {
+      const offsets = body.reminder_day_offsets
+        .map((n) => Number(n))
+        .filter((n) => Number.isFinite(n) && n > 0 && n <= 60);
+      patch.reminder_day_offsets = offsets;
+    }
+    if (typeof body.default_link_expiry_days === "number") {
+      const d = Math.round(body.default_link_expiry_days);
+      if (d < 1 || d > 30) {
+        return NextResponse.json(
+          { error: "default_link_expiry_days must be between 1 and 30" },
+          { status: 400 },
+        );
+      }
+      patch.default_link_expiry_days = d;
+    }
+    if (body.fee_disclosure_text === null || typeof body.fee_disclosure_text === "string") {
+      patch.fee_disclosure_text = body.fee_disclosure_text || null;
+    }
+
+    if (
+      patch.provider === "email_account" &&
+      !patch.email_account_id &&
+      !current.email_account_id
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "Select an email account before switching provider to email_account",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { data, error } = await service
+      .from("payment_email_settings")
+      .update(patch)
+      .eq("id", current.id)
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/settings/signatures/route.ts
+++ b/src/app/api/settings/signatures/route.ts
@@ -1,16 +1,15 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/settings/signatures — get all signatures with account info
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-
-  const { data: accounts } = await supabase
+// GET /api/settings/signatures — get all signatures with account info.
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data: accounts } = await ctx.supabase
     .from("email_accounts")
     .select("id, label, email_address, display_name, is_active")
     .order("created_at");
 
-  const { data: signatures } = await supabase
+  const { data: signatures } = await ctx.supabase
     .from("email_signatures")
     .select("*");
 
@@ -25,18 +24,18 @@ export async function GET() {
   }));
 
   return NextResponse.json(result);
-}
+});
 
-// PUT /api/settings/signatures — upsert signature for an account
-export async function PUT(request: Request) {
+// PUT /api/settings/signatures — upsert signature for an account.
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PUT = withRequestContext({}, async (request, ctx) => {
   const { account_id, signature_html, include_logo, auto_insert } = await request.json();
 
   if (!account_id) {
     return NextResponse.json({ error: "account_id is required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("email_signatures")
     .upsert(
       {
@@ -50,4 +49,4 @@ export async function PUT(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/statuses/route.ts
+++ b/src/app/api/settings/statuses/route.ts
@@ -1,12 +1,13 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// All four methods are logged-in only — previously ungated (recorded for the
+// #78 ungated-endpoint list).
 
 // GET /api/settings/statuses — returns NULL-org defaults plus this org's customizations.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data, error } = await supabase
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const orgId = ctx.orgId;
+  const { data, error } = await ctx.supabase
     .from("job_statuses")
     .select("*")
     .or(`organization_id.is.null,organization_id.eq.${orgId}`)
@@ -14,10 +15,10 @@ export async function GET() {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json(data);
-}
+});
 
 // POST /api/settings/statuses — create new status (always org-owned).
-export async function POST(request: Request) {
+export const POST = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
   const { name, display_label, bg_color, text_color } = body;
 
@@ -25,11 +26,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "name and display_label are required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   // Get max sort_order (across defaults + this org's rows).
-  const { data: existing } = await supabase
+  const { data: existing } = await ctx.supabase
     .from("job_statuses")
     .select("sort_order")
     .or(`organization_id.is.null,organization_id.eq.${orgId}`)
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
 
   const nextOrder = (existing?.[0]?.sort_order ?? 0) + 1;
 
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("job_statuses")
     .insert({
       organization_id: orgId,
@@ -60,18 +60,17 @@ export async function POST(request: Request) {
   }
 
   return NextResponse.json(data, { status: 201 });
-}
+});
 
 // PUT /api/settings/statuses — bulk update (for reordering + editing). Only
 // touches the active org's rows; defaults (NULL-org) are immutable here.
-export async function PUT(request: Request) {
+export const PUT = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   if (Array.isArray(body)) {
     for (const item of body) {
-      const { error } = await supabase
+      const { error } = await ctx.supabase
         .from("job_statuses")
         .update({
           display_label: item.display_label,
@@ -88,7 +87,7 @@ export async function PUT(request: Request) {
   }
 
   const { id, display_label, bg_color, text_color, sort_order } = body;
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("job_statuses")
     .update({ display_label, bg_color, text_color, sort_order })
     .eq("id", id)
@@ -96,19 +95,18 @@ export async function PUT(request: Request) {
 
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ success: true });
-}
+});
 
 // DELETE /api/settings/statuses?id=xxx
-export async function DELETE(request: Request) {
+export const DELETE = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const id = searchParams.get("id");
   if (!id) return NextResponse.json({ error: "id is required" }, { status: 400 });
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   // Read the target row to check default + get the name.
-  const { data: status } = await supabase
+  const { data: status } = await ctx.supabase
     .from("job_statuses")
     .select("is_default, name, organization_id")
     .eq("id", id)
@@ -119,7 +117,7 @@ export async function DELETE(request: Request) {
   }
 
   // Check if any jobs in this org use this status
-  const { count } = await supabase
+  const { count } = await ctx.supabase
     .from("jobs")
     .select("*", { count: "exact", head: true })
     .eq("organization_id", orgId)
@@ -132,11 +130,11 @@ export async function DELETE(request: Request) {
     );
   }
 
-  const { error } = await supabase
+  const { error } = await ctx.supabase
     .from("job_statuses")
     .delete()
     .eq("id", id)
     .eq("organization_id", orgId);
   if (error) return NextResponse.json({ error: error.message }, { status: 500 });
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/settings/users/[id]/permissions/route.ts
+++ b/src/app/api/settings/users/[id]/permissions/route.ts
@@ -1,102 +1,82 @@
 import { NextResponse } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/settings/users/[id]/permissions — from user_organization_permissions
 // scoped to the active org's membership.
-export async function GET(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const service = ctx.serviceClient!;
 
-  let service;
-  try {
-    service = createServiceClient();
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Service client unavailable" },
-      { status: 500 }
-    );
-  }
+    const { data: membership } = await service
+      .from("user_organizations")
+      .select("id")
+      .eq("user_id", id)
+      .eq("organization_id", ctx.orgId)
+      .maybeSingle<{ id: string }>();
+    if (!membership) return NextResponse.json({});
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data: membership } = await service
-    .from("user_organizations")
-    .select("id")
-    .eq("user_id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string }>();
-  if (!membership) return NextResponse.json({});
+    const { data, error } = await service
+      .from("user_organization_permissions")
+      .select("permission_key, granted")
+      .eq("user_organization_id", membership.id);
 
-  const { data, error } = await service
-    .from("user_organization_permissions")
-    .select("permission_key, granted")
-    .eq("user_organization_id", membership.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    const permsMap: Record<string, boolean> = {};
+    for (const p of data || []) {
+      permsMap[p.permission_key] = p.granted;
+    }
 
-  const permsMap: Record<string, boolean> = {};
-  for (const p of data || []) {
-    permsMap[p.permission_key] = p.granted;
-  }
-
-  return NextResponse.json(permsMap);
-}
+    return NextResponse.json(permsMap);
+  },
+);
 
 // PUT /api/settings/users/[id]/permissions — writes go to both
 // user_organization_permissions (the new source of truth) and the legacy
 // user_permissions table so 18a revert is safe.
-export async function PUT(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const body = await request.json() as Record<string, boolean>;
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PUT = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json() as Record<string, boolean>;
+    const service = ctx.serviceClient!;
 
-  let service;
-  try {
-    service = createServiceClient();
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Service client unavailable" },
-      { status: 500 }
-    );
-  }
+    const { data: membership } = await service
+      .from("user_organizations")
+      .select("id")
+      .eq("user_id", id)
+      .eq("organization_id", ctx.orgId)
+      .maybeSingle<{ id: string }>();
+    if (!membership) {
+      return NextResponse.json({ error: "user is not a member of the active org" }, { status: 404 });
+    }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const { data: membership } = await service
-    .from("user_organizations")
-    .select("id")
-    .eq("user_id", id)
-    .eq("organization_id", orgId)
-    .maybeSingle<{ id: string }>();
-  if (!membership) {
-    return NextResponse.json({ error: "user is not a member of the active org" }, { status: 404 });
-  }
+    const uopUpserts = Object.entries(body).map(([permission_key, granted]) => ({
+      user_organization_id: membership.id,
+      permission_key,
+      granted,
+    }));
+    const upUpserts = Object.entries(body).map(([permission_key, granted]) => ({
+      user_id: id,
+      permission_key,
+      granted,
+    }));
 
-  const uopUpserts = Object.entries(body).map(([permission_key, granted]) => ({
-    user_organization_id: membership.id,
-    permission_key,
-    granted,
-  }));
-  const upUpserts = Object.entries(body).map(([permission_key, granted]) => ({
-    user_id: id,
-    permission_key,
-    granted,
-  }));
+    const { error } = await service
+      .from("user_organization_permissions")
+      .upsert(uopUpserts, { onConflict: "user_organization_id,permission_key" });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  const { error } = await service
-    .from("user_organization_permissions")
-    .upsert(uopUpserts, { onConflict: "user_organization_id,permission_key" });
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    await service
+      .from("user_permissions")
+      .upsert(upUpserts, { onConflict: "user_id,permission_key" });
 
-  await service
-    .from("user_permissions")
-    .upsert(upUpserts, { onConflict: "user_id,permission_key" });
-
-  return NextResponse.json({ success: true });
-}
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/users/[id]/route.ts
+++ b/src/app/api/settings/users/[id]/route.ts
@@ -1,59 +1,48 @@
 import { NextResponse } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // PATCH /api/settings/users/[id] — update user profile. Role updates land
 // on user_organizations (scoped to the active org) not user_profiles, since
 // build48 dropped user_profiles.role.
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const body = await request.json();
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const PATCH = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json();
+    const service = ctx.serviceClient!;
 
-  let service;
-  try {
-    service = createServiceClient();
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Service client unavailable" },
-      { status: 500 }
-    );
-  }
+    const profileUpdates: Record<string, unknown> = {};
+    if (body.full_name !== undefined) profileUpdates.full_name = body.full_name;
+    if (body.phone !== undefined) profileUpdates.phone = body.phone || null;
+    if (body.is_active !== undefined) profileUpdates.is_active = body.is_active;
 
-  const profileUpdates: Record<string, unknown> = {};
-  if (body.full_name !== undefined) profileUpdates.full_name = body.full_name;
-  if (body.phone !== undefined) profileUpdates.phone = body.phone || null;
-  if (body.is_active !== undefined) profileUpdates.is_active = body.is_active;
+    if (Object.keys(profileUpdates).length > 0) {
+      const { error } = await service
+        .from("user_profiles")
+        .update(profileUpdates)
+        .eq("id", id);
 
-  if (Object.keys(profileUpdates).length > 0) {
-    const { error } = await service
-      .from("user_profiles")
-      .update(profileUpdates)
-      .eq("id", id);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    if (body.role !== undefined) {
+      const { error } = await service
+        .from("user_organizations")
+        .update({ role: body.role })
+        .eq("user_id", id)
+        .eq("organization_id", ctx.orgId);
+      if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  if (body.role !== undefined) {
-    const supabase = await createServerSupabaseClient();
-    const orgId = await getActiveOrganizationId(supabase);
-    const { error } = await service
-      .from("user_organizations")
-      .update({ role: body.role })
-      .eq("user_id", id)
-      .eq("organization_id", orgId);
-    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    // If deactivating, also ban the auth user
+    if (body.is_active === false) {
+      await service.auth.admin.updateUserById(id, { ban_duration: "876000h" }); // ~100 years
+    } else if (body.is_active === true) {
+      await service.auth.admin.updateUserById(id, { ban_duration: "none" });
+    }
 
-  // If deactivating, also ban the auth user
-  if (body.is_active === false) {
-    await service.auth.admin.updateUserById(id, { ban_duration: "876000h" }); // ~100 years
-  } else if (body.is_active === true) {
-    await service.auth.admin.updateUserById(id, { ban_duration: "none" });
-  }
-
-  return NextResponse.json({ success: true });
-}
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/users/route.ts
+++ b/src/app/api/settings/users/route.ts
@@ -1,7 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 const ALL_PERMISSIONS = [
   "view_jobs", "edit_jobs", "create_jobs",
@@ -26,118 +24,114 @@ const ROLE_DEFAULTS: Record<string, string[]> = {
 
 // GET /api/settings/users — list all members of the active org with their
 // user_profiles joined. Role is sourced from user_organizations (per-org).
-// Uses the cookie-aware SSR client so RLS sees the caller's auth.uid() and
-// the user_orgs_member_read policy (build51) grants visibility into other
-// members of the same org.
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+// The User client (ctx.supabase) lets RLS see the caller's auth.uid() so the
+// user_orgs_member_read policy (build51) grants visibility into other members
+// of the same org.
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx) => {
+    const { data: memberships, error } = await ctx.supabase
+      .from("user_organizations")
+      .select("id, user_id, role, created_at, user_profiles:user_id ( id, full_name, phone, profile_photo_path, is_active, last_login_at, created_at )")
+      .eq("organization_id", ctx.orgId)
+      .order("created_at");
 
-  const { data: memberships, error } = await supabase
-    .from("user_organizations")
-    .select("id, user_id, role, created_at, user_profiles:user_id ( id, full_name, phone, profile_photo_path, is_active, last_login_at, created_at )")
-    .eq("organization_id", orgId)
-    .order("created_at");
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    // Get auth emails via the Service client.
+    try {
+      const { data: authUsers } = await ctx.serviceClient!.auth.admin.listUsers();
 
-  // Get auth emails via service client
-  try {
-    const service = createServiceClient();
-    const { data: authUsers } = await service.auth.admin.listUsers();
+      const enriched = (memberships || []).map((m) => {
+        const profile = Array.isArray(m.user_profiles) ? m.user_profiles[0] : m.user_profiles;
+        const authUser = authUsers?.users?.find((u) => u.id === m.user_id);
+        return {
+          ...(profile ?? {}),
+          id: m.user_id,
+          role: m.role,
+          membership_id: m.id,
+          email: authUser?.email || "",
+        };
+      });
 
-    const enriched = (memberships || []).map((m) => {
-      const profile = Array.isArray(m.user_profiles) ? m.user_profiles[0] : m.user_profiles;
-      const authUser = authUsers?.users?.find((u) => u.id === m.user_id);
-      return {
-        ...(profile ?? {}),
-        id: m.user_id,
-        role: m.role,
-        membership_id: m.id,
-        email: authUser?.email || "",
-      };
-    });
-
-    return NextResponse.json(enriched);
-  } catch {
-    // If service key not set, return memberships without emails
-    return NextResponse.json(memberships || []);
-  }
-}
+      return NextResponse.json(enriched);
+    } catch {
+      // If the auth admin lookup fails, return memberships without emails.
+      return NextResponse.json(memberships || []);
+    }
+  },
+);
 
 // POST /api/settings/users — invite new user. Creates the auth user (which
 // fires handle_new_user to create user_profiles), then inserts the
 // user_organizations row and default permissions.
-export async function POST(request: Request) {
-  const { email, full_name, phone, role } = await request.json();
+//
+// Logged-in only — previously ungated (recorded for the #78 ungated list).
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const { email, full_name, phone, role } = await request.json();
 
-  if (!email || !full_name) {
-    return NextResponse.json({ error: "Email and name are required" }, { status: 400 });
-  }
-
-  let service;
-  try {
-    service = createServiceClient();
-  } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Service client unavailable" },
-      { status: 500 }
-    );
-  }
-
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
-  const chosenRole = role || "crew_member";
-
-  // Create auth user with invite — handle_new_user trigger creates user_profiles row.
-  const { data: authData, error: authError } = await service.auth.admin.createUser({
-    email,
-    email_confirm: true,
-    user_metadata: { full_name, role: chosenRole },
-  });
-
-  if (authError) {
-    if (authError.message.includes("already been registered")) {
-      return NextResponse.json({ error: "A user with this email already exists" }, { status: 409 });
+    if (!email || !full_name) {
+      return NextResponse.json({ error: "Email and name are required" }, { status: 400 });
     }
-    return NextResponse.json({ error: authError.message }, { status: 500 });
-  }
 
-  const userId = authData.user.id;
+    const service = ctx.serviceClient!;
+    const orgId = ctx.orgId;
+    const chosenRole = role || "crew_member";
 
-  // Fill out user_profiles with optional fields (no role column post-build48).
-  await service.from("user_profiles").update({
-    full_name,
-    phone: phone || null,
-  }).eq("id", userId);
+    // Create auth user with invite — handle_new_user trigger creates user_profiles row.
+    const { data: authData, error: authError } = await service.auth.admin.createUser({
+      email,
+      email_confirm: true,
+      user_metadata: { full_name, role: chosenRole },
+    });
 
-  // Create the membership in the active org.
-  const { data: membership, error: memErr } = await service
-    .from("user_organizations")
-    .insert({ user_id: userId, organization_id: orgId, role: chosenRole })
-    .select("id")
-    .single();
-  if (memErr) return NextResponse.json({ error: memErr.message }, { status: 500 });
+    if (authError) {
+      if (authError.message.includes("already been registered")) {
+        return NextResponse.json({ error: "A user with this email already exists" }, { status: 409 });
+      }
+      return NextResponse.json({ error: authError.message }, { status: 500 });
+    }
 
-  // Set default permissions on the new membership in user_organization_permissions.
-  // Write the legacy user_permissions table too so revert during 18a is safe.
-  const grantedPerms = ROLE_DEFAULTS[chosenRole] || ROLE_DEFAULTS.crew_member;
-  const uopInserts = ALL_PERMISSIONS.map((perm) => ({
-    user_organization_id: membership.id,
-    permission_key: perm,
-    granted: grantedPerms.includes(perm),
-  }));
-  const upInserts = ALL_PERMISSIONS.map((perm) => ({
-    user_id: userId,
-    permission_key: perm,
-    granted: grantedPerms.includes(perm),
-  }));
-  await service.from("user_organization_permissions").upsert(uopInserts, {
-    onConflict: "user_organization_id,permission_key",
-  });
-  await service.from("user_permissions").upsert(upInserts, {
-    onConflict: "user_id,permission_key",
-  });
+    const userId = authData.user.id;
 
-  return NextResponse.json({ id: userId, email, full_name, role: chosenRole }, { status: 201 });
-}
+    // Fill out user_profiles with optional fields (no role column post-build48).
+    await service.from("user_profiles").update({
+      full_name,
+      phone: phone || null,
+    }).eq("id", userId);
+
+    // Create the membership in the active org.
+    const { data: membership, error: memErr } = await service
+      .from("user_organizations")
+      .insert({ user_id: userId, organization_id: orgId, role: chosenRole })
+      .select("id")
+      .single();
+    if (memErr) return NextResponse.json({ error: memErr.message }, { status: 500 });
+
+    // Set default permissions on the new membership in user_organization_permissions.
+    // Write the legacy user_permissions table too so revert during 18a is safe.
+    const grantedPerms = ROLE_DEFAULTS[chosenRole] || ROLE_DEFAULTS.crew_member;
+    const uopInserts = ALL_PERMISSIONS.map((perm) => ({
+      user_organization_id: membership.id,
+      permission_key: perm,
+      granted: grantedPerms.includes(perm),
+    }));
+    const upInserts = ALL_PERMISSIONS.map((perm) => ({
+      user_id: userId,
+      permission_key: perm,
+      granted: grantedPerms.includes(perm),
+    }));
+    await service.from("user_organization_permissions").upsert(uopInserts, {
+      onConflict: "user_organization_id,permission_key",
+    });
+    await service.from("user_permissions").upsert(upInserts, {
+      onConflict: "user_id,permission_key",
+    });
+
+    return NextResponse.json({ id: userId, email, full_name, role: chosenRole }, { status: 201 });
+  },
+);

--- a/src/app/api/settings/vendors/[id]/deactivate/route.ts
+++ b/src/app/api/settings/vendors/[id]/deactivate/route.ts
@@ -1,21 +1,16 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_vendors");
-  if (!guard.ok) return guard.response;
-  const { id } = await params;
-
-  const service = createServiceClient();
-  const { error } = await service
-    .from("vendors")
-    .update({ is_active: false })
-    .eq("id", id)
-    .eq("organization_id", await getActiveOrganizationId(supabase));
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ success: true });
-}
+export const POST = withRequestContext(
+  { permission: "manage_vendors", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { error } = await ctx
+      .serviceClient!.from("vendors")
+      .update({ is_active: false })
+      .eq("id", id)
+      .eq("organization_id", ctx.orgId);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/vendors/[id]/reactivate/route.ts
+++ b/src/app/api/settings/vendors/[id]/reactivate/route.ts
@@ -1,21 +1,16 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_vendors");
-  if (!guard.ok) return guard.response;
-  const { id } = await params;
-
-  const service = createServiceClient();
-  const { error } = await service
-    .from("vendors")
-    .update({ is_active: true })
-    .eq("id", id)
-    .eq("organization_id", await getActiveOrganizationId(supabase));
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ success: true });
-}
+export const POST = withRequestContext(
+  { permission: "manage_vendors", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { error } = await ctx
+      .serviceClient!.from("vendors")
+      .update({ is_active: true })
+      .eq("id", id)
+      .eq("organization_id", ctx.orgId);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/settings/vendors/[id]/route.ts
+++ b/src/app/api/settings/vendors/[id]/route.ts
@@ -1,39 +1,34 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
-  const supabase = await createServerSupabaseClient();
-  const guard = await requirePermission(supabase, "manage_vendors");
-  if (!guard.ok) return guard.response;
+export const PATCH = withRequestContext(
+  { permission: "manage_vendors", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json();
+    const { name, vendor_type, default_category_id, is_1099, tax_id, notes } = body as Record<string, unknown>;
 
-  const { id } = await params;
-  const body = await request.json();
-  const { name, vendor_type, default_category_id, is_1099, tax_id, notes } = body as Record<string, unknown>;
+    const allowedTypes = ["supplier", "subcontractor", "equipment_rental", "fuel", "other"];
+    if (vendor_type !== undefined && (typeof vendor_type !== "string" || !allowedTypes.includes(vendor_type))) {
+      return NextResponse.json({ error: "invalid vendor_type" }, { status: 400 });
+    }
 
-  const allowedTypes = ["supplier", "subcontractor", "equipment_rental", "fuel", "other"];
-  if (vendor_type !== undefined && (typeof vendor_type !== "string" || !allowedTypes.includes(vendor_type))) {
-    return NextResponse.json({ error: "invalid vendor_type" }, { status: 400 });
-  }
+    const updates: Record<string, unknown> = {};
+    if (typeof name === "string") updates.name = name.trim();
+    if (typeof vendor_type === "string") updates.vendor_type = vendor_type;
+    if (default_category_id !== undefined) updates.default_category_id = default_category_id ?? null;
+    if (is_1099 !== undefined) updates.is_1099 = Boolean(is_1099);
+    if (tax_id !== undefined) updates.tax_id = tax_id ?? null;
+    if (notes !== undefined) updates.notes = notes ?? null;
 
-  const updates: Record<string, unknown> = {};
-  if (typeof name === "string") updates.name = name.trim();
-  if (typeof vendor_type === "string") updates.vendor_type = vendor_type;
-  if (default_category_id !== undefined) updates.default_category_id = default_category_id ?? null;
-  if (is_1099 !== undefined) updates.is_1099 = Boolean(is_1099);
-  if (tax_id !== undefined) updates.tax_id = tax_id ?? null;
-  if (notes !== undefined) updates.notes = notes ?? null;
-
-  const service = createServiceClient();
-  const { data, error } = await service
-    .from("vendors")
-    .update(updates)
-    .eq("id", id)
-    .eq("organization_id", await getActiveOrganizationId(supabase))
-    .select()
-    .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+    const { data, error } = await ctx
+      .serviceClient!.from("vendors")
+      .update(updates)
+      .eq("id", id)
+      .eq("organization_id", ctx.orgId)
+      .select()
+      .single();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/settings/vendors/route.ts
+++ b/src/app/api/settings/vendors/route.ts
@@ -1,81 +1,97 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-async function requireAnyAuth() {
-  const supabase = await createServerSupabaseClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return { ok: false as const, response: NextResponse.json({ error: "Not authenticated" }, { status: 401 }) };
-  return { ok: true as const, user, supabase };
-}
+// GET — list, any authenticated user (used by the Log Expense modal
+// autocomplete too). Reads vendors with the Service client.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get("q")?.trim() ?? "";
+    const active = searchParams.get("active");
+    const type = searchParams.get("type");
+    const is1099 = searchParams.get("is_1099");
 
-// GET — any authenticated user (used by Log Expense modal autocomplete too)
-export async function GET(request: Request) {
-  const auth = await requireAnyAuth();
-  if (!auth.ok) return auth.response;
+    let query = ctx
+      .serviceClient!.from("vendors")
+      .select("*, default_category:expense_categories!default_category_id(id, display_label, bg_color, text_color)")
+      .eq("organization_id", ctx.orgId)
+      .order("name", { ascending: true });
 
-  const { searchParams } = new URL(request.url);
-  const q = searchParams.get("q")?.trim() ?? "";
-  const active = searchParams.get("active");
-  const type = searchParams.get("type");
-  const is1099 = searchParams.get("is_1099");
+    if (q) query = query.ilike("name", `%${q}%`);
+    if (active === "true") query = query.eq("is_active", true);
+    if (active === "false") query = query.eq("is_active", false);
+    if (type) query = query.eq("vendor_type", type);
+    if (is1099 === "true") query = query.eq("is_1099", true);
 
-  const service = createServiceClient();
-  let query = service.from("vendors")
-    .select("*, default_category:expense_categories!default_category_id(id, display_label, bg_color, text_color)")
-    .eq("organization_id", await getActiveOrganizationId(auth.supabase))
-    .order("name", { ascending: true });
+    const { data, error } = await query;
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data);
+  },
+);
 
-  if (q) query = query.ilike("name", `%${q}%`);
-  if (active === "true") query = query.eq("is_active", true);
-  if (active === "false") query = query.eq("is_active", false);
-  if (type) query = query.eq("vendor_type", type);
-  if (is1099 === "true") query = query.eq("is_1099", true);
+// POST — create. Quick-add (vendor_type=other, minimal fields) requires the
+// `log_expenses` permission; full creates require `manage_vendors`. Because
+// the required key depends on the request body — and the two are disjoint
+// requirements the static rule cannot express — the wrapper's rule admits
+// either key (a coarse pre-filter that still 401s / 403s a caller holding
+// neither) and the route re-checks the exact key as its own business logic.
+// Admins always pass.
+export const POST = withRequestContext(
+  { permission: ["log_expenses", "manage_vendors"], serviceClient: true },
+  async (request, ctx) => {
+    const body = await request.json();
+    const { name, vendor_type, default_category_id, is_1099, tax_id, notes } = body as Record<string, unknown>;
 
-  const { data, error } = await query;
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data);
-}
+    const quickAdd =
+      vendor_type === "other" &&
+      (default_category_id == null) &&
+      !is_1099 &&
+      (tax_id == null || tax_id === "") &&
+      (notes == null || notes === "");
 
-// POST — create. Quick-add (vendor_type=other, minimal fields) allows users
-// with log_expenses permission; full creates require manage_vendors.
-export async function POST(request: Request) {
-  const body = await request.json();
-  const { name, vendor_type, default_category_id, is_1099, tax_id, notes } = body as Record<string, unknown>;
+    // Narrow the wrapper's either-key admission to the exact key this
+    // request needs. Admins always pass.
+    const neededKey = quickAdd ? "log_expenses" : "manage_vendors";
+    if (ctx.role !== "admin") {
+      const { data: membership } = await ctx.supabase
+        .from("user_organizations")
+        .select("id")
+        .eq("user_id", ctx.userId)
+        .eq("organization_id", ctx.orgId)
+        .maybeSingle<{ id: string }>();
+      const { data: grant } = membership
+        ? await ctx.supabase
+            .from("user_organization_permissions")
+            .select("granted")
+            .eq("user_organization_id", membership.id)
+            .eq("permission_key", neededKey)
+            .maybeSingle<{ granted: boolean }>()
+        : { data: null };
+      if (grant?.granted !== true) {
+        return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+      }
+    }
 
-  const quickAdd =
-    vendor_type === "other" &&
-    (default_category_id == null) &&
-    !is_1099 &&
-    (tax_id == null || tax_id === "") &&
-    (notes == null || notes === "");
+    if (typeof name !== "string" || !name.trim()) {
+      return NextResponse.json({ error: "name is required" }, { status: 400 });
+    }
+    const allowedTypes = ["supplier", "subcontractor", "equipment_rental", "fuel", "other"];
+    if (typeof vendor_type !== "string" || !allowedTypes.includes(vendor_type)) {
+      return NextResponse.json({ error: "invalid vendor_type" }, { status: 400 });
+    }
 
-  const supabase = await createServerSupabaseClient();
-  const neededKey = quickAdd ? "log_expenses" : "manage_vendors";
-  const guard = await requirePermission(supabase, neededKey);
-  if (!guard.ok) return guard.response;
+    const { data, error } = await ctx.serviceClient!.from("vendors").insert({
+      organization_id: ctx.orgId,
+      name: name.trim(),
+      vendor_type,
+      default_category_id: (default_category_id as string | null | undefined) ?? null,
+      is_1099: Boolean(is_1099),
+      tax_id: (tax_id as string | null | undefined) ?? null,
+      notes: (notes as string | null | undefined) ?? null,
+    }).select().single();
 
-  if (typeof name !== "string" || !name.trim()) {
-    return NextResponse.json({ error: "name is required" }, { status: 400 });
-  }
-  const allowedTypes = ["supplier", "subcontractor", "equipment_rental", "fuel", "other"];
-  if (typeof vendor_type !== "string" || !allowedTypes.includes(vendor_type)) {
-    return NextResponse.json({ error: "invalid vendor_type" }, { status: 400 });
-  }
-
-  const service = createServiceClient();
-  const { data, error } = await service.from("vendors").insert({
-    organization_id: await getActiveOrganizationId(supabase),
-    name: name.trim(),
-    vendor_type,
-    default_category_id: (default_category_id as string | null | undefined) ?? null,
-    is_1099: Boolean(is_1099),
-    tax_id: (tax_id as string | null | undefined) ?? null,
-    notes: (notes as string | null | undefined) ?? null,
-  }).select().single();
-
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json(data, { status: 201 });
-}
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json(data, { status: 201 });
+  },
+);


### PR DESCRIPTION
## What this does

Converts all 34 `settings` API route files to the `withRequestContext` wrapper built in #79 — slice #84 of the Request Context rollout (#78). No `settings` endpoint imports any of the four old gates anymore.

Behavior-preserving by design: previously-gated routes map 1:1 to equivalent rules, previously-ungated routes are wrapped logged-in-only (`{}`). No access rules are tightened here.

## Rule mapping

**Previously gated → 1:1:**
- `accounting/checklist`, `invoice-email` → `{ adminOnly: true }`
- `payment-email` → `{ permission: "access_settings" }`
- `contract-templates` POST/PATCH/duplicate/pdf-POST/permanent/usage → `{ permission: "manage_contract_templates" }`
- `expense-categories` POST/PUT/DELETE → `{ permission: "manage_expense_categories" }`
- `vendors` PATCH/deactivate/reactivate → `{ permission: "manage_vendors" }`

**Previously ungated → `{}`** (logged-in-only) — 35 endpoints, all recorded in the running ungated-endpoint list.

## Three judgment calls (documented in code)

- **`vendors` POST** — required key depends on the request body (quick-add: `log_expenses`, full create: `manage_vendors`). The static rule admits either key as a coarse pre-filter; the handler re-checks the exact key as business logic.
- **`nav-order` PUT** — had an *any-org* admin check; the wrapper's `adminOnly` only covers the Active Organization, so it's wrapped `{}` and keeps the any-org check inline.
- **`contract-templates/[id]/preview`** — was gated on `manage_contract_templates` but fell back to any logged-in member; effective policy was logged-in-only, so wrapped `{}`.

## Ungated-endpoint list

New `docs/request-context-ungated-endpoints.md` — the running list for #78/#86. It flags the **`users` endpoints** as urgent triage: `PUT /api/settings/users/[id]/permissions` rewrites permission grants with no gate today. Also flags the `contract-templates/[id]` soft-delete that lacks an org filter.

## Tests & verification

- Rewrote `permanent` and `usage` route tests for the wrapper pattern; added `settings/__test-utils__/request-context-fakes.ts`.
- Typecheck clean (only the known pre-existing `sync-folder-incremental.test.ts` error remains); lint clean on the changed surface; full suite **218 tests / 31 files green**.

Closes #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)