### PR TITLE
Request Context: convert email + Jarvis + remaining endpoints (#85)

### DIFF
--- a/src/app/api/email/[id]/route.test.ts
+++ b/src/app/api/email/[id]/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/email/[id] (converted to withRequestContext)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("e-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the email and passes the dynamic [id] param through to the handler", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: {
+          ...memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+          emails: [{ id: "e-1", subject: "Hello" }],
+        },
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("e-1"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ id: "e-1", subject: "Hello" });
+  });
+
+  it("returns 404 when the email is not found", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: {
+          ...memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+          emails: [],
+        },
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test"), paramsFor("missing"));
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/email/[id]/route.ts
+++ b/src/app/api/email/[id]/route.ts
@@ -1,58 +1,58 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/email/[id] — get a single email
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
+// GET /api/email/[id] — get a single email.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const { data, error } = await supabase
-    .from("emails")
-    .select("*, job:jobs(id, job_number, property_address), attachments:email_attachments(*)")
-    .eq("id", id)
-    .single();
+    const { data, error } = await ctx.supabase
+      .from("emails")
+      .select("*, job:jobs(id, job_number, property_address), attachments:email_attachments(*)")
+      .eq("id", id)
+      .single();
 
-  if (error || !data) {
-    return NextResponse.json({ error: "Email not found" }, { status: 404 });
-  }
+    if (error || !data) {
+      return NextResponse.json({ error: "Email not found" }, { status: 404 });
+    }
 
-  return NextResponse.json(data);
-}
+    return NextResponse.json(data);
+  },
+);
 
-// PATCH /api/email/[id] — update email (read, starred, job_id)
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const body = await request.json();
-  const supabase = await createServerSupabaseClient();
+// PATCH /api/email/[id] — update email (read, starred, job_id).
+export const PATCH = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json();
 
-  const updates: Record<string, unknown> = {};
-  if (typeof body.is_read === "boolean") updates.is_read = body.is_read;
-  if (typeof body.is_starred === "boolean") updates.is_starred = body.is_starred;
-  if (body.job_id !== undefined) {
-    updates.job_id = body.job_id || null;
-    updates.matched_by = body.job_id ? "manual" : null;
-  }
+    const updates: Record<string, unknown> = {};
+    if (typeof body.is_read === "boolean") updates.is_read = body.is_read;
+    if (typeof body.is_starred === "boolean") updates.is_starred = body.is_starred;
+    if (body.job_id !== undefined) {
+      updates.job_id = body.job_id || null;
+      updates.matched_by = body.job_id ? "manual" : null;
+    }
 
-  if (Object.keys(updates).length === 0) {
-    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
-  }
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
 
-  const { data, error } = await supabase
-    .from("emails")
-    .update(updates)
-    .eq("id", id)
-    .select()
-    .single();
+    const { data, error } = await ctx.supabase
+      .from("emails")
+      .update(updates)
+      .eq("id", id)
+      .select()
+      .single();
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  return NextResponse.json(data);
-}
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/email/__test-utils__/request-context-fakes.ts
+++ b/src/app/api/email/__test-utils__/request-context-fakes.ts
@@ -1,0 +1,137 @@
+// Supabase fakes for the #85 converted-route tests (email + the misc
+// endpoints batched with it). The routes now run through
+// `withRequestContext`, so a route test exercises the User client the
+// wrapper authenticates against — and, for `serviceClient: true` routes,
+// a Service client the route body reads/writes with.
+//
+// The fakes cover only the query surface these routes touch: a chainable,
+// thenable select/filter builder plus storage and rpc on the Service
+// client. Filters are recorded but only `eq` actually narrows rows — the
+// tests assert on the wrapper's allow/deny, not on query semantics.
+
+type Row = Record<string, unknown>;
+
+interface QueryResult {
+  data: Row[] | Row | null;
+  error: { message: string } | null;
+  count?: number;
+}
+
+// A chainable builder: every filter/modifier returns `this`, and the
+// builder is awaitable (thenable). `single`/`maybeSingle` resolve to one
+// row; awaiting the builder directly resolves to the row list.
+function queryBuilder(rows: Row[]): Record<string, unknown> {
+  let filtered = [...rows];
+  const builder: Record<string, unknown> = {};
+  const passthrough = [
+    "select", "order", "limit", "range", "or", "ilike", "not", "in",
+    "gt", "gte", "lt", "lte", "neq", "overlaps", "update", "insert", "delete",
+  ];
+  for (const m of passthrough) {
+    builder[m] = () => builder;
+  }
+  builder.eq = (col: string, val: unknown) => {
+    filtered = filtered.filter((r) => r[col] === val);
+    return builder;
+  };
+  builder.single = async () => ({
+    data: filtered[0] ?? null,
+    error: filtered[0] ? null : { message: "no rows" },
+  });
+  builder.maybeSingle = async () => ({ data: filtered[0] ?? null, error: null });
+  builder.then = (resolve: (v: QueryResult) => unknown) =>
+    resolve({ data: filtered, error: null, count: filtered.length });
+  return builder;
+}
+
+// A fake User client — what `withRequestContext` authenticates against.
+// `tables` seeds whatever the wrapper or route reads; at minimum
+// `user_organizations` (membership) and `user_organization_permissions`
+// (grants), built conveniently via `memberTables`.
+export function fakeUserClient(opts: {
+  user: { id: string } | null;
+  tables?: Record<string, Row[]>;
+}) {
+  const tables = opts.tables ?? {};
+  return {
+    auth: {
+      async getUser() {
+        return { data: { user: opts.user }, error: null };
+      },
+    },
+    from(table: string) {
+      return queryBuilder(tables[table] ?? []);
+    },
+    storage: {
+      from() {
+        return {
+          async download() {
+            return { data: null, error: { message: "not found" } };
+          },
+          async upload() {
+            return { data: null, error: null };
+          },
+          async remove() {
+            return { data: [], error: null };
+          },
+        };
+      },
+    },
+  };
+}
+
+// A fake Service client for `serviceClient: true` routes.
+export function fakeServiceClient(opts: { tables?: Record<string, Row[]> } = {}) {
+  const tables = opts.tables ?? {};
+  return {
+    from(table: string) {
+      return queryBuilder(tables[table] ?? []);
+    },
+    async rpc() {
+      return { data: [], error: null };
+    },
+    storage: {
+      from() {
+        return {
+          async download() {
+            return { data: null, error: { message: "not found" } };
+          },
+          async upload() {
+            return { data: null, error: null };
+          },
+          async remove() {
+            return { data: [], error: null };
+          },
+        };
+      },
+    },
+  };
+}
+
+// Build the `tables` map for a caller who is a member of the active
+// organization with a given role and set of granted permission keys.
+export function memberTables(opts: {
+  userId: string;
+  membershipId?: string;
+  orgId?: string;
+  role: string;
+  grants?: string[];
+}): Record<string, Row[]> {
+  const membershipId = opts.membershipId ?? "m-1";
+  const orgId = opts.orgId ?? "org-1";
+  return {
+    user_organizations: [
+      {
+        id: membershipId,
+        role: opts.role,
+        user_id: opts.userId,
+        organization_id: orgId,
+      },
+    ],
+    user_organization_permissions: (opts.grants ?? []).map((permission_key) => ({
+      user_organization_id: membershipId,
+      permission_key,
+      granted: true,
+    })),
+  };
+}

--- a/src/app/api/email/accounts/[id]/route.ts
+++ b/src/app/api/email/accounts/[id]/route.ts
@@ -1,62 +1,62 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
 
 // DELETE /api/email/accounts/[id]
-export async function DELETE(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const DELETE = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const { error } = await supabase
-    .from("email_accounts")
-    .delete()
-    .eq("id", id);
+    const { error } = await ctx.supabase
+      .from("email_accounts")
+      .delete()
+      .eq("id", id);
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({ success: true });
-}
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ success: true });
+  },
+);
 
 // PATCH /api/email/accounts/[id] — update account settings
-export async function PATCH(
-  request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const body = await request.json();
-  const supabase = await createServerSupabaseClient();
+export const PATCH = withRequestContext(
+  {},
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json();
 
-  // If password is being updated, encrypt it
-  const updates: Record<string, unknown> = {};
-  const allowedFields = ["label", "email_address", "display_name", "provider", "imap_host", "imap_port", "smtp_host", "smtp_port", "username", "is_active", "is_default", "signature", "color"];
+    // If password is being updated, encrypt it
+    const updates: Record<string, unknown> = {};
+    const allowedFields = ["label", "email_address", "display_name", "provider", "imap_host", "imap_port", "smtp_host", "smtp_port", "username", "is_active", "is_default", "signature", "color"];
 
-  for (const field of allowedFields) {
-    if (body[field] !== undefined) {
-      updates[field] = body[field];
+    for (const field of allowedFields) {
+      if (body[field] !== undefined) {
+        updates[field] = body[field];
+      }
     }
-  }
 
-  if (body.password) {
-    updates.encrypted_password = encrypt(body.password);
-  }
+    if (body.password) {
+      updates.encrypted_password = encrypt(body.password);
+    }
 
-  if (Object.keys(updates).length === 0) {
-    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
-  }
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+    }
 
-  const { data, error } = await supabase
-    .from("email_accounts")
-    .update(updates)
-    .eq("id", id)
-    .select("id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, created_at, updated_at")
-    .single();
+    const { data, error } = await ctx.supabase
+      .from("email_accounts")
+      .update(updates)
+      .eq("id", id)
+      .select("id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, created_at, updated_at")
+      .single();
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json(data);
-}
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/email/accounts/[id]/test/route.ts
+++ b/src/app/api/email/accounts/[id]/test/route.ts
@@ -1,71 +1,72 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
 import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
 
-// POST /api/email/accounts/[id]/test — test IMAP and SMTP connections
-export async function POST(
-  _request: Request,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
+// POST /api/email/accounts/[id]/test — test IMAP and SMTP connections.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  const { data: account, error } = await supabase
-    .from("email_accounts")
-    .select("*")
-    .eq("id", id)
-    .single();
+    const { data: account, error } = await ctx.supabase
+      .from("email_accounts")
+      .select("*")
+      .eq("id", id)
+      .single();
 
-  if (error || !account) {
-    return NextResponse.json({ error: "Account not found" }, { status: 404 });
-  }
+    if (error || !account) {
+      return NextResponse.json({ error: "Account not found" }, { status: 404 });
+    }
 
-  let password: string;
-  try {
-    password = decrypt(account.encrypted_password);
-  } catch (err) {
-    return NextResponse.json(
-      { error: `Failed to decrypt password: ${err instanceof Error ? err.message : "check ENCRYPTION_KEY"}` },
-      { status: 500 }
-    );
-  }
+    let password: string;
+    try {
+      password = decrypt(account.encrypted_password);
+    } catch (err) {
+      return NextResponse.json(
+        { error: `Failed to decrypt password: ${err instanceof Error ? err.message : "check ENCRYPTION_KEY"}` },
+        { status: 500 }
+      );
+    }
 
-  const results = { imap: false, smtp: false, imapError: "", smtpError: "" };
+    const results = { imap: false, smtp: false, imapError: "", smtpError: "" };
 
-  // Test IMAP
-  try {
-    const client = new ImapFlow({
-      host: account.imap_host,
-      port: account.imap_port,
-      secure: account.imap_port === 993,
-      auth: { user: account.username, pass: password },
-      logger: false,
-      tls: { rejectUnauthorized: process.env.EMAIL_TLS_REJECT_UNAUTHORIZED === "true" },
-    });
-    await client.connect();
-    await client.logout();
-    results.imap = true;
-  } catch (err) {
-    results.imapError = err instanceof Error ? err.message : "IMAP connection failed";
-  }
+    // Test IMAP
+    try {
+      const client = new ImapFlow({
+        host: account.imap_host,
+        port: account.imap_port,
+        secure: account.imap_port === 993,
+        auth: { user: account.username, pass: password },
+        logger: false,
+        tls: { rejectUnauthorized: process.env.EMAIL_TLS_REJECT_UNAUTHORIZED === "true" },
+      });
+      await client.connect();
+      await client.logout();
+      results.imap = true;
+    } catch (err) {
+      results.imapError = err instanceof Error ? err.message : "IMAP connection failed";
+    }
 
-  // Test SMTP
-  try {
-    const transporter = nodemailer.createTransport({
-      host: account.smtp_host,
-      port: account.smtp_port,
-      secure: account.smtp_port === 465,
-      auth: { user: account.username, pass: password },
-      tls: { rejectUnauthorized: process.env.EMAIL_TLS_REJECT_UNAUTHORIZED === "true" },
-    });
-    await transporter.verify();
-    transporter.close();
-    results.smtp = true;
-  } catch (err) {
-    results.smtpError = err instanceof Error ? err.message : "SMTP connection failed";
-  }
+    // Test SMTP
+    try {
+      const transporter = nodemailer.createTransport({
+        host: account.smtp_host,
+        port: account.smtp_port,
+        secure: account.smtp_port === 465,
+        auth: { user: account.username, pass: password },
+        tls: { rejectUnauthorized: process.env.EMAIL_TLS_REJECT_UNAUTHORIZED === "true" },
+      });
+      await transporter.verify();
+      transporter.close();
+      results.smtp = true;
+    } catch (err) {
+      results.smtpError = err instanceof Error ? err.message : "SMTP connection failed";
+    }
 
-  return NextResponse.json(results);
-}
+    return NextResponse.json(results);
+  },
+);

--- a/src/app/api/email/accounts/route.ts
+++ b/src/app/api/email/accounts/route.ts
@@ -1,26 +1,26 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { assignAccountColor } from "@/lib/email/assign-account-color";
 
-// GET /api/email/accounts — list accounts for the active org (passwords excluded)
-export async function GET() {
-  const supabase = await createServerSupabaseClient();
-  const { data, error } = await supabase
+// GET /api/email/accounts — list accounts for the active org (passwords excluded).
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext({}, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
     .from("email_accounts")
     .select("id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, last_synced_uid, created_at, updated_at")
-    .eq("organization_id", await getActiveOrganizationId(supabase))
+    .eq("organization_id", ctx.orgId)
     .order("created_at", { ascending: true });
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
   return NextResponse.json(data);
-}
+});
 
 // POST /api/email/accounts — add a new email account for the active org.
-export async function POST(request: Request) {
+export const POST = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
   const { label, email_address, display_name, provider, imap_host, imap_port, smtp_host, smtp_port, username, password, color: colorOverride } = body;
 
@@ -33,11 +33,10 @@ export async function POST(request: Request) {
 
   const encrypted_password = encrypt(password);
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const orgId = ctx.orgId;
 
   // Auto-assign the next palette color for this org (caller may override).
-  const { data: existing } = await supabase
+  const { data: existing } = await ctx.supabase
     .from("email_accounts")
     .select("color")
     .eq("organization_id", orgId);
@@ -46,7 +45,7 @@ export async function POST(request: Request) {
     .filter((c): c is string => typeof c === "string");
   const color = assignAccountColor(orgId, existingColors, colorOverride);
 
-  const { data, error } = await supabase
+  const { data, error } = await ctx.supabase
     .from("email_accounts")
     .insert({
       organization_id: orgId,
@@ -69,4 +68,4 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
   return NextResponse.json(data, { status: 201 });
-}
+});

--- a/src/app/api/email/attachments/[id]/route.ts
+++ b/src/app/api/email/attachments/[id]/route.ts
@@ -1,41 +1,42 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/email/attachments/[id] — download an attachment
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const supabase = await createServerSupabaseClient();
+// GET /api/email/attachments/[id] — download an attachment.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
 
-  // Get attachment metadata
-  const { data: attachment, error } = await supabase
-    .from("email_attachments")
-    .select("*")
-    .eq("id", id)
-    .single();
+    // Get attachment metadata
+    const { data: attachment, error } = await ctx.supabase
+      .from("email_attachments")
+      .select("*")
+      .eq("id", id)
+      .single();
 
-  if (error || !attachment || !attachment.storage_path) {
-    return NextResponse.json({ error: "Attachment not found" }, { status: 404 });
-  }
+    if (error || !attachment || !attachment.storage_path) {
+      return NextResponse.json({ error: "Attachment not found" }, { status: 404 });
+    }
 
-  // Download from storage
-  const { data: fileData, error: dlError } = await supabase.storage
-    .from("email-attachments")
-    .download(attachment.storage_path);
+    // Download from storage
+    const { data: fileData, error: dlError } = await ctx.supabase.storage
+      .from("email-attachments")
+      .download(attachment.storage_path);
 
-  if (dlError || !fileData) {
-    return NextResponse.json({ error: "File not found in storage" }, { status: 404 });
-  }
+    if (dlError || !fileData) {
+      return NextResponse.json({ error: "File not found in storage" }, { status: 404 });
+    }
 
-  const arrayBuffer = await fileData.arrayBuffer();
+    const arrayBuffer = await fileData.arrayBuffer();
 
-  return new NextResponse(arrayBuffer, {
-    headers: {
-      "Content-Type": attachment.content_type || "application/octet-stream",
-      "Content-Disposition": `attachment; filename="${encodeURIComponent(attachment.filename)}"`,
-      "Content-Length": String(arrayBuffer.byteLength),
-    },
-  });
-}
+    return new NextResponse(arrayBuffer, {
+      headers: {
+        "Content-Type": attachment.content_type || "application/octet-stream",
+        "Content-Disposition": `attachment; filename="${encodeURIComponent(attachment.filename)}"`,
+        "Content-Length": String(arrayBuffer.byteLength),
+      },
+    });
+  },
+);

--- a/src/app/api/email/attachments/upload/route.ts
+++ b/src/app/api/email/attachments/upload/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// POST /api/email/attachments/upload — upload a file for composing
-// Returns { id, filename, content_type, file_size, storage_path }
-export async function POST(request: NextRequest) {
+// POST /api/email/attachments/upload — upload a file for composing.
+// Returns { id, filename, content_type, file_size, storage_path }.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const formData = await request.formData();
   const file = formData.get("file") as File | null;
 
@@ -11,12 +13,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "No file provided" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
   const timestamp = Date.now();
   const storagePath = `drafts/${timestamp}-${file.name}`;
 
   const arrayBuffer = await file.arrayBuffer();
-  const { error: uploadError } = await supabase.storage
+  const { error: uploadError } = await ctx.supabase.storage
     .from("email-attachments")
     .upload(storagePath, arrayBuffer, {
       contentType: file.type || "application/octet-stream",
@@ -33,4 +34,4 @@ export async function POST(request: NextRequest) {
     file_size: file.size,
     storage_path: storagePath,
   });
-}
+});

--- a/src/app/api/email/bulk/route.ts
+++ b/src/app/api/email/bulk/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // PATCH /api/email/bulk — bulk update emails
 // Body: { ids: string[], action: "mark_read" | "mark_unread" | "archive" | "trash" | "assign_job", jobId?: string }
-export async function PATCH(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const PATCH = withRequestContext({}, async (request, ctx) => {
   const body = await request.json();
   const { ids, action, jobId } = body;
 
@@ -19,7 +21,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ error: "action is required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
   let updates: Record<string, unknown> = {};
 
   switch (action) {
@@ -48,7 +49,7 @@ export async function PATCH(request: NextRequest) {
       return NextResponse.json({ error: `Unknown action: ${action}` }, { status: 400 });
   }
 
-  const { error, count } = await supabase
+  const { error, count } = await ctx.supabase
     .from("emails")
     .update(updates)
     .in("id", ids);
@@ -58,4 +59,4 @@ export async function PATCH(request: NextRequest) {
   }
 
   return NextResponse.json({ updated: count ?? ids.length });
-}
+});

--- a/src/app/api/email/contacts/route.ts
+++ b/src/app/api/email/contacts/route.ts
@@ -1,12 +1,13 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { escapeOrFilterValue } from "@/lib/postgrest";
 
-// GET /api/email/contacts?q=search — autocomplete contacts + recent email addresses
-export async function GET(request: NextRequest) {
+// GET /api/email/contacts?q=search — autocomplete contacts + recent email addresses.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const q = searchParams.get("q") || "";
-  const supabase = await createServerSupabaseClient();
 
   const results: { email: string; name: string }[] = [];
   const seen = new Set<string>();
@@ -14,7 +15,7 @@ export async function GET(request: NextRequest) {
   // 1. Search contacts table
   if (q.length >= 1) {
     const term = escapeOrFilterValue(`%${q}%`);
-    const { data: contacts } = await supabase
+    const { data: contacts } = await ctx.supabase
       .from("contacts")
       .select("first_name, last_name, email")
       .not("email", "is", null)
@@ -36,7 +37,7 @@ export async function GET(request: NextRequest) {
 
   // 2. Search previously emailed addresses from emails table
   if (q.length >= 2) {
-    const { data: fromEmails } = await supabase
+    const { data: fromEmails } = await ctx.supabase
       .from("emails")
       .select("from_address, from_name")
       .ilike("from_address", `%${q}%`)
@@ -58,4 +59,4 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json(results.slice(0, 15));
-}
+});

--- a/src/app/api/email/counts/route.ts
+++ b/src/app/api/email/counts/route.ts
@@ -1,23 +1,23 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/email/counts?accountId=... — get unread counts per folder
-export async function GET(request: NextRequest) {
+// GET /api/email/counts?accountId=... — get unread counts per folder.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const accountId = searchParams.get("accountId"); // null = all accounts
-
-  const supabase = await createServerSupabaseClient();
 
   const folders = ["inbox", "sent", "drafts", "trash", "spam", "archive"];
   const counts: Record<string, { total: number; unread: number }> = {};
 
   for (const folder of folders) {
-    let totalQuery = supabase
+    let totalQuery = ctx.supabase
       .from("emails")
       .select("id", { count: "exact", head: true })
       .eq("folder", folder);
 
-    let unreadQuery = supabase
+    let unreadQuery = ctx.supabase
       .from("emails")
       .select("id", { count: "exact", head: true })
       .eq("folder", folder)
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   }
 
   // Starred count (across all folders)
-  let starredQuery = supabase
+  let starredQuery = ctx.supabase
     .from("emails")
     .select("id", { count: "exact", head: true })
     .eq("is_starred", true);
@@ -50,7 +50,7 @@ export async function GET(request: NextRequest) {
   counts.starred = { total: starredResult.count || 0, unread: 0 };
 
   // Category unread counts for inbox only
-  let categoryQuery = supabase
+  let categoryQuery = ctx.supabase
     .from("emails")
     .select("category")
     .eq("folder", "inbox")
@@ -77,7 +77,7 @@ export async function GET(request: NextRequest) {
 
   // Starred count for the inbox tab (total, not unread — starred status is
   // independent of read state and users want to see the full set).
-  let starredInboxQuery = supabase
+  let starredInboxQuery = ctx.supabase
     .from("emails")
     .select("id", { count: "exact", head: true })
     .eq("folder", "inbox")
@@ -91,4 +91,4 @@ export async function GET(request: NextRequest) {
   categoryUnread.starred = starredInboxResult.count || 0;
 
   return NextResponse.json({ ...counts, categoryUnread });
-}
+});

--- a/src/app/api/email/drafts/route.ts
+++ b/src/app/api/email/drafts/route.ts
@@ -1,9 +1,11 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/drafts — save or update a draft
 // Body: { draftId?, accountId, to, cc, bcc, subject, bodyText, bodyHtml, jobId?, replyToMessageId? }
-export async function POST(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const {
     draftId,
     accountId,
@@ -21,10 +23,8 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "accountId is required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-
   // Get account for from address + org scope
-  const { data: account } = await supabase
+  const { data: account } = await ctx.supabase
     .from("email_accounts")
     .select("email_address, display_name, organization_id")
     .eq("id", accountId)
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
 
   if (draftId) {
     // Update existing draft
-    const { data, error } = await supabase
+    const { data, error } = await ctx.supabase
       .from("emails")
       .update(draftData)
       .eq("id", draftId)
@@ -83,7 +83,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ id: data.id, updated: true });
   } else {
     // Create new draft
-    const { data, error } = await supabase
+    const { data, error } = await ctx.supabase
       .from("emails")
       .insert(draftData)
       .select("id")
@@ -94,4 +94,4 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json({ id: data.id, created: true });
   }
-}
+});

--- a/src/app/api/email/list/route.test.ts
+++ b/src/app/api/email/list/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/email/list (converted to withRequestContext)", () => {
+  it("returns 401 when unauthenticated — the route body never runs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/email/list"), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("lists emails for any logged-in caller — it was ungated, so no permission is required", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: {
+          ...memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+          emails: [
+            { id: "e-1", folder: "inbox" },
+            { id: "e-2", folder: "inbox" },
+            { id: "e-3", folder: "sent" },
+          ],
+        },
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/email/list"), noParams);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.emails.map((e: { id: string }) => e.id)).toEqual(["e-1", "e-2"]);
+  });
+});

--- a/src/app/api/email/list/route.ts
+++ b/src/app/api/email/list/route.ts
@@ -1,8 +1,10 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/list?folder=inbox&accountId=...&search=...&page=1&limit=50
-export async function GET(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext({}, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const folder = searchParams.get("folder") || "inbox";
   const accountId = searchParams.get("accountId"); // null = all accounts
@@ -12,10 +14,9 @@ export async function GET(request: NextRequest) {
   const starred = searchParams.get("starred");
   const category = searchParams.get("category");
 
-  const supabase = await createServerSupabaseClient();
   const offset = (page - 1) * limit;
 
-  let query = supabase
+  let query = ctx.supabase
     .from("emails")
     .select("*, job:jobs(id, job_number, property_address)", { count: "exact" });
 
@@ -63,4 +64,4 @@ export async function GET(request: NextRequest) {
     limit,
     hasMore: (count || 0) > offset + limit,
   });
-}
+});

--- a/src/app/api/email/mark-all-read/route.ts
+++ b/src/app/api/email/mark-all-read/route.ts
@@ -1,18 +1,18 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/mark-all-read — mark all emails in a folder as read
 // Body: { folder: string, accountId?: string }
-export async function POST(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const { folder, accountId } = await request.json();
 
   if (!folder) {
     return NextResponse.json({ error: "folder is required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
-
-  let query = supabase
+  let query = ctx.supabase
     .from("emails")
     .update({ is_read: true })
     .eq("is_read", false)
@@ -29,4 +29,4 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ success: true });
-}
+});

--- a/src/app/api/email/send/route.ts
+++ b/src/app/api/email/send/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
 import nodemailer from "nodemailer";
 
@@ -12,7 +12,9 @@ interface UploadedAttachment {
 
 // POST /api/email/send
 // Body: { accountId, to, subject, body, bodyHtml?, cc?, bcc?, jobId?, replyToMessageId?, attachments? }
-export async function POST(request: Request) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const { accountId, jobId, to, cc, bcc, subject, body, bodyHtml, replyToMessageId, attachments, draftId } =
     await request.json() as {
       accountId: string; jobId?: string; to: string; cc?: string; bcc?: string;
@@ -27,7 +29,7 @@ export async function POST(request: Request) {
     );
   }
 
-  const supabase = await createServerSupabaseClient();
+  const supabase = ctx.supabase;
 
   // Get account
   const { data: account, error: accError } = await supabase
@@ -178,4 +180,4 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+});

--- a/src/app/api/email/sync-folder/route.ts
+++ b/src/app/api/email/sync-folder/route.ts
@@ -1,12 +1,11 @@
-import { NextRequest, NextResponse, after } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse, after } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
 import { ImapFlow } from "imapflow";
 import { matchEmailToJob, type MatcherCache, type JobRow, type ContactRow } from "@/lib/email-matcher";
 import { categorizeEmail, type CategoryRule } from "@/lib/email-categorizer";
 import { emailAttachmentPath } from "@/lib/storage/paths";
 import { syncFolderIncremental, type EmailFolderState } from "@/lib/email/sync-folder-incremental";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 
 // Subset of mapFolder from /api/email/sync — we only need the target
 // folder names this endpoint supports.
@@ -52,7 +51,9 @@ const ALLOWED_FOLDERS = new Set([
 //
 // The client throttles concurrent calls; this endpoint always does the
 // work it's asked to do.
-export async function POST(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const startedAt = Date.now();
   const body = (await request.json()) as { accountId?: string; folder?: string };
   const { accountId, folder } = body;
@@ -64,8 +65,8 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const supabase = await createServerSupabaseClient();
-  const orgId = await getActiveOrganizationId(supabase);
+  const supabase = ctx.supabase;
+  const orgId = ctx.orgId;
   if (!orgId) {
     return NextResponse.json({ error: "no active organization" }, { status: 401 });
   }
@@ -356,4 +357,4 @@ export async function POST(request: NextRequest) {
     total_synced: totalSynced,
     errors: errors.length > 0 ? errors.slice(0, 10) : undefined,
   });
-}
+});

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -1,5 +1,5 @@
-import { NextRequest, NextResponse, after } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse, after } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
 import { ImapFlow } from "imapflow";
 import { matchEmailToJob, type MatcherCache, type JobRow, type ContactRow } from "@/lib/email-matcher";
@@ -42,7 +42,9 @@ function mapFolder(imapPath: string): string {
 //
 // First sync per account also runs the one-time category backfill (Pass
 // 1 + Pass 2) — that path is intentionally not optimized.
-export async function POST(request: NextRequest) {
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const POST = withRequestContext({}, async (request, ctx) => {
   const startedAt = Date.now();
   const { accountId, maxPerFolder = 50 } = await request.json();
 
@@ -50,7 +52,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "accountId is required" }, { status: 400 });
   }
 
-  const supabase = await createServerSupabaseClient();
+  const supabase = ctx.supabase;
 
   const { data: account, error: accError } = await supabase
     .from("email_accounts")
@@ -517,4 +519,4 @@ export async function POST(request: NextRequest) {
     folders_synced: foldersSynced,
     errors: errors.length > 0 ? errors.slice(0, 10) : undefined,
   });
-}
+});

--- a/src/app/api/email/thread/[threadId]/route.ts
+++ b/src/app/api/email/thread/[threadId]/route.ts
@@ -1,23 +1,24 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/email/thread/[threadId] — get all emails in a thread
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ threadId: string }> }
-) {
-  const { threadId } = await params;
-  const supabase = await createServerSupabaseClient();
+// GET /api/email/thread/[threadId] — get all emails in a thread.
+// Previously ungated (relied on RLS via the User client); now logged-in
+// only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  {},
+  async (_request, ctx, { params }: { params: Promise<{ threadId: string }> }) => {
+    const { threadId } = await params;
 
-  const { data, error } = await supabase
-    .from("emails")
-    .select("*, job:jobs(id, job_number, property_address), attachments:email_attachments(*)")
-    .eq("thread_id", threadId)
-    .order("received_at", { ascending: true });
+    const { data, error } = await ctx.supabase
+      .from("emails")
+      .select("*, job:jobs(id, job_number, property_address), attachments:email_attachments(*)")
+      .eq("thread_id", threadId)
+      .order("received_at", { ascending: true });
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  return NextResponse.json(data || []);
-}
+    return NextResponse.json(data || []);
+  },
+);

--- a/src/app/api/estimate-templates/[id]/route.ts
+++ b/src/app/api/estimate-templates/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import {
   getTemplateWithContents,
@@ -10,23 +9,21 @@ import {
 } from "@/lib/estimate-templates";
 import type { TemplateStructure, TemplateWithContents } from "@/lib/types";
 
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "view_estimates");
-  if (!auth.ok) return auth.response;
-
-  const { id } = await context.params;
-  try {
-    const tmpl = await getTemplateWithContents(supabase, id);
-    if (!tmpl) return NextResponse.json({ error: "not_found" }, { status: 404 });
-    return NextResponse.json(tmpl);
-  } catch (e: unknown) {
-    return apiDbError(e instanceof Error ? e.message : String(e), "GET /api/estimate-templates/[id]");
-  }
-}
+// Reading a template needs the `view_estimates` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const GET = withRequestContext(
+  { permission: "view_estimates" },
+  async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    try {
+      const tmpl = await getTemplateWithContents(ctx.supabase, id);
+      if (!tmpl) return NextResponse.json({ error: "not_found" }, { status: 404 });
+      return NextResponse.json(tmpl);
+    } catch (e: unknown) {
+      return apiDbError(e instanceof Error ? e.message : String(e), "GET /api/estimate-templates/[id]");
+    }
+  },
+);
 
 interface PutBody {
   name?: string;
@@ -42,53 +39,49 @@ interface PutBody {
   builder_state?: TemplateWithContents;
 }
 
-export async function PUT(
-  request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_templates");
-  if (!auth.ok) return auth.response;
+// Updating a template needs the `manage_templates` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const PUT = withRequestContext(
+  { permission: "manage_templates" },
+  async (request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    const body = (await request.json().catch(() => null)) as PutBody | null;
+    if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
 
-  const { id } = await context.params;
-  const body = (await request.json().catch(() => null)) as PutBody | null;
-  if (!body) return NextResponse.json({ error: "body required" }, { status: 400 });
+    try {
+      const patch: Parameters<typeof updateTemplate>[2] = {};
+      if (body.name !== undefined) patch.name = body.name;
+      if (body.description !== undefined) patch.description = body.description;
+      if (body.damage_type_tags !== undefined) patch.damage_type_tags = body.damage_type_tags;
+      if (body.opening_statement !== undefined) patch.opening_statement = body.opening_statement;
+      if (body.closing_statement !== undefined) patch.closing_statement = body.closing_statement;
 
-  try {
-    const patch: Parameters<typeof updateTemplate>[2] = {};
-    if (body.name !== undefined) patch.name = body.name;
-    if (body.description !== undefined) patch.description = body.description;
-    if (body.damage_type_tags !== undefined) patch.damage_type_tags = body.damage_type_tags;
-    if (body.opening_statement !== undefined) patch.opening_statement = body.opening_statement;
-    if (body.closing_statement !== undefined) patch.closing_statement = body.closing_statement;
+      // Structure: prefer explicit; else compute from builder_state
+      if (body.structure !== undefined) {
+        patch.structure = body.structure;
+      } else if (body.builder_state !== undefined) {
+        patch.structure = serializeStructureFromBuilder(body.builder_state);
+      }
 
-    // Structure: prefer explicit; else compute from builder_state
-    if (body.structure !== undefined) {
-      patch.structure = body.structure;
-    } else if (body.builder_state !== undefined) {
-      patch.structure = serializeStructureFromBuilder(body.builder_state);
+      const tmpl = await updateTemplate(ctx.supabase, id, patch);
+      return NextResponse.json(tmpl);
+    } catch (e: unknown) {
+      return apiDbError(e instanceof Error ? e.message : String(e), "PUT /api/estimate-templates/[id]");
     }
+  },
+);
 
-    const tmpl = await updateTemplate(supabase, id, patch);
-    return NextResponse.json(tmpl);
-  } catch (e: unknown) {
-    return apiDbError(e instanceof Error ? e.message : String(e), "PUT /api/estimate-templates/[id]");
-  }
-}
-
-export async function DELETE(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_templates");
-  if (!auth.ok) return auth.response;
-
-  const { id } = await context.params;
-  try {
-    await deactivateTemplate(supabase, id);
-    return NextResponse.json({ ok: true });
-  } catch (e: unknown) {
-    return apiDbError(e instanceof Error ? e.message : String(e), "DELETE /api/estimate-templates/[id]");
-  }
-}
+// Deleting a template needs the `manage_templates` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const DELETE = withRequestContext(
+  { permission: "manage_templates" },
+  async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    try {
+      await deactivateTemplate(ctx.supabase, id);
+      return NextResponse.json({ ok: true });
+    } catch (e: unknown) {
+      return apiDbError(e instanceof Error ? e.message : String(e), "DELETE /api/estimate-templates/[id]");
+    }
+  },
+);

--- a/src/app/api/estimate-templates/route.ts
+++ b/src/app/api/estimate-templates/route.ts
@@ -1,33 +1,32 @@
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import { listTemplates, createTemplate } from "@/lib/estimate-templates";
 
-export async function GET(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "view_estimates");
-  if (!auth.ok) return auth.response;
+// Listing templates needs the `view_estimates` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const GET = withRequestContext(
+  { permission: "view_estimates" },
+  async (request, ctx) => {
+    const url = new URL(request.url);
+    const search = url.searchParams.get("search") ?? undefined;
+    const damageType = url.searchParams.get("damage_type") ?? undefined;
+    const isActiveParam = url.searchParams.get("is_active");
+    const isActive =
+      isActiveParam === "true" ? true :
+      isActiveParam === "false" ? false :
+      null;
 
-  const url = new URL(request.url);
-  const search = url.searchParams.get("search") ?? undefined;
-  const damageType = url.searchParams.get("damage_type") ?? undefined;
-  const isActiveParam = url.searchParams.get("is_active");
-  const isActive =
-    isActiveParam === "true" ? true :
-    isActiveParam === "false" ? false :
-    null;
-
-  try {
-    const orgId = await getActiveOrganizationId(supabase);
-    if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
-    const rows = await listTemplates(supabase, orgId, { search, damageType, isActive });
-    return NextResponse.json({ rows });
-  } catch (e: unknown) {
-    return apiDbError(e instanceof Error ? e.message : String(e), "GET /api/estimate-templates list");
-  }
-}
+    try {
+      const orgId = ctx.orgId;
+      if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
+      const rows = await listTemplates(ctx.supabase, orgId, { search, damageType, isActive });
+      return NextResponse.json({ rows });
+    } catch (e: unknown) {
+      return apiDbError(e instanceof Error ? e.message : String(e), "GET /api/estimate-templates list");
+    }
+  },
+);
 
 interface PostBody {
   name: string;
@@ -37,30 +36,29 @@ interface PostBody {
   closing_statement?: string | null;
 }
 
-export async function POST(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_templates");
-  if (!auth.ok) return auth.response;
+// Creating a template needs the `manage_templates` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const POST = withRequestContext(
+  { permission: "manage_templates" },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as PostBody | null;
+    if (!body || typeof body.name !== "string" || !body.name.trim()) {
+      return NextResponse.json({ error: "name required" }, { status: 400 });
+    }
 
-  const body = (await request.json().catch(() => null)) as PostBody | null;
-  if (!body || typeof body.name !== "string" || !body.name.trim()) {
-    return NextResponse.json({ error: "name required" }, { status: 400 });
-  }
-
-  try {
-    const orgId = await getActiveOrganizationId(supabase);
-    if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return NextResponse.json({ error: "unauthorized" }, { status: 401 });
-    const tmpl = await createTemplate(supabase, orgId, user.id, {
-      name: body.name,
-      description: body.description ?? null,
-      damage_type_tags: body.damage_type_tags ?? [],
-      opening_statement: body.opening_statement ?? null,
-      closing_statement: body.closing_statement ?? null,
-    });
-    return NextResponse.json(tmpl);
-  } catch (e: unknown) {
-    return apiDbError(e instanceof Error ? e.message : String(e), "POST /api/estimate-templates create");
-  }
-}
+    try {
+      const orgId = ctx.orgId;
+      if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
+      const tmpl = await createTemplate(ctx.supabase, orgId, ctx.userId, {
+        name: body.name,
+        description: body.description ?? null,
+        damage_type_tags: body.damage_type_tags ?? [],
+        opening_statement: body.opening_statement ?? null,
+        closing_statement: body.closing_statement ?? null,
+      });
+      return NextResponse.json(tmpl);
+    } catch (e: unknown) {
+      return apiDbError(e instanceof Error ? e.message : String(e), "POST /api/estimate-templates create");
+    }
+  },
+);

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -1,8 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { buildSystemPrompt } from "@/lib/jarvis/prompts/jarvis-core";
 import {
   jarvisToolDefinitions,
@@ -15,7 +13,19 @@ export const maxDuration = 120;
 const MAX_TOOL_ITERATIONS = 5;
 const MAX_CONVERSATION_MESSAGES = 30;
 
-export async function POST(request: NextRequest) {
+// Shape of a `job_adjusters` row as selected for the job-context lookup
+// below — the Service client returns these loosely typed.
+interface JobAdjusterRow {
+  is_primary: boolean;
+  adjuster: { first_name: string; last_name: string; email: string | null } | null;
+}
+
+// Cookie-authenticated (logged-in only) — the wrapper resolves the caller
+// and the Active Organization. Jarvis reads broadly across the org, so it
+// asks the wrapper for the Service client.
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
   try {
     // Parse request
     const body = await request.json();
@@ -40,36 +50,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Authenticate
-    const authSupabase = await createServerSupabaseClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await authSupabase.auth.getUser();
+    // Service client for broad data access — opted in via the rule.
+    const supabase = ctx.serviceClient!;
 
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Service client for broad data access
-    const supabase = createServiceClient();
-
-    // Fetch user profile + active-org membership role.
+    // Fetch user profile. The membership role is already resolved by the
+    // wrapper and carried on the Request Context.
     const { data: profile } = await supabase
       .from("user_profiles")
       .select("full_name")
-      .eq("id", user.id)
+      .eq("id", ctx.userId)
       .single();
 
-    const { data: membership } = await supabase
-      .from("user_organizations")
-      .select("role")
-      .eq("user_id", user.id)
-      .eq("organization_id", await getActiveOrganizationId(authSupabase))
-      .maybeSingle<{ role: string }>();
-
     const userName = profile?.full_name || "User";
-    const userRole = membership?.role || "crew_member";
+    const userRole = ctx.role || "crew_member";
 
     // Build context for system prompt
     let jobData = null;
@@ -99,10 +92,10 @@ export async function POST(request: NextRequest) {
           insuranceCompany: job.insurance_company,
           claimNumber: job.claim_number,
           adjusterName: (() => {
-            const adj = job.job_adjusters?.find((ja: any) => ja.is_primary)?.adjuster;
+            const adj = job.job_adjusters?.find((ja: JobAdjusterRow) => ja.is_primary)?.adjuster;
             return adj ? `${adj.first_name} ${adj.last_name}` : null;
           })(),
-          adjusterEmail: job.job_adjusters?.find((ja: any) => ja.is_primary)?.adjuster?.email || null,
+          adjusterEmail: job.job_adjusters?.find((ja: JobAdjusterRow) => ja.is_primary)?.adjuster?.email || null,
           createdAt: job.created_at,
         };
       }
@@ -354,7 +347,7 @@ export async function POST(request: NextRequest) {
             toolUse.name,
             toolUse.input as Record<string, unknown>,
             {
-              userId: user.id,
+              userId: ctx.userId,
               userName,
               userRole,
               jobId: job_id,
@@ -469,4 +462,5 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
-}
+  },
+);

--- a/src/app/api/knowledge/documents/[id]/route.ts
+++ b/src/app/api/knowledge/documents/[id]/route.ts
@@ -1,79 +1,70 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/knowledge/documents/[id] — get a single document with chunk count
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  const { id } = await params;
-  const supabase = createServiceClient();
-
-  const { data, error } = await supabase
-    .from("knowledge_documents")
-    .select("*")
-    .eq("id", id)
-    .single();
-
-  if (error || !data) {
-    return NextResponse.json({ error: "Document not found" }, { status: 404 });
-  }
-
-  return NextResponse.json(data);
-}
-
-// DELETE /api/knowledge/documents/[id] — delete document, chunks (CASCADE), and storage file
-export async function DELETE(
-  _request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    // Auth check
-    const authSupabase = await createServerSupabaseClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await authSupabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
+// GET /api/knowledge/documents/[id] — get a single document with chunk count.
+// Previously ungated (read with the Service client, no auth check); now
+// logged-in only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
-    const supabase = createServiceClient();
 
-    // 1. Get the document to find its storage path
-    const { data: doc, error: fetchError } = await supabase
+    const { data, error } = await ctx.serviceClient!
       .from("knowledge_documents")
-      .select("id, file_path")
+      .select("*")
       .eq("id", id)
       .single();
 
-    if (fetchError || !doc) {
+    if (error || !data) {
       return NextResponse.json({ error: "Document not found" }, { status: 404 });
     }
 
-    // 2. Delete from storage bucket
-    if (doc.file_path) {
-      await supabase.storage.from("knowledge-docs").remove([doc.file_path]);
+    return NextResponse.json(data);
+  },
+);
+
+// DELETE /api/knowledge/documents/[id] — delete document, chunks (CASCADE), and storage file.
+// Logged-in only — matches the route's prior cookie-auth check.
+export const DELETE = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    try {
+      const { id } = await params;
+      const supabase = ctx.serviceClient!;
+
+      // 1. Get the document to find its storage path
+      const { data: doc, error: fetchError } = await supabase
+        .from("knowledge_documents")
+        .select("id, file_path")
+        .eq("id", id)
+        .single();
+
+      if (fetchError || !doc) {
+        return NextResponse.json({ error: "Document not found" }, { status: 404 });
+      }
+
+      // 2. Delete from storage bucket
+      if (doc.file_path) {
+        await supabase.storage.from("knowledge-docs").remove([doc.file_path]);
+      }
+
+      // 3. Delete the document row (chunks cascade automatically)
+      const { error: deleteError } = await supabase
+        .from("knowledge_documents")
+        .delete()
+        .eq("id", id);
+
+      if (deleteError) {
+        return NextResponse.json(
+          { error: `Delete failed: ${deleteError.message}` },
+          { status: 500 }
+        );
+      }
+
+      return NextResponse.json({ success: true });
+    } catch (err) {
+      console.error("Knowledge document delete error:", err);
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
     }
-
-    // 3. Delete the document row (chunks cascade automatically)
-    const { error: deleteError } = await supabase
-      .from("knowledge_documents")
-      .delete()
-      .eq("id", id);
-
-    if (deleteError) {
-      return NextResponse.json(
-        { error: `Delete failed: ${deleteError.message}` },
-        { status: 500 }
-      );
-    }
-
-    return NextResponse.json({ success: true });
-  } catch (err) {
-    console.error("Knowledge document delete error:", err);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+  },
+);

--- a/src/app/api/knowledge/documents/route.ts
+++ b/src/app/api/knowledge/documents/route.ts
@@ -1,18 +1,21 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-// GET /api/knowledge/documents — list all knowledge documents
-export async function GET(_request: NextRequest) {
-  const supabase = createServiceClient();
+// GET /api/knowledge/documents — list all knowledge documents.
+// Previously ungated (read with the Service client, no auth check); now
+// logged-in only. Recorded for the #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (_request, ctx) => {
+    const { data, error } = await ctx.serviceClient!
+      .from("knowledge_documents")
+      .select("*")
+      .order("created_at", { ascending: false });
 
-  const { data, error } = await supabase
-    .from("knowledge_documents")
-    .select("*")
-    .order("created_at", { ascending: false });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json(data || []);
-}
+    return NextResponse.json(data || []);
+  },
+);

--- a/src/app/api/knowledge/search/route.ts
+++ b/src/app/api/knowledge/search/route.ts
@@ -1,68 +1,61 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { embedQuery } from "@/lib/knowledge/embeddings";
 
-// POST /api/knowledge/search — semantic search over knowledge chunks
-export async function POST(request: NextRequest) {
-  try {
-    // Auth check
-    const authSupabase = await createServerSupabaseClient();
-    const {
-      data: { user },
-      error: authError,
-    } = await authSupabase.auth.getUser();
-    if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
+// POST /api/knowledge/search — semantic search over knowledge chunks.
+// Logged-in only — matches the route's prior cookie-auth check.
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    try {
+      const body = await request.json();
+      const { query, document_id, standard_id, limit = 5 } = body;
 
-    const body = await request.json();
-    const { query, document_id, standard_id, limit = 5 } = body;
-
-    if (!query || typeof query !== "string") {
-      return NextResponse.json({ error: "query is required" }, { status: 400 });
-    }
-
-    // 1. Embed the query via Voyage AI
-    const queryEmbedding = await embedQuery(query);
-
-    const supabase = createServiceClient();
-
-    // 2. Run vector similarity search via the database function
-    const { data, error } = await supabase.rpc("search_knowledge_chunks", {
-      query_embedding: JSON.stringify(queryEmbedding),
-      match_count: Math.min(limit, 20),
-      filter_document_id: document_id || null,
-    });
-
-    if (error) {
-      console.error("Search error:", error);
-      return NextResponse.json(
-        { error: `Search failed: ${error.message}` },
-        { status: 500 }
-      );
-    }
-
-    let results = data || [];
-
-    // Optional: filter by standard_id (requires joining with knowledge_documents)
-    if (standard_id && results.length > 0) {
-      const docIds = [...new Set(results.map((r: { document_id: string }) => r.document_id))];
-      const { data: docs } = await supabase
-        .from("knowledge_documents")
-        .select("id, standard_id")
-        .in("id", docIds)
-        .eq("standard_id", standard_id);
-
-      if (docs) {
-        const matchingDocIds = new Set(docs.map((d) => d.id));
-        results = results.filter((r: { document_id: string }) => matchingDocIds.has(r.document_id));
+      if (!query || typeof query !== "string") {
+        return NextResponse.json({ error: "query is required" }, { status: 400 });
       }
-    }
 
-    return NextResponse.json({ results });
-  } catch (err) {
-    console.error("Knowledge search error:", err);
-    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
-  }
-}
+      // 1. Embed the query via Voyage AI
+      const queryEmbedding = await embedQuery(query);
+
+      const supabase = ctx.serviceClient!;
+
+      // 2. Run vector similarity search via the database function
+      const { data, error } = await supabase.rpc("search_knowledge_chunks", {
+        query_embedding: JSON.stringify(queryEmbedding),
+        match_count: Math.min(limit, 20),
+        filter_document_id: document_id || null,
+      });
+
+      if (error) {
+        console.error("Search error:", error);
+        return NextResponse.json(
+          { error: `Search failed: ${error.message}` },
+          { status: 500 }
+        );
+      }
+
+      let results = data || [];
+
+      // Optional: filter by standard_id (requires joining with knowledge_documents)
+      if (standard_id && results.length > 0) {
+        const docIds = [...new Set(results.map((r: { document_id: string }) => r.document_id))];
+        const { data: docs } = await supabase
+          .from("knowledge_documents")
+          .select("id, standard_id")
+          .in("id", docIds)
+          .eq("standard_id", standard_id);
+
+        if (docs) {
+          const matchingDocIds = new Set(docs.map((d) => d.id));
+          results = results.filter((r: { document_id: string }) => matchingDocIds.has(r.document_id));
+        }
+      }
+
+      return NextResponse.json({ results });
+    } catch (err) {
+      console.error("Knowledge search error:", err);
+      return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+  },
+);

--- a/src/app/api/marketing/assets/route.ts
+++ b/src/app/api/marketing/assets/route.ts
@@ -1,155 +1,147 @@
-import { NextRequest, NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 const ALLOWED_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/webp", "image/gif"];
 const MAX_SIZE = 10 * 1024 * 1024; // 10MB
 
-export async function GET(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+// Logged-in only — matches the route's prior cookie-auth check. Reads and
+// writes the marketing-asset library with the Service client, org-scoped
+// to the Active Organization.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const supabase = ctx.serviceClient!;
+    const tags = new URL(request.url).searchParams.get("tags");
 
-  const supabase = createServiceClient();
-  const tags = request.nextUrl.searchParams.get("tags");
+    let query = supabase
+      .from("marketing_assets")
+      .select("*")
+      .eq("organization_id", ctx.orgId)
+      .order("created_at", { ascending: false });
 
-  let query = supabase
-    .from("marketing_assets")
-    .select("*")
-    .eq("organization_id", await getActiveOrganizationId(authSupabase))
-    .order("created_at", { ascending: false });
-
-  if (tags) {
-    const tagArr = tags.split(",").map((t) => t.trim()).filter(Boolean);
-    if (tagArr.length > 0) {
-      query = query.overlaps("tags", tagArr);
+    if (tags) {
+      const tagArr = tags.split(",").map((t) => t.trim()).filter(Boolean);
+      if (tagArr.length > 0) {
+        query = query.overlaps("tags", tagArr);
+      }
     }
-  }
 
-  const { data, error } = await query;
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  return NextResponse.json({ assets: data || [] });
-}
+    return NextResponse.json({ assets: data || [] });
+  },
+);
 
-export async function POST(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const formData = await request.formData();
+    const file = formData.get("file") as File | null;
+    const description = formData.get("description") as string | null;
+    const tagsStr = formData.get("tags") as string | null;
 
-  const formData = await request.formData();
-  const file = formData.get("file") as File | null;
-  const description = formData.get("description") as string | null;
-  const tagsStr = formData.get("tags") as string | null;
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
 
-  if (!file) {
-    return NextResponse.json({ error: "No file provided" }, { status: 400 });
-  }
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: "Invalid file type. Use PNG, JPG, WebP, or GIF." },
+        { status: 400 }
+      );
+    }
 
-  if (!ALLOWED_TYPES.includes(file.type)) {
-    return NextResponse.json(
-      { error: "Invalid file type. Use PNG, JPG, WebP, or GIF." },
-      { status: 400 }
-    );
-  }
+    if (file.size > MAX_SIZE) {
+      return NextResponse.json(
+        { error: "File too large. Maximum 10MB." },
+        { status: 400 }
+      );
+    }
 
-  if (file.size > MAX_SIZE) {
-    return NextResponse.json(
-      { error: "File too large. Maximum 10MB." },
-      { status: 400 }
-    );
-  }
+    const orgId = ctx.orgId;
+    const supabase = ctx.serviceClient!;
+    const ext = file.name.split(".").pop() || "png";
+    const storagePath = `${orgId}/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
+    const buffer = Buffer.from(await file.arrayBuffer());
 
-  const orgId = await getActiveOrganizationId(authSupabase);
-  const supabase = createServiceClient();
-  const ext = file.name.split(".").pop() || "png";
-  const storagePath = `${orgId}/${Date.now()}-${Math.random().toString(36).slice(2, 8)}.${ext}`;
-  const buffer = Buffer.from(await file.arrayBuffer());
+    const { error: uploadError } = await supabase.storage
+      .from("marketing-assets")
+      .upload(storagePath, buffer, { contentType: file.type });
 
-  const { error: uploadError } = await supabase.storage
-    .from("marketing-assets")
-    .upload(storagePath, buffer, { contentType: file.type });
+    if (uploadError) {
+      return NextResponse.json(
+        { error: `Upload failed: ${uploadError.message}` },
+        { status: 500 }
+      );
+    }
 
-  if (uploadError) {
-    return NextResponse.json(
-      { error: `Upload failed: ${uploadError.message}` },
-      { status: 500 }
-    );
-  }
+    const tags = tagsStr
+      ? tagsStr.split(",").map((t) => t.trim()).filter(Boolean)
+      : [];
 
-  const tags = tagsStr
-    ? tagsStr.split(",").map((t) => t.trim()).filter(Boolean)
-    : [];
+    const { data, error: insertError } = await supabase
+      .from("marketing_assets")
+      .insert({
+        organization_id: orgId,
+        file_name: file.name,
+        storage_path: storagePath,
+        description: description || null,
+        tags,
+        uploaded_by: ctx.userId,
+      })
+      .select()
+      .single();
 
-  const { data, error: insertError } = await supabase
-    .from("marketing_assets")
-    .insert({
-      organization_id: orgId,
-      file_name: file.name,
-      storage_path: storagePath,
-      description: description || null,
-      tags,
-      uploaded_by: user.id,
-    })
-    .select()
-    .single();
+    if (insertError) {
+      // Clean up uploaded file
+      await supabase.storage.from("marketing-assets").remove([storagePath]);
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
 
-  if (insertError) {
-    // Clean up uploaded file
-    await supabase.storage.from("marketing-assets").remove([storagePath]);
-    return NextResponse.json({ error: insertError.message }, { status: 500 });
-  }
+    return NextResponse.json({ asset: data });
+  },
+);
 
-  return NextResponse.json({ asset: data });
-}
+export const DELETE = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const id = new URL(request.url).searchParams.get("id");
+    if (!id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
 
-export async function DELETE(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+    const orgId = ctx.orgId;
+    const supabase = ctx.serviceClient!;
 
-  const id = request.nextUrl.searchParams.get("id");
-  if (!id) {
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
-  }
+    // Get the asset to find storage path (scoped to org)
+    const { data: asset } = await supabase
+      .from("marketing_assets")
+      .select("storage_path")
+      .eq("id", id)
+      .eq("organization_id", orgId)
+      .single();
 
-  const orgId = await getActiveOrganizationId(authSupabase);
-  const supabase = createServiceClient();
+    if (!asset) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
 
-  // Get the asset to find storage path (scoped to org)
-  const { data: asset } = await supabase
-    .from("marketing_assets")
-    .select("storage_path")
-    .eq("id", id)
-    .eq("organization_id", orgId)
-    .single();
+    // Delete from storage
+    await supabase.storage.from("marketing-assets").remove([asset.storage_path]);
 
-  if (!asset) {
-    return NextResponse.json({ error: "Asset not found" }, { status: 404 });
-  }
+    // Delete from DB
+    const { error } = await supabase
+      .from("marketing_assets")
+      .delete()
+      .eq("id", id)
+      .eq("organization_id", orgId);
 
-  // Delete from storage
-  await supabase.storage.from("marketing-assets").remove([asset.storage_path]);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  // Delete from DB
-  const { error } = await supabase
-    .from("marketing_assets")
-    .delete()
-    .eq("id", id)
-    .eq("organization_id", orgId);
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json({ success: true });
-}
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/marketing/drafts/route.ts
+++ b/src/app/api/marketing/drafts/route.ts
@@ -1,41 +1,49 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 
-export async function GET(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+// Logged-in only — matches the route's prior cookie-auth check. Reads and
+// writes the marketing-draft queue with the Service client, org-scoped to
+// the Active Organization.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const supabase = ctx.serviceClient!;
+    const { searchParams } = new URL(request.url);
+    const platform = searchParams.get("platform");
+    const status = searchParams.get("status");
 
-  const supabase = createServiceClient();
-  const platform = request.nextUrl.searchParams.get("platform");
-  const status = request.nextUrl.searchParams.get("status");
+    let query = supabase
+      .from("marketing_drafts")
+      .select("*, image:marketing_assets!image_id(*)")
+      .eq("organization_id", ctx.orgId)
+      .order("created_at", { ascending: false });
 
-  let query = supabase
-    .from("marketing_drafts")
-    .select("*, image:marketing_assets!image_id(*)")
-    .eq("organization_id", await getActiveOrganizationId(authSupabase))
-    .order("created_at", { ascending: false });
+    if (platform) {
+      query = query.eq("platform", platform);
+    }
+    if (status) {
+      query = query.eq("status", status);
+    }
 
-  if (platform) {
-    query = query.eq("platform", platform);
-  }
-  if (status) {
-    query = query.eq("status", status);
-  }
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  const { data, error } = await query;
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    return NextResponse.json({ drafts: data || [] });
+  },
+);
 
-  return NextResponse.json({ drafts: data || [] });
-}
-
-export async function POST(request: NextRequest) {
+// POST is intentionally NOT routed through withRequestContext: it accepts
+// either cookie auth OR an internal service-key call (the marketing AI
+// department saves drafts this way). The wrapper requires a logged-in
+// user, which the service-key path has none of, so this dual-mode handler
+// stays on its inline check. Tracked for the #78 ungated-endpoint list as
+// an internally-authenticated endpoint.
+export async function POST(request: Request) {
   // Accept either cookie auth OR internal service key (for AI tool calls)
   const internalKey = request.headers.get("x-service-key");
   const isInternalCall =
@@ -83,68 +91,61 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({ draft: data });
 }
 
-export async function PATCH(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+export const PATCH = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const body = await request.json();
+    const { id, ...updates } = body;
 
-  const body = await request.json();
-  const { id, ...updates } = body;
+    if (!id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
 
-  if (!id) {
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
-  }
+    const supabase = ctx.serviceClient!;
 
-  const supabase = createServiceClient();
+    // Only allow specific fields to be updated
+    const allowed: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (updates.caption !== undefined) allowed.caption = updates.caption;
+    if (updates.hashtags !== undefined) allowed.hashtags = updates.hashtags;
+    if (updates.status !== undefined) allowed.status = updates.status;
+    if (updates.image_id !== undefined) allowed.image_id = updates.image_id || null;
+    if (updates.image_brief !== undefined) allowed.image_brief = updates.image_brief;
+    if (updates.posted_at !== undefined) allowed.posted_at = updates.posted_at;
 
-  // Only allow specific fields to be updated
-  const allowed: Record<string, unknown> = { updated_at: new Date().toISOString() };
-  if (updates.caption !== undefined) allowed.caption = updates.caption;
-  if (updates.hashtags !== undefined) allowed.hashtags = updates.hashtags;
-  if (updates.status !== undefined) allowed.status = updates.status;
-  if (updates.image_id !== undefined) allowed.image_id = updates.image_id || null;
-  if (updates.image_brief !== undefined) allowed.image_brief = updates.image_brief;
-  if (updates.posted_at !== undefined) allowed.posted_at = updates.posted_at;
+    const { data, error } = await supabase
+      .from("marketing_drafts")
+      .update(allowed)
+      .eq("id", id)
+      .eq("organization_id", ctx.orgId)
+      .select("*, image:marketing_assets!image_id(*)")
+      .single();
 
-  const { data, error } = await supabase
-    .from("marketing_drafts")
-    .update(allowed)
-    .eq("id", id)
-    .eq("organization_id", await getActiveOrganizationId(authSupabase))
-    .select("*, image:marketing_assets!image_id(*)")
-    .single();
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
+    return NextResponse.json({ draft: data });
+  },
+);
 
-  return NextResponse.json({ draft: data });
-}
+export const DELETE = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const id = new URL(request.url).searchParams.get("id");
+    if (!id) {
+      return NextResponse.json({ error: "id is required" }, { status: 400 });
+    }
 
-export async function DELETE(request: NextRequest) {
-  const authSupabase = await createServerSupabaseClient();
-  const { data: { user }, error: authError } = await authSupabase.auth.getUser();
-  if (authError || !user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+    const { error } = await ctx.serviceClient!
+      .from("marketing_drafts")
+      .delete()
+      .eq("id", id)
+      .eq("organization_id", ctx.orgId);
 
-  const id = request.nextUrl.searchParams.get("id");
-  if (!id) {
-    return NextResponse.json({ error: "id is required" }, { status: 400 });
-  }
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
 
-  const supabase = createServiceClient();
-  const { error } = await supabase
-    .from("marketing_drafts")
-    .delete()
-    .eq("id", id)
-    .eq("organization_id", await getActiveOrganizationId(authSupabase));
-
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-
-  return NextResponse.json({ success: true });
-}
+    return NextResponse.json({ success: true });
+  },
+);

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,84 +1,94 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 export const runtime = "nodejs";
 
-export async function GET(req: NextRequest) {
-  const { searchParams } = new URL(req.url);
-  const userId = searchParams.get("userId");
-  if (!userId) {
-    return NextResponse.json(
-      { error: "userId query param required" },
-      { status: 400 },
-    );
-  }
-  const limit = Math.min(Number(searchParams.get("limit") ?? "15"), 100);
-
-  const supabase = createServiceClient();
-
-  const { data: rows, error } = await supabase
-    .from("notifications")
-    .select(
-      "id, user_id, type, title, body, is_read, job_id, href, priority, metadata, created_at",
-    )
-    .eq("user_id", userId)
-    .order("created_at", { ascending: false })
-    .limit(limit);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  const { count, error: cntErr } = await supabase
-    .from("notifications")
-    .select("id", { count: "exact", head: true })
-    .eq("user_id", userId)
-    .eq("is_read", false);
-  if (cntErr)
-    return NextResponse.json({ error: cntErr.message }, { status: 500 });
-
-  return NextResponse.json({
-    notifications: rows ?? [],
-    unread_count: count ?? 0,
-  });
-}
-
-export async function PATCH(req: NextRequest) {
-  const body = (await req.json().catch(() => null)) as
-    | { id?: string; mark_all_read?: boolean; user_id?: string }
-    | null;
-  if (!body) {
-    return NextResponse.json({ error: "invalid body" }, { status: 400 });
-  }
-
-  const supabase = createServiceClient();
-
-  if (body.mark_all_read) {
-    if (!body.user_id) {
+// Previously ungated (read/written with the Service client, no auth
+// check); now logged-in only. The caller still passes the target user id
+// explicitly — behavior unchanged beyond the added 401. Recorded for the
+// #78 ungated-endpoint list.
+export const GET = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+    if (!userId) {
       return NextResponse.json(
-        { error: "user_id required when mark_all_read is true" },
+        { error: "userId query param required" },
         { status: 400 },
       );
     }
-    const { error } = await supabase
+    const limit = Math.min(Number(searchParams.get("limit") ?? "15"), 100);
+
+    const supabase = ctx.serviceClient!;
+
+    const { data: rows, error } = await supabase
       .from("notifications")
-      .update({ is_read: true })
-      .eq("user_id", body.user_id)
+      .select(
+        "id, user_id, type, title, body, is_read, job_id, href, priority, metadata, created_at",
+      )
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(limit);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+
+    const { count, error: cntErr } = await supabase
+      .from("notifications")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
       .eq("is_read", false);
-    if (error)
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    return NextResponse.json({ ok: true });
-  }
+    if (cntErr)
+      return NextResponse.json({ error: cntErr.message }, { status: 500 });
 
-  if (body.id) {
-    const { error } = await supabase
-      .from("notifications")
-      .update({ is_read: true })
-      .eq("id", body.id);
-    if (error)
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    return NextResponse.json({ ok: true });
-  }
+    return NextResponse.json({
+      notifications: rows ?? [],
+      unread_count: count ?? 0,
+    });
+  },
+);
 
-  return NextResponse.json(
-    { error: "body must include either { id } or { mark_all_read: true, user_id }" },
-    { status: 400 },
-  );
-}
+export const PATCH = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as
+      | { id?: string; mark_all_read?: boolean; user_id?: string }
+      | null;
+    if (!body) {
+      return NextResponse.json({ error: "invalid body" }, { status: 400 });
+    }
+
+    const supabase = ctx.serviceClient!;
+
+    if (body.mark_all_read) {
+      if (!body.user_id) {
+        return NextResponse.json(
+          { error: "user_id required when mark_all_read is true" },
+          { status: 400 },
+        );
+      }
+      const { error } = await supabase
+        .from("notifications")
+        .update({ is_read: true })
+        .eq("user_id", body.user_id)
+        .eq("is_read", false);
+      if (error)
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ ok: true });
+    }
+
+    if (body.id) {
+      const { error } = await supabase
+        .from("notifications")
+        .update({ is_read: true })
+        .eq("id", body.id);
+      if (error)
+        return NextResponse.json({ error: error.message }, { status: 500 });
+      return NextResponse.json({ ok: true });
+    }
+
+    return NextResponse.json(
+      { error: "body must include either { id } or { mark_all_read: true, user_id }" },
+      { status: 400 },
+    );
+  },
+);

--- a/src/app/api/pdf-presets/[id]/preview/route.ts
+++ b/src/app/api/pdf-presets/[id]/preview/route.ts
@@ -1,39 +1,35 @@
 // src/app/api/pdf-presets/[id]/preview/route.ts — inline sample PDF.
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requireAnyPermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { getPreset } from "@/lib/pdf-presets";
 import { renderPdf } from "@/lib/pdf-renderer/render";
 import { buildSampleInput } from "@/lib/sample-pdf-data";
 import { apiError } from "@/lib/api-errors";
 
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requireAnyPermission(supabase, ["view_estimates", "view_invoices"]);
-  if (!auth.ok) return auth.response;
+// Rendering a preset preview needs either the estimates or the invoices
+// view permission (admins auto-pass) — mapped 1:1 from the old gate.
+export const GET = withRequestContext(
+  { permission: ["view_estimates", "view_invoices"] },
+  async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    const orgId = ctx.orgId;
+    if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
 
-  const { id } = await context.params;
-  const orgId = await getActiveOrganizationId(supabase);
-  if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
-
-  try {
-    const preset = await getPreset(supabase, id);
-    if (!preset) return NextResponse.json({ error: "not found" }, { status: 404 });
-    const input = buildSampleInput(preset, orgId);
-    const buffer = await renderPdf(input);
-    return new NextResponse(new Uint8Array(buffer), {
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Disposition": `inline; filename="preset-preview.pdf"`,
-        "Cache-Control": "no-store",
-      },
-    });
-  } catch (e) {
-    return apiError(e, "GET /api/pdf-presets/[id]/preview render");
-  }
-}
+    try {
+      const preset = await getPreset(ctx.supabase, id);
+      if (!preset) return NextResponse.json({ error: "not found" }, { status: 404 });
+      const input = buildSampleInput(preset, orgId);
+      const buffer = await renderPdf(input);
+      return new NextResponse(new Uint8Array(buffer), {
+        headers: {
+          "Content-Type": "application/pdf",
+          "Content-Disposition": `inline; filename="preset-preview.pdf"`,
+          "Cache-Control": "no-store",
+        },
+      });
+    } catch (e) {
+      return apiError(e, "GET /api/pdf-presets/[id]/preview render");
+    }
+  },
+);

--- a/src/app/api/pdf-presets/[id]/route.ts
+++ b/src/app/api/pdf-presets/[id]/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/pdf-presets/[id]/route.ts — GET, PUT (incl. is_default flip), DELETE
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission, requireAnyPermission } from "@/lib/permissions-api";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { getPreset, updatePreset, deletePreset } from "@/lib/pdf-presets";
 import { apiError } from "@/lib/api-errors";
 import type { PdfPresetUpdatePayload } from "@/lib/types";
@@ -29,103 +28,97 @@ const BOOL_FIELDS: BoolKeys[] = [
 // the underlying columns are `text` (uncapped). Sized for typical preset names.
 const MAX_TEXT_LEN = 200;
 
-export async function GET(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requireAnyPermission(supabase, ["view_estimates", "view_invoices"]);
-  if (!auth.ok) return auth.response;
-
-  const { id } = await context.params;
-  try {
-    const preset = await getPreset(supabase, id);
-    if (!preset) return NextResponse.json({ error: "not found" }, { status: 404 });
-    return NextResponse.json({ preset });
-  } catch (e) {
-    return apiError(e, "GET /api/pdf-presets/[id]");
-  }
-}
-
-export async function PUT(
-  request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_pdf_presets");
-  if (!auth.ok) return auth.response;
-
-  const { id } = await context.params;
-
-  let raw: unknown;
-  try { raw = await request.json(); }
-  catch { return NextResponse.json({ error: "invalid JSON body" }, { status: 400 }); }
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
-  }
-  const body = raw as PdfPresetUpdatePayload;
-
-  // Validate strings if present.
-  if (body.name !== undefined) {
-    if (typeof body.name !== "string" || !body.name.trim()) {
-      return NextResponse.json({ error: "name must be non-empty string" }, { status: 400 });
+// Reading a preset needs either the estimates or the invoices view
+// permission (admins auto-pass) — mapped 1:1 from the old gate.
+export const GET = withRequestContext(
+  { permission: ["view_estimates", "view_invoices"] },
+  async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    try {
+      const preset = await getPreset(ctx.supabase, id);
+      if (!preset) return NextResponse.json({ error: "not found" }, { status: 404 });
+      return NextResponse.json({ preset });
+    } catch (e) {
+      return apiError(e, "GET /api/pdf-presets/[id]");
     }
-    if (body.name.length > MAX_TEXT_LEN) {
-      return NextResponse.json({ error: "name too long (max 200)" }, { status: 400 });
-    }
-    body.name = body.name.trim();
-  }
-  if (body.document_title !== undefined) {
-    if (typeof body.document_title !== "string" || !body.document_title.trim()) {
-      return NextResponse.json({ error: "document_title must be non-empty string" }, { status: 400 });
-    }
-    if (body.document_title.length > MAX_TEXT_LEN) {
-      return NextResponse.json({ error: "document_title too long (max 200)" }, { status: 400 });
-    }
-    body.document_title = body.document_title.trim();
-  }
+  },
+);
 
-  // Validate booleans if present — runtime check (TS types don't enforce at runtime).
-  // A non-boolean value would otherwise reach Postgres as the wrong shape and 500.
-  for (const field of BOOL_FIELDS) {
-    const v = body[field];
-    if (v !== undefined && typeof v !== "boolean") {
-      return NextResponse.json({ error: `${field} must be boolean` }, { status: 400 });
+// Updating a preset needs the `manage_pdf_presets` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const PUT = withRequestContext(
+  { permission: "manage_pdf_presets" },
+  async (request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+
+    let raw: unknown;
+    try { raw = await request.json(); }
+    catch { return NextResponse.json({ error: "invalid JSON body" }, { status: 400 }); }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
     }
-  }
+    const body = raw as PdfPresetUpdatePayload;
 
-  try {
-    const preset = await updatePreset(supabase, id, body);
-    return NextResponse.json({ preset });
-  } catch (e) {
-    if (e instanceof Error && e.message === "preset not found") {
-      return NextResponse.json({ error: "not found" }, { status: 404 });
+    // Validate strings if present.
+    if (body.name !== undefined) {
+      if (typeof body.name !== "string" || !body.name.trim()) {
+        return NextResponse.json({ error: "name must be non-empty string" }, { status: 400 });
+      }
+      if (body.name.length > MAX_TEXT_LEN) {
+        return NextResponse.json({ error: "name too long (max 200)" }, { status: 400 });
+      }
+      body.name = body.name.trim();
     }
-    return apiError(e, "PUT /api/pdf-presets/[id]");
-  }
-}
+    if (body.document_title !== undefined) {
+      if (typeof body.document_title !== "string" || !body.document_title.trim()) {
+        return NextResponse.json({ error: "document_title must be non-empty string" }, { status: 400 });
+      }
+      if (body.document_title.length > MAX_TEXT_LEN) {
+        return NextResponse.json({ error: "document_title too long (max 200)" }, { status: 400 });
+      }
+      body.document_title = body.document_title.trim();
+    }
 
-export async function DELETE(
-  _request: Request,
-  context: { params: Promise<{ id: string }> },
-) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_pdf_presets");
-  if (!auth.ok) return auth.response;
+    // Validate booleans if present — runtime check (TS types don't enforce at runtime).
+    // A non-boolean value would otherwise reach Postgres as the wrong shape and 500.
+    for (const field of BOOL_FIELDS) {
+      const v = body[field];
+      if (v !== undefined && typeof v !== "boolean") {
+        return NextResponse.json({ error: `${field} must be boolean` }, { status: 400 });
+      }
+    }
 
-  const { id } = await context.params;
-  try {
-    await deletePreset(supabase, id);
-    return NextResponse.json({ ok: true });
-  } catch (e) {
-    if (e instanceof Error) {
-      if (e.message === "preset not found") {
+    try {
+      const preset = await updatePreset(ctx.supabase, id, body);
+      return NextResponse.json({ preset });
+    } catch (e) {
+      if (e instanceof Error && e.message === "preset not found") {
         return NextResponse.json({ error: "not found" }, { status: 404 });
       }
-      if (e.message === "cannot delete default preset") {
-        return NextResponse.json({ error: "cannot delete default preset" }, { status: 409 });
-      }
+      return apiError(e, "PUT /api/pdf-presets/[id]");
     }
-    return apiError(e, "DELETE /api/pdf-presets/[id]");
-  }
-}
+  },
+);
+
+// Deleting a preset needs the `manage_pdf_presets` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const DELETE = withRequestContext(
+  { permission: "manage_pdf_presets" },
+  async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
+    const { id } = await context.params;
+    try {
+      await deletePreset(ctx.supabase, id);
+      return NextResponse.json({ ok: true });
+    } catch (e) {
+      if (e instanceof Error) {
+        if (e.message === "preset not found") {
+          return NextResponse.json({ error: "not found" }, { status: 404 });
+        }
+        if (e.message === "cannot delete default preset") {
+          return NextResponse.json({ error: "cannot delete default preset" }, { status: 409 });
+        }
+      }
+      return apiError(e, "DELETE /api/pdf-presets/[id]");
+    }
+  },
+);

--- a/src/app/api/pdf-presets/route.test.ts
+++ b/src/app/api/pdf-presets/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+vi.mock("@/lib/pdf-presets", () => ({
+  listPresets: vi.fn(),
+  createPreset: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { listPresets } from "@/lib/pdf-presets";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../email/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(listPresets).mockResolvedValue([]);
+});
+
+describe("GET /api/pdf-presets (converted to withRequestContext)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/pdf-presets"), noParams);
+
+    expect(res.status).toBe(401);
+    expect(listPresets).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when a non-admin holds neither view_estimates nor view_invoices", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/pdf-presets"), noParams);
+
+    expect(res.status).toBe(403);
+    expect(listPresets).not.toHaveBeenCalled();
+  });
+
+  it("allows a non-admin holding either of the two view permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["view_invoices"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/pdf-presets"), noParams);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ presets: [] });
+  });
+
+  it("allows an admin who holds no explicit grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/pdf-presets"), noParams);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/pdf-presets/route.ts
+++ b/src/app/api/pdf-presets/route.ts
@@ -1,9 +1,7 @@
 // src/app/api/pdf-presets/route.ts — GET list, POST create
 
 import { NextResponse } from "next/server";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission, requireAnyPermission } from "@/lib/permissions-api";
-import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { listPresets, createPreset } from "@/lib/pdf-presets";
 import { apiError } from "@/lib/api-errors";
 import type { DocumentType, PdfPresetCreatePayload } from "@/lib/types";
@@ -18,82 +16,85 @@ function asBool(v: unknown, defaultValue: boolean): boolean {
   return typeof v === "boolean" ? v : defaultValue;
 }
 
-export async function GET(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requireAnyPermission(supabase, ["view_estimates", "view_invoices"]);
-  if (!auth.ok) return auth.response;
+// Listing presets needs either the estimates or the invoices view
+// permission (admins auto-pass) — mapped 1:1 from the old
+// requireAnyPermission gate.
+export const GET = withRequestContext(
+  { permission: ["view_estimates", "view_invoices"] },
+  async (request, ctx) => {
+    const url = new URL(request.url);
+    const dtRaw = url.searchParams.get("document_type");
+    let documentType: DocumentType | undefined;
+    if (dtRaw !== null) {
+      if (!isValidDocType(dtRaw)) {
+        return NextResponse.json({ error: "document_type must be estimate|invoice" }, { status: 400 });
+      }
+      documentType = dtRaw;
+    }
+    try {
+      const presets = await listPresets(ctx.supabase, documentType);
+      return NextResponse.json({ presets });
+    } catch (e) {
+      return apiError(e, "GET /api/pdf-presets list");
+    }
+  },
+);
 
-  const url = new URL(request.url);
-  const dtRaw = url.searchParams.get("document_type");
-  let documentType: DocumentType | undefined;
-  if (dtRaw !== null) {
-    if (!isValidDocType(dtRaw)) {
+// Creating a preset needs the `manage_pdf_presets` permission (admins
+// auto-pass) — mapped 1:1 from the old requirePermission gate.
+export const POST = withRequestContext(
+  { permission: "manage_pdf_presets" },
+  async (request, ctx) => {
+    let raw: unknown;
+    try { raw = await request.json(); }
+    catch { return NextResponse.json({ error: "invalid JSON body" }, { status: 400 }); }
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+    }
+    const body = raw as Partial<PdfPresetCreatePayload>;
+
+    // Required string fields
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return NextResponse.json({ error: "name required" }, { status: 400 });
+    }
+    if (typeof body.document_title !== "string" || !body.document_title.trim()) {
+      return NextResponse.json({ error: "document_title required" }, { status: 400 });
+    }
+    if (!isValidDocType(body.document_type)) {
       return NextResponse.json({ error: "document_type must be estimate|invoice" }, { status: 400 });
     }
-    documentType = dtRaw;
-  }
-  try {
-    const presets = await listPresets(supabase, documentType);
-    return NextResponse.json({ presets });
-  } catch (e) {
-    return apiError(e, "GET /api/pdf-presets list");
-  }
-}
 
-export async function POST(request: Request) {
-  const supabase = await createServerSupabaseClient();
-  const auth = await requirePermission(supabase, "manage_pdf_presets");
-  if (!auth.ok) return auth.response;
+    const name = body.name.trim();
+    if (name.length > 200) return NextResponse.json({ error: "name too long (max 200)" }, { status: 400 });
+    const documentTitle = body.document_title.trim();
+    if (documentTitle.length > 200) return NextResponse.json({ error: "document_title too long (max 200)" }, { status: 400 });
 
-  let raw: unknown;
-  try { raw = await request.json(); }
-  catch { return NextResponse.json({ error: "invalid JSON body" }, { status: 400 }); }
-  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
-    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
-  }
-  const body = raw as Partial<PdfPresetCreatePayload>;
+    // Boolean fields default to spec defaults if absent or not a boolean.
+    // Note: createPreset() in @/lib/pdf-presets atomically demotes any prior
+    // default for (org, document_type) when is_default is true.
+    const payload: PdfPresetCreatePayload = {
+      name,
+      document_type: body.document_type,
+      document_title: documentTitle,
+      show_markup: asBool(body.show_markup, true),
+      show_discount: asBool(body.show_discount, true),
+      show_tax: asBool(body.show_tax, true),
+      show_opening_statement: asBool(body.show_opening_statement, true),
+      show_closing_statement: asBool(body.show_closing_statement, true),
+      show_category_subtotals: asBool(body.show_category_subtotals, false),
+      show_code_column: asBool(body.show_code_column, true),
+      show_notes_column: asBool(body.show_notes_column, false),
+      is_default: asBool(body.is_default, false),
+    };
 
-  // Required string fields
-  if (typeof body.name !== "string" || !body.name.trim()) {
-    return NextResponse.json({ error: "name required" }, { status: 400 });
-  }
-  if (typeof body.document_title !== "string" || !body.document_title.trim()) {
-    return NextResponse.json({ error: "document_title required" }, { status: 400 });
-  }
-  if (!isValidDocType(body.document_type)) {
-    return NextResponse.json({ error: "document_type must be estimate|invoice" }, { status: 400 });
-  }
+    const orgId = ctx.orgId;
+    if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
 
-  const name = body.name.trim();
-  if (name.length > 200) return NextResponse.json({ error: "name too long (max 200)" }, { status: 400 });
-  const documentTitle = body.document_title.trim();
-  if (documentTitle.length > 200) return NextResponse.json({ error: "document_title too long (max 200)" }, { status: 400 });
-
-  // Boolean fields default to spec defaults if absent or not a boolean.
-  // Note: createPreset() in @/lib/pdf-presets atomically demotes any prior
-  // default for (org, document_type) when is_default is true.
-  const payload: PdfPresetCreatePayload = {
-    name,
-    document_type: body.document_type,
-    document_title: documentTitle,
-    show_markup: asBool(body.show_markup, true),
-    show_discount: asBool(body.show_discount, true),
-    show_tax: asBool(body.show_tax, true),
-    show_opening_statement: asBool(body.show_opening_statement, true),
-    show_closing_statement: asBool(body.show_closing_statement, true),
-    show_category_subtotals: asBool(body.show_category_subtotals, false),
-    show_code_column: asBool(body.show_code_column, true),
-    show_notes_column: asBool(body.show_notes_column, false),
-    is_default: asBool(body.is_default, false),
-  };
-
-  const orgId = await getActiveOrganizationId(supabase);
-  if (!orgId) return NextResponse.json({ error: "no active org" }, { status: 400 });
-
-  try {
-    const preset = await createPreset(supabase, orgId, auth.userId, payload);
-    return NextResponse.json({ preset }, { status: 201 });
-  } catch (e) {
-    return apiError(e, "POST /api/pdf-presets create");
-  }
-}
+    try {
+      const preset = await createPreset(ctx.supabase, orgId, ctx.userId, payload);
+      return NextResponse.json({ preset }, { status: 201 });
+    } catch (e) {
+      return apiError(e, "POST /api/pdf-presets create");
+    }
+  },
+);

--- a/src/app/api/stripe/connect/start/route.ts
+++ b/src/app/api/stripe/connect/start/route.ts
@@ -1,31 +1,31 @@
-import { NextResponse, type NextRequest } from "next/server";
+import { NextResponse } from "next/server";
 import { signOAuthState } from "@/lib/stripe-oauth";
-import { requirePermission } from "@/lib/permissions-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(_req: NextRequest) {
-  const supabase = await createServerSupabaseClient();
-  const gate = await requirePermission(supabase, "access_settings");
-  if (!gate.ok) return gate.response;
+// Starting the Stripe Connect OAuth flow needs the `access_settings`
+// permission (admins auto-pass) — mapped 1:1 from the old gate.
+export const POST = withRequestContext(
+  { permission: "access_settings" },
+  async (_request, ctx) => {
+    const clientId = process.env.STRIPE_CONNECT_CLIENT_ID;
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL;
+    if (!clientId) {
+      return NextResponse.json({ error: "STRIPE_CONNECT_CLIENT_ID not set" }, { status: 500 });
+    }
+    if (!appUrl) {
+      return NextResponse.json({ error: "NEXT_PUBLIC_APP_URL not set" }, { status: 500 });
+    }
 
-  const clientId = process.env.STRIPE_CONNECT_CLIENT_ID;
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  if (!clientId) {
-    return NextResponse.json({ error: "STRIPE_CONNECT_CLIENT_ID not set" }, { status: 500 });
-  }
-  if (!appUrl) {
-    return NextResponse.json({ error: "NEXT_PUBLIC_APP_URL not set" }, { status: 500 });
-  }
+    const state = signOAuthState(ctx.userId);
+    const redirectUri = `${appUrl}/api/stripe/connect/callback`;
+    const oauthUrl = new URL("https://connect.stripe.com/oauth/authorize");
+    oauthUrl.searchParams.set("response_type", "code");
+    oauthUrl.searchParams.set("client_id", clientId);
+    oauthUrl.searchParams.set("scope", "read_write");
+    oauthUrl.searchParams.set("redirect_uri", redirectUri);
+    oauthUrl.searchParams.set("state", state);
+    oauthUrl.searchParams.set("stripe_user[business_type]", "company");
 
-  const state = signOAuthState(gate.userId);
-  const redirectUri = `${appUrl}/api/stripe/connect/callback`;
-  const oauthUrl = new URL("https://connect.stripe.com/oauth/authorize");
-  oauthUrl.searchParams.set("response_type", "code");
-  oauthUrl.searchParams.set("client_id", clientId);
-  oauthUrl.searchParams.set("scope", "read_write");
-  oauthUrl.searchParams.set("redirect_uri", redirectUri);
-  oauthUrl.searchParams.set("state", state);
-  oauthUrl.searchParams.set("stripe_user[business_type]", "company");
-
-  return NextResponse.redirect(oauthUrl.toString(), { status: 303 });
-}
+    return NextResponse.redirect(oauthUrl.toString(), { status: 303 });
+  },
+);

--- a/src/app/api/stripe/disconnect/route.ts
+++ b/src/app/api/stripe/disconnect/route.ts
@@ -1,20 +1,18 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
-export async function POST(_req: NextRequest) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
-
-  const supabase = createServiceClient();
-  const { error } = await supabase
-    .from("stripe_connection")
-    .delete()
-    .neq("id", "00000000-0000-0000-0000-000000000000");
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json({ ok: true });
-}
+// Disconnecting Stripe needs the `access_settings` permission (admins
+// auto-pass) — mapped 1:1 from the old gate.
+export const POST = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (_request, ctx) => {
+    const { error } = await ctx.serviceClient!
+      .from("stripe_connection")
+      .delete()
+      .neq("id", "00000000-0000-0000-0000-000000000000");
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/stripe/settings/route.test.ts
+++ b/src/app/api/stripe/settings/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+} from "../../email/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({
+      tables: { stripe_connection: [{ id: "conn-1", mode: "test" }] },
+    }) as never,
+  );
+});
+
+describe("GET /api/stripe/settings (converted to withRequestContext)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/stripe/settings"), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when a non-admin lacks the access_settings permission", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/stripe/settings"), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the connection for a caller holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/stripe/settings"), noParams);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connection: { id: "conn-1", mode: "test" } });
+  });
+});

--- a/src/app/api/stripe/settings/route.ts
+++ b/src/app/api/stripe/settings/route.ts
@@ -1,7 +1,5 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
-import { requirePermission } from "@/lib/permissions-api";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 interface SettingsPatch {
   ach_enabled?: boolean;
@@ -23,70 +21,69 @@ const ALLOWED: (keyof SettingsPatch)[] = [
   "surcharge_disclosure",
 ];
 
-export async function GET() {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
-
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("stripe_connection")
-    .select("*")
-    .limit(1)
-    .maybeSingle();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ connection: data });
-}
-
-export async function PATCH(req: NextRequest) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
-
-  const body = (await req.json()) as SettingsPatch;
-  const patch: Record<string, unknown> = {};
-  for (const key of ALLOWED) {
-    if (Object.prototype.hasOwnProperty.call(body, key)) {
-      patch[key] = body[key];
-    }
-  }
-
-  if (patch.default_statement_descriptor && typeof patch.default_statement_descriptor === "string") {
-    if ((patch.default_statement_descriptor as string).length > 22) {
-      return NextResponse.json({ error: "descriptor_too_long" }, { status: 400 });
-    }
-  }
-  if (typeof patch.card_fee_percent === "number") {
-    if (patch.card_fee_percent < 0 || patch.card_fee_percent > 5) {
-      return NextResponse.json({ error: "fee_out_of_range" }, { status: 400 });
-    }
-  }
-  if (patch.ach_enabled === false && patch.card_enabled === false) {
-    return NextResponse.json({ error: "at_least_one_method_required" }, { status: 400 });
-  }
-  if (patch.ach_enabled === false || patch.card_enabled === false) {
-    const supabaseRead = createServiceClient();
-    const { data: cur } = await supabaseRead
+// Reading and writing Stripe settings need the `access_settings`
+// permission (admins auto-pass) — mapped 1:1 from the old gate.
+export const GET = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (_request, ctx) => {
+    const { data, error } = await ctx.serviceClient!
       .from("stripe_connection")
-      .select("ach_enabled, card_enabled")
+      .select("*")
       .limit(1)
       .maybeSingle();
-    if (cur) {
-      const nextAch = patch.ach_enabled ?? cur.ach_enabled;
-      const nextCard = patch.card_enabled ?? cur.card_enabled;
-      if (!nextAch && !nextCard) {
-        return NextResponse.json({ error: "at_least_one_method_required" }, { status: 400 });
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ connection: data });
+  },
+);
+
+export const PATCH = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (request, ctx) => {
+    const supabase = ctx.serviceClient!;
+
+    const body = (await request.json()) as SettingsPatch;
+    const patch: Record<string, unknown> = {};
+    for (const key of ALLOWED) {
+      if (Object.prototype.hasOwnProperty.call(body, key)) {
+        patch[key] = body[key];
       }
     }
-  }
 
-  const supabase = createServiceClient();
-  const { data, error } = await supabase
-    .from("stripe_connection")
-    .update(patch)
-    .neq("id", "00000000-0000-0000-0000-000000000000")
-    .select("*")
-    .maybeSingle();
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-  return NextResponse.json({ connection: data });
-}
+    if (patch.default_statement_descriptor && typeof patch.default_statement_descriptor === "string") {
+      if ((patch.default_statement_descriptor as string).length > 22) {
+        return NextResponse.json({ error: "descriptor_too_long" }, { status: 400 });
+      }
+    }
+    if (typeof patch.card_fee_percent === "number") {
+      if (patch.card_fee_percent < 0 || patch.card_fee_percent > 5) {
+        return NextResponse.json({ error: "fee_out_of_range" }, { status: 400 });
+      }
+    }
+    if (patch.ach_enabled === false && patch.card_enabled === false) {
+      return NextResponse.json({ error: "at_least_one_method_required" }, { status: 400 });
+    }
+    if (patch.ach_enabled === false || patch.card_enabled === false) {
+      const { data: cur } = await supabase
+        .from("stripe_connection")
+        .select("ach_enabled, card_enabled")
+        .limit(1)
+        .maybeSingle();
+      if (cur) {
+        const nextAch = patch.ach_enabled ?? cur.ach_enabled;
+        const nextCard = patch.card_enabled ?? cur.card_enabled;
+        if (!nextAch && !nextCard) {
+          return NextResponse.json({ error: "at_least_one_method_required" }, { status: 400 });
+        }
+      }
+    }
+
+    const { data, error } = await supabase
+      .from("stripe_connection")
+      .update(patch)
+      .neq("id", "00000000-0000-0000-0000-000000000000")
+      .select("*")
+      .maybeSingle();
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
+    return NextResponse.json({ connection: data });
+  },
+);

--- a/src/app/api/stripe/webhook-secret/route.ts
+++ b/src/app/api/stripe/webhook-secret/route.ts
@@ -1,8 +1,6 @@
-import { NextResponse, type NextRequest } from "next/server";
-import { createServiceClient } from "@/lib/supabase-api";
-import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
-import { requirePermission } from "@/lib/permissions-api";
 
 export const runtime = "nodejs";
 
@@ -10,49 +8,50 @@ interface Body {
   secret: string | null;
 }
 
-export async function POST(req: NextRequest) {
-  const auth = await createServerSupabaseClient();
-  const gate = await requirePermission(auth, "access_settings");
-  if (!gate.ok) return gate.response;
+// Setting the Stripe webhook signing secret needs the `access_settings`
+// permission (admins auto-pass) — mapped 1:1 from the old gate.
+export const POST = withRequestContext(
+  { permission: "access_settings", serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as Body | null;
+    if (!body) {
+      return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+    }
+    const secretOrNull = body.secret;
+    if (secretOrNull !== null && typeof secretOrNull !== "string") {
+      return NextResponse.json(
+        { error: "secret must be a string or null" },
+        { status: 400 },
+      );
+    }
+    if (typeof secretOrNull === "string" && !secretOrNull.startsWith("whsec_")) {
+      return NextResponse.json(
+        { error: "secret must start with whsec_" },
+        { status: 400 },
+      );
+    }
 
-  const body = (await req.json().catch(() => null)) as Body | null;
-  if (!body) {
-    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
-  }
-  const secretOrNull = body.secret;
-  if (secretOrNull !== null && typeof secretOrNull !== "string") {
-    return NextResponse.json(
-      { error: "secret must be a string or null" },
-      { status: 400 },
-    );
-  }
-  if (typeof secretOrNull === "string" && !secretOrNull.startsWith("whsec_")) {
-    return NextResponse.json(
-      { error: "secret must start with whsec_" },
-      { status: 400 },
-    );
-  }
+    const supabase = ctx.serviceClient!;
+    const encryptedOrNull = secretOrNull ? encrypt(secretOrNull) : null;
 
-  const supabase = createServiceClient();
-  const encryptedOrNull = secretOrNull ? encrypt(secretOrNull) : null;
+    const { data: existing } = await supabase
+      .from("stripe_connection")
+      .select("id")
+      .limit(1)
+      .maybeSingle<{ id: string }>();
+    if (!existing) {
+      return NextResponse.json(
+        { error: "Connect Stripe before setting the webhook signing secret." },
+        { status: 400 },
+      );
+    }
 
-  const { data: existing } = await supabase
-    .from("stripe_connection")
-    .select("id")
-    .limit(1)
-    .maybeSingle<{ id: string }>();
-  if (!existing) {
-    return NextResponse.json(
-      { error: "Connect Stripe before setting the webhook signing secret." },
-      { status: 400 },
-    );
-  }
+    const { error } = await supabase
+      .from("stripe_connection")
+      .update({ webhook_signing_secret_encrypted: encryptedOrNull })
+      .eq("id", existing.id);
+    if (error) return NextResponse.json({ error: error.message }, { status: 500 });
 
-  const { error } = await supabase
-    .from("stripe_connection")
-    .update({ webhook_signing_secret_encrypted: encryptedOrNull })
-    .eq("id", existing.id);
-  if (error) return NextResponse.json({ error: error.message }, { status: 500 });
-
-  return NextResponse.json({ ok: true });
-}
+    return NextResponse.json({ ok: true });
+  },
+);


### PR DESCRIPTION
Closes #85. Parent: #78.

Converts the remaining user-authenticated API endpoints to the `withRequestContext` wrapper built in #79 — 32 route files across `email`, `jarvis`, `marketing`, `knowledge`, `notifications`, `pdf-presets`, `stripe`, and `estimate-templates`.

## Rules applied

| Group | Files | Rule |
|---|---|---|
| email (16) | `[id]`, `accounts`, `accounts/[id]`, `accounts/[id]/test`, `attachments/[id]`, `attachments/upload`, `bulk`, `contacts`, `counts`, `drafts`, `list`, `mark-all-read`, `send`, `sync`, `sync-folder`, `thread/[threadId]` | `{}` — were ungated (RLS via User client) → logged-in-only |
| jarvis (1) | `chat` | `{ serviceClient: true }` — membership role now from `ctx.role` |
| knowledge (3) | `documents`, `documents/[id]`, `search` | `{ serviceClient: true }` |
| marketing (2) | `assets`, `drafts` (GET/PATCH/DELETE) | `{ serviceClient: true }` |
| notifications (1) | `route` | `{ serviceClient: true }` — was ungated |
| pdf-presets (3) | `route`, `[id]`, `[id]/preview` | `{ permission: [...] }` / `{ permission: "manage_pdf_presets" }` — 1:1 from old gates |
| stripe (4) | `connect/start`, `disconnect`, `settings`, `webhook-secret` | `{ permission: "access_settings", serviceClient: true }` — 1:1 from old gates |
| estimate-templates (2) | `route`, `[id]` | `{ permission: "view_estimates" }` / `{ permission: "manage_templates" }` — 1:1 from old gates |

Behavior-preserving: gated endpoints map 1:1 to equivalent rules; previously-ungated endpoints are wrapped logged-in-only (`{}`) — no access change beyond the added 401, recorded for the #78 ungated-endpoint list.

## Left untouched (out of scope)

- **Public:** `stripe/webhook` (signature-authenticated), `stripe/connect/callback` (OAuth callback gated by HMAC state, no required logged-in user).
- **Internally service-key-authenticated dual-mode** (cookie auth *or* `x-service-key`): `knowledge/ingest`, `jarvis/field-ops`, `jarvis/marketing`, `jarvis/rnd`, and `marketing/drafts` POST. The wrapper requires a logged-in user those paths lack; each is annotated in-code and flagged for the #78 ungated-endpoint list.
- `test/photo-upload-fail` — no-auth synthetic test fixture.

## Scope note

`estimate-templates` is a top-level dir not literally named by a sibling issue, so it was treated as #85's catch-all and converted (keeps the #86 "no user-auth endpoint on old gates" check satisfiable). Easy to reassign to #81 if preferred.

## Verification

- Typecheck clean (only the pre-existing unrelated `sync-folder-incremental.test.ts` `TS2322`).
- Lint clean on the changed surface.
- Full suite **230 green** — 218 existing + 12 new converted-route tests across the `{}`, dynamic, permission, and permission+serviceClient archetypes, with a shared test-utils fake.
- `next build` compiles; Next 16's route-type validator accepts the `export const GET = withRequestContext(...)` form including dynamic routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)