### PR TITLE
Email UI: Settings Shared/Personal view + inbox account switcher (#142)

### DIFF
--- a/src/app/settings/email/page.test.tsx
+++ b/src/app/settings/email/page.test.tsx
@@ -1,0 +1,269 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+// #142 — the Settings → Email management view brings the UI in line with
+// the access module's Shared/Personal matrix. These light UI tests cover
+// what the component itself decides: which fetch view it asks for, how it
+// labels each account's kind, and whether the connect dialog offers an
+// Owner picker. Route-level access (canRead/canSee/canManage, ownership)
+// is already covered by the #139 / #141 route + module suites.
+
+// `useAuth` is the component's only source of the caller's role. A hoisted
+// mutable holder lets each test set admin vs non-admin before render.
+const auth = vi.hoisted(() => ({
+  value: {
+    profile: null as { id: string; full_name: string; role: string } | null,
+    loading: false,
+  },
+}));
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => auth.value,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+import EmailSettingsPage from "./page";
+
+type Account = {
+  id: string;
+  user_id: string | null;
+  label: string;
+  email_address: string;
+  display_name: string;
+  provider: string;
+  signature: string | null;
+  imap_host: string;
+  imap_port: number;
+  smtp_host: string;
+  smtp_port: number;
+  username: string;
+  is_active: boolean;
+  is_default: boolean;
+  color: string | null;
+  last_synced_at: string | null;
+  created_at: string;
+};
+
+function account(overrides: Partial<Account> = {}): Account {
+  return {
+    id: "acc-1",
+    user_id: null,
+    label: "Main Office",
+    email_address: "office@example.com",
+    display_name: "AAA",
+    provider: "hostinger",
+    signature: null,
+    imap_host: "imap.example.com",
+    imap_port: 993,
+    smtp_host: "smtp.example.com",
+    smtp_port: 465,
+    username: "office@example.com",
+    is_active: true,
+    is_default: false,
+    color: "#2563eb",
+    last_synced_at: null,
+    created_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+type Member = { id: string; full_name: string; email: string; role: string };
+
+function stubFetch({
+  accounts = [],
+  members = [],
+}: { accounts?: Account[]; members?: Member[] } = {}) {
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  const spy = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url.startsWith("/api/email/accounts")) {
+      if (init?.method === "POST") return json({ id: "new-acc" }, 201);
+      return json(accounts);
+    }
+    if (url.startsWith("/api/settings/users")) return json(members);
+    return json({});
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+// The JSON body of the connect-dialog POST to /api/email/accounts.
+function postBody(spy: ReturnType<typeof stubFetch>): Record<string, unknown> | null {
+  const call = spy.mock.calls.find(
+    (c) =>
+      String(c[0]).startsWith("/api/email/accounts") &&
+      (c[1] as RequestInit | undefined)?.method === "POST",
+  );
+  return call ? JSON.parse(String((call[1] as RequestInit).body)) : null;
+}
+
+function asAdmin(id = "admin-1", full_name = "Ada Admin") {
+  auth.value = { profile: { id, full_name, role: "admin" }, loading: false };
+}
+function asNonAdmin(id = "user-1", full_name = "Nick NonAdmin") {
+  auth.value = { profile: { id, full_name, role: "crew_lead" }, loading: false };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EmailSettingsPage — connect dialog Owner picker (#142)", () => {
+  it("renders an Owner picker in the connect dialog for an admin", async () => {
+    asAdmin();
+    stubFetch({
+      members: [
+        { id: "admin-1", full_name: "Ada Admin", email: "ada@x.com", role: "admin" },
+        { id: "user-1", full_name: "Nick NonAdmin", email: "nick@x.com", role: "crew_lead" },
+      ],
+    });
+
+    render(<EmailSettingsPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add email account/i }),
+    );
+
+    expect(screen.getByRole("combobox", { name: /owner/i })).toBeDefined();
+  });
+
+  it("omits the Owner picker in the connect dialog for a non-admin", async () => {
+    asNonAdmin();
+    stubFetch();
+
+    render(<EmailSettingsPage />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add email account/i }),
+    );
+
+    // The connect dialog itself is open (its provider select is present)…
+    expect(screen.getByText("Email Provider")).toBeDefined();
+    // …but a non-admin gets no Owner picker — they are auto-assigned owner.
+    expect(screen.queryByRole("combobox", { name: /owner/i })).toBeNull();
+  });
+});
+
+describe("EmailSettingsPage — account kind label (#142)", () => {
+  it("shows a 'Shared' badge on a Shared account row", async () => {
+    asNonAdmin();
+    stubFetch({
+      accounts: [account({ id: "s1", user_id: null, label: "Front Desk" })],
+    });
+
+    render(<EmailSettingsPage />);
+
+    expect(await screen.findByText("Front Desk")).toBeDefined();
+    expect(screen.getByText("Shared")).toBeDefined();
+  });
+
+  it("shows 'Owner: <name>' on a Personal account row, resolving the name from the member list", async () => {
+    asAdmin();
+    stubFetch({
+      accounts: [account({ id: "p1", user_id: "user-7", label: "Jane's Inbox" })],
+      members: [
+        { id: "user-7", full_name: "Jane Tradesman", email: "jane@x.com", role: "crew_member" },
+      ],
+    });
+
+    render(<EmailSettingsPage />);
+
+    expect(await screen.findByText("Jane's Inbox")).toBeDefined();
+    // The member-list fetch resolves the owner uuid to a display name.
+    expect(await screen.findByText(/Owner: Jane Tradesman/)).toBeDefined();
+    expect(screen.queryByText("Shared")).toBeNull();
+  });
+});
+
+describe("EmailSettingsPage — which account view is fetched (#142)", () => {
+  it("an admin requests the org-wide admin view (?asAdmin=true)", async () => {
+    asAdmin();
+    const spy = stubFetch({ accounts: [account()] });
+
+    render(<EmailSettingsPage />);
+    await screen.findByText("Main Office");
+
+    const accountUrls = spy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((u) => u.startsWith("/api/email/accounts"));
+    expect(accountUrls.some((u) => u.includes("asAdmin=true"))).toBe(true);
+  });
+
+  it("a non-admin requests only their readable accounts — no admin view, no member list", async () => {
+    asNonAdmin();
+    const spy = stubFetch({ accounts: [account()] });
+
+    render(<EmailSettingsPage />);
+    await screen.findByText("Main Office");
+
+    const urls = spy.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.startsWith("/api/email/accounts"))).toBe(true);
+    expect(urls.some((u) => u.includes("asAdmin=true"))).toBe(false);
+    // A non-admin has no business enumerating the Organization's members.
+    expect(urls.some((u) => u.startsWith("/api/settings/users"))).toBe(false);
+  });
+});
+
+describe("EmailSettingsPage — owner assigned when connecting an account (#142)", () => {
+  it("a non-admin's new account is owned by the caller", async () => {
+    asNonAdmin("user-1");
+    const spy = stubFetch();
+
+    const { container } = render(<EmailSettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add email account/i }),
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(postBody(spy)).toMatchObject({ user_id: "user-1" });
+    });
+  });
+
+  it("an admin's new account is owned by the member chosen in the Owner picker", async () => {
+    asAdmin();
+    const spy = stubFetch({
+      members: [
+        { id: "user-9", full_name: "Pat Picked", email: "pat@x.com", role: "crew_member" },
+      ],
+    });
+
+    const { container } = render(<EmailSettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add email account/i }),
+    );
+
+    fireEvent.change(await screen.findByRole("combobox", { name: /owner/i }), {
+      target: { value: "user-9" },
+    });
+    fireEvent.submit(container.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(postBody(spy)).toMatchObject({ user_id: "user-9" });
+    });
+  });
+
+  it("an admin's new account is Shared (no owner) when the Owner picker is left on Shared", async () => {
+    asAdmin();
+    const spy = stubFetch();
+
+    const { container } = render(<EmailSettingsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /add email account/i }),
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    await waitFor(() => {
+      expect(postBody(spy)).toMatchObject({ user_id: null });
+    });
+  });
+});

--- a/src/app/settings/email/page.tsx
+++ b/src/app/settings/email/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
 import {
   Mail,
   Plus,
@@ -21,9 +21,13 @@ import {
   ACCOUNT_COLOR_PALETTE,
   ACCOUNT_COLOR_FALLBACK,
 } from "@/lib/email/assign-account-color";
+import { useAuth } from "@/lib/auth-context";
 
 interface EmailAccount {
   id: string;
+  // null marks a Shared (org-wide) account; a uuid marks a Personal
+  // account owned by that user. Drives the "Shared" vs "Owner: X" label.
+  user_id: string | null;
   label: string;
   email_address: string;
   display_name: string;
@@ -41,8 +45,22 @@ interface EmailAccount {
   created_at: string;
 }
 
+// A member of the active Organization — enough to label a Personal
+// account's owner and to populate the connect dialog's Owner picker.
+interface OrgMember {
+  id: string;
+  full_name: string;
+  email: string;
+}
+
 export default function EmailSettingsPage() {
+  const { profile, loading: authLoading } = useAuth();
+  const isAdmin = profile?.role === "admin";
+
   const [accounts, setAccounts] = useState<EmailAccount[]>([]);
+  const [members, setMembers] = useState<OrgMember[]>([]);
+  // Owner picked in the connect dialog: "" means Shared (no owner).
+  const [ownerId, setOwnerId] = useState("");
   const [loading, setLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [testingId, setTestingId] = useState<string | null>(null);
@@ -81,28 +99,73 @@ export default function EmailSettingsPage() {
     }
   }
 
+  // An admin manages every account in the Organization, including Personal
+  // accounts owned by others — that needs the Service-client admin view
+  // (?asAdmin=true). A non-admin gets the default view: the accounts they
+  // can read (Shared plus their own Personal), which is all they may touch.
+  const accountsUrl = isAdmin
+    ? "/api/email/accounts?asAdmin=true"
+    : "/api/email/accounts";
+
+  // Re-run by the connect / edit / delete / sync handlers to refresh the
+  // list after a mutation. The initial load lives in the effect below.
   const fetchAccounts = useCallback(async () => {
-    const res = await fetch("/api/email/accounts");
+    const res = await fetch(accountsUrl);
     if (res.ok) {
       const data = await res.json();
       setAccounts(data);
     }
     setLoading(false);
-  }, []);
+  }, [accountsUrl]);
 
+  // Initial account load. Wait for auth to resolve first — the chosen view
+  // hinges on the caller's role.
   useEffect(() => {
-    fetchAccounts();
-  }, [fetchAccounts]);
+    if (authLoading) return;
+    fetch(accountsUrl)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (Array.isArray(data)) setAccounts(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [authLoading, accountsUrl]);
+
+  // Member list — only an admin needs it: to resolve a Personal account's
+  // "Owner: X" label and to populate the connect dialog's Owner picker. A
+  // non-admin only ever sees Shared accounts plus their own Personal one,
+  // so their own profile is enough and /api/settings/users is never hit.
+  useEffect(() => {
+    if (authLoading || !isAdmin) return;
+    fetch("/api/settings/users")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!Array.isArray(data)) return;
+        setMembers(
+          data.map((m: { id: string; full_name?: string; email?: string }) => ({
+            id: m.id,
+            full_name: m.full_name || m.email || "Unknown",
+            email: m.email || "",
+          })),
+        );
+      })
+      .catch(() => {});
+  }, [authLoading, isAdmin]);
 
   async function handleAdd(e: React.FormEvent) {
     e.preventDefault();
     setSaving(true);
+    // Owner of the new account. An admin's choice comes from the Owner
+    // picker ("" → Shared, i.e. no owner). A non-admin has no picker and is
+    // always the owner of what they connect — the route enforces this too.
+    const owner = isAdmin ? ownerId || null : profile?.id ?? null;
     const res = await fetch("/api/email/accounts", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         ...form,
         username: form.username || form.email_address,
+        user_id: owner,
       }),
     });
     if (res.ok) {
@@ -119,6 +182,7 @@ export default function EmailSettingsPage() {
         username: "",
         password: "",
       });
+      setOwnerId("");
       fetchAccounts();
     }
     setSaving(false);
@@ -194,6 +258,22 @@ export default function EmailSettingsPage() {
       setTestResults((prev) => ({ ...prev, [id]: data }));
     }
     setTestingId(null);
+  }
+
+  const memberNameById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const m of members) map.set(m.id, m.full_name);
+    return map;
+  }, [members]);
+
+  // Display name for a Personal account's owner. An admin resolves any
+  // member via the member list; a non-admin only ever sees their own
+  // Personal account, so their profile covers it.
+  function ownerLabel(userId: string): string {
+    return (
+      memberNameById.get(userId) ??
+      (profile && userId === profile.id ? profile.full_name : "Unknown")
+    );
   }
 
   return (
@@ -299,6 +379,17 @@ export default function EmailSettingsPage() {
                       <p className="text-sm text-muted-foreground">{account.email_address}</p>
                       {account.display_name && (
                         <p className="text-xs text-muted-foreground/60">Sends as: {account.display_name}</p>
+                      )}
+                      {/* Account kind — a Shared account carries no owner;
+                          a Personal account names the member who owns it. */}
+                      {account.user_id === null ? (
+                        <span className="inline-flex items-center text-xs font-medium px-2 py-0.5 mt-1 rounded-full bg-blue-50 text-blue-700">
+                          Shared
+                        </span>
+                      ) : (
+                        <p className="text-xs text-muted-foreground/60 mt-1">
+                          Owner: {ownerLabel(account.user_id)}
+                        </p>
                       )}
                     </div>
                   )}
@@ -493,6 +584,30 @@ export default function EmailSettingsPage() {
               ))}
             </select>
           </div>
+
+          {/* Owner — admins only. An admin may connect a Shared account
+              (no owner) or a Personal account on behalf of any member.
+              A non-admin has no picker; they are auto-assigned as owner. */}
+          {isAdmin && (
+            <div>
+              <label className="block text-sm font-medium text-foreground mb-1">
+                Owner
+              </label>
+              <select
+                aria-label="Owner"
+                value={ownerId}
+                onChange={(e) => setOwnerId(e.target.value)}
+                className="w-full border border-border rounded-lg px-3 py-2 text-sm bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-primary/30 focus:border-primary"
+              >
+                <option value="">Shared — entire organization</option>
+                {members.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.full_name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>

--- a/src/components/email-inbox.test.tsx
+++ b/src/components/email-inbox.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+
+// #142 — the inbox account switcher must offer exactly the accounts the
+// caller can read: Shared accounts in their Organization plus their own
+// Personal accounts. The switcher gets that set straight from the default
+// GET /api/email/accounts view, which #141 already scoped to the caller's
+// canRead set. This test pins the switcher to that response so a future
+// change (e.g. fetching the ?asAdmin view) can't leak others' Personal
+// accounts into the picker.
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("@/lib/email/use-email-sync", () => ({
+  useEmailSync: () => ({
+    syncing: false,
+    lastSyncedAt: null,
+    syncFailed: false,
+    syncSilent: vi.fn(),
+    syncVisible: vi.fn(),
+  }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Subcomponents whose internals aren't under test.
+vi.mock("@/components/email-reader", () => ({ default: () => null }));
+vi.mock("@/components/compose-email", () => ({ default: () => null }));
+vi.mock("@/components/email/icon-rail", () => ({ default: () => null }));
+vi.mock("@/components/email/category-tabs", () => ({ default: () => null }));
+
+import EmailInbox from "./email-inbox";
+
+function emailAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "acc-1",
+    user_id: null,
+    label: "Account",
+    email_address: "a@example.com",
+    display_name: "AAA",
+    provider: "hostinger",
+    imap_host: "imap.example.com",
+    imap_port: 993,
+    smtp_host: "smtp.example.com",
+    smtp_port: 465,
+    username: "a@example.com",
+    encrypted_password: "",
+    signature: null,
+    is_active: true,
+    is_default: false,
+    color: "#2563eb",
+    last_synced_at: null,
+    last_synced_uid: null,
+    created_at: "2026-05-20T00:00:00Z",
+    updated_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function stubFetch(accounts: Record<string, unknown>[]) {
+  const json = (body: unknown) =>
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  const spy = vi.fn(async (url: string) => {
+    if (url.startsWith("/api/email/accounts")) return json(accounts);
+    if (url.startsWith("/api/email/list"))
+      return json({ emails: [], total: 0, page: 1, hasMore: false });
+    if (url.startsWith("/api/email/counts")) return json({});
+    return json({});
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("EmailInbox account switcher (#142)", () => {
+  it("lists exactly the accounts GET /api/email/accounts returns — the caller's canRead set", async () => {
+    // The default view is the caller's canRead set: a Shared account plus
+    // their own Personal account. A Personal account owned by another user
+    // is never in this response, so it can't reach the switcher.
+    const canRead = [
+      emailAccount({ id: "shared-1", user_id: null, label: "Front Desk" }),
+      emailAccount({ id: "personal-mine", user_id: "me", label: "My Inbox" }),
+    ];
+    const spy = stubFetch(canRead);
+
+    render(<EmailInbox />);
+
+    const switcher = await screen.findByRole("combobox");
+    await waitFor(() => {
+      expect(
+        within(switcher).getByRole("option", { name: "Front Desk" }),
+      ).toBeDefined();
+    });
+
+    // Every account from the route response is offered…
+    expect(
+      within(switcher).getByRole("option", { name: "My Inbox" }),
+    ).toBeDefined();
+    // …and nothing the route did not return. The static "All Inboxes"
+    // entry is the only extra: exactly canRead.length + 1 options.
+    expect(within(switcher).getAllByRole("option")).toHaveLength(
+      canRead.length + 1,
+    );
+
+    // The switcher's only account source is the default route — it never
+    // requests the admin (?asAdmin) view that would surface others'
+    // Personal accounts.
+    const urls = spy.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.startsWith("/api/email/accounts"))).toBe(true);
+    expect(urls.some((u) => u.includes("asAdmin"))).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #142.

Brings the two email-related UI surfaces in line with the #139 access
matrix now that the #141 routes enforce it.

## Settings → Email management view (`src/app/settings/email/page.tsx`)

- Account rows show a **"Shared"** badge (for org-wide accounts) or an
  **"Owner: \<name\>"** line (for Personal accounts), resolved per kind
  from `user_id`.
- An **admin** loads the org-wide `?asAdmin=true` view (every account in
  the Organization, including others' Personal accounts). A **non-admin**
  loads the default view — their `canRead` set (Shared + own Personal) —
  and never requests the member list.
- The connect dialog shows an **Owner picker** for admins only (any member,
  or "Shared — entire organization"). Non-admins get no picker and are
  auto-assigned as owner via `user_id` on the `POST`.

## Inbox account switcher (`src/components/email-inbox.tsx`)

No code change — the switcher already fetches the default `canRead` view.
Added a test that pins the switcher's list to that route response, so it
can't drift to the `?asAdmin` view and leak Personal accounts belonging to
other users.

## Notes

- The mount fetches were restructured into inline `.then()` chains so the
  file is now `react-hooks/set-state-in-effect` clean (`main` shipped one
  such error here).

## Tests

- `src/app/settings/email/page.test.tsx` — 9 light UI tests (owner picker
  admin vs non-admin, kind labels, which view is fetched, owner assignment)
- `src/components/email-inbox.test.tsx` — 1 test (switcher list = `canRead`)
- Full suite green (729 passed); lint + typecheck clean on the changed
  surface. One pre-existing, unrelated `tsc` error in
  `src/lib/email/sync-folder-incremental.test.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)