### PR TITLE
request-context: gate jobs files/photos + jobs/search (#103)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -185,11 +185,25 @@ because they do not use session-based auth:
 - `POST /api/jobs/[id]/photos/bulk-tag` — bulk-tag job photos
 - `POST /api/jobs/[id]/photos/download` — bulk-download job photos
 
+> **#103 — gated.** These eight no longer run logged-in-only. Reads take
+> the job-view key, writes/deletes take the job-edit key, both from the
+> canonical #96 vocabulary:
+> - `view_jobs` → `GET .../files`, `GET .../files/[fileId]/url`
+> - `edit_jobs` → `POST .../files`, `PATCH`/`DELETE .../files/[fileId]`,
+>   `DELETE .../photos/bulk`, `POST .../photos/bulk-tag`,
+>   `POST .../photos/download`
+>
+> The download route is treated as a write (`edit_jobs`) per the #103 spec
+> — it produces signed URLs for an explicit, multi-select bulk export, a
+> heavier action than a single-file view. Admins auto-pass every rule.
+
 ### ⚠️ jobs/search — no prior auth at all
 
 - `GET /api/jobs/search` — job search/autocomplete. Wrapped `{}`. Had **no
   auth check whatsoever** before conversion; the wrapper now adds a
   logged-in gate.
+
+> **#103 — gated.** Now requires `view_jobs` (admins auto-pass).
 
 ### payments (wrapped `{ serviceClient: true }`, except GET)
 

--- a/src/app/api/__test-utils__/request-context-fakes.ts
+++ b/src/app/api/__test-utils__/request-context-fakes.ts
@@ -76,9 +76,31 @@ function queryBuilder(rows: Row[]): QueryBuilder {
   return builder;
 }
 
+// Storage stub shared by both client fakes: `remove` echoes the paths back
+// and `createSignedUrl` returns a deterministic test URL.
+function fakeStorage() {
+  return {
+    from() {
+      return {
+        async remove(paths: string[]) {
+          return { data: paths.map((name) => ({ name })), error: null };
+        },
+        async createSignedUrl(path: string) {
+          return {
+            data: { signedUrl: `https://signed.test/${path}` },
+            error: null,
+          };
+        },
+      };
+    },
+  };
+}
+
 // A fake User client. `tables` seeds whatever the wrapper or route reads:
 // `user_organizations` (membership), `user_organization_permissions`
-// (grants), and any table a logged-in-only route queries directly.
+// (grants), and any table a route queries directly. `storage` is stubbed so
+// permission-gated routes that read/write storage on the User client (the
+// job files/photos routes) can be exercised end-to-end.
 export function fakeUserClient(opts: {
   user: { id: string } | null;
   tables?: Record<string, Row[]>;
@@ -93,6 +115,7 @@ export function fakeUserClient(opts: {
     from(table: string) {
       return queryBuilder(tables[table] ?? []);
     },
+    storage: fakeStorage(),
   };
 }
 
@@ -137,20 +160,6 @@ export function fakeServiceClient(opts: {
     from(table: string) {
       return queryBuilder(tables[table] ?? []);
     },
-    storage: {
-      from() {
-        return {
-          async remove(paths: string[]) {
-            return { data: paths.map((name) => ({ name })), error: null };
-          },
-          async createSignedUrl(path: string) {
-            return {
-              data: { signedUrl: `https://signed.test/${path}` },
-              error: null,
-            };
-          },
-        };
-      },
-    },
+    storage: fakeStorage(),
   };
 }

--- a/src/app/api/jobs/[id]/files/[fileId]/route.test.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/route.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH, DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1", fileId: "f-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              job_files: [
+                { id: "f-1", filename: "old.pdf", storage_path: "org-1/job-1/f-1.pdf" },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+function patchRequest(body: unknown) {
+  return new Request("http://test", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — job file writes and deletes require `edit_jobs`.
+describe("PATCH /api/jobs/[id]/files/[fileId] (gated on edit_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await PATCH(patchRequest({ filename: "new.pdf" }), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await PATCH(patchRequest({ filename: "new.pdf" }), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("renames the file for a member holding edit_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await PATCH(patchRequest({ filename: "new.pdf" }), paramsFor);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("DELETE /api/jobs/[id]/files/[fileId] (gated on edit_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await DELETE(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await DELETE(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("deletes the file for a member holding edit_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await DELETE(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/src/app/api/jobs/[id]/files/[fileId]/route.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // PATCH /api/jobs/[id]/files/[fileId] — rename
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const PATCH = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (
     request,
     ctx,
@@ -42,8 +42,9 @@ export const PATCH = withRequestContext(
 );
 
 // DELETE /api/jobs/[id]/files/[fileId] — delete storage object, then row
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const DELETE = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (
     _request,
     ctx,

--- a/src/app/api/jobs/[id]/files/[fileId]/url/route.test.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/url/route.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1", fileId: "f-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              job_files: [
+                { id: "f-1", storage_path: "org-1/job-1/f-1.pdf" },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — the job-file signed-URL read requires `view_jobs`.
+describe("GET /api/jobs/[id]/files/[fileId]/url (gated on view_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: [] });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns a signed URL for a member holding view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toContain("signed.test");
+  });
+});

--- a/src/app/api/jobs/[id]/files/[fileId]/url/route.ts
+++ b/src/app/api/jobs/[id]/files/[fileId]/url/route.ts
@@ -8,9 +8,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 // an <a download> link on the client. Do NOT pass the `download` option
 // to createSignedUrl — that forces Content-Disposition: attachment and
 // breaks iframe preview.
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `view_jobs` (#103).
 export const GET = withRequestContext(
-  {},
+  { permission: "view_jobs" },
   async (
     _request,
     ctx,

--- a/src/app/api/jobs/[id]/files/route.test.ts
+++ b/src/app/api/jobs/[id]/files/route.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              job_files: [
+                { id: "f-1", organization_id: "org-1", job_id: "job-1" },
+                { id: "f-2", organization_id: "org-1", job_id: "job-1" },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — job file reads require `view_jobs`, writes require `edit_jobs`.
+describe("GET /api/jobs/[id]/files (gated on view_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: [] });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("lists the job's files for a member holding view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.map((f: { id: string }) => f.id)).toEqual(["f-1", "f-2"]);
+  });
+
+  it("lists the job's files for an admin without an explicit grant", async () => {
+    mockCaller({ user: { id: "u1" }, role: "admin", grants: [] });
+    const res = await GET(new Request("http://test"), paramsFor);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/jobs/[id]/files (gated on edit_jobs, #103)", () => {
+  function uploadRequest() {
+    return new Request("http://test", { method: "POST", body: new FormData() });
+  }
+
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await POST(uploadRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await POST(uploadRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("admits a member holding edit_jobs (body runs — 400 on an empty upload)", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await POST(uploadRequest(), paramsFor);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/jobs/[id]/files/route.ts
+++ b/src/app/api/jobs/[id]/files/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { randomUUID } from "crypto";
 
 // GET /api/jobs/[id]/files — list files for a job (scoped to active org).
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `view_jobs` (#103).
 export const GET = withRequestContext(
-  {},
+  { permission: "view_jobs" },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id: jobId } = await params;
 
@@ -26,8 +26,9 @@ export const GET = withRequestContext(
 
 // POST /api/jobs/[id]/files — upload one or more files
 // Returns { succeeded: JobFile[], failed: { filename: string, error: string }[] }
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const POST = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id: jobId } = await params;
     const formData = await request.formData();

--- a/src/app/api/jobs/[id]/photos/bulk-tag/route.test.ts
+++ b/src/app/api/jobs/[id]/photos/bulk-tag/route.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              photos: [{ id: "p-1", job_id: "job-1" }],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+function tagRequest() {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify({
+      photoIds: ["p-1"],
+      tagIds: ["t-1"],
+      action: "add",
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — bulk photo tagging requires `edit_jobs`.
+describe("POST /api/jobs/[id]/photos/bulk-tag (gated on edit_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await POST(tagRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await POST(tagRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("tags the photos for a member holding edit_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await POST(tagRequest(), paramsFor);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ updated: 1 });
+  });
+});

--- a/src/app/api/jobs/[id]/photos/bulk-tag/route.ts
+++ b/src/app/api/jobs/[id]/photos/bulk-tag/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/jobs/[id]/photos/bulk-tag — add/remove tags on selected photos.
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const POST = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id: jobId } = await params;
     const { photoIds, tagIds, action } = await request.json() as {

--- a/src/app/api/jobs/[id]/photos/bulk/route.test.ts
+++ b/src/app/api/jobs/[id]/photos/bulk/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              photos: [
+                { id: "p-1", job_id: "job-1", storage_path: "org-1/job-1/p-1.jpg" },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+function deleteRequest() {
+  return new Request("http://test", {
+    method: "DELETE",
+    body: JSON.stringify({ photoIds: ["p-1"] }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — bulk photo delete requires `edit_jobs`.
+describe("DELETE /api/jobs/[id]/photos/bulk (gated on edit_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await DELETE(deleteRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await DELETE(deleteRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("bulk-deletes the photos for a member holding edit_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await DELETE(deleteRequest(), paramsFor);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ deleted: 1 });
+  });
+});

--- a/src/app/api/jobs/[id]/photos/bulk/route.ts
+++ b/src/app/api/jobs/[id]/photos/bulk/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // DELETE /api/jobs/[id]/photos/bulk — bulk-delete photos.
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const DELETE = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id: jobId } = await params;
     const { photoIds } = await request.json() as { photoIds: string[] };

--- a/src/app/api/jobs/[id]/photos/download/route.test.ts
+++ b/src/app/api/jobs/[id]/photos/download/route.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1" }) };
+
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              photos: [
+                {
+                  id: "p-1",
+                  job_id: "job-1",
+                  storage_path: "org-1/job-1/p-1.jpg",
+                  caption: "before",
+                },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+function downloadRequest() {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify({ photoIds: ["p-1"] }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #103 — bulk photo download requires `edit_jobs`.
+describe("POST /api/jobs/[id]/photos/download (gated on edit_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await POST(downloadRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await POST(downloadRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns signed URLs for a member holding edit_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["edit_jobs"] });
+    const res = await POST(downloadRequest(), paramsFor);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.urls).toHaveLength(1);
+    expect(body.urls[0].url).toContain("signed.test");
+  });
+});

--- a/src/app/api/jobs/[id]/photos/download/route.ts
+++ b/src/app/api/jobs/[id]/photos/download/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/jobs/[id]/photos/download — signed URLs for selected photos.
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
+// Previously ungated (RLS-only); now requires `edit_jobs` (#103).
 export const POST = withRequestContext(
-  {},
+  { permission: "edit_jobs" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id: jobId } = await params;
     const { photoIds } = await request.json() as { photoIds: string[] };

--- a/src/app/api/jobs/search/route.test.ts
+++ b/src/app/api/jobs/search/route.test.ts
@@ -18,14 +18,21 @@ import {
   memberTables,
 } from "../../__test-utils__/request-context-fakes";
 
+const seededJobs = {
+  jobs: [
+    { id: "job-1", job_number: "1001", property_address: "1 Main St" },
+    { id: "job-2", job_number: "1002", property_address: "2 Oak Ave" },
+  ],
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-// Job search was previously ungated (RLS-only); it is now logged-in only.
-describe("GET /api/jobs/search (converted to withRequestContext, logged-in only)", () => {
-  it("returns 401 when unauthenticated — no permission required, but logged-in is", async () => {
+// Job search was previously ungated (RLS-only); #103 gates it on `view_jobs`.
+describe("GET /api/jobs/search (gated on view_jobs, #103)", () => {
+  it("returns 401 when unauthenticated", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
       fakeUserClient({ user: null }) as never,
     );
@@ -37,7 +44,7 @@ describe("GET /api/jobs/search (converted to withRequestContext, logged-in only)
     expect(res.status).toBe(401);
   });
 
-  it("returns jobs for any logged-in caller, even one with no permission grants", async () => {
+  it("returns 403 when the caller lacks view_jobs", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
       fakeUserClient({
         user: { id: "user-1" },
@@ -45,12 +52,27 @@ describe("GET /api/jobs/search (converted to withRequestContext, logged-in only)
           userId: "user-1",
           role: "member",
           grants: [],
-          extraTables: {
-            jobs: [
-              { id: "job-1", job_number: "1001", property_address: "1 Main St" },
-              { id: "job-2", job_number: "1002", property_address: "2 Oak Ave" },
-            ],
-          },
+          extraTables: seededJobs,
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/jobs/search"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns jobs for a member holding view_jobs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["view_jobs"],
+          extraTables: seededJobs,
         }),
       }) as never,
     );
@@ -65,5 +87,27 @@ describe("GET /api/jobs/search (converted to withRequestContext, logged-in only)
       "job-1",
       "job-2",
     ]);
+  });
+
+  it("returns jobs for an admin without an explicit grant", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "admin",
+          grants: [],
+          extraTables: seededJobs,
+        }),
+      }) as never,
+    );
+
+    const res = await GET(new Request("http://test/api/jobs/search"), {
+      params: Promise.resolve({}),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobs).toHaveLength(2);
   });
 });

--- a/src/app/api/jobs/search/route.ts
+++ b/src/app/api/jobs/search/route.ts
@@ -2,8 +2,8 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/jobs/search?q=...&limit=10
-// Previously ungated (RLS-only); now logged-in only via `withRequestContext`.
-export const GET = withRequestContext({}, async (request, ctx) => {
+// Previously ungated (RLS-only); now requires `view_jobs` (#103).
+export const GET = withRequestContext({ permission: "view_jobs" }, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const q = (searchParams.get("q") || "").replace(/[%,.*()]/g, "");
   const limit = Math.min(Math.max(parseInt(searchParams.get("limit") || "10") || 10, 1), 50);


### PR DESCRIPTION
## Summary

PRD #95 slice **#103**. The job file/photo endpoints and `jobs/search` ran logged-in-only after the #78 Request Context conversion. This slice tightens them with job-scoped permission rules from the canonical #96 vocabulary.

| Key | Endpoints |
|---|---|
| `view_jobs` | `GET /api/jobs/[id]/files`, `GET /api/jobs/[id]/files/[fileId]/url`, `GET /api/jobs/search` |
| `edit_jobs` | `POST /api/jobs/[id]/files`, `PATCH`/`DELETE /api/jobs/[id]/files/[fileId]`, `DELETE /api/jobs/[id]/photos/bulk`, `POST /api/jobs/[id]/photos/bulk-tag`, `POST /api/jobs/[id]/photos/download` |

`withRequestContext` keeps `ctx.supabase` as the User client regardless of the rule, so the route bodies are unchanged — only the gate is added. The `download` route is gated as a write (`edit_jobs`) per the issue spec: it produces signed URLs for an explicit multi-select bulk export.

## Tests

Each route gets 401 / 403 / authorized coverage (member holding the key, plus admin auto-pass). `fakeUserClient` gains a shared `storage` stub so the storage-backed routes can be exercised end-to-end. The existing `jobs/search` logged-in-only test is rewritten for the new gate.

- 29 new/updated tests for the changed surface — all green
- Full suite: **398 passed / 64 files**
- Typecheck clean on the changed surface (the unrelated pre-existing `sync-folder-incremental.test.ts` `TS2322` remains)
- Lint clean on all changed files

## Acceptance criteria (#103)

- [x] Job file/photo reads require the job-view permission (`view_jobs`)
- [x] Job file/photo writes and deletes require the job-edit permission (`edit_jobs`)
- [x] `jobs/search` requires the job-view permission
- [x] A member lacking the key is denied (403); a member holding it (and admins) retain access
- [x] Decisions recorded in `docs/request-context-ungated-endpoints.md`
- [x] Typecheck, lint (changed surface), and the full test suite stay green

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)