### PR TITLE
request-context: gate the contracts endpoints (#106)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -593,3 +593,61 @@ policy); a member holding neither key now gets a `403`.
   (per #96), and the email vocabulary has exactly two keys. `view_email`
   covers reading the account list; everything that changes account state is
   a write.
+
+---
+
+## #106 — contracts: gated on the job permissions
+
+PRD #95 slice #106 tightens the `contracts` endpoints the #80 conversion
+wrapped logged-in-only (listed under [`## #80`](#80--contracts)).
+
+**Human decision (the HITL question #106 was raised for).** The canonical
+#96 vocabulary has `manage_contract_templates` (for contract *templates*)
+but **no key for contract instances** — the sent / signed / voided
+documents. The slice issue framed the decision as: reuse the job keys, or
+introduce a new `manage_contracts` key. The decision recorded here is to
+**reuse `view_jobs` / `edit_jobs`** — no new key. A contract is a job
+sub-resource: it always carries a `job_id`, the UI surfaces it on the job
+detail Overview tab, and the immediately-prior slice [#103](#83--jobs--payments--payment-requests)
+gated the other job sub-resources (files, photos) the same way. Reusing the
+job keys keeps the vocabulary stable and means no `settings/users`
+seed / role-defaults migration.
+
+The split is read-vs-write — a pure `GET` requires `view_jobs`; every
+mutation requires `edit_jobs`. Admins auto-pass either rule; a member
+holding neither key now gets a `403` before the handler runs. The
+`serviceClient` opt-in on each route is unchanged.
+
+### `view_jobs` — read endpoints
+
+- `GET /api/contracts/preflight` — pre-send validation/readiness check
+- `GET /api/contracts/[id]/pdf` — signed URL / stream for the contract PDF
+- `GET /api/contracts/by-job/[jobId]` — list contracts for a job
+
+### `edit_jobs` — mutation endpoints
+
+- `POST /api/contracts/send` — send a contract for signature
+- `POST /api/contracts/in-person` — record an in-person signature
+- `POST /api/contracts/in-person/start` — begin an in-person signing flow
+- `POST /api/contracts/[id]/void` — void a sent contract
+- `DELETE /api/contracts/[id]` — soft-delete a contract
+- `POST /api/contracts/[id]/restore` — restore a soft-deleted contract
+- `POST /api/contracts/[id]/resend` — resend the signing request
+- `POST /api/contracts/[id]/remind` — send a signing reminder
+
+### Org-scoping — `by-job/[jobId]`
+
+`GET /api/contracts/by-job/[jobId]` flagged in `## #80` as having had **no
+prior auth at all** (RLS-only). Beyond the `view_jobs` rule it now also runs
+the caller-supplied `jobId` through the #97 Active-Organization scoping
+guard (`belongsToActiveOrganization`, `{ jobId }` locator) before the read:
+a job in another Organization is indistinguishable from a missing one —
+both return 404. `jobs` was already a registered resolver, so the guard's
+`RESOLVERS` map needed no change.
+
+### Notes — endpoints deliberately left unchanged
+
+- `GET /api/contracts/reminders` — the hourly auto-reminder Vercel Cron
+  endpoint. It is authenticated by `CRON_SECRET` (not a session), is not
+  wrapped with `withRequestContext`, and was never in the ungated set — out
+  of scope, unchanged. (Same class as `qb/sync-scheduled` under `## #82`.)

--- a/src/app/api/contracts/[id]/pdf/route.test.ts
+++ b/src/app/api/contracts/[id]/pdf/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/c-1/pdf");
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// #106 — the signed-PDF download is a contracts read, gated on `view_jobs`.
+// A holder / admin passes the gate; with no contract seeded the handler then
+// returns 404 — proof the wrapper let it run.
+describe("GET /api/contracts/[id]/pdf — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseFake().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await GET(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await GET(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding view_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const res = await GET(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await GET(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/contracts/[id]/pdf/route.ts
+++ b/src/app/api/contracts/[id]/pdf/route.ts
@@ -7,9 +7,10 @@ import type { Contract } from "@/lib/contracts/types";
 // Pass ?inline=1 to render in-browser — used by the View button so the
 // user can scroll through the signed contract without saving it first.
 //
-// Logged-in only; the Service client downloads the signed PDF blob.
+// Requires `view_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client downloads the signed PDF blob.
 export const GET = withRequestContext(
-  { serviceClient: true },
+  { permission: "view_jobs", serviceClient: true },
   async (req, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const inline = new URL(req.url).searchParams.get("inline") === "1";
     const { id } = await params;

--- a/src/app/api/contracts/[id]/remind/route.test.ts
+++ b/src/app/api/contracts/[id]/remind/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/c-1/remind", { method: "POST" });
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// Service fake seeded with a contract-email-settings row that has no
+// send-from configured, so a caller past the gate gets a deterministic 400.
+function seededService() {
+  const service = makeSupabaseFake();
+  service.seed("contract_email_settings", [
+    { id: "s-1", send_from_email: null, send_from_name: null },
+  ]);
+  return service;
+}
+
+// #106 — sending a manual reminder is a contracts mutation, gated on
+// `edit_jobs`. A holder / admin passes the gate; the handler then returns
+// 400 (no send-from configured) — proof the wrapper let it run.
+describe("POST /api/contracts/[id]/remind — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      seededService().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding edit_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/[id]/remind/route.ts
+++ b/src/app/api/contracts/[id]/remind/route.ts
@@ -10,10 +10,10 @@ import type { Contract, ContractSigner, ContractEmailSettings } from "@/lib/cont
 // NOT shift contracts.next_reminder_at — the auto cron continues on its
 // schedule. Reuses the configured reminder subject/body templates.
 //
-// Logged-in only; the Service client loads settings/contract/signers and
-// sends the reminder.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client loads settings/contract/signers and sends the reminder.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const supabase = ctx.serviceClient!;

--- a/src/app/api/contracts/[id]/resend/route.test.ts
+++ b/src/app/api/contracts/[id]/resend/route.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/c-1/resend", { method: "POST" });
+}
+
+function paramsFor(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+// Service fake seeded with a contract-email-settings row that has no
+// send-from configured, so a caller past the gate gets a deterministic 400.
+function seededService() {
+  const service = makeSupabaseFake();
+  service.seed("contract_email_settings", [
+    { id: "s-1", send_from_email: null, send_from_name: null },
+  ]);
+  return service;
+}
+
+// #106 — resending a signing request is a contracts mutation, gated on
+// `edit_jobs`. A holder / admin passes the gate; the handler then returns
+// 400 (no send-from configured) — proof the wrapper let it run.
+describe("POST /api/contracts/[id]/resend — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      seededService().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding edit_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/[id]/resend/route.ts
+++ b/src/app/api/contracts/[id]/resend/route.ts
@@ -17,9 +17,10 @@ function appUrl(): string {
 // email. Used for 'expired' contracts (the Resend row action) and the
 // Remind action on active ones if the user wants to push a new link.
 //
-// Logged-in only; the Service client regenerates the token and re-sends.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client regenerates the token and re-sends.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = (await request.json().catch(() => ({}))) as { expiryDays?: number };

--- a/src/app/api/contracts/[id]/restore/route.test.ts
+++ b/src/app/api/contracts/[id]/restore/route.test.ts
@@ -51,7 +51,7 @@ describe("POST /api/contracts/[id]/restore — load contract", () => {
 
   it("returns 404 when the contract is missing", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     vi.mocked(createServiceClient).mockReturnValue(service.client as never);
@@ -71,7 +71,7 @@ describe("POST /api/contracts/[id]/restore — status guard", () => {
     "returns 409 when contract status is %s (only voided can be restored)",
     async (status) => {
       vi.mocked(createServerSupabaseClient).mockResolvedValue(
-        makeAuthedFake() as never,
+        makeAuthedFake("user-1", { role: "admin" }) as never,
       );
       const service = makeSupabaseFake();
       service.seed("contracts", [
@@ -100,7 +100,7 @@ describe("POST /api/contracts/[id]/restore — happy path", () => {
 
   it("restores a voided contract via restore_contract RPC and leaves storage untouched", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake("user-7") as never,
+      makeAuthedFake("user-7", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -136,7 +136,7 @@ describe("POST /api/contracts/[id]/restore — happy path", () => {
 
   it("returns 500 when restore_contract RPC fails", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -154,5 +154,58 @@ describe("POST /api/contracts/[id]/restore — happy path", () => {
 
     const res = await POST(makeRequest(), paramsFor("c-1"));
     expect(res.status).toBe(500);
+  });
+});
+
+// #106 — restoring a contract requires `edit_jobs` (contracts are gated on
+// the job permissions). Every test above authenticates as an admin, who
+// auto-passes the rule.
+describe("POST /api/contracts/[id]/restore — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      {
+        id: "c-1",
+        job_id: "job-1",
+        status: "voided",
+        signed_at: null,
+        first_viewed_at: null,
+        sent_at: "2026-05-13T10:00:00Z",
+      },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("allows a member holding edit_jobs to restore", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      {
+        id: "c-1",
+        job_id: "job-1",
+        status: "voided",
+        signed_at: null,
+        first_viewed_at: null,
+        sent_at: "2026-05-13T10:00:00Z",
+      },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(200);
+    expect(service.state.rpcCalls[0]).toMatchObject({ name: "restore_contract" });
   });
 });

--- a/src/app/api/contracts/[id]/restore/route.ts
+++ b/src/app/api/contracts/[id]/restore/route.ts
@@ -9,9 +9,10 @@ import type { Contract } from "@/lib/contracts/types";
 // sent_at → 'sent', else 'draft'). No payment-block check — restore is the
 // opposite of destruction. No confirmation dialog upstream.
 //
-// Logged-in only; the Service client runs the restore RPC.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client runs the restore RPC.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const supabase = ctx.serviceClient!;

--- a/src/app/api/contracts/[id]/route.test.ts
+++ b/src/app/api/contracts/[id]/route.test.ts
@@ -47,7 +47,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("returns 404 when the contract is missing", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     vi.mocked(createServiceClient).mockReturnValue(service.client as never);
@@ -61,7 +61,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
     "returns 409 when contract status is %s (alive contracts must be voided first)",
     async (status) => {
       vi.mocked(createServerSupabaseClient).mockResolvedValue(
-        makeAuthedFake() as never,
+        makeAuthedFake("user-1", { role: "admin" }) as never,
       );
       const service = makeSupabaseFake();
       service.seed("contracts", [
@@ -82,7 +82,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("deletes a draft via delete_contract RPC without running the payment-block check", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -116,7 +116,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("permanently deletes a voided contract: removes canonical + sidecar from storage, runs payment-block, then calls delete_contract RPC", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -158,7 +158,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("returns 409 when voided contract's job has recorded payments (payment-block fires)", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -181,7 +181,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("permanently deletes a voided-without-signed-PDF contract without touching storage", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -205,7 +205,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("returns 500 when storage.remove fails on a voided contract and does NOT call the RPC (storage-first order)", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -226,7 +226,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("returns 500 when delete_contract RPC fails", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -246,7 +246,7 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
 
   it("returns 500 when delete_contract RPC fails on the voided branch (storage already removed)", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -265,5 +265,44 @@ describe("DELETE /api/contracts/[id] — draft + voided branches", () => {
     // Storage was removed first; blob is orphaned but the DB row survives
     // for a manual retry.
     expect(service.state.storageRemovals).toHaveLength(1);
+  });
+});
+
+// #106 — deleting a contract requires `edit_jobs` (contracts are gated on
+// the job permissions). Every test above authenticates as an admin, who
+// auto-passes the rule.
+describe("DELETE /api/contracts/[id] — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      { id: "c-1", job_id: "job-1", status: "draft", signed_pdf_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("allows a member holding edit_jobs to delete", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      { id: "c-1", job_id: "job-1", status: "draft", signed_pdf_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await DELETE(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(200);
+    expect(service.state.rpcCalls[0]).toMatchObject({ name: "delete_contract" });
   });
 });

--- a/src/app/api/contracts/[id]/route.ts
+++ b/src/app/api/contracts/[id]/route.ts
@@ -16,9 +16,10 @@ import type { Contract } from "@/lib/contracts/types";
 //     storage cleanup of canonical + .voided.pdf sidecar, then RPC.
 // Alive statuses (sent/viewed/signed/expired) must be voided first.
 //
-// Logged-in only; the Service client runs the load, storage cleanup, and RPC.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client runs the load, storage cleanup, and RPC.
 export const DELETE = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const supabase = ctx.serviceClient!;

--- a/src/app/api/contracts/[id]/void/route.test.ts
+++ b/src/app/api/contracts/[id]/void/route.test.ts
@@ -53,7 +53,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("returns 404 when the contract is missing", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     vi.mocked(createServiceClient).mockReturnValue(service.client as never);
@@ -64,7 +64,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("returns 409 when the contract is already voided", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -83,7 +83,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("returns 409 when the job has payments on record", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -105,7 +105,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("voiding a draft contract does not touch storage", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -136,7 +136,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("voiding a sent contract does not touch storage", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     service.seed("contracts", [
@@ -161,7 +161,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("voiding a signed contract uploads stamped bytes to the sidecar key and leaves the canonical key untouched", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     const canonicalPath = "org-1/contracts/c-1-signed.pdf";
@@ -210,7 +210,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("voids a signed contract with a missing canonical PDF: soft-skips sidecar, calls RPC, does NOT 500", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     const canonicalPath = "orgs/o/contracts/c-1/signed.pdf";
@@ -244,7 +244,7 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
 
   it("returns 500 when the sidecar upload fails", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
-      makeAuthedFake() as never,
+      makeAuthedFake("user-1", { role: "admin" }) as never,
     );
     const service = makeSupabaseFake();
     const canonicalPath = "org-1/contracts/c-1-signed.pdf";
@@ -269,5 +269,45 @@ describe("POST /api/contracts/[id]/void — sidecar watermark", () => {
     expect(res.status).toBe(500);
     // RPC must not have been called when the sidecar write failed.
     expect(service.state.rpcCalls).toHaveLength(0);
+  });
+});
+
+// #106 — voiding a contract requires `edit_jobs` (contracts are gated on
+// the job permissions). Admin coverage is the rest of this file: every
+// test above authenticates as an admin, who auto-passes the rule.
+describe("POST /api/contracts/[id]/void — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      { id: "c-1", job_id: "job-1", status: "draft", signed_pdf_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(403);
+    // The wrapper rejected before the handler ran — no RPC.
+    expect(service.state.rpcCalls).toHaveLength(0);
+  });
+
+  it("allows a member holding edit_jobs to void", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const service = makeSupabaseFake();
+    service.seed("contracts", [
+      { id: "c-1", job_id: "job-1", status: "draft", signed_pdf_path: null },
+    ]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+
+    const res = await POST(makeRequest(), paramsFor("c-1"));
+    expect(res.status).toBe(200);
+    expect(service.state.rpcCalls[0]).toMatchObject({ name: "void_contract" });
   });
 });

--- a/src/app/api/contracts/[id]/void/route.ts
+++ b/src/app/api/contracts/[id]/void/route.ts
@@ -22,9 +22,10 @@ import type { Contract } from "@/lib/contracts/types";
 //     restore-after-void of a signed contract recoverable — the canonical
 //     key is always the clean original.
 //
-// Logged-in only; the Service client runs the load, sidecar write, and RPC.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client runs the load, sidecar write, and RPC.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
     const body = (await request.json().catch(() => ({}))) as { reason?: string };

--- a/src/app/api/contracts/by-job/[jobId]/route.test.ts
+++ b/src/app/api/contracts/by-job/[jobId]/route.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/by-job/job-1");
+}
+
+const paramsFor = { params: Promise.resolve({ jobId: "job-1" }) };
+
+// Wires the User client the wrapper authenticates against. `jobOrgId` sets
+// which Organization the seeded `job-1` belongs to (the #97 guard resolves
+// the contract list's tenant scope through it); omit it for "job missing".
+function mockCaller(opts: {
+  user: { id: string } | null;
+  role?: string;
+  grants?: string[];
+  jobOrgId?: string;
+}) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: opts.user,
+      tables: opts.user
+        ? memberTables({
+            userId: opts.user.id,
+            role: opts.role ?? "member",
+            grants: opts.grants ?? [],
+            extraTables: {
+              jobs: opts.jobOrgId
+                ? [{ id: "job-1", organization_id: opts.jobOrgId }]
+                : [],
+              contracts: [
+                {
+                  id: "c-1",
+                  job_id: "job-1",
+                  status: "sent",
+                  created_at: "2026-05-13T10:00:00Z",
+                },
+              ],
+            },
+          })
+        : undefined,
+    }) as never,
+  );
+}
+
+// #106 — by-job is a contracts read, gated on `view_jobs`, and the
+// caller-supplied `jobId` is additionally run through the #97
+// Active-Organization scoping guard.
+describe("GET /api/contracts/by-job/[jobId] — permission gate + org scope (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    mockCaller({ user: { id: "u1" }, grants: [], jobOrgId: "org-1" });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("lists the job's contracts for a member holding view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"], jobOrgId: "org-1" });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toHaveLength(1);
+  });
+
+  it("lists the job's contracts for an admin", async () => {
+    mockCaller({ user: { id: "u1" }, role: "admin", jobOrgId: "org-1" });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toHaveLength(1);
+  });
+
+  it("returns 404 when the job belongs to another Organization", async () => {
+    mockCaller({
+      user: { id: "u1" },
+      grants: ["view_jobs"],
+      jobOrgId: "org-OTHER",
+    });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the job does not exist", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await GET(makeRequest(), paramsFor);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/contracts/by-job/[jobId]/route.ts
+++ b/src/app/api/contracts/by-job/[jobId]/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { belongsToActiveOrganization } from "@/lib/request-context/belongs-to-active-organization";
 import type { ContractListItem } from "@/lib/contracts/types";
 
 interface DbRow {
@@ -31,15 +32,21 @@ interface DbRow {
 // reminder counters (for the "reminders sent: N" indicator on the job
 // header).
 //
-// Previously this route ran no auth check at all — it relied on the User
-// client's row-level security to scope reads. The `{}` rule makes it
-// logged-in-only, which matches today (an unauthenticated User client
-// already returns nothing). Noted for the #78 ungated-endpoint list.
+// Requires `view_jobs` (#106) — a contract is a job sub-resource, so the
+// contracts area is gated on the job permissions. The `jobId` is caller-
+// supplied, so the route also runs it through the #97 Active-Organization
+// scoping guard before the read: a job in another Organization is
+// indistinguishable from a missing one (both 404).
 export const GET = withRequestContext(
-  {},
+  { permission: "view_jobs" },
   async (_req, ctx, { params }: { params: Promise<{ jobId: string }> }) => {
     const { jobId } = await params;
     const supabase = ctx.supabase;
+
+    if (!(await belongsToActiveOrganization(supabase, { jobId }, ctx.orgId))) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+
     const { data, error } = await supabase
       .from("contracts")
       .select(

--- a/src/app/api/contracts/in-person/route.test.ts
+++ b/src/app/api/contracts/in-person/route.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/in-person", { method: "POST" });
+}
+
+const routeCtx = { params: Promise.resolve({}) };
+
+// #106 — recording an in-person signature is a contracts mutation, gated on
+// `edit_jobs`. A holder / admin passes the gate; with an empty body the
+// handler then returns 400 — proof the wrapper let it run.
+describe("POST /api/contracts/in-person — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseFake().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding edit_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/in-person/route.ts
+++ b/src/app/api/contracts/in-person/route.ts
@@ -10,9 +10,10 @@ import type { Contract, ContractSigner, ContractTemplate } from "@/lib/contracts
 // (admin-on-iPad flow); the request body provides contract_id + signer_id
 // so a single user account can drive multiple signers in turn.
 //
-// Logged-in only; the Service client drives the stamping pipeline.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client drives the stamping pipeline.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (request, ctx) => {
     const supabase = ctx.serviceClient!;
 

--- a/src/app/api/contracts/in-person/start/route.test.ts
+++ b/src/app/api/contracts/in-person/start/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/in-person/start", {
+    method: "POST",
+  });
+}
+
+const routeCtx = { params: Promise.resolve({}) };
+
+// #106 — starting an in-person signing session is a contracts mutation,
+// gated on `edit_jobs`. A holder / admin passes the gate; with an empty body
+// the handler then returns 400 — proof the wrapper let it run.
+describe("POST /api/contracts/in-person/start — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseFake().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding edit_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/in-person/start/route.ts
+++ b/src/app/api/contracts/in-person/start/route.ts
@@ -24,9 +24,10 @@ interface StartBody {
 // No link_token, no expiry, no email. Caller redirects to the internal
 // /contracts/[id]/sign-in-person route once this returns.
 //
-// Logged-in only; the Service client creates the draft contract.
+// Requires `edit_jobs` (#106) — contracts are gated on the job permissions.
+// The Service client creates the draft contract.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (request, ctx) => {
     const body = (await request.json().catch(() => null)) as StartBody | null;
     if (!body?.jobId || !body?.templateId || !Array.isArray(body?.signers) || !body.signers.length) {

--- a/src/app/api/contracts/preflight/route.test.ts
+++ b/src/app/api/contracts/preflight/route.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/preflight");
+}
+
+// preflight is non-dynamic; the wrapper still passes a route context.
+const routeCtx = { params: Promise.resolve({}) };
+
+// #106 — preflight is a contracts read, gated on `view_jobs` (contracts are
+// job sub-resources). A holder / admin passes the gate and the handler then
+// returns 400 for the missing query params — proof the wrapper let it run.
+describe("GET /api/contracts/preflight — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseFake().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await GET(makeRequest(), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await GET(makeRequest(), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding view_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const res = await GET(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await GET(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/preflight/route.ts
+++ b/src/app/api/contracts/preflight/route.ts
@@ -10,10 +10,11 @@ import type { OverlayField } from "@/lib/contracts/types";
 // merge field resolves to null for the target job. Lets the send modal warn
 // the sender before they click send (per #70 AC).
 //
-// Logged-in only; the Service client reads the template + merge values,
-// scoped to the caller's Active Organization.
+// Requires `view_jobs` (#106) — a contract is a job sub-resource, so the
+// contracts area is gated on the job permissions. The Service client reads
+// the template + merge values, scoped to the caller's Active Organization.
 export const GET = withRequestContext(
-  { serviceClient: true },
+  { permission: "view_jobs", serviceClient: true },
   async (request, ctx) => {
     const url = new URL(request.url);
     const jobId = url.searchParams.get("jobId");

--- a/src/app/api/contracts/send/route.test.ts
+++ b/src/app/api/contracts/send/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  makeUnauthedFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+function makeRequest(): Request {
+  return new Request("http://test/api/contracts/send", { method: "POST" });
+}
+
+const routeCtx = { params: Promise.resolve({}) };
+
+// #106 — sending a contract is a job-edit-class mutation, gated on
+// `edit_jobs`. A holder / admin passes the gate; with an empty body the
+// handler then returns 400 — proof the wrapper let it run.
+describe("POST /api/contracts/send — permission gate (#106)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(createServiceClient).mockReturnValue(
+      makeSupabaseFake().client as never,
+    );
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeUnauthedFake() as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller has no job permissions", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: [] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["view_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("a member holding edit_jobs passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "member", grants: ["edit_jobs"] }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+
+  it("an admin passes the gate", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const res = await POST(makeRequest(), routeCtx);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/contracts/send/route.ts
+++ b/src/app/api/contracts/send/route.ts
@@ -40,10 +40,12 @@ function appUrl(): string {
 //   - Stamps the initial next_reminder_at so the hourly cron can pick
 //     the contract up once the first offset elapses.
 //
-// Logged-in only; the Service client creates the draft + sends the email,
-// scoped to the caller's Active Organization.
+// Requires `edit_jobs` (#106) — sending a contract is a job-edit-class
+// mutation; the contracts area is gated on the job permissions. The Service
+// client creates the draft + sends the email, scoped to the caller's Active
+// Organization.
 export const POST = withRequestContext(
-  { serviceClient: true },
+  { permission: "edit_jobs", serviceClient: true },
   async (request, ctx) => {
     const body = (await request.json().catch(() => null)) as SendBody | null;
     if (!body?.jobId || !body?.templateId || !Array.isArray(body?.signers) || !body.signers.length) {

--- a/src/lib/contracts/__test-utils__/supabase-fake.ts
+++ b/src/lib/contracts/__test-utils__/supabase-fake.ts
@@ -75,6 +75,16 @@ export function makeSupabaseFake(): SupabaseFake {
         filters[col] = vals;
         return builder;
       },
+      // Ordering / row-cap are no-ops on the fake — the seeded row set is
+      // already small and deterministic. Present so routes that chain
+      // `.limit(1)` / `.order(...)` before `.maybeSingle()` / await don't
+      // hit an undefined method.
+      limit() {
+        return builder;
+      },
+      order() {
+        return builder;
+      },
       async maybeSingle() {
         const err = state.errors[`${table}.select`];
         if (err) return { data: null, error: err };
@@ -239,13 +249,25 @@ export function makeAuthedFake(
     user_organizations: membership,
     user_organization_permissions: grants,
   };
+  // A minimal JWT whose payload segment carries the active-organization
+  // claim `getActiveOrganizationId` decodes. Header and signature are
+  // placeholders the decoder never inspects — only the middle segment is
+  // real. Without this the org claim resolves null and a `permission` rule
+  // can never match the seeded membership (which is org-scoped).
+  const accessToken = `header.${Buffer.from(
+    JSON.stringify({ active_organization_id: orgId }),
+  ).toString("base64url")}.sig`;
+
   return {
     auth: {
       async getUser() {
         return { data: { user: { id: userId } }, error: null };
       },
       async getSession() {
-        return { data: { session: null }, error: null };
+        return {
+          data: { session: { access_token: accessToken } },
+          error: null,
+        };
       },
     },
     from(table: string) {


### PR DESCRIPTION
## Summary

PRD [#95](https://github.com/ericdaniels22/Nookleus/issues/95) slice [#106](https://github.com/ericdaniels22/Nookleus/issues/106). Tightens the 11 `contracts` endpoints the #80 Request-Context conversion left logged-in-only.

**HITL decision recorded:** contracts reuse the **job permissions** rather than a new `manage_contracts` key. A contract is a job sub-resource (carries `job_id`, surfaced on the job detail Overview tab), and the prior slice #103 gated the other job sub-resources — files, photos — the same way. No new key, no `settings/users` seed / role-defaults migration.

## Gating (read-vs-write split)

- **`view_jobs`** — `GET preflight`, `GET [id]/pdf`, `GET by-job/[jobId]`
- **`edit_jobs`** — `POST send`, `in-person`, `in-person/start`, `[id]/void`, `DELETE [id]`, `[id]/restore`, `[id]/resend`, `[id]/remind`

Admins auto-pass; a member holding neither key gets a 403 before the handler runs.

## Org-scoping

`GET /api/contracts/by-job/[jobId]` — flagged in #80 as having had **no prior auth at all** — additionally runs the caller-supplied `jobId` through the #97 `belongsToActiveOrganization` guard before the read: a job in another Organization 404s, indistinguishable from missing.

## Left unchanged

`GET /api/contracts/reminders` is the `CRON_SECRET`-authenticated hourly cron, not wrapped with `withRequestContext`, never in the ungated set — out of scope (same class as `qb/sync-scheduled`).

## Tests

- 3 existing route tests (`void` / `restore` / `[id]` DELETE) re-authenticate as admin (auto-passes the rule) + new 403/holder gate tests
- 8 new `route.test.ts` files — 401 / 403 / holder / admin throughout; `by-job` adds own-org / other-org / missing-job org-scoping
- `supabase-fake` test util: `getSession` embeds the active-org claim so `permission` rules resolve against the seeded membership; `.limit()` / `.order()` builder no-ops added
- Decision recorded in `docs/request-context-ungated-endpoints.md` (`## #106`)

## Verification

- Typecheck clean on the changed surface (only the pre-existing unrelated `sync-folder-incremental.test.ts` `TS2322` remains)
- Lint: 0 errors on changed files
- Full suite: **651 green / 109 files**

Closes #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)