### PR TITLE
email: email-account-access module — Shared/Personal access matrix (#139)

### DIFF
--- a/src/lib/email/email-account-access.test.ts
+++ b/src/lib/email/email-account-access.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateEmailAccountAccess,
+  type EmailAccount,
+  type EmailAccountCaller,
+} from "./email-account-access";
+
+const ORG = "org-1";
+const OTHER_ORG = "org-2";
+const ALICE = "user-alice";
+const BOB = "user-bob";
+
+function caller(overrides: Partial<EmailAccountCaller> = {}): EmailAccountCaller {
+  return {
+    userId: ALICE,
+    organizationId: ORG,
+    role: "crew_lead",
+    grantedPermissions: [],
+    ...overrides,
+  };
+}
+
+function shared(overrides: Partial<EmailAccount> = {}): EmailAccount {
+  return {
+    kind: "shared",
+    organizationId: ORG,
+    userId: null,
+    ...overrides,
+  };
+}
+
+function personal(owner: string, overrides: Partial<EmailAccount> = {}): EmailAccount {
+  return {
+    kind: "personal",
+    organizationId: ORG,
+    userId: owner,
+    ...overrides,
+  };
+}
+
+describe("evaluateEmailAccountAccess", () => {
+  describe("shared account", () => {
+    it("same-org admin: see + read + manage", () => {
+      expect(
+        evaluateEmailAccountAccess(caller({ role: "admin" }), shared()),
+      ).toEqual({ canSee: true, canRead: true, canManage: true });
+    });
+
+    it("same-org non-admin with view_email: see + read, no manage", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ role: "crew_lead", grantedPermissions: ["view_email"] }),
+          shared(),
+        ),
+      ).toEqual({ canSee: true, canRead: true, canManage: false });
+    });
+
+    it("same-org non-admin without view_email: all false", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ role: "crew_member", grantedPermissions: [] }),
+          shared(),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+
+    it("cross-org admin with view_email: all false", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({
+            organizationId: OTHER_ORG,
+            role: "admin",
+            grantedPermissions: ["view_email"],
+          }),
+          shared(),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+  });
+
+  describe("personal account owned by caller", () => {
+    it("owner: see + read + manage (regardless of email perms)", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ role: "crew_lead", grantedPermissions: [] }),
+          personal(ALICE),
+        ),
+      ).toEqual({ canSee: true, canRead: true, canManage: true });
+    });
+  });
+
+  describe("personal account owned by someone else in same org", () => {
+    it("same-org admin: see + manage, no read (content-private)", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ role: "admin" }),
+          personal(BOB),
+        ),
+      ).toEqual({ canSee: true, canRead: false, canManage: true });
+    });
+
+    it("same-org non-admin with view_email: all false (Personal is owner-private)", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({
+            role: "crew_lead",
+            grantedPermissions: ["view_email", "send_email"],
+          }),
+          personal(BOB),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+
+    it("same-org non-admin without perms: all false", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ role: "crew_member", grantedPermissions: [] }),
+          personal(BOB),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+  });
+
+  describe("account in another organization", () => {
+    it("cross-org admin on a Personal account: all false", () => {
+      expect(
+        evaluateEmailAccountAccess(
+          caller({
+            organizationId: OTHER_ORG,
+            role: "admin",
+            grantedPermissions: ["view_email"],
+          }),
+          personal(BOB),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+
+    it("a caller's userId matching the account's userId across orgs does NOT grant ownership", () => {
+      // Owner-by-userId is meaningful only when the caller is in the
+      // account's Organization. A stale `user_id` survival into another
+      // org's account must not leak access.
+      expect(
+        evaluateEmailAccountAccess(
+          caller({ organizationId: OTHER_ORG, role: "crew_lead" }),
+          personal(ALICE),
+        ),
+      ).toEqual({ canSee: false, canRead: false, canManage: false });
+    });
+  });
+
+  describe("guard rails", () => {
+    it("throws for an unknown account kind (never quietly returns all-false)", () => {
+      const bogus = {
+        kind: "service" as unknown as EmailAccount["kind"],
+        organizationId: ORG,
+        userId: null,
+      };
+      expect(() =>
+        evaluateEmailAccountAccess(caller({ role: "admin" }), bogus),
+      ).toThrow(/unknown email account kind "service"/);
+    });
+  });
+});

--- a/src/lib/email/email-account-access.ts
+++ b/src/lib/email/email-account-access.ts
@@ -1,0 +1,119 @@
+// `evaluateEmailAccountAccess` — the access-decision module for Email
+// accounts. A pure function: no I/O, no Supabase, no HTTP. Given a caller
+// and an Email account, it answers the three questions every email-area
+// route needs:
+//
+//   canSee    — does the account appear in the caller's UI?
+//   canRead   — can the caller open its mail?
+//   canManage — can the caller edit its settings or disconnect it?
+//
+// The decision matrix is fixed by ADR 0001 (Shared and Personal email
+// accounts). The matrix varies by account kind and the caller's role and
+// permissions within the account's Organization; cross-Organization
+// callers get all-false on every account, regardless of permissions —
+// the same 404-equivalent convention as #98/#101/#119.
+//
+// This module is the single source of truth for the matrix. Routes
+// delegate to it rather than re-implementing the rule; the next slice
+// wires it into the email-area Service-client routes.
+//
+// An unknown account kind throws, never quietly returns all-false —
+// same posture as the #97 resolver registry: an unregistered case is a
+// programming error, not a silent deny.
+
+export type EmailAccountKind = "shared" | "personal";
+
+// The fields of an Email account this module needs. A Shared account has
+// `userId === null`; a Personal account has `userId === <owner>`.
+export interface EmailAccount {
+  kind: EmailAccountKind;
+  organizationId: string;
+  userId: string | null;
+}
+
+// What the caller is, as resolved from the Active Organization the
+// request came in on. `role` is null when the caller has no membership
+// in their Active Organization; `grantedPermissions` is then empty.
+export interface EmailAccountCaller {
+  userId: string;
+  organizationId: string;
+  role: string | null;
+  grantedPermissions: string[];
+}
+
+export interface EmailAccountAccess {
+  canSee: boolean;
+  canRead: boolean;
+  canManage: boolean;
+}
+
+const DENY: EmailAccountAccess = {
+  canSee: false,
+  canRead: false,
+  canManage: false,
+};
+
+// One evaluator per account kind. The caller is already known to be in
+// the account's Organization when an evaluator runs — the cross-org
+// short-circuit lives in `evaluateEmailAccountAccess` so each evaluator
+// only deals with the in-org branches of the matrix.
+type Evaluator = (
+  caller: EmailAccountCaller,
+  account: EmailAccount,
+) => EmailAccountAccess;
+
+const evaluateSharedAccess: Evaluator = (caller) => {
+  const isAdmin = caller.role === "admin";
+  const hasViewEmail =
+    isAdmin || caller.grantedPermissions.includes("view_email");
+  return {
+    canSee: hasViewEmail,
+    canRead: hasViewEmail,
+    canManage: isAdmin,
+  };
+};
+
+const evaluatePersonalAccess: Evaluator = (caller, account) => {
+  if (account.userId === caller.userId) {
+    return { canSee: true, canRead: true, canManage: true };
+  }
+  if (caller.role === "admin") {
+    // Content-private: an admin can see + disconnect a Personal account
+    // they do not own, but cannot read its mail. See ADR 0001.
+    return { canSee: true, canRead: false, canManage: true };
+  }
+  return DENY;
+};
+
+// Every account kind the module knows how to evaluate, and how. A kind
+// absent from this map is a deliberate gap: `evaluateEmailAccountAccess`
+// throws, so adding a kind is a conscious act of registering it here
+// (along with its row in the ADR's matrix).
+const EVALUATORS: Record<EmailAccountKind, Evaluator> = {
+  shared: evaluateSharedAccess,
+  personal: evaluatePersonalAccess,
+};
+
+/**
+ * Decides, for a (caller, Email account) pair, whether the caller can
+ * see, read, and manage the account.
+ *
+ * Cross-Organization callers get all-false on every account, regardless
+ * of role or permission grants. An unknown account kind throws — an
+ * unrecognized kind is a programming error, never a quiet allow or deny.
+ */
+export function evaluateEmailAccountAccess(
+  caller: EmailAccountCaller,
+  account: EmailAccount,
+): EmailAccountAccess {
+  if (caller.organizationId !== account.organizationId) {
+    return DENY;
+  }
+  const evaluator = EVALUATORS[account.kind];
+  if (!evaluator) {
+    throw new Error(
+      `evaluateEmailAccountAccess: unknown email account kind "${account.kind}"`,
+    );
+  }
+  return evaluator(caller, account);
+}


### PR DESCRIPTION
## Summary

- A single pure module — `src/lib/email/email-account-access.ts` — that answers `{ canSee, canRead, canManage }` for any (caller, Email account) pair, so every email-area route can delegate to it instead of re-implementing the matrix.
- Encodes the matrix fixed by [ADR 0001](docs/adr/0001-shared-and-personal-email-accounts.md): Shared accounts are admin-managed and visible to every same-org member with `view_email`; Personal accounts are owner-private (only the owner reads mail) but admin-disconnectable. Cross-Organization callers get all-false on every account regardless of permission — the same 404-equivalent convention as #98 / #101 / #119.
- Mirrors `belongsToActiveOrganization` (#97): a per-kind evaluator registry, and an unknown kind throws rather than silently returning all-false.

This slice ships the module + its unit tests only. No route consumes it yet — that's slice #141.

Decision matrix the module enforces:

| account kind | caller is admin (own org) | caller is owner | caller is other (same org) with `view_email` | caller is in a different org |
| --- | --- | --- | --- | --- |
| Shared       | see + read + manage     | n/a                  | see + read (no manage) | all false |
| Personal     | see + manage (no read)  | see + read + manage  | all false              | all false |

## Test plan

- [x] 11 unit tests cover the full decision matrix per the AC: `{ Shared, Personal-owned-by-caller, Personal-owned-by-other, account-in-other-org } × { admin, owner, member with email perm, member without email perm }`, plus the cross-org spoof case (caller userId matches the account's userId across orgs) and the unknown-kind throw.
- [x] Tests follow the shape of `belongs-to-active-organization.test.ts` (#97) and `evaluate-permission-rule.test.ts` (#96) — pure-function assertions on the returned booleans.
- [x] Full suite: **688 passed / 115 files** (was 677 / 114 pre-PR; +11 new tests, +1 new file).
- [x] Typecheck clean on the changed surface (only the pre-existing `sync-folder-incremental.test.ts` `TS2322` remains).
- [x] Lint clean on the changed surface.

Closes #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)