### PR TITLE
notifications: derive target user from ctx.userId (#119)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -411,6 +411,10 @@ missing rule — the fix is to derive the target from `ctx.userId` rather
 than request input. **Called out for follow-up;** the logged-in gate
 itself stays.
 
+> **#119 — fixed.** Both handlers now derive the target user from
+> `ctx.userId`; the logged-in gate is unchanged. See
+> [`## #119`](#119--notifications-target-user-derived-from-ctxuserid).
+
 **Jarvis chat — ⚠️ flagged** ([#120](#)). `POST /api/jarvis/chat`.
 Jarvis is a company-wide assistant — every member, crew included, is
 expected to use it, and no key carves it by role — so logged-in-only is
@@ -593,3 +597,29 @@ policy); a member holding neither key now gets a `403`.
   (per #96), and the email vocabulary has exactly two keys. `view_email`
   covers reading the account list; everything that changes account state is
   a write.
+
+## #119 — notifications: target user derived from `ctx.userId`
+
+PRD #95 bug [#119](#) — the IDOR gap the #99 triage flagged for the
+`notifications` endpoints above. The gate is **unchanged**: notifications
+are per-user and not role-gated, so logged-in-only (`{ serviceClient:
+true }`) is the right gate *class*. The fix is a data-scoping one — both
+handlers now derive the target user from the authenticated caller
+(`ctx.userId`, resolved by `withRequestContext`) instead of trusting
+client input:
+
+- `GET /api/notifications` — the `userId` query param is dropped; both
+  the list read and the unread-count read filter `.eq("user_id",
+  ctx.userId)`. A caller can no longer read another user's notifications
+  by changing the param. (`limit` is still honoured.)
+- `PATCH { mark_all_read: true }` — marks `.eq("user_id", ctx.userId)`,
+  not `body.user_id` (which is dropped). The mark-all is always the
+  caller's own folder.
+- `PATCH { id }` — the update is scoped `.eq("id", id).eq("user_id",
+  ctx.userId)` and reads the affected row back; a notification that does
+  not belong to the caller (or does not exist) matches nothing and
+  returns **404** — indistinguishable from a missing one, consistent
+  with the #98 / #101 cross-org 404 convention.
+
+The `notification-bell` consumer was trimmed to stop sending the now-
+ignored `userId` / `user_id` values. No permission key was introduced.

--- a/src/app/api/notifications/__test-utils__/notifications-service-fake.ts
+++ b/src/app/api/notifications/__test-utils__/notifications-service-fake.ts
@@ -1,0 +1,59 @@
+// Behavioral Service-client fake for the notifications route tests (#119).
+//
+// The notifications route runs through `withRequestContext({ serviceClient:
+// true })`, so the route bodies read and write through the Service client.
+// Unlike the shared no-op `fakeServiceClient`, this fake actually applies
+// `update()`s to the seeded rows — the #119 fix is about *which* rows a
+// caller's read/write reaches, so a test must be able to observe that a
+// mutation hit only the caller's own notifications and never another
+// user's. The seeded array is held by reference; inspect it after the call.
+//
+// Covers only the surface the two route bodies touch: a chainable
+// select / eq / order / limit / update builder. `eq` narrows rows; an
+// awaited builder resolves `{ data, error, count }`, applying any recorded
+// `update` payload to the narrowed rows first.
+
+type Row = Record<string, unknown>;
+
+function builder(rows: Row[]): Record<string, unknown> {
+  let filtered = [...rows];
+  let updatePayload: Row | null = null;
+  const b: Record<string, unknown> = {};
+  for (const m of ["select", "order", "limit"]) {
+    b[m] = () => b;
+  }
+  b.update = (payload: Row) => {
+    updatePayload = payload;
+    return b;
+  };
+  b.eq = (col: string, val: unknown) => {
+    filtered = filtered.filter((r) => r[col] === val);
+    return b;
+  };
+  b.then = (
+    resolve: (v: { data: Row[]; error: null; count: number }) => unknown,
+  ) => {
+    if (updatePayload) {
+      for (const r of filtered) Object.assign(r, updatePayload);
+    }
+    return resolve({ data: filtered, error: null, count: filtered.length });
+  };
+  return b;
+}
+
+// A fake Service client for the notifications route bodies. `notifications`
+// seeds the rows the route reads and writes; the array is held by
+// reference so a test can assert which rows were (and were not) marked
+// read after a PATCH.
+export function fakeNotificationsServiceClient(
+  opts: { notifications?: Row[] } = {},
+) {
+  const tables: Record<string, Row[]> = {
+    notifications: opts.notifications ?? [],
+  };
+  return {
+    from(table: string) {
+      return builder(tables[table] ?? []);
+    },
+  };
+}

--- a/src/app/api/notifications/route.test.ts
+++ b/src/app/api/notifications/route.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { fakeUserClient } from "../__test-utils__/request-context-fakes";
+import { fakeNotificationsServiceClient } from "./__test-utils__/notifications-service-fake";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// #119 — the notifications route stays logged-in-only (notifications are
+// per-user, not role-gated), but both handlers must derive the target user
+// from the authenticated caller (`ctx.userId`), never from a client-supplied
+// `userId` query param / `user_id` body field.
+
+describe("GET /api/notifications — caller scoping (#119)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient() as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/notifications?userId=user-1"),
+      noParams,
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("ignores a userId param pointing at another user and returns only the caller's notifications", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" } }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient({
+        notifications: [
+          { id: "n1", user_id: "user-1", is_read: false },
+          { id: "n2", user_id: "user-2", is_read: false },
+        ],
+      }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/notifications?userId=user-2"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.notifications.map((n: { id: string }) => n.id)).toEqual(["n1"]);
+  });
+
+  it("counts only the caller's unread notifications", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" } }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient({
+        notifications: [
+          { id: "n1", user_id: "user-1", is_read: false },
+          { id: "n2", user_id: "user-1", is_read: false },
+          { id: "n3", user_id: "user-1", is_read: true },
+          { id: "n4", user_id: "user-2", is_read: false },
+        ],
+      }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/notifications?userId=user-2"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.unread_count).toBe(2);
+  });
+});
+
+function patch(body: unknown) {
+  return new Request("http://test/api/notifications", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/notifications — caller scoping (#119)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient() as never,
+    );
+
+    const res = await PATCH(patch({ mark_all_read: true }), noParams);
+
+    expect(res.status).toBe(401);
+  });
+
+  it("mark_all_read marks the caller's notifications, not the body user_id's", async () => {
+    const notifications = [
+      { id: "n1", user_id: "user-1", is_read: false },
+      { id: "n2", user_id: "user-2", is_read: false },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" } }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient({ notifications }) as never,
+    );
+
+    const res = await PATCH(
+      patch({ mark_all_read: true, user_id: "user-2" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    expect(notifications.find((n) => n.id === "n1")!.is_read).toBe(true);
+    expect(notifications.find((n) => n.id === "n2")!.is_read).toBe(false);
+  });
+
+  it("returns 404 and leaves the row unread for { id } of another user's notification", async () => {
+    const notifications = [{ id: "n1", user_id: "user-2", is_read: false }];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" } }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient({ notifications }) as never,
+    );
+
+    const res = await PATCH(patch({ id: "n1" }), noParams);
+
+    expect(res.status).toBe(404);
+    expect(notifications[0].is_read).toBe(false);
+  });
+
+  it("marks the caller's own notification read for { id }", async () => {
+    const notifications = [{ id: "n1", user_id: "user-1", is_read: false }];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "user-1" } }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeNotificationsServiceClient({ notifications }) as never,
+    );
+
+    const res = await PATCH(patch({ id: "n1" }), noParams);
+
+    expect(res.status).toBe(200);
+    expect(notifications[0].is_read).toBe(true);
+  });
+});

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -3,21 +3,14 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 export const runtime = "nodejs";
 
-// Previously ungated (read/written with the Service client, no auth
-// check); now logged-in only. The caller still passes the target user id
-// explicitly — behavior unchanged beyond the added 401. Recorded for the
-// #78 ungated-endpoint list.
+// Logged-in only — notifications are per-user, not role-gated. The target
+// user is the authenticated caller (`ctx.userId`): the route reads/writes
+// with the Service client (RLS bypassed), so it must never trust a
+// client-supplied user id. See #119.
 export const GET = withRequestContext(
   { serviceClient: true },
   async (request, ctx) => {
     const { searchParams } = new URL(request.url);
-    const userId = searchParams.get("userId");
-    if (!userId) {
-      return NextResponse.json(
-        { error: "userId query param required" },
-        { status: 400 },
-      );
-    }
     const limit = Math.min(Number(searchParams.get("limit") ?? "15"), 100);
 
     const supabase = ctx.serviceClient!;
@@ -27,7 +20,7 @@ export const GET = withRequestContext(
       .select(
         "id, user_id, type, title, body, is_read, job_id, href, priority, metadata, created_at",
       )
-      .eq("user_id", userId)
+      .eq("user_id", ctx.userId)
       .order("created_at", { ascending: false })
       .limit(limit);
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
@@ -35,7 +28,7 @@ export const GET = withRequestContext(
     const { count, error: cntErr } = await supabase
       .from("notifications")
       .select("id", { count: "exact", head: true })
-      .eq("user_id", userId)
+      .eq("user_id", ctx.userId)
       .eq("is_read", false);
     if (cntErr)
       return NextResponse.json({ error: cntErr.message }, { status: 500 });
@@ -51,7 +44,7 @@ export const PATCH = withRequestContext(
   { serviceClient: true },
   async (request, ctx) => {
     const body = (await request.json().catch(() => null)) as
-      | { id?: string; mark_all_read?: boolean; user_id?: string }
+      | { id?: string; mark_all_read?: boolean }
       | null;
     if (!body) {
       return NextResponse.json({ error: "invalid body" }, { status: 400 });
@@ -60,16 +53,10 @@ export const PATCH = withRequestContext(
     const supabase = ctx.serviceClient!;
 
     if (body.mark_all_read) {
-      if (!body.user_id) {
-        return NextResponse.json(
-          { error: "user_id required when mark_all_read is true" },
-          { status: 400 },
-        );
-      }
       const { error } = await supabase
         .from("notifications")
         .update({ is_read: true })
-        .eq("user_id", body.user_id)
+        .eq("user_id", ctx.userId)
         .eq("is_read", false);
       if (error)
         return NextResponse.json({ error: error.message }, { status: 500 });
@@ -77,17 +64,28 @@ export const PATCH = withRequestContext(
     }
 
     if (body.id) {
-      const { error } = await supabase
+      // Scope the update to the caller and read back the affected row: a
+      // notification that does not belong to the caller (or does not exist)
+      // matches nothing and is indistinguishable from a missing one — 404.
+      const { data, error } = await supabase
         .from("notifications")
         .update({ is_read: true })
-        .eq("id", body.id);
+        .eq("id", body.id)
+        .eq("user_id", ctx.userId)
+        .select("id");
       if (error)
         return NextResponse.json({ error: error.message }, { status: 500 });
+      if (!data || data.length === 0) {
+        return NextResponse.json(
+          { error: "notification not found" },
+          { status: 404 },
+        );
+      }
       return NextResponse.json({ ok: true });
     }
 
     return NextResponse.json(
-      { error: "body must include either { id } or { mark_all_read: true, user_id }" },
+      { error: "body must include either { id } or { mark_all_read: true }" },
       { status: 400 },
     );
   },

--- a/src/components/notification-bell.tsx
+++ b/src/components/notification-bell.tsx
@@ -63,7 +63,9 @@ export default function NotificationBell() {
 
   const fetchNotifications = useCallback(async () => {
     if (!user) return;
-    const res = await fetch(`/api/notifications?userId=${user.id}&limit=15`);
+    // The target user is the authenticated caller, derived server-side
+    // from the session (#119) — no user id is sent.
+    const res = await fetch(`/api/notifications?limit=15`);
     if (res.ok) {
       const data = await res.json();
       setNotifications(data.notifications || []);
@@ -106,7 +108,7 @@ export default function NotificationBell() {
     await fetch("/api/notifications", {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mark_all_read: true, user_id: user.id }),
+      body: JSON.stringify({ mark_all_read: true }),
     });
     setNotifications((prev) => prev.map((n) => ({ ...n, is_read: true })));
     setUnreadCount(0);


### PR DESCRIPTION
## Summary

Fixes the horizontal-privilege / IDOR gap in `/api/notifications` flagged by the #99 triage — a slice of PRD #95.

Both handlers ran with the Service client (RLS bypassed) but trusted a client-supplied identity. They now derive the target user from `ctx.userId` (resolved by `withRequestContext`):

- **`GET`** — drops the `userId` query param; the list read and unread-count read both filter `.eq("user_id", ctx.userId)`.
- **`PATCH { mark_all_read }`** — uses `ctx.userId`, not `body.user_id`.
- **`PATCH { id }`** — scopes the update `.eq("id", id).eq("user_id", ctx.userId)` and reads the row back; a notification the caller does not own (or that does not exist) returns **404**, consistent with the #98 / #101 cross-resource 404 convention.

The logged-in gate is **unchanged** — notifications are per-user, not role-gated. The `notification-bell` consumer is trimmed to stop sending the now-ignored `userId` / `user_id` values. No permission key introduced.

## Tests

New behavioral Service-client test fake (applies `update()`s to seeded rows) + 7 route tests, built TDD red→green: 401 unauth, GET cross-user param ignored, unread-count scoping, mark_all_read scoping, `{id}` own→200 / other-user→404.

## Verification

- Typecheck clean on the changed surface (only the pre-existing `sync-folder-incremental.test.ts` `TS2322` remains)
- Lint clean on all changed files (the one pre-existing `notification-bell.tsx` `set-state-in-effect` error is unchanged from base)
- Full suite **617 passed / 102 files**

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)