### PR TITLE
Gate the payments endpoints (#102)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -414,3 +414,22 @@ department routes from the #85 special-case notes — out of #99 scope.)
 logged-in-only confirmed. Three follow-ups recorded for separate slices —
 knowledge `DELETE` ([#121](#)), notifications `GET`/`PATCH` ([#119](#)),
 Jarvis chat ([#120](#)). #99 changed no code.
+
+### #102 — payments
+
+The four `payments` endpoints listed under [#83](#83--jobs--payments--payment-requests)
+were logged-in-only. Tightened to canonical #96 keys:
+
+- `GET /api/payments` → `{ permission: "view_billing" }` — listing payments
+  is a billing-area read.
+- `POST /api/payments` → `{ permission: "record_payments", serviceClient: true }`
+- `PATCH /api/payments/[id]` → `{ permission: "record_payments", serviceClient: true }`
+- `DELETE /api/payments/[id]` → `{ permission: "record_payments", serviceClient: true }`
+
+`view_billing` and `record_payments` both already exist in
+`PERMISSION_CATALOG` (group "Billing"); no new key was introduced. Admins
+auto-pass a `permission` rule. A member lacking the key now gets 403 — the
+wrapper rejects before the handler runs.
+
+`POST /api/payments/[id]/retry-qb-sync` was already gated on
+`record_payments` at conversion time and needed no change.

--- a/src/app/api/payments/[id]/route.ts
+++ b/src/app/api/payments/[id]/route.ts
@@ -16,7 +16,7 @@ interface PatchBody {
 }
 
 export const PATCH = withRequestContext(
-  { serviceClient: true },
+  { permission: "record_payments", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = (await request.json().catch(() => null)) as PatchBody | null;
@@ -44,7 +44,7 @@ export const PATCH = withRequestContext(
 );
 
 export const DELETE = withRequestContext(
-  { serviceClient: true },
+  { permission: "record_payments", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const { error } = await ctx.serviceClient!.from("payments").delete().eq("id", id);

--- a/src/app/api/payments/route.ts
+++ b/src/app/api/payments/route.ts
@@ -16,9 +16,9 @@ interface CreatePaymentBody {
   notes?: string | null;
 }
 
-// Listing payments is logged-in only; the User client's RLS scopes rows to
-// the active organization.
-export const GET = withRequestContext({}, async (request, ctx) => {
+// Listing payments needs `view_billing` (admins auto-pass); the User
+// client's RLS scopes rows to the active organization.
+export const GET = withRequestContext({ permission: "view_billing" }, async (request, ctx) => {
   const url = new URL(request.url);
   const invoiceId = url.searchParams.get("invoiceId");
   const jobId = url.searchParams.get("jobId");
@@ -37,10 +37,11 @@ export const GET = withRequestContext({}, async (request, ctx) => {
   return NextResponse.json({ rows: data ?? [] });
 });
 
-// Recording a payment is logged-in only; it writes with the Service client
-// so the insert and the draft-invoice guard bypass RLS.
+// Recording a payment needs `record_payments` (admins auto-pass); it writes
+// with the Service client so the insert and the draft-invoice guard bypass
+// RLS.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "record_payments", serviceClient: true },
   async (request, ctx) => {
     const body = (await request.json().catch(() => null)) as CreatePaymentBody | null;
     if (!body?.jobId || !body?.source || !body?.method || !body.amount) {


### PR DESCRIPTION
## What

Slice of PRD #95 (security triage of the ungated endpoints). The four `payments` endpoints were left logged-in-only by the #78 Request Context conversion; this applies real permission rules from the #96 canonical vocabulary.

| Endpoint | Rule |
|---|---|
| `GET /api/payments` | `{ permission: "view_billing" }` |
| `POST /api/payments` | `{ permission: "record_payments", serviceClient: true }` |
| `PATCH /api/payments/[id]` | `{ permission: "record_payments", serviceClient: true }` |
| `DELETE /api/payments/[id]` | `{ permission: "record_payments", serviceClient: true }` |

Both keys already exist in `PERMISSION_CATALOG` (group "Billing") — no new key introduced, per #102's "confirm against the canonical vocabulary" instruction. Admins auto-pass a `permission` rule; a member lacking the key now gets 403 before the handler runs. `POST /api/payments/[id]/retry-qb-sync` was already gated on `record_payments` and needed no change.

## Acceptance criteria

- [x] Payment mutations require `record_payments`
- [x] The payments list read requires the billing-view permission (`view_billing`)
- [x] A member lacking the key is denied (403); a member holding it (and admins) retain access — enforced structurally by `withRequestContext` + `evaluatePermissionRule`
- [x] Decision recorded in `docs/request-context-ungated-endpoints.md` (new "Triage decisions (PRD #95)" section)
- [x] Typecheck clean on the changed surface (only the pre-existing `sync-folder-incremental.test.ts` TS2322 remains); lint clean; full suite **354 green / 55 files**

Closes #102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)