### PR TITLE
invoices: wrap wide tables for horizontal scroll at iPad-landscape widths (#145)

### DIFF
--- a/src/components/invoices/invoice-list-client.tsx
+++ b/src/components/invoices/invoice-list-client.tsx
@@ -168,6 +168,7 @@ export default function InvoiceListClient() {
         </div>
       ) : filter === "trash" ? (
         <div className="bg-card border border-border rounded-xl overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
               <tr>
@@ -230,9 +231,11 @@ export default function InvoiceListClient() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       ) : (
         <div className="bg-card border border-border rounded-xl overflow-hidden">
+          <div className="overflow-x-auto">
           <table className="w-full text-sm">
             <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
               <tr>
@@ -323,6 +326,7 @@ export default function InvoiceListClient() {
               ))}
             </tbody>
           </table>
+          </div>
         </div>
       )}
 

--- a/src/components/invoices/invoice-read-only-client.tsx
+++ b/src/components/invoices/invoice-read-only-client.tsx
@@ -107,6 +107,7 @@ export default function InvoiceReadOnlyClient({
         {invoice.sections.map((s) => (
           <div key={s.id} className="rounded-lg border border-border p-4">
             <h3 className="font-semibold">{s.title}</h3>
+            <div className="overflow-x-auto">
             <table className="w-full mt-2 text-sm">
               <thead>
                 <tr className="text-left text-muted-foreground">
@@ -147,6 +148,7 @@ export default function InvoiceReadOnlyClient({
                 )}
               </tbody>
             </table>
+            </div>
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

- Wraps the invoice list (`invoice-list-client.tsx`, both the main 10-column table and the 7-column trash table) and the invoice read-only view (`invoice-read-only-client.tsx`, 5-column section tables) in `<div class="overflow-x-auto">` containers inside their existing rounded-card wrappers.
- The other tables in the transactional audit surface (estimate view's `ItemsTable`) were already correctly wrapped — no change needed.
- Closes #145. Part of parent PRD #143.

## Why

At the iPad-mini landscape content width (~752px after the 208px desktop sidebar and `p-8` content padding), these tables' columns add up to more than the available width. Because the cards already had `overflow-hidden` for border-radius clipping, the rightmost columns were clipped silently with no horizontal scroll affordance.

## What changed

For each affected table, added an inner `overflow-x-auto` div between the existing rounded card wrapper and the `<table>`:

- Outer card keeps `overflow-hidden` so the rounded corners still clip.
- Inner div allows the table to be wider than the card and exposes a horizontal scrollbar when it is.

Other audit findings (estimate-builder line-item rows, job-detail 3-column grid, metadata bar) were inspected and found to be safe at 752px — they use proper `min-w-0` flex children or have minimum-content totals well under the iPad-landscape budget.

## Test plan

- [ ] (HITL #147) On a real iPad in landscape, visit `/invoices`: the table fits the viewport, and if any row content is wider than the visible area, the table scrolls horizontally inside its card rather than clipping silently.
- [ ] (HITL #147) On a real iPad in landscape, view an invoice (`/invoices/[id]`): each section's items table behaves the same.
- [ ] Spot-check the same routes at 1024px and 1366px viewports in a desktop browser to confirm no regression on wider iPad-landscape sizes.

> ⚠️ Live browser verification at iPad-landscape widths was not run during authoring — these pages are auth-gated and the fixes are pure structural CSS pattern changes (the textbook table-overflow-wrapper). Final visual sign-off lives in HITL ticket #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)