### PR TITLE
Gate the email content and accounts endpoints (#105)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -540,3 +540,56 @@ handler runs.
   `payment-email` live under `/api/settings/` but already carry real
   permission rules (`manage_*` / `view_accounting` / billing keys) — out of
   this slice's scope, unchanged.
+
+---
+
+## #105 — email content + accounts: tightened to the email vocabulary
+
+PRD #95 slice #105 is the follow-up the intro promises: it **tightens** the
+email routes #85 wrapped logged-in-only. Every email content and
+email-accounts endpoint listed under `## #85` above now carries a real
+permission rule, drawn from the canonical #96 vocabulary (`view_email`,
+`send_email`). They are no longer in the "ungated" set.
+
+The split is read-vs-write — a pure `GET` requires `view_email`; every
+mutation (`POST` / `PATCH` / `DELETE`), including account management,
+requires `send_email`. Admins auto-pass either rule (`evaluatePermissionRule`
+policy); a member holding neither key now gets a `403`.
+
+### `view_email` — read endpoints
+
+- `GET /api/email/[id]` — read one message
+- `GET /api/email/thread/[threadId]` — read a message thread
+- `GET /api/email/list` — list messages in a folder
+- `GET /api/email/counts` — unread counts per folder/account
+- `GET /api/email/contacts` — email contact autocomplete
+- `GET /api/email/attachments/[id]` — download an attachment
+- `GET /api/email/accounts` — list connected email accounts
+
+### `send_email` — mutation + account-management endpoints
+
+- `PATCH /api/email/[id]` — update a message (read/starred/job_id)
+- `PATCH /api/email/bulk` — bulk message actions
+- `POST /api/email/mark-all-read` — mark a folder/account all read
+- `POST /api/email/drafts` — save / update a draft
+- `POST /api/email/send` — send an email
+- `POST /api/email/sync` — sync an account's mailboxes
+- `POST /api/email/sync-folder` — sync a single folder
+- `POST /api/email/attachments/upload` — upload an attachment
+- `POST /api/email/accounts` — connect a new email account
+- `PATCH /api/email/accounts/[id]` — update an email account
+- `DELETE /api/email/accounts/[id]` — disconnect an email account
+- `POST /api/email/accounts/[id]/test` — test an account's connection
+
+### Read-vs-write notes
+
+- `PATCH /api/email/[id]` is a message **mutation** (flags, folder
+  assignment), so it is gated `send_email` — consistent with the bulk
+  message actions (`PATCH /api/email/bulk`) and `mark-all-read`, which the
+  issue's key mapping places under `send_email`. It is not treated as a
+  "pure read" despite the message-content read living on the same path.
+- Account management (connect / update / disconnect / test) is gated
+  `send_email`, not a separate key — #105's scope is "existing keys only"
+  (per #96), and the email vocabulary has exactly two keys. `view_email`
+  covers reading the account list; everything that changes account state is
+  a write.

--- a/src/app/api/email/[id]/route.ts
+++ b/src/app/api/email/[id]/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/[id] — get a single email.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
 export const GET = withRequestContext(
-  {},
+  { permission: "view_email" },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
@@ -24,8 +24,10 @@ export const GET = withRequestContext(
 );
 
 // PATCH /api/email/[id] — update email (read, starred, job_id).
+// Requires `send_email` (#105, PRD #95) — a message mutation, gated like the
+// bulk / mark-all-read message-state writes.
 export const PATCH = withRequestContext(
-  {},
+  { permission: "send_email" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = await request.json();

--- a/src/app/api/email/accounts/[id]/route.test.ts
+++ b/src/app/api/email/accounts/[id]/route.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { DELETE, PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function patchReq() {
+  return new Request("http://test", { method: "PATCH", body: "{}" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("DELETE /api/email/accounts/[id] — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      paramsFor("acc-1"),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      paramsFor("acc-1"),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("disconnects the account when the caller holds send_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      paramsFor("acc-1"),
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      paramsFor("acc-1"),
+    );
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("PATCH /api/email/accounts/[id] — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    // Empty body — the handler rejects with 400 for no updatable fields,
+    // proving the gate let the request through rather than rejecting it 403.
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/email/accounts/[id]/route.ts
+++ b/src/app/api/email/accounts/[id]/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
 
-// DELETE /api/email/accounts/[id]
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
+// DELETE /api/email/accounts/[id] — disconnect an email account.
+// Requires `send_email` (#105, PRD #95) — account management is a write,
+// tightened from the logged-in-only #85 Request-Context conversion gate.
 export const DELETE = withRequestContext(
-  {},
+  { permission: "send_email" },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
@@ -22,9 +22,10 @@ export const DELETE = withRequestContext(
   },
 );
 
-// PATCH /api/email/accounts/[id] — update account settings
+// PATCH /api/email/accounts/[id] — update account settings.
+// Requires `send_email` (#105, PRD #95) — account management is a write.
 export const PATCH = withRequestContext(
-  {},
+  { permission: "send_email" },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = await request.json();

--- a/src/app/api/email/accounts/[id]/test/route.test.ts
+++ b/src/app/api/email/accounts/[id]/test/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/accounts/[id]/test — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    // No account seeded, so the handler returns 404 — proving the gate let
+    // the request through rather than rejecting it with 403.
+    expect(res.status).toBe(404);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/accounts/[id]/test/route.ts
+++ b/src/app/api/email/accounts/[id]/test/route.ts
@@ -5,10 +5,10 @@ import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
 
 // POST /api/email/accounts/[id]/test — test IMAP and SMTP connections.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
+// Requires `send_email` (#105, PRD #95) — account management is a write,
+// tightened from the logged-in-only #85 Request-Context conversion gate.
 export const POST = withRequestContext(
-  {},
+  { permission: "send_email" },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 

--- a/src/app/api/email/accounts/route.test.ts
+++ b/src/app/api/email/accounts/route.test.ts
@@ -10,7 +10,7 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
 
-import { GET, PATCH } from "./route";
+import { GET, POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
@@ -18,9 +18,7 @@ import {
   memberTables,
 } from "../__test-utils__/request-context-fakes";
 
-function paramsFor(id: string) {
-  return { params: Promise.resolve({ id }) };
-}
+const noParams = { params: Promise.resolve({}) };
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -28,11 +26,8 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function patchReq() {
-  return new Request("http://test", {
-    method: "PATCH",
-    body: JSON.stringify({ is_read: true }),
-  });
+function postReq() {
+  return new Request("http://test", { method: "POST", body: "{}" });
 }
 
 beforeEach(() => {
@@ -40,11 +35,11 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("GET /api/email/[id] — gated on view_email (#105)", () => {
+describe("GET /api/email/accounts — gated on view_email (#105)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await GET(new Request("http://test"), paramsFor("e-1"));
+    const res = await GET(new Request("http://test/api/email/accounts"), noParams);
 
     expect(res.status).toBe(401);
   });
@@ -55,55 +50,12 @@ describe("GET /api/email/[id] — gated on view_email (#105)", () => {
       tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test"), paramsFor("e-1"));
+    const res = await GET(new Request("http://test/api/email/accounts"), noParams);
 
     expect(res.status).toBe(403);
   });
 
-  it("returns the email — and the [id] param — when the caller holds view_email", async () => {
-    authed({
-      user: { id: "user-1" },
-      tables: {
-        ...memberTables({
-          userId: "user-1",
-          role: "crew_member",
-          grants: ["view_email"],
-        }),
-        emails: [{ id: "e-1", subject: "Hello" }],
-      },
-    });
-
-    const res = await GET(new Request("http://test"), paramsFor("e-1"));
-
-    expect(res.status).toBe(200);
-    expect(await res.json()).toMatchObject({ id: "e-1", subject: "Hello" });
-  });
-
-  it("admins retain access without holding the key", async () => {
-    authed({
-      user: { id: "admin-1" },
-      tables: {
-        ...memberTables({ userId: "admin-1", role: "admin", grants: [] }),
-        emails: [{ id: "e-1", subject: "Hello" }],
-      },
-    });
-
-    const res = await GET(new Request("http://test"), paramsFor("e-1"));
-
-    expect(res.status).toBe(200);
-  });
-});
-
-describe("PATCH /api/email/[id] — gated on send_email (#105)", () => {
-  it("returns 401 when unauthenticated", async () => {
-    authed({ user: null });
-
-    const res = await PATCH(patchReq(), paramsFor("e-1"));
-
-    expect(res.status).toBe(401);
-  });
-
-  it("returns 403 when the caller lacks send_email", async () => {
+  it("lists accounts when the caller holds view_email", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
@@ -113,26 +65,72 @@ describe("PATCH /api/email/[id] — gated on send_email (#105)", () => {
       }),
     });
 
-    const res = await PATCH(patchReq(), paramsFor("e-1"));
+    const res = await GET(new Request("http://test/api/email/accounts"), noParams);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("admins retain access without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await GET(new Request("http://test/api/email/accounts"), noParams);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/email/accounts — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
 
     expect(res.status).toBe(403);
   });
 
-  it("updates the email when the caller holds send_email", async () => {
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
     authed({
       user: { id: "user-1" },
-      tables: {
-        ...memberTables({
-          userId: "user-1",
-          role: "crew_member",
-          grants: ["send_email"],
-        }),
-        emails: [{ id: "e-1", is_read: false }],
-      },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
     });
 
-    const res = await PATCH(patchReq(), paramsFor("e-1"));
+    const res = await POST(postReq(), noParams);
 
-    expect(res.status).toBe(200);
+    // Empty body — the handler rejects with 400 for missing fields, proving
+    // the gate let the request through rather than rejecting it with 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
   });
 });

--- a/src/app/api/email/accounts/route.ts
+++ b/src/app/api/email/accounts/route.ts
@@ -4,9 +4,9 @@ import { encrypt } from "@/lib/encryption";
 import { assignAccountColor } from "@/lib/email/assign-account-color";
 
 // GET /api/email/accounts — list accounts for the active org (passwords excluded).
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const GET = withRequestContext({}, async (_request, ctx) => {
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const GET = withRequestContext({ permission: "view_email" }, async (_request, ctx) => {
   const { data, error } = await ctx.supabase
     .from("email_accounts")
     .select("id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, last_synced_uid, created_at, updated_at")
@@ -20,7 +20,9 @@ export const GET = withRequestContext({}, async (_request, ctx) => {
 });
 
 // POST /api/email/accounts — add a new email account for the active org.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — account management is a write, like
+// account update / disconnect / test.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const body = await request.json();
   const { label, email_address, display_name, provider, imap_host, imap_port, smtp_host, smtp_port, username, password, color: colorOverride } = body;
 

--- a/src/app/api/email/attachments/[id]/route.test.ts
+++ b/src/app/api/email/attachments/[id]/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/email/attachments/[id] — gated on view_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await GET(new Request("http://test"), paramsFor("att-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
+    });
+
+    const res = await GET(new Request("http://test"), paramsFor("att-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds view_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await GET(new Request("http://test"), paramsFor("att-1"));
+
+    // No attachment seeded, so the handler returns 404 — proving the gate
+    // let the request through rather than rejecting it with 403.
+    expect(res.status).toBe(404);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await GET(new Request("http://test"), paramsFor("att-1"));
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/attachments/[id]/route.ts
+++ b/src/app/api/email/attachments/[id]/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/attachments/[id] — download an attachment.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
 export const GET = withRequestContext(
-  {},
+  { permission: "view_email" },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 

--- a/src/app/api/email/attachments/upload/route.test.ts
+++ b/src/app/api/email/attachments/upload/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST", body: new FormData() });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/attachments/upload — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    // Empty form data — the handler rejects with 400 for the missing file,
+    // proving the gate let the request through rather than rejecting it 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/attachments/upload/route.ts
+++ b/src/app/api/email/attachments/upload/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/attachments/upload — upload a file for composing.
 // Returns { id, filename, content_type, file_size, storage_path }.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const formData = await request.formData();
   const file = formData.get("file") as File | null;
 

--- a/src/app/api/email/bulk/route.test.ts
+++ b/src/app/api/email/bulk/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function patchReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("PATCH /api/email/bulk — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await PATCH(patchReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await PATCH(patchReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("bulk-updates emails when the caller holds send_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await PATCH(
+      patchReq({ ids: ["e-1", "e-2"], action: "mark_read" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await PATCH(
+      patchReq({ ids: ["e-1"], action: "mark_read" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/email/bulk/route.ts
+++ b/src/app/api/email/bulk/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // PATCH /api/email/bulk — bulk update emails
 // Body: { ids: string[], action: "mark_read" | "mark_unread" | "archive" | "trash" | "assign_job", jobId?: string }
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const PATCH = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const PATCH = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const body = await request.json();
   const { ids, action, jobId } = body;
 

--- a/src/app/api/email/contacts/route.test.ts
+++ b/src/app/api/email/contacts/route.test.ts
@@ -31,11 +31,11 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("GET /api/email/list — gated on view_email (#105)", () => {
-  it("returns 401 when unauthenticated — the route body never runs", async () => {
+describe("GET /api/email/contacts — gated on view_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/contacts"), noParams);
 
     expect(res.status).toBe(401);
   });
@@ -46,45 +46,33 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
       tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/contacts"), noParams);
 
     expect(res.status).toBe(403);
   });
 
-  it("lists emails when the caller holds view_email", async () => {
+  it("returns contacts when the caller holds view_email", async () => {
     authed({
       user: { id: "user-1" },
-      tables: {
-        ...memberTables({
-          userId: "user-1",
-          role: "crew_member",
-          grants: ["view_email"],
-        }),
-        emails: [
-          { id: "e-1", folder: "inbox" },
-          { id: "e-2", folder: "inbox" },
-          { id: "e-3", folder: "sent" },
-        ],
-      },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/contacts"), noParams);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.emails.map((e: { id: string }) => e.id)).toEqual(["e-1", "e-2"]);
   });
 
   it("admins retain access without holding the key", async () => {
     authed({
       user: { id: "admin-1" },
-      tables: {
-        ...memberTables({ userId: "admin-1", role: "admin", grants: [] }),
-        emails: [{ id: "e-1", folder: "inbox" }],
-      },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/contacts"), noParams);
 
     expect(res.status).toBe(200);
   });

--- a/src/app/api/email/contacts/route.ts
+++ b/src/app/api/email/contacts/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { escapeOrFilterValue } from "@/lib/postgrest";
 
 // GET /api/email/contacts?q=search — autocomplete contacts + recent email addresses.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const GET = withRequestContext({}, async (request, ctx) => {
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const GET = withRequestContext({ permission: "view_email" }, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const q = searchParams.get("q") || "";
 

--- a/src/app/api/email/counts/route.test.ts
+++ b/src/app/api/email/counts/route.test.ts
@@ -31,11 +31,11 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("GET /api/email/list — gated on view_email (#105)", () => {
-  it("returns 401 when unauthenticated — the route body never runs", async () => {
+describe("GET /api/email/counts — gated on view_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/counts"), noParams);
 
     expect(res.status).toBe(401);
   });
@@ -46,45 +46,33 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
       tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/counts"), noParams);
 
     expect(res.status).toBe(403);
   });
 
-  it("lists emails when the caller holds view_email", async () => {
+  it("returns counts when the caller holds view_email", async () => {
     authed({
       user: { id: "user-1" },
-      tables: {
-        ...memberTables({
-          userId: "user-1",
-          role: "crew_member",
-          grants: ["view_email"],
-        }),
-        emails: [
-          { id: "e-1", folder: "inbox" },
-          { id: "e-2", folder: "inbox" },
-          { id: "e-3", folder: "sent" },
-        ],
-      },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/counts"), noParams);
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.emails.map((e: { id: string }) => e.id)).toEqual(["e-1", "e-2"]);
   });
 
   it("admins retain access without holding the key", async () => {
     authed({
       user: { id: "admin-1" },
-      tables: {
-        ...memberTables({ userId: "admin-1", role: "admin", grants: [] }),
-        emails: [{ id: "e-1", folder: "inbox" }],
-      },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test/api/email/counts"), noParams);
 
     expect(res.status).toBe(200);
   });

--- a/src/app/api/email/counts/route.ts
+++ b/src/app/api/email/counts/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/counts?accountId=... — get unread counts per folder.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const GET = withRequestContext({}, async (request, ctx) => {
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const GET = withRequestContext({ permission: "view_email" }, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const accountId = searchParams.get("accountId"); // null = all accounts
 

--- a/src/app/api/email/drafts/route.test.ts
+++ b/src/app/api/email/drafts/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST", body: "{}" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/drafts — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    // Empty body — the handler rejects with 400 for the missing accountId,
+    // proving the gate let the request through rather than rejecting it 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/drafts/route.ts
+++ b/src/app/api/email/drafts/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/drafts — save or update a draft
 // Body: { draftId?, accountId, to, cc, bcc, subject, bodyText, bodyHtml, jobId?, replyToMessageId? }
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const {
     draftId,
     accountId,

--- a/src/app/api/email/list/route.ts
+++ b/src/app/api/email/list/route.ts
@@ -2,9 +2,9 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/list?folder=inbox&accountId=...&search=...&page=1&limit=50
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const GET = withRequestContext({}, async (request, ctx) => {
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const GET = withRequestContext({ permission: "view_email" }, async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const folder = searchParams.get("folder") || "inbox";
   const accountId = searchParams.get("accountId"); // null = all accounts

--- a/src/app/api/email/mark-all-read/route.test.ts
+++ b/src/app/api/email/mark-all-read/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/mark-all-read — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("marks a folder read when the caller holds send_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq({ folder: "inbox" }), noParams);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq({ folder: "inbox" }), noParams);
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/email/mark-all-read/route.ts
+++ b/src/app/api/email/mark-all-read/route.ts
@@ -3,9 +3,9 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/mark-all-read — mark all emails in a folder as read
 // Body: { folder: string, accountId?: string }
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const { folder, accountId } = await request.json();
 
   if (!folder) {

--- a/src/app/api/email/send/route.test.ts
+++ b/src/app/api/email/send/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST", body: "{}" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/send — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    // Empty body — the handler rejects with 400 for missing fields, proving
+    // the gate let the request through rather than rejecting it with 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/send/route.ts
+++ b/src/app/api/email/send/route.ts
@@ -12,9 +12,9 @@ interface UploadedAttachment {
 
 // POST /api/email/send
 // Body: { accountId, to, subject, body, bodyHtml?, cc?, bcc?, jobId?, replyToMessageId?, attachments? }
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const { accountId, jobId, to, cc, bcc, subject, body, bodyHtml, replyToMessageId, attachments, draftId } =
     await request.json() as {
       accountId: string; jobId?: string; to: string; cc?: string; bcc?: string;

--- a/src/app/api/email/sync-folder/route.test.ts
+++ b/src/app/api/email/sync-folder/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST", body: "{}" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/sync-folder — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    // Empty body — the handler rejects with 400 for the missing folder,
+    // proving the gate let the request through rather than rejecting it 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/sync-folder/route.ts
+++ b/src/app/api/email/sync-folder/route.ts
@@ -51,9 +51,9 @@ const ALLOWED_FOLDERS = new Set([
 //
 // The client throttles concurrent calls; this endpoint always does the
 // work it's asked to do.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const startedAt = Date.now();
   const body = (await request.json()) as { accountId?: string; folder?: string };
   const { accountId, folder } = body;

--- a/src/app/api/email/sync/route.test.ts
+++ b/src/app/api/email/sync/route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq() {
+  return new Request("http://test", { method: "POST", body: "{}" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/email/sync — gated on send_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_email", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["view_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_member",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    // Empty body — the handler rejects with 400 for the missing accountId,
+    // proving the gate let the request through rather than rejecting it 403.
+    expect(res.status).toBe(400);
+  });
+
+  it("admins pass the gate without holding the key", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -42,9 +42,9 @@ function mapFolder(imapPath: string): string {
 //
 // First sync per account also runs the one-time category backfill (Pass
 // 1 + Pass 2) — that path is intentionally not optimized.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
-export const POST = withRequestContext({}, async (request, ctx) => {
+// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
+export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const startedAt = Date.now();
   const { accountId, maxPerFolder = 50 } = await request.json();
 

--- a/src/app/api/email/thread/[threadId]/route.test.ts
+++ b/src/app/api/email/thread/[threadId]/route.test.ts
@@ -16,9 +16,11 @@ import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
   fakeUserClient,
   memberTables,
-} from "../__test-utils__/request-context-fakes";
+} from "../../__test-utils__/request-context-fakes";
 
-const noParams = { params: Promise.resolve({}) };
+function paramsFor(threadId: string) {
+  return { params: Promise.resolve({ threadId }) };
+}
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -31,11 +33,11 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("GET /api/email/list — gated on view_email (#105)", () => {
-  it("returns 401 when unauthenticated — the route body never runs", async () => {
+describe("GET /api/email/thread/[threadId] — gated on view_email (#105)", () => {
+  it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test"), paramsFor("t-1"));
 
     expect(res.status).toBe(401);
   });
@@ -46,12 +48,12 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
       tables: memberTables({ userId: "user-1", role: "crew_member", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test"), paramsFor("t-1"));
 
     expect(res.status).toBe(403);
   });
 
-  it("lists emails when the caller holds view_email", async () => {
+  it("returns the thread when the caller holds view_email", async () => {
     authed({
       user: { id: "user-1" },
       tables: {
@@ -60,31 +62,22 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
           role: "crew_member",
           grants: ["view_email"],
         }),
-        emails: [
-          { id: "e-1", folder: "inbox" },
-          { id: "e-2", folder: "inbox" },
-          { id: "e-3", folder: "sent" },
-        ],
+        emails: [{ id: "e-1", thread_id: "t-1" }],
       },
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test"), paramsFor("t-1"));
 
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.emails.map((e: { id: string }) => e.id)).toEqual(["e-1", "e-2"]);
   });
 
   it("admins retain access without holding the key", async () => {
     authed({
       user: { id: "admin-1" },
-      tables: {
-        ...memberTables({ userId: "admin-1", role: "admin", grants: [] }),
-        emails: [{ id: "e-1", folder: "inbox" }],
-      },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
 
-    const res = await GET(new Request("http://test/api/email/list"), noParams);
+    const res = await GET(new Request("http://test"), paramsFor("t-1"));
 
     expect(res.status).toBe(200);
   });

--- a/src/app/api/email/thread/[threadId]/route.ts
+++ b/src/app/api/email/thread/[threadId]/route.ts
@@ -2,10 +2,10 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // GET /api/email/thread/[threadId] — get all emails in a thread.
-// Previously ungated (relied on RLS via the User client); now logged-in
-// only. Recorded for the #78 ungated-endpoint list.
+// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
+// gate the #85 Request-Context conversion gave this previously-ungated route.
 export const GET = withRequestContext(
-  {},
+  { permission: "view_email" },
   async (_request, ctx, { params }: { params: Promise<{ threadId: string }> }) => {
     const { threadId } = await params;
 


### PR DESCRIPTION
Closes #105 — PRD #95 slice (Security triage of the ungated endpoints).

## What changed

The email content routes (read/update messages, threads, drafts, counts, contacts, bulk actions, mark-all-read, attachments) and the email-accounts routes (list/connect/update/disconnect/test) were wrapped **logged-in-only** by the #85 Request-Context conversion — several had no auth check at all before #78. This tightens them to the canonical #96 email vocabulary.

**16 route files** — `withRequestContext({}, …)` → a real permission rule:

| Key | Endpoints |
|-----|-----------|
| `view_email` | GET `[id]`, `thread/[threadId]`, `list`, `counts`, `contacts`, `attachments/[id]`, `accounts` |
| `send_email` | PATCH `[id]` · `bulk`; POST `mark-all-read`, `drafts`, `send`, `sync`, `sync-folder`, `attachments/upload`, `accounts`, `accounts/[id]/test`; PATCH/DELETE `accounts/[id]` |

**Read-vs-write split:** every pure `GET` requires `view_email`; every mutation (`POST`/`PATCH`/`DELETE`), including account management, requires `send_email`. Admins auto-pass either rule; a member holding neither key now gets a `403`.

`PATCH /api/email/[id]` is treated as a write (it mutates flags/folder), consistent with `bulk` / `mark-all-read`. Account management uses `send_email` rather than a new key — #105's scope is "existing keys only" per #96.

## Tests

16 `route.test.ts` files — 2 rewritten (`list` / `[id]` previously asserted the now-removed logged-in-only behavior), 14 new. Each covers 401 unauth, 403 lacking key, 2xx holding key, admin auto-pass.

## Docs

`docs/request-context-ungated-endpoints.md` — new `## #105` section recording the key assignments and the read-vs-write rationale.

## Acceptance criteria

- [x] Email read endpoints require `view_email`
- [x] Email send / mutation / account-management endpoints require `send_email`
- [x] A member lacking the key is denied (403); a member holding it (and admins) retain access
- [x] Decisions recorded in `docs/request-context-ungated-endpoints.md`
- [x] Typecheck, lint (changed surface), and the full test suite stay green

## Verification

- Email tests: **16 files / 74 tests green**
- Full suite: **69 files / 423 tests green**
- Typecheck: clean on the changed surface — only the pre-existing, unrelated `sync-folder-incremental.test.ts` `TS2322` remains (carried)
- Lint: clean on `src/app/api/email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)