### PR TITLE
jobs: cover photo schema + set from Photos tab (#160)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -918,8 +918,10 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           jobId={jobId}
           tags={tags}
           supabaseUrl={supabaseUrl}
+          coverPhotoId={job?.cover_photo_id ?? null}
           onPhotosAdded={fetchData}
           onPhotoUpdated={fetchData}
+          onCoverPhotoChanged={fetchData}
           onSelectPhoto={(photo) => setSelectedPhoto(photo)}
         />
       )}

--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase";
 import { Photo, PhotoTag } from "@/lib/types";
 import { format } from "date-fns";
-import { Loader2, Plus } from "lucide-react";
+import { Loader2, Plus, Star } from "lucide-react";
+import { toast } from "sonner";
 import PhotoUploadModal from "@/components/photo-upload";
 import JSZip from "jszip";
 
@@ -12,8 +13,10 @@ interface JobPhotosTabProps {
   jobId: string;
   tags: PhotoTag[];
   supabaseUrl: string;
+  coverPhotoId: string | null;
   onPhotosAdded: () => void;
   onPhotoUpdated: () => void;
+  onCoverPhotoChanged: () => void;
   onSelectPhoto: (photo: Photo) => void;
 }
 
@@ -23,8 +26,10 @@ export default function JobPhotosTab({
   jobId,
   tags,
   supabaseUrl,
+  coverPhotoId,
   onPhotosAdded,
   onPhotoUpdated,
+  onCoverPhotoChanged,
   onSelectPhoto,
 }: JobPhotosTabProps) {
   const [photos, setPhotos] = useState<Photo[]>([]);
@@ -48,6 +53,9 @@ export default function JobPhotosTab({
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [tagPopoverOpen, setTagPopoverOpen] = useState(false);
   const [downloading, setDownloading] = useState(false);
+
+  // Cover photo: id of the photo whose "Set as cover" write is in flight
+  const [settingCover, setSettingCover] = useState<string | null>(null);
 
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -233,6 +241,24 @@ export default function JobPhotosTab({
     URL.revokeObjectURL(a.href);
     setDownloading(false);
     setSelectedIds(new Set());
+  };
+
+  // Promote a photo to be the job's cover. Writes jobs.cover_photo_id
+  // directly, mirroring the single-field job updates in job-detail.tsx.
+  const handleSetCover = async (photoId: string) => {
+    setSettingCover(photoId);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("jobs")
+      .update({ cover_photo_id: photoId })
+      .eq("id", jobId);
+    setSettingCover(null);
+    if (error) {
+      toast.error("Failed to set cover photo.");
+      return;
+    }
+    toast.success("Cover photo updated.");
+    onCoverPhotoChanged();
   };
 
   return (
@@ -460,11 +486,16 @@ export default function JobPhotosTab({
               >
                 {group.photos.map((photo) => {
                   const isSelected = selectedIds.has(photo.id);
+                  const isCover = photo.id === coverPhotoId;
                   return (
                     <div key={photo.id} className="cursor-pointer">
                       <div
                         className={`aspect-square rounded-lg overflow-hidden relative transition-transform hover:scale-[1.03] ${
-                          isSelected ? "ring-[3px] ring-[#2B5EA7]" : ""
+                          isSelected
+                            ? "ring-[3px] ring-[#2B5EA7]"
+                            : isCover
+                            ? "ring-[3px] ring-[#F5A623]"
+                            : ""
                         }`}
                         onClick={(e) => {
                           if (e.shiftKey || selectedIds.size > 0) {
@@ -488,6 +519,34 @@ export default function JobPhotosTab({
                         <div className="absolute bottom-1.5 left-1.5 w-6 h-6 rounded-full bg-[#2B5EA7] border-2 border-white flex items-center justify-center">
                           <span className="text-[9px] font-bold text-white">{getInitials(photo.taken_by)}</span>
                         </div>
+                        {/* Cover photo control */}
+                        {isCover ? (
+                          <div
+                            className="absolute top-1.5 left-1.5 flex items-center gap-1 h-6 px-1.5 rounded-full bg-[#F5A623] text-white text-[10px] font-semibold"
+                            title="Current cover photo"
+                          >
+                            <Star size={11} fill="currentColor" />
+                            Cover
+                          </div>
+                        ) : (
+                          <button
+                            type="button"
+                            title="Set as cover photo"
+                            aria-label="Set as cover photo"
+                            disabled={settingCover === photo.id}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleSetCover(photo.id);
+                            }}
+                            className="absolute top-1.5 left-1.5 w-6 h-6 rounded-full bg-black/45 text-white flex items-center justify-center hover:bg-black/70 transition-colors disabled:opacity-60"
+                          >
+                            {settingCover === photo.id ? (
+                              <Loader2 size={12} className="animate-spin" />
+                            ) : (
+                              <Star size={12} />
+                            )}
+                          </button>
+                        )}
                         {/* Selection checkmark */}
                         {isSelected && (
                           <div className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-[#2B5EA7] flex items-center justify-center">

--- a/src/lib/jobs/cover-photo.test.ts
+++ b/src/lib/jobs/cover-photo.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { resolveCoverPhotoUrl } from "./cover-photo";
+
+const SUPABASE_URL = "https://proj.supabase.co";
+
+describe("resolveCoverPhotoUrl — cover with thumbnail", () => {
+  it("returns the thumbnail URL when the cover photo has a thumbnail", () => {
+    const url = resolveCoverPhotoUrl(
+      {
+        thumbnail_path: "thumbs/abc.jpg",
+        annotated_path: "annotated/abc.jpg",
+        storage_path: "originals/abc.jpg",
+      },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/thumbs/abc.jpg",
+    );
+  });
+});
+
+describe("resolveCoverPhotoUrl — cover without thumbnail", () => {
+  it("falls back to the annotated image when there is no thumbnail", () => {
+    const url = resolveCoverPhotoUrl(
+      {
+        thumbnail_path: null,
+        annotated_path: "annotated/abc.jpg",
+        storage_path: "originals/abc.jpg",
+      },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/annotated/abc.jpg",
+    );
+  });
+
+  it("falls back to the original image when there is no thumbnail or annotation", () => {
+    const url = resolveCoverPhotoUrl(
+      {
+        thumbnail_path: null,
+        annotated_path: null,
+        storage_path: "originals/abc.jpg",
+      },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+});
+
+describe("resolveCoverPhotoUrl — no cover set", () => {
+  it("returns null when the job has no cover photo", () => {
+    expect(resolveCoverPhotoUrl(null, SUPABASE_URL)).toBeNull();
+  });
+});
+
+describe("resolveCoverPhotoUrl — cover photo row absent", () => {
+  // The FK is ON DELETE SET NULL, so deleting the referenced photo nulls
+  // cover_photo_id and the join yields no embedded row at all (undefined).
+  it("returns null when the joined cover photo row is missing", () => {
+    expect(resolveCoverPhotoUrl(undefined, SUPABASE_URL)).toBeNull();
+  });
+});

--- a/src/lib/jobs/cover-photo.ts
+++ b/src/lib/jobs/cover-photo.ts
@@ -1,0 +1,30 @@
+// The subset of a photo row the cover-photo resolver reads.
+export interface CoverPhotoSource {
+  thumbnail_path: string | null;
+  annotated_path: string | null;
+  storage_path: string;
+}
+
+const PHOTOS_BUCKET_PREFIX = "/storage/v1/object/public/photos/";
+
+/**
+ * Resolve the public image URL for a job's cover photo.
+ *
+ * Given the job's joined cover-photo row, returns the URL to display,
+ * preferring the lightweight thumbnail and falling back to the annotated
+ * then the original full-size image. Returns null when the job has no
+ * cover — either none was ever set (cover_photo_id IS NULL), or the
+ * referenced photo was deleted (the FK is ON DELETE SET NULL, so the join
+ * yields no row). The app never auto-selects a cover.
+ */
+export function resolveCoverPhotoUrl(
+  coverPhoto: CoverPhotoSource | null | undefined,
+  supabaseUrl: string,
+): string | null {
+  if (!coverPhoto) return null;
+  const path =
+    coverPhoto.thumbnail_path ??
+    coverPhoto.annotated_path ??
+    coverPhoto.storage_path;
+  return `${supabaseUrl}${PHOTOS_BUCKET_PREFIX}${path}`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -37,6 +37,7 @@ export interface Job {
   hoa_contact_phone: string | null;
   hoa_contact_email: string | null;
   access_notes: string | null;
+  cover_photo_id: string | null;
   has_signed_contract?: boolean;
   has_pending_contract?: boolean;
   created_at: string;
@@ -45,6 +46,7 @@ export interface Job {
   // Joined fields
   contact?: Contact;
   job_adjusters?: JobAdjuster[];
+  cover_photo?: Photo | null;
 }
 
 export interface JobAdjuster {

--- a/supabase/migration-build77-job-cover-photo.sql
+++ b/supabase/migration-build77-job-cover-photo.sql
@@ -1,0 +1,18 @@
+-- build77 (issue #160): add a user-chosen cover photo to jobs.
+--
+-- The cover photo is an existing photo, already attached to the job, that
+-- the user promotes to represent the job visually. It is set from the
+-- job's Photos tab and surfaced in the Jobs tab's Comfortable view
+-- (parent feature #152). The app never auto-selects a cover — a job has
+-- no cover until a user picks one.
+--
+-- cover_photo_id is nullable and references photos(id) ON DELETE SET NULL:
+-- deleting the referenced photo silently reverts the job to having no
+-- cover, rather than blocking the photo delete or leaving a dangling id.
+
+ALTER TABLE public.jobs
+  ADD COLUMN cover_photo_id uuid
+    REFERENCES public.photos(id) ON DELETE SET NULL;
+
+-- ROLLBACK ---
+-- ALTER TABLE public.jobs DROP COLUMN cover_photo_id;


### PR DESCRIPTION
Implements #160 — the cover-photo foundation for the Jobs view-modes feature (parent #152).

## What's in it
- **Migration `build77`** — `jobs.cover_photo_id`, a nullable FK to `photos(id)` with `ON DELETE SET NULL`. Already applied to AAA prod (approved + verified).
- **`resolveCoverPhotoUrl`** (`src/lib/jobs/cover-photo.ts`) — pure resolver: prefers `thumbnail_path`, falls back to `annotated_path` → `storage_path`, returns `null` when no cover is set. The app never auto-selects a cover.
- **`JobPhotosTab`** — per-photo "Set as cover photo" star action (direct `jobs` update, mirroring `job-detail.tsx`'s `updateStatus` pattern); the current cover is marked with an amber ★ "Cover" pill + ring.

## Testing
- TDD red→green on the resolver — 5 cycles (thumbnail, no-thumbnail→annotated, →storage, no cover, deleted/absent).
- Full suite: **734/734 passing**.
- FK verified in prod: `FOREIGN KEY (cover_photo_id) REFERENCES photos(id) ON DELETE SET NULL`.

Fixes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)