### PR TITLE
Gate settings/users/* on access_settings (#100)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -276,3 +276,37 @@ A few #85 routes were deliberately **not** wrapped with
   `knowledge/ingest` — custom auth: a session cookie **or** an
   `x-service-key` header.
 - `stripe/webhook` — authenticated by Stripe signature verification.
+
+---
+
+## Triage decisions (PRD #95)
+
+The conversion above is behavior-preserving — it only made "no check"
+visible as "logged-in only". PRD [#95](https://github.com/ericdaniels22/Nookleus/issues/95)
+is the follow-up that replaces those logged-in-only gates with real
+permission rules. Each tightening slice records its decision here.
+
+### #100 — settings/users
+
+The five `settings/users` endpoints flagged above as
+[**highest-priority triage**](#️-users--highest-priority-triage) were
+logged-in-only — any authenticated member of any role could call them. They
+mutate org membership, roles, profiles, ban state, and **permission grants**;
+in particular a non-admin could grant themselves every permission via
+`PUT /api/settings/users/[id]/permissions`.
+
+All five are now gated on `access_settings` (the `serviceClient` opt-in is
+unchanged):
+
+- `GET /api/settings/users` → `{ permission: "access_settings", serviceClient: true }`
+- `POST /api/settings/users` → `{ permission: "access_settings", serviceClient: true }`
+- `PATCH /api/settings/users/[id]` → `{ permission: "access_settings", serviceClient: true }`
+- `GET /api/settings/users/[id]/permissions` → `{ permission: "access_settings", serviceClient: true }`
+- `PUT /api/settings/users/[id]/permissions` → `{ permission: "access_settings", serviceClient: true }`
+
+`access_settings` already exists in `PERMISSION_CATALOG` (group "Admin"); no
+new key was introduced. It is chosen over a hard `adminOnly` rule so settings
+administration can be delegated without granting full admin — consistent with
+`stripe/settings` and the rest of `settings/*`. Admins auto-pass a
+`permission` rule. A member lacking the key now gets 403 — the wrapper
+rejects before the handler runs, closing the self-privilege-escalation hole.

--- a/src/app/api/settings/users/[id]/permissions/route.test.ts
+++ b/src/app/api/settings/users/[id]/permissions/route.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, PUT } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+import { fakeUsersServiceClient } from "../../__test-utils__/service-fake";
+
+const params = { params: Promise.resolve({ id: "target-user" }) };
+
+// The target member exists in the active org — so the PUT body's
+// membership lookup succeeds and any failure is the wrapper's gate, not a
+// missing-member 404.
+const serviceWithTarget = () =>
+  fakeUsersServiceClient({
+    tables: {
+      user_organizations: [
+        { id: "m-target", user_id: "target-user", organization_id: "org-1" },
+      ],
+    },
+  });
+
+const putGrants = () =>
+  new Request("http://test/api/settings/users/target-user/permissions", {
+    method: "PUT",
+    body: JSON.stringify({ access_settings: true }),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(serviceWithTarget() as never);
+});
+
+// #100 — these two endpoints were ungated logged-in-only. The PUT is the
+// self-privilege-escalation hole the PRD called out: a non-admin could
+// grant themselves every permission. Both are now gated on
+// `access_settings`.
+describe("GET /api/settings/users/[id]/permissions — gated on access_settings (#100)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(putGrants(), params);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(putGrants(), params);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a member holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(putGrants(), params);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PUT /api/settings/users/[id]/permissions — gated on access_settings (#100)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await PUT(putGrants(), params);
+
+    expect(res.status).toBe(401);
+  });
+
+  // The privilege-escalation guard: a non-admin without `access_settings`
+  // can no longer rewrite anyone's permission grants — including their own.
+  it("returns 403 for a non-admin without access_settings (privilege escalation blocked)", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await PUT(putGrants(), params);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a member holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await PUT(putGrants(), params);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("allows an admin regardless of grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+
+    const res = await PUT(putGrants(), params);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/settings/users/[id]/permissions/route.ts
+++ b/src/app/api/settings/users/[id]/permissions/route.ts
@@ -4,9 +4,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 // GET /api/settings/users/[id]/permissions — from user_organization_permissions
 // scoped to the active org's membership.
 //
-// Logged-in only — previously ungated (recorded for the #78 ungated list).
+// Gated on `access_settings` (#100) — was previously ungated logged-in-only.
 export const GET = withRequestContext(
-  { serviceClient: true },
+  { permission: "access_settings", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const service = ctx.serviceClient!;
@@ -39,9 +39,9 @@ export const GET = withRequestContext(
 // user_organization_permissions (the new source of truth) and the legacy
 // user_permissions table so 18a revert is safe.
 //
-// Logged-in only — previously ungated (recorded for the #78 ungated list).
+// Gated on `access_settings` (#100) — was previously ungated logged-in-only.
 export const PUT = withRequestContext(
-  { serviceClient: true },
+  { permission: "access_settings", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = await request.json() as Record<string, boolean>;

--- a/src/app/api/settings/users/[id]/route.test.ts
+++ b/src/app/api/settings/users/[id]/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+import { fakeUsersServiceClient } from "../__test-utils__/service-fake";
+
+const params = { params: Promise.resolve({ id: "target-user" }) };
+
+const patch = () =>
+  new Request("http://test/api/settings/users/target-user", {
+    method: "PATCH",
+    body: JSON.stringify({ full_name: "Renamed Member" }),
+  });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeUsersServiceClient() as never,
+  );
+});
+
+// #100 — PATCH /api/settings/users/[id] was ungated logged-in-only; it is
+// now gated on `access_settings`.
+describe("PATCH /api/settings/users/[id] — gated on access_settings (#100)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await PATCH(patch(), params);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await PATCH(patch(), params);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a member holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await PATCH(patch(), params);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/settings/users/[id]/route.ts
+++ b/src/app/api/settings/users/[id]/route.ts
@@ -5,9 +5,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 // on user_organizations (scoped to the active org) not user_profiles, since
 // build48 dropped user_profiles.role.
 //
-// Logged-in only — previously ungated (recorded for the #78 ungated list).
+// Gated on `access_settings` (#100) — was previously ungated logged-in-only.
 export const PATCH = withRequestContext(
-  { serviceClient: true },
+  { permission: "access_settings", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = await request.json();

--- a/src/app/api/settings/users/__test-utils__/service-fake.ts
+++ b/src/app/api/settings/users/__test-utils__/service-fake.ts
@@ -1,0 +1,64 @@
+// Service-client fake for the `settings/users` route tests. These routes
+// run through `withRequestContext` with `serviceClient: true`, so a route
+// test exercises two clients: the User client the wrapper authenticates
+// against (`fakeUserClient` from the shared `settings` fakes) and this
+// Service client the route bodies read/write with.
+//
+// The fake covers only the surface the three route bodies touch: a
+// chainable select/insert/upsert/update builder plus `auth.admin` for the
+// invite / ban calls. Filters are recorded but only `eq` narrows rows —
+// the tests assert on the wrapper's allow/deny, not on query semantics.
+
+type Row = Record<string, unknown>;
+
+function builder(rows: Row[]): Record<string, unknown> {
+  let filtered = [...rows];
+  let inserted: Row[] = [];
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "order", "limit", "update", "delete", "upsert"]) {
+    b[m] = () => b;
+  }
+  b.insert = (r: Row | Row[]) => {
+    inserted = Array.isArray(r) ? r : [r];
+    return b;
+  };
+  b.eq = (col: string, val: unknown) => {
+    filtered = filtered.filter((r) => r[col] === val);
+    return b;
+  };
+  b.maybeSingle = async () => ({ data: filtered[0] ?? null, error: null });
+  b.single = async () => {
+    const row = inserted[0] ?? filtered[0] ?? null;
+    return { data: row, error: row ? null : { message: "no rows" } };
+  };
+  b.then = (resolve: (v: { data: Row[]; error: null }) => unknown) =>
+    resolve({ data: filtered, error: null });
+  return b;
+}
+
+// A fake Service client for the `settings/users` route bodies. `tables`
+// seeds rows the bodies read (e.g. the target member's `user_organizations`
+// row for the `permissions` PUT). `auth.admin` stubs the invite/ban calls.
+export function fakeUsersServiceClient(
+  opts: { tables?: Record<string, Row[]> } = {},
+) {
+  const tables = opts.tables ?? {};
+  return {
+    from(table: string) {
+      return builder(tables[table] ?? []);
+    },
+    auth: {
+      admin: {
+        async listUsers() {
+          return { data: { users: [] }, error: null };
+        },
+        async inviteUserByEmail() {
+          return { data: { user: { id: "invited-user" } }, error: null };
+        },
+        async updateUserById() {
+          return { data: { user: null }, error: null };
+        },
+      },
+    },
+  };
+}

--- a/src/app/api/settings/users/route.test.ts
+++ b/src/app/api/settings/users/route.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+import { fakeUsersServiceClient } from "./__test-utils__/service-fake";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeUsersServiceClient() as never,
+  );
+});
+
+// #100 — these two endpoints were ungated logged-in-only; they are now
+// gated on `access_settings`.
+describe("GET /api/settings/users — gated on access_settings (#100)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/settings/users"), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/settings/users"), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a member holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/settings/users"), noParams);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/settings/users — gated on access_settings (#100)", () => {
+  const invite = () =>
+    new Request("http://test/api/settings/users", {
+      method: "POST",
+      body: JSON.stringify({ email: "new@test.com", full_name: "New Member" }),
+    });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(invite(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "crew_lead", grants: [] }),
+      }) as never,
+    );
+
+    const res = await POST(invite(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a member holding access_settings", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_lead",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+
+    const res = await POST(invite(), noParams);
+
+    expect(res.status).toBe(201);
+  });
+
+  it("allows an admin regardless of grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+
+    const res = await POST(invite(), noParams);
+
+    expect(res.status).toBe(201);
+  });
+});

--- a/src/app/api/settings/users/route.ts
+++ b/src/app/api/settings/users/route.ts
@@ -24,9 +24,9 @@ const ROLE_DEFAULTS: Record<string, readonly PermissionKey[]> = {
 // user_orgs_member_read policy (build51) grants visibility into other members
 // of the same org.
 //
-// Logged-in only — previously ungated (recorded for the #78 ungated list).
+// Gated on `access_settings` (#100) — was previously ungated logged-in-only.
 export const GET = withRequestContext(
-  { serviceClient: true },
+  { permission: "access_settings", serviceClient: true },
   async (_request, ctx) => {
     const { data: memberships, error } = await ctx.supabase
       .from("user_organizations")
@@ -64,9 +64,9 @@ export const GET = withRequestContext(
 // fires handle_new_user to create user_profiles), then inserts the
 // user_organizations row and default permissions.
 //
-// Logged-in only — previously ungated (recorded for the #78 ungated list).
+// Gated on `access_settings` (#100) — was previously ungated logged-in-only.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "access_settings", serviceClient: true },
   async (request, ctx) => {
     const { email, full_name, phone, role } = await request.json();
 


### PR DESCRIPTION
## Summary

Closes #100 — slice of PRD #95 (security triage of the ungated endpoints).

The five `settings/users` endpoints were ungated logged-in-only — any
authenticated member of any role could call them. They mutate org
membership, roles, profiles, ban state, and **permission grants**; a
non-admin could grant themselves every permission via
`PUT /api/settings/users/[id]/permissions`.

All five now carry `{ permission: "access_settings", serviceClient: true }`
(was `{ serviceClient: true }`):

- `GET` / `POST /api/settings/users`
- `PATCH /api/settings/users/[id]`
- `GET` / `PUT /api/settings/users/[id]/permissions`

`access_settings` already exists in `PERMISSION_CATALOG` (group "Admin") —
no new key. It is chosen over a hard `adminOnly` rule so settings
administration can be delegated without full admin, consistent with
`stripe/settings` and the rest of `settings/*`. Admins auto-pass a
`permission` rule; a member lacking the key now gets 403 before the
handler runs.

## Tests

3 new route test files (17 tests) — 401 / 403 / allow on each endpoint,
including the explicit self-privilege-escalation guard on
`PUT .../permissions` — plus a `settings/users` service-client test fake.
Decision recorded in `docs/request-context-ungated-endpoints.md`.

## Verification

- Typecheck clean on the changed surface (only the pre-existing unrelated
  `sync-folder-incremental.test.ts` `TS2322` remains).
- Lint zero-issue on all changed/new files.
- Full suite **371 green / 58 files**.

## Merge note

A `## Triage decisions (PRD #95)` section is added to
`docs/request-context-ungated-endpoints.md`. Parallel #95 slices in flight
add the same section — expect a doc-only merge conflict if another #95 PR
lands first; the code is conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)