### PR TITLE
settings/users: roll back login-email editor; keep org-membership guard (#137)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,11 +36,31 @@ Active Organization. Carried by a Request Context only when a route
 explicitly opts in.
 _Avoid_: admin client, master client
 
+**Email account**:
+A connection to an external mailbox (IMAP/SMTP) that Nookleus syncs and
+sends mail through. Belongs to exactly one Organization. Comes in two kinds
+— a Shared account or a Personal account.
+_Avoid_: mailbox, inbox connection
+
+**Shared email account**:
+An Email account the whole Organization works from — e.g. a `team@` address
+where job-related mail arrives. Every member with email access can read it
+and send from it; only admins change its settings or disconnect it.
+_Avoid_: company account, org inbox
+
+**Personal email account**:
+An Email account owned by one User and content-private to them — only the
+owner reads its mail. An admin can see the account is connected and can
+disconnect it (e.g. when the owner leaves the company) but cannot read its
+messages.
+_Avoid_: private inbox, user account
+
 ## Relationships
 
 - A **User** belongs to one or more **Organizations**; each membership carries a role.
 - A **Request Context** names exactly one **Active Organization**.
 - A **Request Context** always carries a **User client**; it carries a **Service client** only when the route opts in.
+- An **Email account** belongs to one **Organization**; a **Personal email account** is additionally owned by one **User**, a **Shared email account** by none.
 
 ## Example dialogue
 

--- a/src/app/api/settings/users/[id]/route.test.ts
+++ b/src/app/api/settings/users/[id]/route.test.ts
@@ -22,6 +22,14 @@ import { fakeUsersServiceClient } from "../__test-utils__/service-fake";
 
 const params = { params: Promise.resolve({ id: "target-user" }) };
 
+// Seeds the membership row the route's org-scoping guard reads: the target
+// user belongs to the caller's Active Organization (org-1).
+const memberOrg = {
+  user_organizations: [
+    { id: "m1", user_id: "target-user", organization_id: "org-1" },
+  ],
+};
+
 const patch = () =>
   new Request("http://test/api/settings/users/target-user", {
     method: "PATCH",
@@ -32,7 +40,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
   vi.mocked(createServiceClient).mockReturnValue(
-    fakeUsersServiceClient() as never,
+    fakeUsersServiceClient({ tables: memberOrg }) as never,
   );
 });
 
@@ -77,5 +85,38 @@ describe("PATCH /api/settings/users/[id] — gated on access_settings (#100)", (
     const res = await PATCH(patch(), params);
 
     expect(res.status).toBe(200);
+  });
+});
+
+// The [id] path param is client-supplied. A target user who is not a member
+// of the caller's Active Organization must be unreachable — without this
+// guard the Service client (which bypasses RLS) would let an admin in any
+// Organization edit a stranger's profile.
+describe("PATCH /api/settings/users/[id] — Organization scoping", () => {
+  it("returns 404 when the target user is not in the caller's Organization", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["access_settings"],
+        }),
+      }) as never,
+    );
+    // Service client seeds no membership for `target-user` in org-1.
+    const service = fakeUsersServiceClient();
+    vi.mocked(createServiceClient).mockReturnValue(service as never);
+
+    const res = await PATCH(
+      new Request("http://test/api/settings/users/target-user", {
+        method: "PATCH",
+        body: JSON.stringify({ full_name: "Attacker" }),
+      }),
+      params,
+    );
+
+    expect(res.status).toBe(404);
+    expect(service.auth.admin.updateUserById).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/settings/users/[id]/route.ts
+++ b/src/app/api/settings/users/[id]/route.ts
@@ -13,6 +13,21 @@ export const PATCH = withRequestContext(
     const body = await request.json();
     const service = ctx.serviceClient!;
 
+    // The [id] path param is client-supplied. Verify the target user is a
+    // member of the caller's Active Organization before any write — the
+    // Service client bypasses row-level security, so this route owns the
+    // scoping check itself. A user from another Organization (or one that
+    // does not exist) is reported as 404, never edited.
+    const { data: membership } = await service
+      .from("user_organizations")
+      .select("id")
+      .eq("user_id", id)
+      .eq("organization_id", ctx.orgId)
+      .maybeSingle();
+    if (!membership) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
     const profileUpdates: Record<string, unknown> = {};
     if (body.full_name !== undefined) profileUpdates.full_name = body.full_name;
     if (body.phone !== undefined) profileUpdates.phone = body.phone || null;

--- a/src/app/api/settings/users/__test-utils__/service-fake.ts
+++ b/src/app/api/settings/users/__test-utils__/service-fake.ts
@@ -8,6 +8,10 @@
 // chainable select/insert/upsert/update builder plus `auth.admin` for the
 // invite / ban calls. Filters are recorded but only `eq` narrows rows —
 // the tests assert on the wrapper's allow/deny, not on query semantics.
+// The `auth.admin` methods are vi.fn spies so a test can assert what (or
+// whether) the route passed anything to them.
+
+import { vi } from "vitest";
 
 type Row = Record<string, unknown>;
 
@@ -38,7 +42,8 @@ function builder(rows: Row[]): Record<string, unknown> {
 
 // A fake Service client for the `settings/users` route bodies. `tables`
 // seeds rows the bodies read (e.g. the target member's `user_organizations`
-// row for the `permissions` PUT). `auth.admin` stubs the invite/ban calls.
+// row for the `permissions` PUT, or the membership row the PATCH guard
+// reads). `auth.admin` stubs the invite/ban calls.
 export function fakeUsersServiceClient(
   opts: { tables?: Record<string, Row[]> } = {},
 ) {
@@ -49,15 +54,15 @@ export function fakeUsersServiceClient(
     },
     auth: {
       admin: {
-        async listUsers() {
-          return { data: { users: [] }, error: null };
-        },
-        async inviteUserByEmail() {
-          return { data: { user: { id: "invited-user" } }, error: null };
-        },
-        async updateUserById() {
-          return { data: { user: null }, error: null };
-        },
+        listUsers: vi.fn(async () => ({ data: { users: [] }, error: null })),
+        inviteUserByEmail: vi.fn(async () => ({
+          data: { user: { id: "invited-user" } },
+          error: null,
+        })),
+        updateUserById: vi.fn(async () => ({
+          data: { user: null },
+          error: null,
+        })),
       },
     },
   };


### PR DESCRIPTION
## Summary

PRD #134's first slice. Rolls back the misbuilt "Edit user" login-email editor (built on a misread of the original report) while keeping the real cross-Organization profile-edit IDOR fix discovered during that work.

**Rolled back:**
- `email` branch in `PATCH /api/settings/users/[id]` (the `auth.admin.updateUserById` path that took a new login email and 409'd on already-registered)
- Pencil "Edit user" button, the Edit dialog, and the `openEdit` / `handleSaveEdit` flow on the Users settings page
- 200/409 email-update tests + the `updateUserResult` knob on the service fake (only consumer was the dropped 409 test)

**Kept:**
- Membership guard at the top of the PATCH handler — queries `user_organizations` for `(user_id = [id], organization_id = ctx.orgId)` and returns 404 if no row. Same 404-on-cross-org convention as #98/#101/#119
- 404 membership-guard test (renamed body from email-takeover phrasing to generic profile-edit)
- `vi.fn` conversion of `fakeUsersServiceClient.auth.admin.{listUsers, inviteUserByEmail, updateUserById}` — the kept 404 test asserts `updateUserById` was not called, which needs the spy
- `memberOrg` seed threaded through the existing happy-path tests
- `CONTEXT.md` additions: \`Email account\` / \`Shared email account\` / \`Personal email account\` terms (PRD #134's domain language foundation)

## Test plan

- [x] Full suite: **677 passed (114 files)**
- [x] Route test green: 4 tests (401 / 403 / 200 happy-path / 404 cross-org)
- [x] Typecheck clean on changed surface (pre-existing \`sync-folder-incremental.test.ts\` \`TS2322\` carried)
- [x] Lint clean on changed surface (pre-existing \`react-hooks/set-state-in-effect\` at \`page.tsx:94\` carried — was at \`:102\` in carry-over, back at \`:94\` after rollback)
- [ ] Visual: open Settings → Users; confirm no Pencil button per row; only Reset link, Permissions, Activate/Deactivate icons remain
- [ ] Network: attempt \`PATCH /api/settings/users/{id}\` with \`{email}\` — payload is silently ignored (route no longer reads it); attempt against a foreign-org user id returns 404

Closes #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)