### PR TITLE
ios: allow iPad to rotate to landscape (#144)

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -53,6 +53,9 @@
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>


### PR DESCRIPTION
## Summary

- Add `LandscapeLeft`, `LandscapeRight`, and `PortraitUpsideDown` to the iPad-specific `UISupportedInterfaceOrientations~ipad` array in `ios/App/App/Info.plist`. iPhone stays portrait-only.
- Closes #144. Part of parent PRD #143.
- `npx cap sync ios` was run as required by the acceptance criteria. Its only resulting diff was worktree-relative path rewrites in `ios/App/CapApp-SPM/Package.swift` — those were **not** committed because that file is cap-sync-managed and the worktree-relative paths would break Xcode Cloud per the `project_capacitor_plugins_npm_declaration` memory note. `Info.plist` is not an SPM input, so a sync from main post-merge is a no-op.

## Test plan

- [ ] Once merged, Xcode Cloud auto-delivers a TestFlight build (per `project_xcode_cloud_testflight_delivery` memory).
- [ ] Install the TestFlight build on a real iPad; rotate to landscape-left, landscape-right, portrait-upside-down. The app rotates with the device — no letterboxing.
- [ ] Install on a real iPhone; rotate to landscape. The app **stays** portrait — no rotation.
- [ ] Full acceptance walkthrough lives in HITL ticket #147 (blocked on #144, #145, #146).

🤖 Generated with [Claude Code](https://claude.com/claude-code)