### PR TITLE
Org-scope Jarvis chat + tool data queries (#120)

### DIFF
--- a/docs/request-context-ungated-endpoints.md
+++ b/docs/request-context-ungated-endpoints.md
@@ -432,6 +432,19 @@ the tool executions in `@/lib/jarvis/tools` should be reviewed for the
 same gap. (`jarvis/field-ops`/`marketing`/`rnd` are the custom-auth
 department routes from the #85 special-case notes — out of #99 scope.)
 
+> **#120 — scoped.** Every Jarvis data query now carries an
+> `organization_id` filter. In `route.ts` the business-snapshot
+> `jobs`/`invoices`/`payments`/`job_activities` reads and the
+> job-context lookup are scoped to `ctx.orgId`. In `@/lib/jarvis/tools`,
+> `ToolExecutionContext` gained an `orgId` field (threaded from
+> `ctx.orgId`); `get_job_details`, `search_jobs`, and
+> `get_business_metrics` scope their reads, and `log_activity` /
+> `create_alert` scope their parent-job lookup so a `job_id` from
+> another tenant reads as "not found" and is never written across the
+> boundary. `consult_rnd`/`consult_marketing` query no org data. The
+> logged-in-only auth gate is unchanged. Covered by
+> `src/lib/jarvis/tools.test.ts`.
+
 **Summary.** marketing (6 endpoints) and knowledge search + reads (3):
 logged-in-only confirmed. Three follow-ups recorded for separate slices —
 knowledge `DELETE` ([#121](#)), notifications `GET`/`PATCH` ([#119](#)),

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -69,13 +69,15 @@ export const POST = withRequestContext(
     let businessSnapshot = null;
 
     if (context_type === "job" && job_id) {
-      // Fetch job context
+      // Fetch job context — scoped to the caller's org so a job_id from
+      // another tenant is not loadable (#120).
       const { data: job } = await supabase
         .from("jobs")
         .select(
           "*, contact:contacts!contact_id(full_name), job_adjusters(*, adjuster:contacts!contact_id(full_name, email))"
         )
         .eq("id", job_id)
+        .eq("organization_id", ctx.orgId)
         .single();
 
       if (job) {
@@ -98,12 +100,14 @@ export const POST = withRequestContext(
         };
       }
     } else {
-      // Fetch business snapshot for general context
+      // Fetch business snapshot for general context — every read scoped to
+      // the caller's org so the snapshot reflects one tenant only (#120).
       const activeStatuses = ["new", "in_progress", "pending_invoice"];
 
       const { data: allJobs } = await supabase
         .from("jobs")
-        .select("status");
+        .select("status")
+        .eq("organization_id", ctx.orgId);
 
       const jobsByStatus: Record<string, number> = {};
       let activeCount = 0;
@@ -116,6 +120,7 @@ export const POST = withRequestContext(
       const { data: activeJobIds } = await supabase
         .from("jobs")
         .select("id")
+        .eq("organization_id", ctx.orgId)
         .in("status", activeStatuses);
 
       let totalOutstanding = 0;
@@ -124,12 +129,14 @@ export const POST = withRequestContext(
         const { data: invoices } = await supabase
           .from("invoices")
           .select("total_amount")
+          .eq("organization_id", ctx.orgId)
           .in("job_id", ids)
           .in("status", ["draft", "sent", "partial"]);
 
         const { data: payments } = await supabase
           .from("payments")
           .select("amount")
+          .eq("organization_id", ctx.orgId)
           .in("job_id", ids)
           .eq("status", "received");
 
@@ -152,6 +159,7 @@ export const POST = withRequestContext(
       const { data: activeJobs } = await supabase
         .from("jobs")
         .select("id, updated_at")
+        .eq("organization_id", ctx.orgId)
         .in("status", activeStatuses);
 
       let overdueCount = 0;
@@ -159,6 +167,7 @@ export const POST = withRequestContext(
         const { data: recentActivities } = await supabase
           .from("job_activities")
           .select("job_id, created_at")
+          .eq("organization_id", ctx.orgId)
           .in(
             "job_id",
             activeJobs.map((j) => j.id)
@@ -350,6 +359,7 @@ export const POST = withRequestContext(
               userRole,
               jobId: job_id,
               supabase,
+              orgId: ctx.orgId,
             }
           );
           toolResults.push({

--- a/src/lib/jarvis/tools.test.ts
+++ b/src/lib/jarvis/tools.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+
+// `getActiveOrganizationId` decodes a JWT off a user-session client; the
+// Service client the tools run on has no session, so it is always mocked
+// here. `create_alert`'s only safe org source is the job it references.
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn().mockResolvedValue(null),
+}));
+
+import { executeJarvisTool, type ToolExecutionContext } from "./tools";
+import { fakeClient } from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+// Issue #120 — every Jarvis tool runs against the Service client, which
+// bypasses row-level security, so each data query must scope to the caller's
+// Active Organization itself. These tests seed two organizations and assert
+// no tool ever surfaces or writes to the foreign one.
+
+type Tables = Parameters<typeof fakeClient>[0]["tables"];
+
+function contextWith(tables: Tables): ToolExecutionContext {
+  return {
+    userId: "user-1",
+    userName: "Tester",
+    userRole: "admin",
+    orgId: "org-1",
+    supabase: fakeClient({ tables }) as never,
+  };
+}
+
+describe("executeJarvisTool — organization scoping (#120)", () => {
+  it("get_job_details does not return a job from another organization", async () => {
+    const ctx = contextWith({
+      jobs: [{ id: "job-x", organization_id: "other-org", job_number: "1001" }],
+    });
+
+    const raw = await executeJarvisTool(
+      "get_job_details",
+      { job_id: "job-x" },
+      ctx,
+    );
+
+    expect(JSON.parse(raw)).toEqual({ error: "Job not found" });
+  });
+
+  it("get_job_details returns a job that belongs to the caller's organization", async () => {
+    const ctx = contextWith({
+      jobs: [{ id: "job-1", organization_id: "org-1", job_number: "1001" }],
+    });
+
+    const raw = await executeJarvisTool(
+      "get_job_details",
+      { job_id: "job-1" },
+      ctx,
+    );
+
+    expect(JSON.parse(raw)).toMatchObject({ id: "job-1", job_number: "1001" });
+  });
+
+  it("search_jobs returns only jobs in the caller's organization", async () => {
+    const ctx = contextWith({
+      jobs: [
+        { id: "job-1", organization_id: "org-1", job_number: "1001" },
+        { id: "job-2", organization_id: "other-org", job_number: "2002" },
+      ],
+    });
+
+    const raw = await executeJarvisTool("search_jobs", {}, ctx);
+
+    const result = JSON.parse(raw) as { jobs: { id: string }[]; total: number };
+    expect(result.jobs.map((j) => j.id)).toEqual(["job-1"]);
+    expect(result.total).toBe(1);
+  });
+
+  it("get_business_metrics counts jobs and revenue from the caller's organization only", async () => {
+    const ctx = contextWith({
+      jobs: [
+        { id: "j1", organization_id: "org-1", status: "new" },
+        { id: "j2", organization_id: "other-org", status: "new" },
+        { id: "j3", organization_id: "other-org", status: "in_progress" },
+      ],
+      payments: [
+        {
+          job_id: "j1",
+          organization_id: "org-1",
+          amount: 100,
+          source: "insurance",
+          status: "received",
+        },
+        {
+          job_id: "j2",
+          organization_id: "other-org",
+          amount: 999,
+          source: "insurance",
+          status: "received",
+        },
+      ],
+    });
+
+    const raw = await executeJarvisTool("get_business_metrics", {}, ctx);
+
+    const result = JSON.parse(raw) as {
+      active_jobs: number;
+      revenue: { total: number };
+    };
+    expect(result.active_jobs).toBe(1);
+    expect(result.revenue.total).toBe(100);
+  });
+
+  it("log_activity refuses to write to a job in another organization", async () => {
+    const ctx = contextWith({
+      jobs: [{ id: "job-x", organization_id: "other-org" }],
+    });
+
+    const raw = await executeJarvisTool(
+      "log_activity",
+      { job_id: "job-x", title: "Crossed a tenant boundary" },
+      ctx,
+    );
+
+    expect(JSON.parse(raw)).toEqual({ error: "job not found" });
+  });
+
+  it("create_alert does not adopt the organization of a job in another tenant", async () => {
+    // jarvis_alerts is seeded so the unscoped code path would *succeed* —
+    // returning an alert_id for an alert written to other-org. Scoping must
+    // turn that into a refusal instead.
+    const ctx = contextWith({
+      jobs: [{ id: "job-x", organization_id: "other-org" }],
+      jarvis_alerts: [{ id: "alert-1" }],
+    });
+
+    const raw = await executeJarvisTool(
+      "create_alert",
+      {
+        job_id: "job-x",
+        message: "Follow up",
+        due_date: "2026-06-01",
+      },
+      ctx,
+    );
+
+    // The foreign job's org must not become the alert's org; with no other
+    // org source the alert is refused rather than written to other-org.
+    const result = JSON.parse(raw) as { alert_id?: string; error?: string };
+    expect(result.alert_id).toBeUndefined();
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/lib/jarvis/tools.ts
+++ b/src/lib/jarvis/tools.ts
@@ -10,6 +10,12 @@ export interface ToolExecutionContext {
   userRole: string;
   jobId?: string;
   supabase: SupabaseClient;
+  // The caller's Active Organization. Every tool runs against the Service
+  // client, which bypasses row-level security, so each data query must scope
+  // to this value itself (#120). Null when the caller has no membership in
+  // the Active Organization — scoping by null then matches nothing, which is
+  // the safe outcome.
+  orgId: string | null;
 }
 
 // --- Tool Definitions for Claude API ---
@@ -278,13 +284,15 @@ async function toolGetJobDetails(
 ) {
   const { supabase } = ctx;
 
-  // Job with contact joins
+  // Job with contact joins — scoped to the caller's org so a job_id from
+  // another tenant reads as "not found".
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
     .select(
       "*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))"
     )
     .eq("id", input.job_id)
+    .eq("organization_id", ctx.orgId)
     .single();
 
   if (jobErr || !job) return { error: "Job not found" };
@@ -404,6 +412,7 @@ async function toolSearchJobs(
   let query = supabase
     .from("jobs")
     .select("*, contact:contacts!contact_id(full_name)")
+    .eq("organization_id", ctx.orgId)
     .order("created_at", { ascending: false })
     .limit(limit);
 
@@ -474,10 +483,11 @@ async function toolGetBusinessMetrics(
 
   const startISO = startDate.toISOString();
 
-  // Jobs by status
+  // Jobs by status — scoped to the caller's org.
   const { data: allJobs } = await supabase
     .from("jobs")
-    .select("status, created_at");
+    .select("status, created_at")
+    .eq("organization_id", ctx.orgId);
 
   const jobsByStatus: Record<string, number> = {};
   let activeCount = 0;
@@ -494,6 +504,7 @@ async function toolGetBusinessMetrics(
   const { data: periodPayments } = await supabase
     .from("payments")
     .select("amount, source")
+    .eq("organization_id", ctx.orgId)
     .eq("status", "received")
     .gte("created_at", startISO);
 
@@ -512,6 +523,7 @@ async function toolGetBusinessMetrics(
   const { data: activeJobIds } = await supabase
     .from("jobs")
     .select("id")
+    .eq("organization_id", ctx.orgId)
     .in("status", activeStatuses);
 
   let outstandingBalance = 0;
@@ -520,6 +532,7 @@ async function toolGetBusinessMetrics(
     const { data: invoices } = await supabase
       .from("invoices")
       .select("total_amount")
+      .eq("organization_id", ctx.orgId)
       .in("job_id", ids)
       .in("status", ["draft", "sent", "partial"])
       .is("deleted_at", null);
@@ -527,6 +540,7 @@ async function toolGetBusinessMetrics(
     const { data: receivedPayments } = await supabase
       .from("payments")
       .select("amount")
+      .eq("organization_id", ctx.orgId)
       .in("job_id", ids)
       .eq("status", "received");
 
@@ -549,6 +563,7 @@ async function toolGetBusinessMetrics(
   const { data: activeJobs } = await supabase
     .from("jobs")
     .select("id, job_number, property_address, updated_at")
+    .eq("organization_id", ctx.orgId)
     .in("status", activeStatuses);
 
   let overdueCount = 0;
@@ -559,6 +574,7 @@ async function toolGetBusinessMetrics(
     const { data: recentActivities } = await supabase
       .from("job_activities")
       .select("job_id, created_at")
+      .eq("organization_id", ctx.orgId)
       .in(
         "job_id",
         activeJobs.map((j) => j.id)
@@ -617,10 +633,13 @@ async function toolLogActivity(
   const activityType = resolveActivityType(input.activity_type);
 
   // Derive org from the parent job so the activity lands in the right tenant.
+  // Scoped to the caller's org — a job_id from another tenant reads as
+  // "not found", so the activity can never be written across the boundary.
   const { data: job } = await supabase
     .from("jobs")
     .select("organization_id")
     .eq("id", input.job_id)
+    .eq("organization_id", ctx.orgId)
     .maybeSingle<{ organization_id: string }>();
   if (!job) return { error: "job not found" };
 
@@ -744,10 +763,13 @@ async function toolCreateAlert(
   // 18b contract.
   let orgId: string | null = null;
   if (input.job_id) {
+    // Scoped to the caller's org — a job_id from another tenant reads as
+    // "not found", so its organization can never become the alert's.
     const { data: job } = await supabase
       .from("jobs")
       .select("organization_id")
       .eq("id", input.job_id)
+      .eq("organization_id", ctx.orgId)
       .maybeSingle<{ organization_id: string }>();
     orgId = job?.organization_id ?? null;
   }


### PR DESCRIPTION
## Problem

`POST /api/jarvis/chat` and the executors in `@/lib/jarvis/tools` run on the
Service client, which bypasses row-level security, but queried org data with
**no `organization_id` filter**:

- The general-context business snapshot summed `jobs` / `invoices` /
  `payments` / `job_activities` **platform-wide** into the Jarvis system prompt.
- Job lookups (route job-context branch, `get_job_details`, and the
  parent-job lookups in `log_activity` / `create_alert`) loaded a job by
  `job_id` alone, regardless of tenant.

A caller could have Jarvis surface another org's aggregate financials and an
arbitrary job's details. Same class of cross-tenant scoping bug as #79.

## Fix

Scope every Jarvis data query to the caller's Active Organization:

- **`route.ts`** — business-snapshot reads and the job-context lookup take
  `.eq("organization_id", ctx.orgId)`; `orgId` is threaded into the tool
  execution context.
- **`tools.ts`** — `ToolExecutionContext` gains a required `orgId`.
  `get_job_details` / `search_jobs` / `get_business_metrics` scope their
  reads; `log_activity` / `create_alert` scope their parent-job lookup so a
  `job_id` from another tenant reads as "not found" and is never written
  across the boundary. `consult_rnd` / `consult_marketing` read no org data.

The logged-in-only auth gate is unchanged.

## Tests

New `src/lib/jarvis/tools.test.ts` — built TDD, one RED→GREEN cycle per
behavior, 6 cases covering org scoping for each data tool. Full suite
**664/664 green**; typecheck + lint clean on the changed surface.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)