### PR TITLE
email/*: route refactor onto Shared/Personal access module (#141)

### DIFF
--- a/src/app/api/email/accounts/[id]/route.test.ts
+++ b/src/app/api/email/accounts/[id]/route.test.ts
@@ -9,14 +9,34 @@ vi.mock("@/lib/supabase-api", () => ({
 vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
+// `encrypt` reaches into ENCRYPTION_KEY at module load; the post-rewrite
+// route only invokes it when a PATCH body sets `password`, but mocking
+// keeps test setup hermetic.
+vi.mock("@/lib/encryption", () => ({
+  encrypt: vi.fn(() => "enc:test"),
+}));
 
 import { DELETE, PATCH } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../../__test-utils__/request-context-fakes";
+
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function paramsFor(id: string) {
   return { params: Promise.resolve({ id }) };
@@ -28,79 +48,159 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function patchReq() {
-  return new Request("http://test", { method: "PATCH", body: "{}" });
+function deleteReq() {
+  return new Request("http://test", { method: "DELETE" });
 }
+
+function patchReq(body: Record<string, unknown> = { label: "renamed" }) {
+  return new Request("http://test", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+const SHARED_IN_ORG = (id = "acc-shared"): Account => ({
+  id,
+  organization_id: "org-1",
+  user_id: null,
+});
+const PERSONAL_OWNED_BY = (owner: string, id = "acc-personal"): Account => ({
+  id,
+  organization_id: "org-1",
+  user_id: owner,
+});
+const CROSS_ORG = (id = "acc-other"): Account => ({
+  id,
+  organization_id: "org-2",
+  user_id: null,
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("DELETE /api/email/accounts/[id] — gated on send_email (#105)", () => {
+// Both DELETE and PATCH require canManage on the target account per ADR 0001:
+//   Shared    — admin in same org only
+//   Personal  — owner OR admin in same org
+//   Cross-org — never
+// 401/403 from the wrapper precede the access-module check; the access matrix
+// itself decides 404 (canSee false) vs 403 (canSee true, canManage false).
+
+describe("DELETE /api/email/accounts/[id] — requires canManage (#141, ADR 0001)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await DELETE(
-      new Request("http://test", { method: "DELETE" }),
-      paramsFor("acc-1"),
-    );
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
 
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
-        grants: ["view_email"],
+        grants: [],
       }),
     });
 
-    const res = await DELETE(
-      new Request("http://test", { method: "DELETE" }),
-      paramsFor("acc-1"),
-    );
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
 
     expect(res.status).toBe(403);
   });
 
-  it("disconnects the account when the caller holds send_email", async () => {
-    authed({
-      user: { id: "user-1" },
-      tables: memberTables({
-        userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
-      }),
-    });
-
-    const res = await DELETE(
-      new Request("http://test", { method: "DELETE" }),
-      paramsFor("acc-1"),
-    );
-
-    expect(res.status).toBe(200);
-  });
-
-  it("admins pass the gate without holding the key", async () => {
+  it("returns 404 for an account in a different Organization", async () => {
     authed({
       user: { id: "admin-1" },
       tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
+    withAccounts([CROSS_ORG("acc-1")]);
 
-    const res = await DELETE(
-      new Request("http://test", { method: "DELETE" }),
-      paramsFor("acc-1"),
-    );
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal account in own org owned by someone else (non-admin caller)", async () => {
+    // Content-private: a non-owner, non-admin caller cannot even tell the
+    // account exists.
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
+      }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-2", "acc-1")]);
+
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when a non-admin tries to disconnect a Shared account", async () => {
+    // canSee true (view_email holder sees Shared) but canManage false (only
+    // admins manage Shared).
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
+      }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("succeeds when an admin disconnects a Shared account in their org", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("succeeds when the owner disconnects their own Personal account", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-1", "acc-1")]);
+
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("succeeds when an admin disconnects a Personal account owned by another user in the same org (offboarding)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-2", "acc-1")]);
+
+    const res = await DELETE(deleteReq(), paramsFor("acc-1"));
 
     expect(res.status).toBe(200);
   });
 });
 
-describe("PATCH /api/email/accounts/[id] — gated on send_email (#105)", () => {
+describe("PATCH /api/email/accounts/[id] — requires canManage (#141, ADR 0001)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
@@ -109,13 +209,13 @@ describe("PATCH /api/email/accounts/[id] — gated on send_email (#105)", () => 
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
-        grants: ["view_email"],
+        grants: [],
       }),
     });
 
@@ -124,20 +224,93 @@ describe("PATCH /api/email/accounts/[id] — gated on send_email (#105)", () => 
     expect(res.status).toBe(403);
   });
 
-  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+  it("returns 404 for an account in a different Organization", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([CROSS_ORG("acc-1")]);
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal account in own org owned by someone else (non-admin caller)", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
       }),
     });
+    withAccounts([PERSONAL_OWNED_BY("user-2", "acc-1")]);
 
     const res = await PATCH(patchReq(), paramsFor("acc-1"));
 
-    // Empty body — the handler rejects with 400 for no updatable fields,
-    // proving the gate let the request through rather than rejecting it 403.
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when a non-admin tries to edit a Shared account", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
+      }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("admin can edit a Shared account in their org (canManage path)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    // The update reaches the DB; the fake's `.single()` returns no row so
+    // the route exits 500 with "no rows" — `not.toBe(403)` proves the access
+    // module let the caller through.
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
+  });
+
+  it("owner can edit their own Personal account", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-1", "acc-1")]);
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
+  });
+
+  it("admin can edit a Personal account owned by another user in the same org", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-2", "acc-1")]);
+
+    const res = await PATCH(patchReq(), paramsFor("acc-1"));
+
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
   });
 });

--- a/src/app/api/email/accounts/[id]/route.ts
+++ b/src/app/api/email/accounts/[id]/route.ts
@@ -1,16 +1,79 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
+import type { RequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
+import {
+  evaluateEmailAccountAccess,
+  type EmailAccountAccess,
+} from "@/lib/email/email-account-access";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// Fetch the target Email account by id, then evaluate the (caller, account)
+// access matrix from ADR 0001. Returns:
+//   - 404 response when the account does not exist or the caller cannot see it
+//     (cross-org account, or non-owner Personal in the caller's own org);
+//   - 403 response when the caller can see the account but the requested action
+//     is forbidden (Shared account, non-admin caller, canManage required);
+//   - { account, access } otherwise.
+// The Service client bypasses RLS — required so an admin can manage a Personal
+// account they do not own, which the User-client RLS policy would hide.
+async function resolveAccessTo(
+  serviceClient: SupabaseClient,
+  accountId: string,
+  ctx: RequestContext,
+  required: "canRead" | "canManage",
+): Promise<
+  | { kind: "ok"; account: { organization_id: string; user_id: string | null }; access: EmailAccountAccess }
+  | { kind: "response"; response: Response }
+> {
+  const { data: account } = await serviceClient
+    .from("email_accounts")
+    .select("organization_id, user_id")
+    .eq("id", accountId)
+    .maybeSingle<{ organization_id: string; user_id: string | null }>();
+
+  if (!account) {
+    return { kind: "response", response: NextResponse.json({ error: "Not found" }, { status: 404 }) };
+  }
+
+  const access = evaluateEmailAccountAccess(
+    {
+      userId: ctx.userId,
+      organizationId: ctx.orgId ?? "",
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    },
+    {
+      kind: account.user_id === null ? "shared" : "personal",
+      organizationId: account.organization_id,
+      userId: account.user_id,
+    },
+  );
+
+  if (!access.canSee) {
+    return { kind: "response", response: NextResponse.json({ error: "Not found" }, { status: 404 }) };
+  }
+  if (!access[required]) {
+    return { kind: "response", response: NextResponse.json({ error: "Permission denied" }, { status: 403 }) };
+  }
+
+  return { kind: "ok", account, access };
+}
 
 // DELETE /api/email/accounts/[id] — disconnect an email account.
-// Requires `send_email` (#105, PRD #95) — account management is a write,
-// tightened from the logged-in-only #85 Request-Context conversion gate.
+// Gated on view_email at the wrapper (the broadest email perm — anyone with
+// any email perm passes); the canManage rule from the access module is the
+// real gate. ADR 0001: admin manages Shared, owner manages own Personal,
+// admin can disconnect (but not read) others' Personal in the same org.
 export const DELETE = withRequestContext(
-  { permission: "send_email" },
+  { permission: "view_email", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
-    const { error } = await ctx.supabase
+    const resolved = await resolveAccessTo(ctx.serviceClient!, id, ctx, "canManage");
+    if (resolved.kind === "response") return resolved.response;
+
+    const { error } = await ctx.serviceClient!
       .from("email_accounts")
       .delete()
       .eq("id", id);
@@ -23,14 +86,17 @@ export const DELETE = withRequestContext(
 );
 
 // PATCH /api/email/accounts/[id] — update account settings.
-// Requires `send_email` (#105, PRD #95) — account management is a write.
+// Same canManage gating as DELETE.
 export const PATCH = withRequestContext(
-  { permission: "send_email" },
+  { permission: "view_email", serviceClient: true },
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
+
+    const resolved = await resolveAccessTo(ctx.serviceClient!, id, ctx, "canManage");
+    if (resolved.kind === "response") return resolved.response;
+
     const body = await request.json();
 
-    // If password is being updated, encrypt it
     const updates: Record<string, unknown> = {};
     const allowedFields = ["label", "email_address", "display_name", "provider", "imap_host", "imap_port", "smtp_host", "smtp_port", "username", "is_active", "is_default", "signature", "color"];
 
@@ -48,7 +114,7 @@ export const PATCH = withRequestContext(
       return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
     }
 
-    const { data, error } = await ctx.supabase
+    const { data, error } = await ctx.serviceClient!
       .from("email_accounts")
       .update(updates)
       .eq("id", id)

--- a/src/app/api/email/accounts/[id]/route.ts
+++ b/src/app/api/email/accounts/[id]/route.ts
@@ -1,64 +1,7 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
-import type { RequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
-import {
-  evaluateEmailAccountAccess,
-  type EmailAccountAccess,
-} from "@/lib/email/email-account-access";
-import type { SupabaseClient } from "@supabase/supabase-js";
-
-// Fetch the target Email account by id, then evaluate the (caller, account)
-// access matrix from ADR 0001. Returns:
-//   - 404 response when the account does not exist or the caller cannot see it
-//     (cross-org account, or non-owner Personal in the caller's own org);
-//   - 403 response when the caller can see the account but the requested action
-//     is forbidden (Shared account, non-admin caller, canManage required);
-//   - { account, access } otherwise.
-// The Service client bypasses RLS — required so an admin can manage a Personal
-// account they do not own, which the User-client RLS policy would hide.
-async function resolveAccessTo(
-  serviceClient: SupabaseClient,
-  accountId: string,
-  ctx: RequestContext,
-  required: "canRead" | "canManage",
-): Promise<
-  | { kind: "ok"; account: { organization_id: string; user_id: string | null }; access: EmailAccountAccess }
-  | { kind: "response"; response: Response }
-> {
-  const { data: account } = await serviceClient
-    .from("email_accounts")
-    .select("organization_id, user_id")
-    .eq("id", accountId)
-    .maybeSingle<{ organization_id: string; user_id: string | null }>();
-
-  if (!account) {
-    return { kind: "response", response: NextResponse.json({ error: "Not found" }, { status: 404 }) };
-  }
-
-  const access = evaluateEmailAccountAccess(
-    {
-      userId: ctx.userId,
-      organizationId: ctx.orgId ?? "",
-      role: ctx.role,
-      grantedPermissions: ctx.grantedPermissions,
-    },
-    {
-      kind: account.user_id === null ? "shared" : "personal",
-      organizationId: account.organization_id,
-      userId: account.user_id,
-    },
-  );
-
-  if (!access.canSee) {
-    return { kind: "response", response: NextResponse.json({ error: "Not found" }, { status: 404 }) };
-  }
-  if (!access[required]) {
-    return { kind: "response", response: NextResponse.json({ error: "Permission denied" }, { status: 403 }) };
-  }
-
-  return { kind: "ok", account, access };
-}
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 
 // DELETE /api/email/accounts/[id] — disconnect an email account.
 // Gated on view_email at the wrapper (the broadest email perm — anyone with
@@ -70,7 +13,7 @@ export const DELETE = withRequestContext(
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
-    const resolved = await resolveAccessTo(ctx.serviceClient!, id, ctx, "canManage");
+    const resolved = await resolveEmailAccountAccess(ctx.serviceClient!, id, ctx, "canManage");
     if (resolved.kind === "response") return resolved.response;
 
     const { error } = await ctx.serviceClient!
@@ -92,7 +35,7 @@ export const PATCH = withRequestContext(
   async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
-    const resolved = await resolveAccessTo(ctx.serviceClient!, id, ctx, "canManage");
+    const resolved = await resolveEmailAccountAccess(ctx.serviceClient!, id, ctx, "canManage");
     if (resolved.kind === "response") return resolved.response;
 
     const body = await request.json();

--- a/src/app/api/email/accounts/[id]/test/route.test.ts
+++ b/src/app/api/email/accounts/[id]/test/route.test.ts
@@ -12,11 +12,25 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 import { POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../../../__test-utils__/request-context-fakes";
+
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function paramsFor(id: string) {
   return { params: Promise.resolve({ id }) };
@@ -32,12 +46,33 @@ function postReq() {
   return new Request("http://test", { method: "POST" });
 }
 
+const SHARED_IN_ORG = (id = "acc-shared"): Account => ({
+  id,
+  organization_id: "org-1",
+  user_id: null,
+});
+const PERSONAL_OWNED_BY = (owner: string, id = "acc-personal"): Account => ({
+  id,
+  organization_id: "org-1",
+  user_id: owner,
+});
+const CROSS_ORG = (id = "acc-other"): Account => ({
+  id,
+  organization_id: "org-2",
+  user_id: null,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("POST /api/email/accounts/[id]/test — gated on send_email (#105)", () => {
+// The connection-test endpoint reads the account's encrypted password to
+// run the live IMAP/SMTP probes. Reading the credential is a manage-level
+// action — the access matrix puts that in the same column as
+// PATCH/DELETE (admin for Shared, owner-or-admin for Personal).
+
+describe("POST /api/email/accounts/[id]/test — requires canManage (#141, ADR 0001)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
@@ -46,13 +81,13 @@ describe("POST /api/email/accounts/[id]/test — gated on send_email (#105)", ()
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
-        grants: ["view_email"],
+        grants: [],
       }),
     });
 
@@ -61,31 +96,80 @@ describe("POST /api/email/accounts/[id]/test — gated on send_email (#105)", ()
     expect(res.status).toBe(403);
   });
 
-  it("passes the gate when the caller holds send_email — the handler runs", async () => {
-    authed({
-      user: { id: "user-1" },
-      tables: memberTables({
-        userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
-      }),
-    });
-
-    const res = await POST(postReq(), paramsFor("acc-1"));
-
-    // No account seeded, so the handler returns 404 — proving the gate let
-    // the request through rather than rejecting it with 403.
-    expect(res.status).toBe(404);
-  });
-
-  it("admins pass the gate without holding the key", async () => {
+  it("returns 404 for an account in a different Organization", async () => {
     authed({
       user: { id: "admin-1" },
       tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
+    withAccounts([CROSS_ORG("acc-1")]);
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal account in own org owned by someone else (non-admin caller)", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
+      }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-2", "acc-1")]);
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when a non-admin tries to test a Shared account", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email", "send_email"],
+      }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("admin testing a Shared account passes the access gate (reaches the IMAP probe)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([SHARED_IN_ORG("acc-1")]);
+
+    const res = await POST(postReq(), paramsFor("acc-1"));
+
+    // The access module lets the caller through. The downstream IMAP probe
+    // fails against a non-existent host, but the access decision is not 403/404.
+    expect(res.status).not.toBe(401);
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
+  });
+
+  it("owner testing their own Personal account passes the access gate", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([PERSONAL_OWNED_BY("user-1", "acc-1")]);
 
     const res = await POST(postReq(), paramsFor("acc-1"));
 
     expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(404);
   });
 });

--- a/src/app/api/email/accounts/[id]/test/route.ts
+++ b/src/app/api/email/accounts/[id]/test/route.ts
@@ -1,18 +1,31 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 import { ImapFlow } from "imapflow";
 import nodemailer from "nodemailer";
 
 // POST /api/email/accounts/[id]/test — test IMAP and SMTP connections.
-// Requires `send_email` (#105, PRD #95) — account management is a write,
-// tightened from the logged-in-only #85 Request-Context conversion gate.
+// Reads the encrypted password, so the gate is canManage from the access
+// module (#139, ADR 0001) — admin for Shared, owner-or-admin for Personal.
+// The withRequestContext gate is the broadest email perm (`view_email`);
+// the access module makes the real call inside.
 export const POST = withRequestContext(
-  { permission: "send_email" },
+  { permission: "view_email", serviceClient: true },
   async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
     const { id } = await params;
 
-    const { data: account, error } = await ctx.supabase
+    const resolved = await resolveEmailAccountAccess(
+      ctx.serviceClient!,
+      id,
+      ctx,
+      "canManage",
+    );
+    if (resolved.kind === "response") return resolved.response;
+
+    // The access check passed; fetch the full row (with credentials) via the
+    // Service client to run the connection test.
+    const { data: account, error } = await ctx.serviceClient!
       .from("email_accounts")
       .select("*")
       .eq("id", id)

--- a/src/app/api/email/accounts/route.test.ts
+++ b/src/app/api/email/accounts/route.test.ts
@@ -9,6 +9,13 @@ vi.mock("@/lib/supabase-api", () => ({
 vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
+// `encrypt` needs ENCRYPTION_KEY in env; the user_id-rule tests reach past
+// the ownership check into the handler body and would otherwise crash on
+// `getKey`. Mock returns a stable bytestring so the route can proceed to
+// the DB insert step the queryBuilder fakes already handle.
+vi.mock("@/lib/encryption", () => ({
+  encrypt: vi.fn(() => "enc:test"),
+}));
 
 import { GET, POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
@@ -26,9 +33,21 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function postReq() {
-  return new Request("http://test", { method: "POST", body: "{}" });
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
+
+// A minimal valid body — all three required fields. Tests of the new
+// user_id rule layer extra fields on top of this so they exercise the
+// validation, not the 400-missing-fields path.
+const VALID_FIELDS = {
+  email_address: "team@example.com",
+  username: "team@example.com",
+  password: "secret",
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -130,6 +149,92 @@ describe("POST /api/email/accounts — gated on send_email (#105)", () => {
     });
 
     const res = await POST(postReq(), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+});
+
+// PRD #134 / ADR 0001: who may own a new Email account.
+//
+//   Admin     — may create Shared (`user_id: null`) or Personal owned by
+//               any member of their Organization.
+//   Non-admin — may only create a Personal account owned by themselves;
+//               any other value (null, or another user's id) returns 403.
+describe("POST /api/email/accounts — user_id ownership rule (#141, PRD #134)", () => {
+  it("rejects a non-admin who tries to create an account owned by someone else", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(
+      postReq({ ...VALID_FIELDS, user_id: "user-2" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a non-admin who tries to create a Shared account (user_id omitted)", async () => {
+    // PRD #134: only admin may create a Shared (`user_id: null`) account.
+    // For a non-admin, omitting `user_id` is also "any other value" → 403.
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(postReq(VALID_FIELDS), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("allows a non-admin to create a Personal account owned by themselves", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["send_email"],
+      }),
+    });
+
+    const res = await POST(
+      postReq({ ...VALID_FIELDS, user_id: "user-1" }),
+      noParams,
+    );
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows an admin to create a Shared account (user_id omitted)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq(VALID_FIELDS), noParams);
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it("allows an admin to create a Personal account on behalf of another user", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(
+      postReq({ ...VALID_FIELDS, user_id: "user-2" }),
+      noParams,
+    );
 
     expect(res.status).not.toBe(403);
   });

--- a/src/app/api/email/accounts/route.test.ts
+++ b/src/app/api/email/accounts/route.test.ts
@@ -19,11 +19,19 @@ vi.mock("@/lib/encryption", () => ({
 
 import { GET, POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../__test-utils__/request-context-fakes";
+
+function withServiceAccounts(accounts: Record<string, unknown>[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 const noParams = { params: Promise.resolve({}) };
 
@@ -98,6 +106,69 @@ describe("GET /api/email/accounts — gated on view_email (#105)", () => {
     const res = await GET(new Request("http://test/api/email/accounts"), noParams);
 
     expect(res.status).toBe(200);
+  });
+
+  // PRD #134: admins get a management view of every account in their org
+  // (including others' Personal accounts they cannot read) through
+  // ?asAdmin=true. RLS hides those rows from the User client; the route
+  // reads through the Service client for this view only.
+  it("?asAdmin=true on an admin returns the Service-client view (sees others' Personal accounts)", async () => {
+    const adminViewable = {
+      id: "acc-personal-of-other",
+      user_id: "user-other",
+      organization_id: "org-1",
+      label: "user-other's inbox",
+    };
+    authed({
+      user: { id: "admin-1" },
+      // Empty `email_accounts` on the User client — RLS would hide Personal
+      // accounts owned by others from the admin.
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withServiceAccounts([adminViewable]);
+
+    const res = await GET(
+      new Request("http://test/api/email/accounts?asAdmin=true"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.map((a: { id: string }) => a.id)).toEqual([
+      "acc-personal-of-other",
+    ]);
+  });
+
+  it("?asAdmin=true on a non-admin is ignored — still uses the User client (own canRead-set only)", async () => {
+    const shouldNotLeak = {
+      id: "acc-personal-of-other",
+      user_id: "user-other",
+      organization_id: "org-1",
+    };
+    authed({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({
+          userId: "user-1",
+          role: "crew_lead",
+          grants: ["view_email"],
+        }),
+        // The User client sees an empty `email_accounts` table — that
+        // mirrors what RLS does for a non-admin who has no own Personal
+        // and no Shared accounts.
+        email_accounts: [],
+      },
+    });
+    withServiceAccounts([shouldNotLeak]);
+
+    const res = await GET(
+      new Request("http://test/api/email/accounts?asAdmin=true"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
   });
 });
 

--- a/src/app/api/email/accounts/route.ts
+++ b/src/app/api/email/accounts/route.ts
@@ -24,13 +24,20 @@ export const GET = withRequestContext({ permission: "view_email" }, async (_requ
 // account update / disconnect / test.
 export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
   const body = await request.json();
-  const { label, email_address, display_name, provider, imap_host, imap_port, smtp_host, smtp_port, username, password, color: colorOverride } = body;
+  const { label, email_address, display_name, provider, imap_host, imap_port, smtp_host, smtp_port, username, password, color: colorOverride, user_id } = body;
 
   if (!email_address || !username || !password) {
     return NextResponse.json(
       { error: "email_address, username, and password are required" },
       { status: 400 }
     );
+  }
+
+  // ADR 0001 ownership rule. Admin may set any owner (or null for Shared);
+  // non-admin may only own the account themselves — any other `user_id`,
+  // including null, is denied.
+  if (ctx.role !== "admin" && user_id !== ctx.userId) {
+    return NextResponse.json({ error: "Permission denied" }, { status: 403 });
   }
 
   const encrypted_password = encrypt(password);
@@ -51,6 +58,10 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
     .from("email_accounts")
     .insert({
       organization_id: orgId,
+      // null marks Shared (org-wide); a uuid marks Personal owned by that
+      // user. The ownership rule above guarantees a non-admin's value here
+      // is their own id; an admin's value is whatever they sent.
+      user_id: user_id ?? null,
       label: label || email_address,
       email_address,
       display_name: display_name || "AAA Disaster Recovery",

--- a/src/app/api/email/accounts/route.ts
+++ b/src/app/api/email/accounts/route.ts
@@ -4,20 +4,43 @@ import { encrypt } from "@/lib/encryption";
 import { assignAccountColor } from "@/lib/email/assign-account-color";
 
 // GET /api/email/accounts — list accounts for the active org (passwords excluded).
-// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
-// gate the #85 Request-Context conversion gave this previously-ungated route.
-export const GET = withRequestContext({ permission: "view_email" }, async (_request, ctx) => {
-  const { data, error } = await ctx.supabase
-    .from("email_accounts")
-    .select("id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, last_synced_uid, created_at, updated_at")
-    .eq("organization_id", ctx.orgId)
-    .order("created_at", { ascending: true });
+//
+// Two views, selected by ?asAdmin=true:
+//   default (no flag) — every account the caller can READ. The User client
+//     plus the migration-140 RLS already returns exactly this set: Shared
+//     accounts in the org plus the caller's own Personal accounts. This is
+//     the inbox-switcher view.
+//   ?asAdmin=true — every account the admin can SEE in the org, including
+//     Personal accounts owned by other users (admins canSee but not canRead
+//     them per ADR 0001 — content-private). Needs Service-client access
+//     because the RLS policy correctly hides those Personal accounts from
+//     the admin's User client. Non-admins ignore the flag and receive their
+//     canRead-set (same as default).
+//
+// `user_id` is now selected so the UI can show "Shared" vs "Owner: X" badges.
+const ACCOUNT_FIELDS = "id, user_id, label, email_address, display_name, provider, signature, imap_host, imap_port, smtp_host, smtp_port, username, is_active, is_default, color, last_synced_at, last_synced_uid, created_at, updated_at";
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 500 });
-  }
-  return NextResponse.json(data);
-});
+export const GET = withRequestContext(
+  { permission: "view_email", serviceClient: true },
+  async (request, ctx) => {
+    const asAdmin =
+      ctx.role === "admin" &&
+      new URL(request.url).searchParams.get("asAdmin") === "true";
+
+    const client = asAdmin ? ctx.serviceClient! : ctx.supabase;
+
+    const { data, error } = await client
+      .from("email_accounts")
+      .select(ACCOUNT_FIELDS)
+      .eq("organization_id", ctx.orgId)
+      .order("created_at", { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data);
+  },
+);
 
 // POST /api/email/accounts — add a new email account for the active org.
 // Requires `send_email` (#105, PRD #95) — account management is a write, like

--- a/src/app/api/email/list/route.test.ts
+++ b/src/app/api/email/list/route.test.ts
@@ -12,13 +12,27 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 import { GET } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../__test-utils__/request-context-fakes";
 
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
 const noParams = { params: Promise.resolve({}) };
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -31,7 +45,7 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("GET /api/email/list — gated on view_email (#105)", () => {
+describe("GET /api/email/list — gated on view_email + canRead per account (#141)", () => {
   it("returns 401 when unauthenticated — the route body never runs", async () => {
     authed({ user: null });
 
@@ -51,7 +65,7 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
     expect(res.status).toBe(403);
   });
 
-  it("lists emails when the caller holds view_email", async () => {
+  it("lists emails when the caller holds view_email (no accountId, RLS scopes the result)", async () => {
     authed({
       user: { id: "user-1" },
       tables: {
@@ -85,6 +99,105 @@ describe("GET /api/email/list — gated on view_email (#105)", () => {
     });
 
     const res = await GET(new Request("http://test/api/email/list"), noParams);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 404 when ?accountId= names an account in a different Organization", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-2", user_id: null }]);
+
+    const res = await GET(
+      new Request("http://test/api/email/list?accountId=acc-1"),
+      noParams,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when ?accountId= names a Personal account in own org owned by someone else", async () => {
+    // Content-private: admin sees the account exists (canSee true) but
+    // cannot read its mail; same-org non-admin sees nothing at all.
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await GET(
+      new Request("http://test/api/email/list?accountId=acc-1"),
+      noParams,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when an admin tries to read a Personal account owned by another user (canRead=false)", async () => {
+    // Admin canSee but not canRead → mapped to 404 since the action (read)
+    // is forbidden; the content-private boundary keeps the mail invisible.
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await GET(
+      new Request("http://test/api/email/list?accountId=acc-1"),
+      noParams,
+    );
+
+    // admin: canSee=true, canManage=true, canRead=false → 403 (visible
+    // but action forbidden)
+    expect(res.status).toBe(403);
+  });
+
+  it("allows the owner to read their own Personal account by ?accountId=", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({
+          userId: "user-1",
+          role: "crew_lead",
+          grants: ["view_email"],
+        }),
+        emails: [{ id: "e-1", folder: "inbox" }],
+      },
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-1" }]);
+
+    const res = await GET(
+      new Request("http://test/api/email/list?accountId=acc-1"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+  });
+
+  it("allows a view_email holder to read a Shared account by ?accountId=", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({
+          userId: "user-1",
+          role: "crew_lead",
+          grants: ["view_email"],
+        }),
+        emails: [{ id: "e-1", folder: "inbox" }],
+      },
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: null }]);
+
+    const res = await GET(
+      new Request("http://test/api/email/list?accountId=acc-1"),
+      noParams,
+    );
 
     expect(res.status).toBe(200);
   });

--- a/src/app/api/email/list/route.ts
+++ b/src/app/api/email/list/route.ts
@@ -1,13 +1,30 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 
 // GET /api/email/list?folder=inbox&accountId=...&search=...&page=1&limit=50
-// Requires `view_email` (#105, PRD #95) — tightened from the logged-in-only
-// gate the #85 Request-Context conversion gave this previously-ungated route.
-export const GET = withRequestContext({ permission: "view_email" }, async (request, ctx) => {
+// Gated on view_email; when an `accountId` is supplied the route additionally
+// confirms canRead on that specific account through the access module
+// (#141, ADR 0001). With no accountId, the route lists across every account
+// the caller can see — RLS keeps Personal accounts the caller does not own
+// out of the result set, so the visible-set is correctly scoped.
+export const GET = withRequestContext(
+  { permission: "view_email", serviceClient: true },
+  async (request, ctx) => {
   const { searchParams } = new URL(request.url);
   const folder = searchParams.get("folder") || "inbox";
   const accountId = searchParams.get("accountId"); // null = all accounts
+
+  if (accountId) {
+    const resolved = await resolveEmailAccountAccess(
+      ctx.serviceClient!,
+      accountId,
+      ctx,
+      "canRead",
+    );
+    if (resolved.kind === "response") return resolved.response;
+  }
+
   const search = searchParams.get("search") || "";
   const page = parseInt(searchParams.get("page") || "1");
   const limit = parseInt(searchParams.get("limit") || "50");

--- a/src/app/api/email/send/route.test.ts
+++ b/src/app/api/email/send/route.test.ts
@@ -12,13 +12,27 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 import { POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../__test-utils__/request-context-fakes";
 
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
 const noParams = { params: Promise.resolve({}) };
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -26,16 +40,29 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function postReq() {
-  return new Request("http://test", { method: "POST", body: "{}" });
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
+
+const COMPLETE_BODY = {
+  to: "customer@example.com",
+  subject: "Hello",
+  body: "Hi",
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("POST /api/email/send — gated on send_email (#105)", () => {
+// PRD #134: "send treated the same as canRead for now" — until that splits,
+// the access matrix uses canRead for /send. Owners of a Personal account
+// can send from it; view_email holders can send from Shared; admins cannot
+// send from a Personal account they do not own (canRead false).
+describe("POST /api/email/send — gated on view_email + canRead per account (#141)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
@@ -44,13 +71,13 @@ describe("POST /api/email/send — gated on send_email (#105)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
-        grants: ["view_email"],
+        grants: [],
       }),
     });
 
@@ -59,31 +86,67 @@ describe("POST /api/email/send — gated on send_email (#105)", () => {
     expect(res.status).toBe(403);
   });
 
-  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+  it("returns 400 when the caller passes the gate but the body omits required fields", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
+        role: "crew_lead",
+        grants: ["view_email"],
       }),
     });
 
     const res = await POST(postReq(), noParams);
 
-    // Empty body — the handler rejects with 400 for missing fields, proving
-    // the gate let the request through rather than rejecting it with 403.
     expect(res.status).toBe(400);
   });
 
-  it("admins pass the gate without holding the key", async () => {
+  it("returns 404 for an accountId in a different Organization", async () => {
     authed({
       user: { id: "admin-1" },
       tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
+    withAccounts([{ id: "acc-1", organization_id: "org-2", user_id: null }]);
 
-    const res = await POST(postReq(), noParams);
+    const res = await POST(
+      postReq({ ...COMPLETE_BODY, accountId: "acc-1" }),
+      noParams,
+    );
 
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal accountId owned by someone else (non-admin caller)", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(
+      postReq({ ...COMPLETE_BODY, accountId: "acc-1" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when an admin tries to send from a Personal account they don't own (canRead=false)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(
+      postReq({ ...COMPLETE_BODY, accountId: "acc-1" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/email/send/route.ts
+++ b/src/app/api/email/send/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 import nodemailer from "nodemailer";
 
 interface UploadedAttachment {
@@ -12,9 +13,13 @@ interface UploadedAttachment {
 
 // POST /api/email/send
 // Body: { accountId, to, subject, body, bodyHtml?, cc?, bcc?, jobId?, replyToMessageId?, attachments? }
-// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
-// gate the #85 Request-Context conversion gave this previously-ungated route.
-export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
+// Gated on view_email at the wrapper; the access module enforces canRead
+// per the bound account (#141, PRD #134 — "send treated the same as canRead
+// for now"). Until the spec splits them, owning a Personal account or
+// reading a Shared one is enough to send from it.
+export const POST = withRequestContext(
+  { permission: "view_email", serviceClient: true },
+  async (request, ctx) => {
   const { accountId, jobId, to, cc, bcc, subject, body, bodyHtml, replyToMessageId, attachments, draftId } =
     await request.json() as {
       accountId: string; jobId?: string; to: string; cc?: string; bcc?: string;
@@ -28,6 +33,14 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
       { status: 400 }
     );
   }
+
+  const resolved = await resolveEmailAccountAccess(
+    ctx.serviceClient!,
+    accountId,
+    ctx,
+    "canRead",
+  );
+  if (resolved.kind === "response") return resolved.response;
 
   const supabase = ctx.supabase;
 

--- a/src/app/api/email/sync-folder/route.test.ts
+++ b/src/app/api/email/sync-folder/route.test.ts
@@ -12,13 +12,27 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 import { POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../__test-utils__/request-context-fakes";
 
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
 const noParams = { params: Promise.resolve({}) };
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -26,8 +40,11 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function postReq() {
-  return new Request("http://test", { method: "POST", body: "{}" });
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
 
 beforeEach(() => {
@@ -35,55 +52,91 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("POST /api/email/sync-folder — gated on send_email (#105)", () => {
+describe("POST /api/email/sync-folder — gated on view_email + canRead per account (#141)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
-    const res = await POST(postReq(), noParams);
+    const res = await POST(postReq({ folder: "inbox" }), noParams);
 
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
+        grants: [],
+      }),
+    });
+
+    const res = await POST(postReq({ folder: "inbox" }), noParams);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when the caller passes the gate but the body omits folder", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
         grants: ["view_email"],
       }),
     });
 
     const res = await POST(postReq(), noParams);
 
-    expect(res.status).toBe(403);
-  });
-
-  it("passes the gate when the caller holds send_email — the handler runs", async () => {
-    authed({
-      user: { id: "user-1" },
-      tables: memberTables({
-        userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
-      }),
-    });
-
-    const res = await POST(postReq(), noParams);
-
-    // Empty body — the handler rejects with 400 for the missing folder,
-    // proving the gate let the request through rather than rejecting it 403.
     expect(res.status).toBe(400);
   });
 
-  it("admins pass the gate without holding the key", async () => {
+  it("returns 404 for an accountId in a different Organization", async () => {
     authed({
       user: { id: "admin-1" },
       tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
+    withAccounts([{ id: "acc-1", organization_id: "org-2", user_id: null }]);
 
-    const res = await POST(postReq(), noParams);
+    const res = await POST(
+      postReq({ accountId: "acc-1", folder: "inbox" }),
+      noParams,
+    );
 
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal accountId owned by someone else (non-admin caller)", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(
+      postReq({ accountId: "acc-1", folder: "inbox" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when admin tries to sync a folder on a Personal account they don't own", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(
+      postReq({ accountId: "acc-1", folder: "inbox" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/email/sync-folder/route.ts
+++ b/src/app/api/email/sync-folder/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, after } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 import { ImapFlow } from "imapflow";
 import { matchEmailToJob, type MatcherCache, type JobRow, type ContactRow } from "@/lib/email-matcher";
 import { categorizeEmail, type CategoryRule } from "@/lib/email-categorizer";
@@ -51,9 +52,14 @@ const ALLOWED_FOLDERS = new Set([
 //
 // The client throttles concurrent calls; this endpoint always does the
 // work it's asked to do.
-// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
-// gate the #85 Request-Context conversion gave this previously-ungated route.
-export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
+// Gated on view_email at the wrapper; per-account canRead via the access
+// module (#141, ADR 0001) when `accountId` is supplied. Without accountId,
+// the fan-out across the org's accounts uses the User client, so RLS scopes
+// the visible set to {Shared + own Personal} — the same canRead-set as the
+// explicit-account path.
+export const POST = withRequestContext(
+  { permission: "view_email", serviceClient: true },
+  async (request, ctx) => {
   const startedAt = Date.now();
   const body = (await request.json()) as { accountId?: string; folder?: string };
   const { accountId, folder } = body;
@@ -63,6 +69,16 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
       { error: "folder is required (inbox, sent, drafts, trash, spam, archive)" },
       { status: 400 },
     );
+  }
+
+  if (accountId) {
+    const resolved = await resolveEmailAccountAccess(
+      ctx.serviceClient!,
+      accountId,
+      ctx,
+      "canRead",
+    );
+    if (resolved.kind === "response") return resolved.response;
   }
 
   const supabase = ctx.supabase;

--- a/src/app/api/email/sync/route.test.ts
+++ b/src/app/api/email/sync/route.test.ts
@@ -12,13 +12,27 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 import { POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import {
+  fakeServiceClient,
   fakeUserClient,
   memberTables,
 } from "../__test-utils__/request-context-fakes";
 
+type Account = {
+  id: string;
+  organization_id: string;
+  user_id: string | null;
+};
+
 const noParams = { params: Promise.resolve({}) };
+
+function withAccounts(accounts: Account[]) {
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { email_accounts: accounts } }) as never,
+  );
+}
 
 function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   vi.mocked(createServerSupabaseClient).mockResolvedValue(
@@ -26,8 +40,11 @@ function authed(opts: Parameters<typeof fakeUserClient>[0]) {
   );
 }
 
-function postReq() {
-  return new Request("http://test", { method: "POST", body: "{}" });
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
 
 beforeEach(() => {
@@ -35,7 +52,7 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
 });
 
-describe("POST /api/email/sync — gated on send_email (#105)", () => {
+describe("POST /api/email/sync — gated on view_email + canRead per account (#141)", () => {
   it("returns 401 when unauthenticated", async () => {
     authed({ user: null });
 
@@ -44,13 +61,13 @@ describe("POST /api/email/sync — gated on send_email (#105)", () => {
     expect(res.status).toBe(401);
   });
 
-  it("returns 403 when the caller holds only view_email", async () => {
+  it("returns 403 when the caller holds no email permission", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
         role: "crew_member",
-        grants: ["view_email"],
+        grants: [],
       }),
     });
 
@@ -59,31 +76,59 @@ describe("POST /api/email/sync — gated on send_email (#105)", () => {
     expect(res.status).toBe(403);
   });
 
-  it("passes the gate when the caller holds send_email — the handler runs", async () => {
+  it("returns 400 when the caller passes the gate but the body omits accountId", async () => {
     authed({
       user: { id: "user-1" },
       tables: memberTables({
         userId: "user-1",
-        role: "crew_member",
-        grants: ["send_email"],
+        role: "crew_lead",
+        grants: ["view_email"],
       }),
     });
 
     const res = await POST(postReq(), noParams);
 
-    // Empty body — the handler rejects with 400 for the missing accountId,
-    // proving the gate let the request through rather than rejecting it 403.
     expect(res.status).toBe(400);
   });
 
-  it("admins pass the gate without holding the key", async () => {
+  it("returns 404 for an accountId in a different Organization", async () => {
     authed({
       user: { id: "admin-1" },
       tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
     });
+    withAccounts([{ id: "acc-1", organization_id: "org-2", user_id: null }]);
 
-    const res = await POST(postReq(), noParams);
+    const res = await POST(postReq({ accountId: "acc-1" }), noParams);
 
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for a Personal accountId in own org owned by someone else (non-admin)", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_email"],
+      }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(postReq({ accountId: "acc-1" }), noParams);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when an admin tries to sync a Personal account they don't own (canRead=false)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    withAccounts([{ id: "acc-1", organization_id: "org-1", user_id: "user-2" }]);
+
+    const res = await POST(postReq({ accountId: "acc-1" }), noParams);
+
+    // canSee=true, canManage=true, but canRead=false → 403
+    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/email/sync/route.ts
+++ b/src/app/api/email/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, after } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { decrypt } from "@/lib/encryption";
+import { resolveEmailAccountAccess } from "@/lib/email/email-account-access-for-route";
 import { ImapFlow } from "imapflow";
 import { matchEmailToJob, type MatcherCache, type JobRow, type ContactRow } from "@/lib/email-matcher";
 import { categorizeEmail, type CategoryRule, type Category } from "@/lib/email-categorizer";
@@ -42,15 +43,26 @@ function mapFolder(imapPath: string): string {
 //
 // First sync per account also runs the one-time category backfill (Pass
 // 1 + Pass 2) — that path is intentionally not optimized.
-// Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
-// gate the #85 Request-Context conversion gave this previously-ungated route.
-export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
+// Gated on view_email at the wrapper; the access module decides canRead
+// per the bound account (#141, ADR 0001 — send-and-sync share canRead with
+// pure-read until/unless the spec splits them).
+export const POST = withRequestContext(
+  { permission: "view_email", serviceClient: true },
+  async (request, ctx) => {
   const startedAt = Date.now();
   const { accountId, maxPerFolder = 50 } = await request.json();
 
   if (!accountId) {
     return NextResponse.json({ error: "accountId is required" }, { status: 400 });
   }
+
+  const resolved = await resolveEmailAccountAccess(
+    ctx.serviceClient!,
+    accountId,
+    ctx,
+    "canRead",
+  );
+  if (resolved.kind === "response") return resolved.response;
 
   const supabase = ctx.supabase;
 

--- a/src/lib/email/email-account-access-for-route.ts
+++ b/src/lib/email/email-account-access-for-route.ts
@@ -1,0 +1,101 @@
+// Bridge between Request Context and the pure email-account-access module.
+//
+// Every Service-client route that acts on a specific Email account by id
+// runs the same three steps:
+//   1. fetch the account row via the Service client (RLS bypassed — needed
+//      so an admin can see Personal accounts they do not own);
+//   2. compose a caller from the Request Context plus a row from the table;
+//   3. ask `evaluateEmailAccountAccess` and map the booleans to HTTP status:
+//        - canSee false   → 404 (cross-org or invisible Personal)
+//        - canManage/Read → 403 (visible but action forbidden)
+//
+// This module owns that orchestration in one place so each route is just
+// a one-line authorize-then-act, and no route invents a slightly different
+// status mapping.
+
+import { NextResponse } from "next/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { RequestContext } from "@/lib/request-context/with-request-context";
+import {
+  evaluateEmailAccountAccess,
+  type EmailAccountAccess,
+} from "./email-account-access";
+
+// The slice of an `email_accounts` row needed to decide access — the rest
+// of the row (credentials, label, host, etc.) is irrelevant to the matrix.
+export interface EmailAccountRow {
+  organization_id: string;
+  user_id: string | null;
+}
+
+// The decision the route asks for. `canSee` is implicit — every route that
+// touches a specific account requires at minimum that the caller can see
+// it; routes additionally pick one of canRead or canManage.
+export type RequiredAccess = "canRead" | "canManage";
+
+export type EmailAccountAccessResult =
+  | { kind: "ok"; account: EmailAccountRow; access: EmailAccountAccess }
+  | { kind: "response"; response: Response };
+
+/**
+ * Looks up an Email account by id via the Service client and asks the
+ * access module whether the caller is allowed to perform the named action
+ * on it. Returns either the ok bundle (the route runs its action) or the
+ * exact response to return (404 or 403, never 500 or 401 — those are the
+ * wrapper's responsibility upstream).
+ *
+ * The Service client is required because the User-client RLS hides
+ * Personal accounts the caller does not own, including from admins who
+ * need to manage them.
+ */
+export async function resolveEmailAccountAccess(
+  serviceClient: SupabaseClient,
+  accountId: string,
+  ctx: RequestContext,
+  required: RequiredAccess,
+): Promise<EmailAccountAccessResult> {
+  const { data: account } = await serviceClient
+    .from("email_accounts")
+    .select("organization_id, user_id")
+    .eq("id", accountId)
+    .maybeSingle<EmailAccountRow>();
+
+  if (!account) {
+    return {
+      kind: "response",
+      response: NextResponse.json({ error: "Not found" }, { status: 404 }),
+    };
+  }
+
+  const access = evaluateEmailAccountAccess(
+    {
+      userId: ctx.userId,
+      // `withRequestContext` guarantees a non-null `orgId` for any rule
+      // that names a permission; routes that opt into this helper all do.
+      // The `?? ""` keeps the type tight without a `!` non-null assertion.
+      organizationId: ctx.orgId ?? "",
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    },
+    {
+      kind: account.user_id === null ? "shared" : "personal",
+      organizationId: account.organization_id,
+      userId: account.user_id,
+    },
+  );
+
+  if (!access.canSee) {
+    return {
+      kind: "response",
+      response: NextResponse.json({ error: "Not found" }, { status: 404 }),
+    };
+  }
+  if (!access[required]) {
+    return {
+      kind: "response",
+      response: NextResponse.json({ error: "Permission denied" }, { status: 403 }),
+    };
+  }
+
+  return { kind: "ok", account, access };
+}

--- a/src/lib/request-context/with-request-context.test.ts
+++ b/src/lib/request-context/with-request-context.test.ts
@@ -140,6 +140,29 @@ describe("withRequestContext", () => {
     expect(received?.role).toBe("member");
   });
 
+  // Handlers that delegate to an access-decision module (#139, PRD #134) need
+  // the caller's permission grants without re-fetching them. The wrapper
+  // already resolved them; carry them through on the Request Context.
+  it("carries the caller's granted permission keys through on the context", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        membership: { id: "m-1", role: "crew_lead" },
+        grants: ["view_email", "send_email"],
+      }) as never,
+    );
+    let received: RequestContext | undefined;
+    const handler = vi.fn((_req: Request, ctx: RequestContext) => {
+      received = ctx;
+      return new Response("ok");
+    });
+
+    const route = withRequestContext({ permission: "view_email" }, handler);
+    await route(new Request("http://test"), paramsContext({}));
+
+    expect(received?.grantedPermissions).toEqual(["view_email", "send_email"]);
+  });
+
   it("admits an admin against a permission rule they hold no grant for", async () => {
     vi.mocked(createServerSupabaseClient).mockResolvedValue(
       fakeUserClient({

--- a/src/lib/request-context/with-request-context.ts
+++ b/src/lib/request-context/with-request-context.ts
@@ -46,6 +46,11 @@ export interface RequestContext {
   userId: string;
   orgId: string | null;
   role: string | null;
+  // The permission keys the wrapper already resolved for this caller —
+  // empty when the caller has no membership in the Active Organization.
+  // Carried through so a handler that delegates to an access-decision
+  // module (#139) does not re-query the grants the wrapper already loaded.
+  grantedPermissions: string[];
   supabase: SupabaseClient;
   serviceClient?: SupabaseClient;
 }
@@ -99,6 +104,7 @@ export function withRequestContext<TParams = Record<string, never>>(
       userId: caller.userId,
       orgId: caller.orgId,
       role: caller.role,
+      grantedPermissions: caller.grantedPermissions,
       supabase,
     };
     if (rule.serviceClient) {


### PR DESCRIPTION
## Summary

PRD #134 slice — wire the [email-account-access module from #139](https://github.com/ericdaniels22/Nookleus/pull/154) into every Email-area route so the access matrix from ADR 0001 is enforced consistently and is no longer re-implemented per-route.

- **POST /api/email/accounts** — new optional \`user_id\` body field. Admin may set any owner in their Organization or omit (Shared); non-admin may only own the account themselves — any other value, including omission, returns 403.
- **GET /api/email/accounts** — default returns the caller's canRead-set (User client + the migration-140 RLS already gives \`{Shared + own Personal}\`). \`?asAdmin=true\` on an admin reads via Service client to surface the full management view, including Personal accounts owned by other users (admin canSee but canRead=false per ADR 0001).
- **PATCH / DELETE / [id]/test POST** — gated on \`canManage\`. Service client + access module: admin manages Shared, owner-or-admin manages Personal. Maps \`canSee=false → 404\`, \`canManage=false → 403\`.
- **GET /api/email/list, POST /api/email/sync, POST /api/email/sync-folder, POST /api/email/send** — gated on \`canRead\` when an \`accountId\` is supplied. Cross-org → 404, admin reading someone's Personal → 403 (canSee true, canRead false), owner-reading-own → through. \`sync\`/\`sync-folder\`/\`send\` previously gated on \`send_email\` at the wrapper; lowered to \`view_email\` so the access module's canRead is the real gate per PRD #134 ("send treated the same as canRead for now").

## Shape

- Extracted \`resolveEmailAccountAccess\` into \`src/lib/email/email-account-access-for-route.ts\` — the bridge between RequestContext + the pure access module. Every Service-client route is now a one-line \`authorize-then-act\` against it.
- Extended \`RequestContext\` with \`grantedPermissions\` so handlers don't re-query the keys the wrapper already resolved.
- Per-route tests follow the issue's 401 / 403 / 404 / kind-specific minimum: 5 tests on POST /accounts user_id rule, 8 each on PATCH and DELETE, 6 on /test, 9 on /list (covering owner-reads, view_email-on-Shared, admin-canRead-false 403, etc.), 6 each on /sync, /sync-folder, /send.

## Test plan
- [ ] CI green (Vercel preview + checks)
- [ ] Sanity-pull and run \`npm test\` locally — expect 719+ passing
- [ ] Smoke on Vercel preview: connect a Shared account as admin, a Personal as a Crew Lead, confirm inbox switcher only shows accounts the caller canRead
- [ ] Smoke as admin: \`?asAdmin=true\` on the settings management view surfaces other users' Personal accounts; the inbox does not
- [ ] Smoke as Crew Lead: PATCH/DELETE on a Shared account → 403; PATCH/DELETE on own Personal → 200

Fixes #141. Continues PRD #134 (next slice: #142 UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)