### PR TITLE
jobs: Cards/List view toggle + minimal List view (#159)

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -5,6 +5,9 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
+import JobListRow from "@/components/job-list-row";
+import JobsViewToggle from "@/components/jobs-view-toggle";
+import { useJobsViewMode } from "@/lib/jobs/use-jobs-view-mode";
 import { Briefcase, FileText, CalendarDays, Flame, RotateCcw, Trash2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConfig } from "@/lib/config-context";
@@ -30,6 +33,7 @@ export default function JobsPage() {
   const [jobs, setJobs] = useState<Job[]>([]);
   const [filter, setFilter] = useState("all");
   const [loading, setLoading] = useState(true);
+  const { mode, setMode } = useJobsViewMode();
 
   const fetchJobs = useCallback(async () => {
     if (filter === "trash") {
@@ -158,8 +162,8 @@ export default function JobsPage() {
         />
       </div>
 
-      {/* Filter pills */}
-      <div className="flex flex-wrap gap-2 mb-6">
+      {/* Filter pills + view toggle */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
         {filterOptions.map((opt) => (
           <button
             key={opt.value}
@@ -177,6 +181,9 @@ export default function JobsPage() {
             {opt.label}
           </button>
         ))}
+        <div className="ml-auto">
+          <JobsViewToggle mode={mode} onChange={setMode} />
+        </div>
       </div>
 
       {/* Job list */}
@@ -197,6 +204,12 @@ export default function JobsPage() {
         <div className="space-y-3">
           {sortedJobs.map((job) => (
             <TrashRow key={job.id} job={job} onChange={fetchJobs} />
+          ))}
+        </div>
+      ) : mode === "list" ? (
+        <div className="space-y-2">
+          {sortedJobs.map((job) => (
+            <JobListRow key={job.id} job={job} />
           ))}
         </div>
       ) : (

--- a/src/components/job-list-row.tsx
+++ b/src/components/job-list-row.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+
+import type { Job } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * One dense row in the Jobs tab List view. This slice shows the core
+ * identifying fields; status/urgency/damage columns are added in #161.
+ */
+export default function JobListRow({ job }: { job: Job }) {
+  const isCompleted =
+    job.status === "completed" || job.status === "cancelled";
+  const contactName = job.contact ? job.contact.full_name : "Unknown";
+
+  return (
+    <Link
+      href={`/jobs/${job.id}`}
+      className={cn(
+        "flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-2.5 transition-all hover:border-primary/30 hover:shadow-sm",
+        isCompleted && "opacity-60",
+      )}
+    >
+      <span className="w-20 shrink-0 truncate font-mono text-xs text-muted-foreground">
+        {job.job_number}
+      </span>
+      <span className="w-44 shrink-0 truncate text-sm font-semibold text-foreground">
+        {contactName}
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+        {job.property_address}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/jobs-view-toggle.tsx
+++ b/src/components/jobs-view-toggle.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { LayoutGrid, List } from "lucide-react";
+
+import type { JobsViewMode } from "@/lib/jobs/view-mode";
+import { cn } from "@/lib/utils";
+
+const OPTIONS: {
+  mode: JobsViewMode;
+  label: string;
+  Icon: React.ComponentType<{ size?: number }>;
+}[] = [
+  { mode: "grid", label: "Card view", Icon: LayoutGrid },
+  { mode: "list", label: "List view", Icon: List },
+];
+
+/**
+ * Segmented control for switching the Jobs tab view mode. This slice
+ * offers Card and List; the Comfortable option is added later (#162).
+ */
+export default function JobsViewToggle({
+  mode,
+  onChange,
+}: {
+  mode: JobsViewMode;
+  onChange: (mode: JobsViewMode) => void;
+}) {
+  return (
+    <div className="inline-flex items-center gap-1 rounded-lg border border-border bg-card p-1">
+      {OPTIONS.map(({ mode: optionMode, label, Icon }) => {
+        const active = mode === optionMode;
+        return (
+          <button
+            key={optionMode}
+            type="button"
+            onClick={() => onChange(optionMode)}
+            aria-pressed={active}
+            aria-label={label}
+            title={label}
+            className={cn(
+              "flex h-8 w-8 items-center justify-center rounded-md transition-all",
+              active
+                ? "bg-[image:var(--gradient-primary)] text-white shadow-sm"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            <Icon size={16} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/jobs/use-jobs-view-mode.ts
+++ b/src/lib/jobs/use-jobs-view-mode.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+import {
+  JOBS_VIEW_MODE_STORAGE_KEY,
+  parseJobsViewMode,
+  type JobsViewMode,
+} from "./view-mode";
+
+type JobsViewModeHook = {
+  mode: JobsViewMode;
+  setMode: (mode: JobsViewMode) => void;
+};
+
+// In-memory source of truth, lazily seeded from localStorage on first read.
+// Keeping it in memory means the toggle still works for the session even
+// when localStorage is unavailable (private browsing / quota).
+let currentMode: JobsViewMode | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange);
+  return () => {
+    listeners.delete(onStoreChange);
+  };
+}
+
+function getSnapshot(): JobsViewMode {
+  if (currentMode === null) {
+    currentMode = parseJobsViewMode(
+      window.localStorage.getItem(JOBS_VIEW_MODE_STORAGE_KEY),
+    );
+  }
+  return currentMode;
+}
+
+// The server has no localStorage; render the default so the server markup
+// matches the first client paint and React hydrates without a mismatch.
+function getServerSnapshot(): JobsViewMode {
+  return "grid";
+}
+
+/**
+ * Per-device Jobs tab view-mode preference, backed by localStorage.
+ *
+ * Reads through `useSyncExternalStore` rather than a state-syncing effect:
+ * the default renders on the server, the stored preference applies on the
+ * client, and there is no hydration mismatch.
+ */
+export function useJobsViewMode(): JobsViewModeHook {
+  const mode = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+
+  const setMode = useCallback((next: JobsViewMode) => {
+    currentMode = next;
+    try {
+      window.localStorage.setItem(JOBS_VIEW_MODE_STORAGE_KEY, next);
+    } catch {
+      // localStorage can throw (private browsing / quota). currentMode is
+      // already updated, so the toggle still works for this session.
+    }
+    for (const listener of listeners) {
+      listener();
+    }
+  }, []);
+
+  return { mode, setMode };
+}

--- a/src/lib/jobs/view-mode.test.ts
+++ b/src/lib/jobs/view-mode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { parseJobsViewMode } from "./view-mode";
+
+describe("parseJobsViewMode", () => {
+  it("returns the mode for a recognized stored value", () => {
+    expect(parseJobsViewMode("list")).toBe("list");
+  });
+
+  it("recognizes every valid view mode", () => {
+    expect(parseJobsViewMode("grid")).toBe("grid");
+    expect(parseJobsViewMode("comfortable")).toBe("comfortable");
+    expect(parseJobsViewMode("list")).toBe("list");
+  });
+
+  it("falls back to grid when nothing is stored", () => {
+    expect(parseJobsViewMode(null)).toBe("grid");
+    expect(parseJobsViewMode(undefined)).toBe("grid");
+  });
+
+  it("falls back to grid for an unrecognized stored value", () => {
+    expect(parseJobsViewMode("banana")).toBe("grid");
+    expect(parseJobsViewMode("")).toBe("grid");
+    expect(parseJobsViewMode("GRID")).toBe("grid");
+  });
+});

--- a/src/lib/jobs/view-mode.ts
+++ b/src/lib/jobs/view-mode.ts
@@ -1,0 +1,19 @@
+export type JobsViewMode = "grid" | "comfortable" | "list";
+
+/** localStorage key holding the Jobs tab's per-device view-mode preference. */
+export const JOBS_VIEW_MODE_STORAGE_KEY = "jobs-view-mode";
+
+const JOBS_VIEW_MODES: readonly JobsViewMode[] = [
+  "grid",
+  "comfortable",
+  "list",
+];
+
+export function parseJobsViewMode(
+  raw: string | null | undefined,
+): JobsViewMode {
+  if (raw && (JOBS_VIEW_MODES as readonly string[]).includes(raw)) {
+    return raw as JobsViewMode;
+  }
+  return "grid";
+}


### PR DESCRIPTION
Implements slice **#159** of the Jobs view-modes feature (#152) — the first tracer bullet: a working view switcher plus a minimal List view.

## What's in it

- **View-mode preference** — a pure, validated `parseJobsViewMode` plus a `useJobsViewMode` hook backed by `localStorage` (key `jobs-view-mode`). Reads through `useSyncExternalStore`: the server renders the default and the client applies the stored value, so there's no hydration mismatch.
- **Toggle** — a Cards/List segmented control, right-aligned on the filter-pills row. (The Comfortable option is added later, in #162.)
- **List view** — dense rows showing job #, contact, and property address; the whole row links to the job. Cards remains the default, so nothing changes for a user until they opt in.

## Testing

- `parseJobsViewMode` is unit-tested (4 cases — every valid value round-trips; `null`/`undefined`/garbage/empty → `grid`). Full suite: **733/733 green**.
- ESLint and `tsc` are clean on all new files.
- Browser verification was **skipped** — no reachable Supabase/auth in this environment. The toggle interaction and persistence rest on the unit-tested validator plus code review; the `/jobs` route did compile and server-render (HTTP 200) under Next 16.

## Notes

- The hook uses `useSyncExternalStore` rather than the effect-based `sidebar-collapse-context` pattern, which trips React's `set-state-in-effect` lint rule.

Part of #152. Unblocks #161 and #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
