### PR TITLE
jobs: List view full columns + header + mobile stripe (#161)

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
-import JobListRow from "@/components/job-list-row";
+import JobListRow, { JobListHeader } from "@/components/job-list-row";
 import JobsViewToggle from "@/components/jobs-view-toggle";
 import { useJobsViewMode } from "@/lib/jobs/use-jobs-view-mode";
 import { Briefcase, FileText, CalendarDays, Flame, RotateCcw, Trash2, Loader2 } from "lucide-react";
@@ -181,9 +181,13 @@ export default function JobsPage() {
             {opt.label}
           </button>
         ))}
-        <div className="ml-auto">
-          <JobsViewToggle mode={mode} onChange={setMode} />
-        </div>
+        {/* The view toggle is hidden in Trash — Trash always renders as
+            rows and is unaffected by the Cards/List preference. */}
+        {filter !== "trash" && (
+          <div className="ml-auto">
+            <JobsViewToggle mode={mode} onChange={setMode} />
+          </div>
+        )}
       </div>
 
       {/* Job list */}
@@ -208,6 +212,7 @@ export default function JobsPage() {
         </div>
       ) : mode === "list" ? (
         <div className="space-y-2">
+          <JobListHeader />
           {sortedJobs.map((job) => (
             <JobListRow key={job.id} job={job} />
           ))}

--- a/src/components/job-list-row.test.tsx
+++ b/src/components/job-list-row.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { Job } from "@/lib/types";
+
+// JobListRow reads status/damage colors + labels from the config context.
+// Stub it so the row renders without a ConfigProvider; the stubbed color
+// strings double as a marker that the row threaded the lookups through.
+vi.mock("@/lib/config-context", () => ({
+  useConfig: () => ({
+    getStatusColor: (name: string) => `status-color-${name}`,
+    getStatusLabel: (name: string) =>
+      name === "in_progress" ? "In Progress" : name,
+    getDamageTypeColor: (name: string) => `damage-color-${name}`,
+    getDamageTypeLabel: (name: string) => (name === "water" ? "Water" : name),
+  }),
+}));
+
+import JobListRow, { JobListHeader } from "./job-list-row";
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "JOB-1001",
+    contact_id: "c-1",
+    status: "in_progress",
+    urgency: "urgent",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "123 Main St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    contact: {
+      id: "c-1",
+      full_name: "Jane Homeowner",
+      phone: null,
+      email: null,
+      role: "homeowner",
+      company: null,
+      title: null,
+      notes: null,
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("JobListRow — core fields (#161)", () => {
+  it("shows job number, contact, and property address", () => {
+    render(<JobListRow job={makeJob()} />);
+
+    expect(screen.getByText("JOB-1001")).toBeDefined();
+    expect(screen.getByText("Jane Homeowner")).toBeDefined();
+    expect(screen.getByText("123 Main St")).toBeDefined();
+  });
+
+  it("links the whole row to the job detail page", () => {
+    render(<JobListRow job={makeJob()} />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/jobs/job-1");
+  });
+});
+
+describe("JobListRow — status / urgency / damage badges (#161)", () => {
+  it("renders colored status, urgency, and damage-type badges", () => {
+    render(<JobListRow job={makeJob()} />);
+
+    const status = screen.getByText("In Progress");
+    const urgency = screen.getByText("Urgent");
+    const damage = screen.getByText("Water");
+
+    // Each badge carries its config-driven / urgency color class.
+    expect(status.className).toContain("status-color-in_progress");
+    expect(urgency.className).toContain("bg-amber-100"); // urgencyColors.urgent
+    expect(damage.className).toContain("damage-color-water");
+  });
+
+  it("hides the status and damage columns below the sm breakpoint", () => {
+    render(<JobListRow job={makeJob()} />);
+
+    const statusCell = screen.getByText("In Progress").parentElement;
+    const damageCell = screen.getByText("Water").parentElement;
+
+    for (const cell of [statusCell, damageCell]) {
+      expect(cell?.className).toContain("hidden");
+      expect(cell?.className).toContain("sm:block");
+    }
+  });
+});
+
+describe("JobListRow — mobile urgency edge stripe (#161)", () => {
+  it("renders a phone-only urgency-colored left-edge stripe", () => {
+    render(<JobListRow job={makeJob({ urgency: "urgent" })} />);
+
+    const stripe = screen.getByTestId("urgency-stripe");
+    expect(stripe.className).toContain("bg-amber-500");
+    // Stripe is the phone stand-in for the urgency badge — gone at sm+.
+    expect(stripe.className).toContain("sm:hidden");
+  });
+
+  it("colors the stripe red for emergency jobs", () => {
+    render(<JobListRow job={makeJob({ urgency: "emergency" })} />);
+
+    expect(screen.getByTestId("urgency-stripe").className).toContain(
+      "bg-red-500",
+    );
+  });
+});
+
+describe("JobListHeader (#161)", () => {
+  it("renders the six column labels", () => {
+    render(<JobListHeader />);
+
+    for (const label of [
+      "Job #",
+      "Contact",
+      "Address",
+      "Status",
+      "Urgency",
+      "Damage",
+    ]) {
+      expect(screen.getByText(label)).toBeDefined();
+    }
+  });
+
+  it("is a label row only — not clickable for sorting", () => {
+    render(<JobListHeader />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+});

--- a/src/components/job-list-row.tsx
+++ b/src/components/job-list-row.tsx
@@ -2,14 +2,65 @@
 
 import Link from "next/link";
 
+import { Badge } from "@/components/ui/badge";
 import type { Job } from "@/lib/types";
+import { urgencyColors, urgencyLabels } from "@/lib/badge-colors";
+import { useConfig } from "@/lib/config-context";
 import { cn } from "@/lib/utils";
 
+// Column widths shared by the header and the rows so the two stay aligned.
+// The three badge columns collapse below the sm breakpoint (phone width).
+const columns = {
+  jobNumber: "w-20 shrink-0",
+  contact: "w-44 shrink-0",
+  address: "min-w-0 flex-1",
+  status: "hidden w-28 shrink-0 sm:block",
+  urgency: "hidden w-24 shrink-0 sm:block",
+  damage: "hidden w-24 shrink-0 sm:block",
+};
+
+const badgeClass = "text-[11px] font-medium px-2 py-0.5 rounded-md";
+
+// Solid edge-stripe color per urgency — the phone-width stand-in for the
+// urgency badge, which is hidden below the sm breakpoint.
+const urgencyStripeColors: Record<Job["urgency"], string> = {
+  emergency: "bg-red-500",
+  urgent: "bg-amber-500",
+  scheduled: "bg-sky-500",
+};
+
 /**
- * One dense row in the Jobs tab List view. This slice shows the core
- * identifying fields; status/urgency/damage columns are added in #161.
+ * Column-label row for the Jobs tab List view. Labels only — the List
+ * view shares the Cards sort (emergencies first, then newest) and is not
+ * sortable by column, so nothing here is clickable.
+ */
+export function JobListHeader() {
+  return (
+    <div className="flex items-center gap-4 border border-transparent px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/70">
+      <span className={columns.jobNumber}>Job #</span>
+      <span className={columns.contact}>Contact</span>
+      <span className={columns.address}>Address</span>
+      <span className={columns.status}>Status</span>
+      <span className={columns.urgency}>Urgency</span>
+      <span className={columns.damage}>Damage</span>
+    </div>
+  );
+}
+
+/**
+ * One dense row in the Jobs tab List view: job number, contact, and
+ * property address, plus colored status / urgency / damage-type badges.
+ * On phone-width screens the badge columns collapse and a colored
+ * left-edge stripe carries the urgency instead, so the row stays
+ * readable without scrolling sideways.
  */
 export default function JobListRow({ job }: { job: Job }) {
+  const {
+    getStatusColor,
+    getStatusLabel,
+    getDamageTypeColor,
+    getDamageTypeLabel,
+  } = useConfig();
   const isCompleted =
     job.status === "completed" || job.status === "cancelled";
   const contactName = job.contact ? job.contact.full_name : "Unknown";
@@ -18,18 +69,67 @@ export default function JobListRow({ job }: { job: Job }) {
     <Link
       href={`/jobs/${job.id}`}
       className={cn(
-        "flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-2.5 transition-all hover:border-primary/30 hover:shadow-sm",
+        "relative flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-2.5 transition-all hover:border-primary/30 hover:shadow-sm",
         isCompleted && "opacity-60",
       )}
     >
-      <span className="w-20 shrink-0 truncate font-mono text-xs text-muted-foreground">
+      {/* Phone-only urgency edge stripe — the stand-in for the urgency
+          badge, which is hidden below the sm breakpoint. */}
+      <span
+        aria-hidden
+        data-testid="urgency-stripe"
+        className={cn(
+          "absolute inset-y-0 left-0 w-1 rounded-l-lg sm:hidden",
+          urgencyStripeColors[job.urgency],
+        )}
+      />
+      <span
+        className={cn(
+          columns.jobNumber,
+          "truncate font-mono text-xs text-muted-foreground",
+        )}
+      >
         {job.job_number}
       </span>
-      <span className="w-44 shrink-0 truncate text-sm font-semibold text-foreground">
+      <span
+        className={cn(
+          columns.contact,
+          "truncate text-sm font-semibold text-foreground",
+        )}
+      >
         {contactName}
       </span>
-      <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
+      <span
+        className={cn(
+          columns.address,
+          "truncate text-sm text-muted-foreground",
+        )}
+      >
         {job.property_address}
+      </span>
+      <span className={columns.status}>
+        <Badge
+          variant="secondary"
+          className={cn(badgeClass, getStatusColor(job.status))}
+        >
+          {getStatusLabel(job.status)}
+        </Badge>
+      </span>
+      <span className={columns.urgency}>
+        <Badge
+          variant="secondary"
+          className={cn(badgeClass, urgencyColors[job.urgency])}
+        >
+          {urgencyLabels[job.urgency]}
+        </Badge>
+      </span>
+      <span className={columns.damage}>
+        <Badge
+          variant="secondary"
+          className={cn(badgeClass, getDamageTypeColor(job.damage_type))}
+        >
+          {getDamageTypeLabel(job.damage_type)}
+        </Badge>
       </span>
     </Link>
   );


### PR DESCRIPTION
## Summary

Slice #161 of PRD #152 — enriches the Jobs tab **List view** from #159's minimal row into the full dense table.

- **`JobListRow`** gains colored **status / urgency / damage-type** badges (status + damage colors via `useConfig`, urgency via `badge-colors`), matching the Cards view.
- New exported **`JobListHeader`** — a labels-only row, **not clickable** (the List view shares the Cards sort and has no column sorting).
- On **phone-width** screens (`<sm`) the three badge columns collapse and a colored **left-edge urgency stripe** stands in — the row stays readable with no horizontal scroll.
- **`jobs/page.tsx`** renders the header above the List rows and **hides the view toggle when the Trash filter is active** (Trash keeps its always-rows rendering). Sort (emergencies-first, then newest) was already shared with Cards via `sortedJobs`.

## Acceptance criteria

- [x] List rows show job number, contact, address, and colored status / urgency / damage-type badges.
- [x] List header row shows column labels and is not clickable for sorting.
- [x] List rows sorted emergencies-first then newest, matching Cards.
- [x] Phone-width: keeps job # / contact / address + urgency edge stripe, hides Status & Damage columns, no horizontal scroll.
- [x] View toggle hidden when Trash filter is active; Trash rendering unchanged.

## Testing

- New `job-list-row.test.tsx` — 8 tests (RED→GREEN): core fields, the three badges + colors, `sm:`-collapsed badge columns, urgency edge stripe (amber/red), `JobListHeader` labels + non-clickability.
- Full suite **746 passed (120 files)**; `tsc` + `eslint` clean on the changed surface (only the two pre-existing findings noted in the #159 handoff remain).
- Not browser-verified — same environment limits as #159 (no reachable Supabase + auth).

Fixes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)