### PR TITLE
jarvis: stamp organization_id on new conversations (#135)

### DIFF
--- a/src/components/jarvis/JarvisChat.test.tsx
+++ b/src/components/jarvis/JarvisChat.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// Issue #135 — when JarvisChat creates a row in `jarvis_conversations`
+// for the first message of a fresh chat, the insert payload must carry
+// `organization_id`. The `tenant_isolation_jarvis_conversations` RLS
+// policy's WITH CHECK clause rejects an org-less insert; without that
+// stamp on the payload, the typing indicator hangs forever in prod.
+
+const insertSpy = vi.fn();
+
+function makeToken(payload: object): string {
+  const encode = (obj: object) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.sig`;
+}
+
+const tokenWithOrg = makeToken({
+  app_metadata: { active_organization_id: "org-abc" },
+});
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    auth: {
+      getSession: vi
+        .fn()
+        .mockResolvedValue({ data: { session: { access_token: tokenWithOrg } } }),
+    },
+    from: (table: string) => {
+      if (table === "jarvis_conversations") {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertSpy(payload);
+            return {
+              select: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: { id: "conv-1", ...payload },
+                    error: null,
+                  }),
+              }),
+            };
+          },
+          update: () => ({
+            eq: () => Promise.resolve({ data: null, error: null }),
+          }),
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                eq: () => ({
+                  eq: () => ({
+                    order: () => ({
+                      limit: () => ({
+                        maybeSingle: () =>
+                          Promise.resolve({ data: null, error: null }),
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+              single: () => Promise.resolve({ data: null, error: null }),
+            }),
+          }),
+        };
+      }
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () => Promise.resolve({ data: null, error: null }),
+            maybeSingle: () => Promise.resolve({ data: null, error: null }),
+          }),
+        }),
+      };
+    },
+  }),
+}));
+
+// Stub out subcomponents whose internals aren't under test.
+vi.mock("./JarvisMessage", () => ({ default: () => null }));
+vi.mock("./JarvisQuickActions", () => ({ default: () => null }));
+vi.mock("./JarvisTypingIndicator", () => ({ default: () => null }));
+vi.mock("./JarvisWelcome", () => ({ default: () => null }));
+
+import JarvisChat from "./JarvisChat";
+
+describe("JarvisChat — new conversation insert (#135)", () => {
+  beforeEach(() => {
+    insertSpy.mockReset();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ content: "hello back" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  it("stamps organization_id from the session JWT on the new-conversation insert", async () => {
+    render(<JarvisChat contextType="general" />);
+
+    const textarea = await screen.findByPlaceholderText(/Message Jarvis/i);
+    fireEvent.change(textarea, { target: { value: "hello jarvis" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(insertSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(insertSpy.mock.calls[0][0]).toMatchObject({
+      organization_id: "org-abc",
+    });
+  });
+});

--- a/src/components/jarvis/JarvisChat.tsx
+++ b/src/components/jarvis/JarvisChat.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useRef, useCallback, type MutableRefObject } from "react";
 import { createClient } from "@/lib/supabase";
 import { useAuth } from "@/lib/auth-context";
+import { resolveActiveOrgId } from "@/lib/supabase/resolve-active-org-id";
 import type { JarvisConversation, JarvisMessage as JarvisMessageType } from "@/lib/types";
 import JarvisMessage from "./JarvisMessage";
 import JarvisInput from "./JarvisInput";
@@ -118,10 +119,19 @@ export default function JarvisChat({
       ? firstMessage.content.slice(0, 47) + "..."
       : firstMessage.content;
 
+    // The tenant_isolation_jarvis_conversations RLS policy rejects an insert
+    // without organization_id; resolve it from the session JWT claim.
+    const { data: { session } } = await supabase.auth.getSession();
+    const orgId = resolveActiveOrgId(session?.access_token);
+    if (!orgId) {
+      throw new Error("No active organization on session — cannot create conversation");
+    }
+
     const { data, error } = await supabase
       .from("jarvis_conversations")
       .insert({
         user_id: user?.id,
+        organization_id: orgId,
         job_id: jobId || null,
         context_type: contextType,
         title,
@@ -170,20 +180,20 @@ export default function JarvisChat({
     let conv = conversation;
     let isNewConversation = false;
 
-    // Create or update conversation optimistically
-    if (!conv) {
-      conv = await createConversation(userMsg);
-      setConversation(conv);
-      isNewConversation = true;
-      // Don't call onConversationCreated yet — it changes the key and remounts us
-    } else {
-      await saveMessages(conv.id, newMessages);
-    }
-
-    // Call the real Jarvis API
-    abortControllerRef.current = new AbortController();
-
+    // Top-level try/catch/finally — finally must always run so that a throw
+    // from createConversation / saveMessages / fetch can never strand the
+    // typing indicator or the neural-network brain state.
     try {
+      if (!conv) {
+        conv = await createConversation(userMsg);
+        setConversation(conv);
+        isNewConversation = true;
+        // Don't call onConversationCreated yet — it changes the key and remounts us
+      } else {
+        await saveMessages(conv.id, newMessages);
+      }
+
+      abortControllerRef.current = new AbortController();
       const response = await fetch("/api/jarvis/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -203,14 +213,10 @@ export default function JarvisChat({
         setBrainState({ mode: "thinking", activeAgent: data.routed_to });
       }
 
-      let assistantContent: string;
-      if (!response.ok) {
-        assistantContent =
-          data.content ||
+      const assistantContent: string = response.ok
+        ? data.content
+        : data.content ||
           "I hit a snag — give me a sec and try again. If this keeps happening, let Eric know.";
-      } else {
-        assistantContent = data.content;
-      }
 
       const assistantMsg: JarvisMessageType = {
         role: "assistant",

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
 import { createClient } from "@/lib/supabase";
+import { resolveActiveOrgId } from "@/lib/supabase/resolve-active-org-id";
 import type { User } from "@supabase/supabase-js";
 
 // role lives on user_organizations (scoped to a specific membership) since
@@ -33,21 +34,6 @@ interface AuthContextType {
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
-
-function readActiveOrgClaim(accessToken: string | undefined): string | null {
-  if (!accessToken) return null;
-  try {
-    const parts = accessToken.split(".");
-    if (parts.length !== 3) return null;
-    const payload = JSON.parse(
-      atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))
-    ) as { app_metadata?: Record<string, unknown> };
-    const claim = payload.app_metadata?.active_organization_id;
-    return typeof claim === "string" && claim.length > 0 ? claim : null;
-  } catch {
-    return null;
-  }
-}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -109,7 +95,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     if (user) {
       const supabase = createClient();
       const { data: { session } } = await supabase.auth.getSession();
-      const activeOrgId = readActiveOrgClaim(session?.access_token);
+      const activeOrgId = resolveActiveOrgId(session?.access_token);
       await loadProfile(user.id, activeOrgId);
     }
   }, [user, loadProfile]);
@@ -132,7 +118,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
       setUser(currentUser);
       if (currentUser) {
-        const activeOrgId = readActiveOrgClaim(accessToken);
+        const activeOrgId = resolveActiveOrgId(accessToken);
         loadProfile(currentUser.id, activeOrgId).finally(() => setLoading(false));
       } else {
         setLoading(false);
@@ -145,7 +131,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         const newUser = session?.user ?? null;
         setUser(newUser);
         if (newUser) {
-          const activeOrgId = readActiveOrgClaim(session?.access_token);
+          const activeOrgId = resolveActiveOrgId(session?.access_token);
           loadProfile(newUser.id, activeOrgId);
         } else {
           setProfile(null);

--- a/src/lib/supabase/resolve-active-org-id.test.ts
+++ b/src/lib/supabase/resolve-active-org-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { resolveActiveOrgId } from "./resolve-active-org-id";
+
+function makeToken(payload: object): string {
+  const encode = (obj: object) =>
+    Buffer.from(JSON.stringify(obj))
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.signature`;
+}
+
+describe("resolveActiveOrgId", () => {
+  it("returns the org id from app_metadata.active_organization_id on a valid token", () => {
+    const token = makeToken({
+      app_metadata: { active_organization_id: "org-123" },
+    });
+
+    expect(resolveActiveOrgId(token)).toBe("org-123");
+  });
+
+  it("returns null when the token has no active_organization_id claim", () => {
+    const token = makeToken({ app_metadata: { other: "value" } });
+
+    expect(resolveActiveOrgId(token)).toBeNull();
+  });
+
+  it("returns null when the token has no app_metadata at all", () => {
+    const token = makeToken({ sub: "user-1" });
+
+    expect(resolveActiveOrgId(token)).toBeNull();
+  });
+
+  it("returns null when the token is not a valid three-part JWT", () => {
+    expect(resolveActiveOrgId("not-a-jwt")).toBeNull();
+    expect(resolveActiveOrgId("only.two-parts")).toBeNull();
+  });
+
+  it("returns null when the payload segment is not valid base64-encoded JSON", () => {
+    expect(resolveActiveOrgId("header.@@@not-json@@@.signature")).toBeNull();
+  });
+
+  it("returns null for empty, undefined, or null input", () => {
+    expect(resolveActiveOrgId("")).toBeNull();
+    expect(resolveActiveOrgId(undefined)).toBeNull();
+    expect(resolveActiveOrgId(null)).toBeNull();
+  });
+});

--- a/src/lib/supabase/resolve-active-org-id.ts
+++ b/src/lib/supabase/resolve-active-org-id.ts
@@ -1,0 +1,32 @@
+// Decodes the `active_organization_id` claim from a Supabase access-token
+// JWT. Pure function — no I/O. Callers that need the token from a session
+// pass `session?.access_token` through directly.
+//
+// Returns `null` when the token is absent, malformed, or carries no claim.
+// Reads only `app_metadata.active_organization_id`, the claim injected by
+// `public.custom_access_token_hook` at token issuance (18b); other claim
+// locations are not honoured here so callers cannot accidentally trust a
+// client-controlled top-level `active_organization_id`.
+
+export function resolveActiveOrgId(
+  accessToken: string | undefined | null,
+): string | null {
+  if (!accessToken) return null;
+  try {
+    const parts = accessToken.split(".");
+    if (parts.length !== 3) return null;
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    const decoded =
+      typeof atob === "function"
+        ? atob(padded)
+        : Buffer.from(padded, "base64").toString("utf-8");
+    const payload = JSON.parse(decoded) as {
+      app_metadata?: Record<string, unknown>;
+    };
+    const claim = payload.app_metadata?.active_organization_id;
+    return typeof claim === "string" && claim.length > 0 ? claim : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #135 — the Jarvis chat bubble that hangs forever on the first message in a fresh chat.

Root cause: `JarvisChat.createConversation` inserts into `jarvis_conversations` without `organization_id`. The `tenant_isolation_jarvis_conversations` RLS policy's `WITH CHECK` clause requires the column be non-null and match the active org. `migration-build57` dropped the transitional allow-all policy in prod, so every new-conversation insert started getting rejected. The thrown error escaped `handleSend`'s fetch-only `try/catch`, so `setIsTyping(false)` never ran and the typing indicator hung forever.

Three changes:

- **`src/lib/supabase/resolve-active-org-id.ts` (new)** — pure JWT-claim decoder, lifted from the inline `readActiveOrgClaim` in `auth-context.tsx`. No I/O. Returns `null` for absent/malformed input.
- **`src/lib/auth-context.tsx`** — imports the new helper; the inline copy is removed. Behavior preserved.
- **`src/components/jarvis/JarvisChat.tsx`** — `createConversation` resolves the active org id from the session JWT and stamps it on the insert payload, refusing to insert when the claim is absent. `handleSend` body is wrapped in a top-level `try/catch/finally` so any future throw from `createConversation` / `saveMessages` / `fetch` clears `isTyping`, resets the brain state, and clears the abort controller.

## Test plan

- [x] 6 new unit tests on `resolveActiveOrgId` cover valid claim, missing claim, missing `app_metadata`, malformed JWT, malformed payload, and empty/undefined/null input
- [x] 1 new component test on `JarvisChat` asserts the first-message insert payload carries `organization_id` matching the JWT claim
- [x] Full vitest suite: **676 passed (114 files)**
- [x] Typecheck clean on changed surface (only the pre-existing `sync-folder-incremental.test.ts` `TS2322` remains, carried)
- [x] Lint clean on all changed files
- [ ] Manual smoke after deploy: open Jarvis from the dashboard and from a job page; send a fresh first message in each context; confirm a reply arrives and a new `jarvis_conversations` row exists with `organization_id` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)