### PR TITLE
jobs: Comfortable view (cover photos + core fields) (#162)

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -6,8 +6,10 @@ import { createClient } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
 import JobListRow, { JobListHeader } from "@/components/job-list-row";
+import JobComfortableRow from "@/components/job-comfortable-row";
 import JobsViewToggle from "@/components/jobs-view-toggle";
 import { useJobsViewMode } from "@/lib/jobs/use-jobs-view-mode";
+import { loadJobsWithCover } from "@/lib/jobs/jobs-with-cover";
 import { Briefcase, FileText, CalendarDays, Flame, RotateCcw, Trash2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConfig } from "@/lib/config-context";
@@ -48,21 +50,10 @@ export default function JobsPage() {
       return;
     }
 
+    // One batched query joins each job to its cover photo, so the
+    // Comfortable view needs no per-job lookup; Cards and List ignore it.
     const supabase = createClient();
-    let query = supabase
-      .from("jobs")
-      .select("*, contact:contacts!contact_id(*)")
-      .is("deleted_at", null)
-      .order("created_at", { ascending: false });
-
-    if (filter === "emergency") {
-      query = query.eq("urgency", "emergency");
-    } else if (filter !== "all") {
-      query = query.eq("status", filter);
-    }
-
-    const { data } = await query;
-    setJobs((data as Job[]) || []);
+    setJobs(await loadJobsWithCover(supabase, filter));
     setLoading(false);
   }, [filter]);
 
@@ -215,6 +206,12 @@ export default function JobsPage() {
           <JobListHeader />
           {sortedJobs.map((job) => (
             <JobListRow key={job.id} job={job} />
+          ))}
+        </div>
+      ) : mode === "comfortable" ? (
+        <div className="space-y-2">
+          {sortedJobs.map((job) => (
+            <JobComfortableRow key={job.id} job={job} />
           ))}
         </div>
       ) : (

--- a/src/components/job-comfortable-row.tsx
+++ b/src/components/job-comfortable-row.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import Link from "next/link";
+import { format } from "date-fns";
+import { ImageOff } from "lucide-react";
+
+import { resolveCoverPhotoUrl } from "@/lib/jobs/cover-photo";
+import type { Job } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
+
+/**
+ * One roomy row in the Jobs tab Comfortable view: a square cover photo,
+ * the job number and contact name, the property address, and the
+ * last-updated date. The whole row links to the job. Status/urgency/
+ * damage badges and the photo/file counts are added later (#163).
+ */
+export default function JobComfortableRow({ job }: { job: Job }) {
+  const isCompleted =
+    job.status === "completed" || job.status === "cancelled";
+  const contactName = job.contact ? job.contact.full_name : "Unknown";
+  const coverUrl = resolveCoverPhotoUrl(job.cover_photo, SUPABASE_URL);
+
+  return (
+    <Link
+      href={`/jobs/${job.id}`}
+      className={cn(
+        "flex items-center gap-4 rounded-xl border border-border bg-card p-3 transition-all hover:border-primary/30 hover:shadow-sm",
+        isCompleted && "opacity-60",
+      )}
+    >
+      {coverUrl ? (
+        // Plain <img> with native lazy loading: the cover is a Supabase
+        // public URL, matching how job-photos-tab.tsx renders photos.
+        <img
+          src={coverUrl}
+          alt=""
+          loading="lazy"
+          className="h-16 w-16 shrink-0 rounded-lg object-cover"
+        />
+      ) : (
+        <div
+          className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-muted"
+          aria-hidden="true"
+        >
+          <ImageOff size={20} className="text-muted-foreground/40" />
+        </div>
+      )}
+
+      <div className="min-w-0 flex-1">
+        <p className="truncate font-mono text-xs text-muted-foreground">
+          {job.job_number}
+        </p>
+        <p className="truncate text-sm font-semibold text-foreground">
+          {contactName}
+        </p>
+        <p className="truncate text-sm text-muted-foreground">
+          {job.property_address}
+        </p>
+      </div>
+
+      <span className="shrink-0 text-xs text-muted-foreground">
+        {format(new Date(job.updated_at), "MMM d, yyyy")}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/jobs-view-toggle.tsx
+++ b/src/components/jobs-view-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { LayoutGrid, List } from "lucide-react";
+import { LayoutGrid, List, Rows3 } from "lucide-react";
 
 import type { JobsViewMode } from "@/lib/jobs/view-mode";
 import { cn } from "@/lib/utils";
@@ -11,12 +11,13 @@ const OPTIONS: {
   Icon: React.ComponentType<{ size?: number }>;
 }[] = [
   { mode: "grid", label: "Card view", Icon: LayoutGrid },
+  { mode: "comfortable", label: "Comfortable view", Icon: Rows3 },
   { mode: "list", label: "List view", Icon: List },
 ];
 
 /**
- * Segmented control for switching the Jobs tab view mode. This slice
- * offers Card and List; the Comfortable option is added later (#162).
+ * Segmented control for switching the Jobs tab view mode between Cards,
+ * Comfortable, and List.
  */
 export default function JobsViewToggle({
   mode,

--- a/src/lib/jobs/jobs-with-cover.test.ts
+++ b/src/lib/jobs/jobs-with-cover.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { Photo } from "@/lib/types";
+import { loadJobsWithCover, shapeJobWithCover } from "./jobs-with-cover";
+
+// A full photo row. The loader and shaper pass it through untouched, so
+// only `id` matters for the identity assertions below; the rest is here
+// purely to satisfy the Photo type.
+function photo(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: "photo-1",
+    job_id: "job-1",
+    storage_path: "job-1/original.jpg",
+    annotated_path: null,
+    thumbnail_path: "job-1/thumb.jpg",
+    caption: null,
+    taken_at: null,
+    taken_by: "user-1",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// A raw jobs row as it arrives from the Comfortable-view query. Built via
+// a helper so the call site passes a value, not a fresh object literal —
+// the latter would trip an excess-property check against the shaper's
+// generic constraint.
+function jobRow(id: string, cover_photo?: Photo | Photo[] | null) {
+  return { id, cover_photo };
+}
+
+// A chainable Supabase query stub: every builder method returns the
+// builder, awaiting it resolves to the supplied result, and `from` calls
+// are counted so a test can prove the load is a single batched query.
+function fakeSupabase(result: { data: unknown; error: unknown }) {
+  let fromCalls = 0;
+  const builder: Record<string, unknown> = {};
+  for (const method of ["select", "is", "order", "eq"]) {
+    builder[method] = () => builder;
+  }
+  builder.then = (resolve: (r: unknown) => void) => resolve(result);
+  const client = {
+    from: () => {
+      fromCalls += 1;
+      return builder;
+    },
+    get fromCalls() {
+      return fromCalls;
+    },
+  };
+  return client as unknown as Parameters<typeof loadJobsWithCover>[0] & {
+    fromCalls: number;
+  };
+}
+
+describe("shapeJobWithCover", () => {
+  it("keeps an embedded cover-photo object on its job", () => {
+    const cover = photo({ id: "cover-A" });
+    const shaped = shapeJobWithCover(jobRow("job-A", cover));
+    expect(shaped).toEqual({ id: "job-A", cover_photo: cover });
+  });
+
+  it("collapses a single-element array embed to one object", () => {
+    const cover = photo({ id: "cover-A" });
+    const shaped = shapeJobWithCover(jobRow("job-A", [cover]));
+    expect(shaped.cover_photo).toEqual(cover);
+  });
+
+  it("shapes a job with no cover set as cover_photo: null", () => {
+    expect(shapeJobWithCover(jobRow("j", null)).cover_photo).toBeNull();
+    expect(shapeJobWithCover(jobRow("j", [])).cover_photo).toBeNull();
+    expect(shapeJobWithCover(jobRow("j")).cover_photo).toBeNull();
+  });
+});
+
+describe("loadJobsWithCover", () => {
+  it("loads jobs in one batched query, each paired with its own cover", async () => {
+    const coverA = photo({ id: "cover-A" });
+    const coverB = photo({ id: "cover-B" });
+    const supabase = fakeSupabase({
+      data: [
+        jobRow("job-A", coverA),
+        jobRow("job-B", [coverB]),
+        jobRow("job-C", null),
+      ],
+      error: null,
+    });
+
+    const jobs = await loadJobsWithCover(supabase);
+
+    expect(supabase.fromCalls).toBe(1);
+    expect(jobs.map((j) => [j.id, j.cover_photo?.id ?? null])).toEqual([
+      ["job-A", "cover-A"],
+      ["job-B", "cover-B"],
+      ["job-C", null],
+    ]);
+  });
+
+  it("returns an empty array when the query fails", async () => {
+    const supabase = fakeSupabase({ data: null, error: { message: "boom" } });
+    expect(await loadJobsWithCover(supabase)).toEqual([]);
+  });
+});

--- a/src/lib/jobs/jobs-with-cover.ts
+++ b/src/lib/jobs/jobs-with-cover.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Job, Photo } from "@/lib/types";
+
+/**
+ * Normalize a raw jobs row so its joined cover photo is a single object,
+ * or `null` when the job has no cover set. A PostgREST to-one embed can
+ * arrive as either an object or a one-element array; this collapses both.
+ * Never auto-picks a cover — a job with no `cover_photo_id` stays null.
+ */
+export function shapeJobWithCover<
+  T extends { cover_photo?: Photo | Photo[] | null },
+>(raw: T): Omit<T, "cover_photo"> & { cover_photo: Photo | null } {
+  const embed = raw.cover_photo;
+  const cover_photo = Array.isArray(embed)
+    ? (embed[0] ?? null)
+    : (embed ?? null);
+  return { ...raw, cover_photo };
+}
+
+/**
+ * Load every non-deleted job together with its cover photo in a single
+ * batched query. The cover is joined through `jobs.cover_photo_id`, so
+ * there is no per-job follow-up query. Rows come back newest-first; an
+ * optional filter narrows them to emergencies or one status, mirroring
+ * the Jobs tab's filter pills. Returns `[]` if the query fails.
+ */
+export async function loadJobsWithCover(
+  supabase: SupabaseClient,
+  filter: string = "all",
+): Promise<Job[]> {
+  let query = supabase
+    .from("jobs")
+    .select(
+      "*, contact:contacts!contact_id(*), cover_photo:photos!cover_photo_id(*)",
+    )
+    .is("deleted_at", null);
+
+  if (filter === "emergency") {
+    query = query.eq("urgency", "emergency");
+  } else if (filter !== "all") {
+    query = query.eq("status", filter);
+  }
+
+  const { data, error } = await query.order("created_at", {
+    ascending: false,
+  });
+  if (error || !data) return [];
+  return (data as Array<{ cover_photo?: Photo | Photo[] | null }>).map((row) =>
+    shapeJobWithCover(row),
+  ) as Job[];
+}


### PR DESCRIPTION
Closes #162 — slice of the Jobs view-modes feature (#152).

## What's in it

- **`loadJobsWithCover` loader** (`src/lib/jobs/jobs-with-cover.ts`) — fetches every non-deleted job with its cover photo joined in a **single batched query** (`cover_photo:photos!cover_photo_id(*)`), no per-job lookup. Honors the existing emergency/status filter pills.
- **`shapeJobWithCover`** — pure row-shaper that normalizes the PostgREST to-one embed (object *or* one-element array) to a single `cover_photo` object, or `null` when no cover is set. Never auto-picks a cover.
- **Comfortable view** — one roomy row per job: square cover photo on the left (resolved via `resolveCoverPhotoUrl`, lazy-loaded; gray placeholder when unset), job number + contact name, property address, and the last-updated date. The whole row links to the job.
- **Toggle** — now offers Cards / Comfortable / List.

## Tests

- 5 new unit tests in `jobs-with-cover.test.ts` — shaper row-shaping (object embed, array embed, no-cover → null) and the loader (single batched query, each job paired with its own cover, empty array on query error).
- Full suite **743 passed (120 files)**; `tsc` + ESLint clean on the changed surface.

## Not browser-verified

No reachable Supabase + auth in this environment (prod creds absent, scratch project paused). The `photos!cover_photo_id` embed hint mirrors the working `contacts!contact_id` embed in the same query and the FK was verified on prod in #160 — but a live `/jobs` check of the Comfortable view is still worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)