### PR TITLE
jobs: Comfortable row badges + photo/file counts (#163)

### DIFF
--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type { Job } from "@/lib/types";
+
+// JobComfortableRow reads status/damage colors + labels from the config
+// context. Stub it so the row renders without a ConfigProvider; the
+// stubbed color strings double as a marker that the row threaded the
+// lookups through.
+vi.mock("@/lib/config-context", () => ({
+  useConfig: () => ({
+    getStatusColor: (name: string) => `status-color-${name}`,
+    getStatusLabel: (name: string) =>
+      name === "in_progress" ? "In Progress" : name,
+    getDamageTypeColor: (name: string) => `damage-color-${name}`,
+    getDamageTypeLabel: (name: string) => (name === "water" ? "Water" : name),
+  }),
+}));
+
+import JobComfortableRow from "./job-comfortable-row";
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "JOB-1001",
+    contact_id: "c-1",
+    status: "in_progress",
+    urgency: "urgent",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "123 Main St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    cover_photo: null,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    contact: {
+      id: "c-1",
+      full_name: "Jane Homeowner",
+      phone: null,
+      email: null,
+      role: "homeowner",
+      company: null,
+      title: null,
+      notes: null,
+      created_at: "2026-05-01T00:00:00Z",
+      updated_at: "2026-05-01T00:00:00Z",
+    },
+    ...overrides,
+  };
+}
+
+describe("JobComfortableRow — status / urgency / damage badges (#163)", () => {
+  it("renders colored status, urgency, and damage-type badges", () => {
+    render(<JobComfortableRow job={makeJob()} />);
+
+    const status = screen.getByText("In Progress");
+    const urgency = screen.getByText("Urgent");
+    const damage = screen.getByText("Water");
+
+    // Each badge carries its config-driven / urgency color class.
+    expect(status.className).toContain("status-color-in_progress");
+    expect(urgency.className).toContain("bg-amber-100"); // urgencyColors.urgent
+    expect(damage.className).toContain("damage-color-water");
+  });
+});
+
+describe("JobComfortableRow — photo / file counts (#163)", () => {
+  it("shows the job's photo count and file count", () => {
+    render(
+      <JobComfortableRow job={makeJob({ photo_count: 7, file_count: 3 })} />,
+    );
+
+    const counts = screen.getByTestId("job-counts");
+    expect(counts.textContent).toContain("7");
+    expect(counts.textContent).toContain("3");
+  });
+
+  it("shows a count of 0 for a job with no photos or files", () => {
+    render(
+      <JobComfortableRow job={makeJob({ photo_count: 0, file_count: 0 })} />,
+    );
+
+    const counts = screen.getByTestId("job-counts");
+    expect(counts.textContent).toContain("0");
+  });
+
+  it("hides the counts below the sm breakpoint, keeping the badges", () => {
+    render(
+      <JobComfortableRow job={makeJob({ photo_count: 7, file_count: 3 })} />,
+    );
+
+    // The count column collapses on a phone-width row...
+    const counts = screen.getByTestId("job-counts");
+    expect(counts.className).toContain("hidden");
+    expect(counts.className).toContain("sm:flex");
+
+    // ...but the status badge — like the urgency and damage badges — is
+    // never hidden, so the row stays informative on a small screen. The
+    // badges wrap (the Badge base class carries `overflow-hidden`), so
+    // assert against the standalone `hidden` utility class, not a
+    // substring.
+    const classes = (el: Element | null | undefined) =>
+      (el?.className ?? "").split(/\s+/);
+    const statusBadge = screen.getByText("In Progress");
+    expect(classes(statusBadge)).not.toContain("hidden");
+    expect(classes(statusBadge.parentElement)).not.toContain("hidden");
+  });
+});

--- a/src/components/job-comfortable-row.tsx
+++ b/src/components/job-comfortable-row.tsx
@@ -2,21 +2,33 @@
 
 import Link from "next/link";
 import { format } from "date-fns";
-import { ImageOff } from "lucide-react";
+import { ImageOff, Image as ImageIcon, Paperclip } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
 import { resolveCoverPhotoUrl } from "@/lib/jobs/cover-photo";
+import { urgencyColors, urgencyLabels } from "@/lib/badge-colors";
+import { useConfig } from "@/lib/config-context";
 import type { Job } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
 
+const badgeClass = "text-[11px] font-medium px-2 py-0.5 rounded-md";
+
 /**
  * One roomy row in the Jobs tab Comfortable view: a square cover photo,
- * the job number and contact name, the property address, and the
- * last-updated date. The whole row links to the job. Status/urgency/
- * damage badges and the photo/file counts are added later (#163).
+ * the job number and contact name, the property address, colored
+ * status / urgency / damage-type badges, and a photo count plus file
+ * count. The whole row links to the job. On phone-width screens the
+ * counts hide while the cover, name/address, and badges stay.
  */
 export default function JobComfortableRow({ job }: { job: Job }) {
+  const {
+    getStatusColor,
+    getStatusLabel,
+    getDamageTypeColor,
+    getDamageTypeLabel,
+  } = useConfig();
   const isCompleted =
     job.status === "completed" || job.status === "cancelled";
   const contactName = job.contact ? job.contact.full_name : "Unknown";
@@ -58,6 +70,44 @@ export default function JobComfortableRow({ job }: { job: Job }) {
         <p className="truncate text-sm text-muted-foreground">
           {job.property_address}
         </p>
+        {/* Badges sit under the address so they stay visible on a
+            phone-width row, where the count column is hidden. */}
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          <Badge
+            variant="secondary"
+            className={cn(badgeClass, getStatusColor(job.status))}
+          >
+            {getStatusLabel(job.status)}
+          </Badge>
+          <Badge
+            variant="secondary"
+            className={cn(badgeClass, urgencyColors[job.urgency])}
+          >
+            {urgencyLabels[job.urgency]}
+          </Badge>
+          <Badge
+            variant="secondary"
+            className={cn(badgeClass, getDamageTypeColor(job.damage_type))}
+          >
+            {getDamageTypeLabel(job.damage_type)}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Photo / file counts — an at-a-glance signal of how documented
+          the job is. */}
+      <div
+        data-testid="job-counts"
+        className="hidden shrink-0 flex-col items-end gap-1 text-xs text-muted-foreground sm:flex"
+      >
+        <span className="flex items-center gap-1">
+          <ImageIcon size={13} className="shrink-0" aria-hidden="true" />
+          <span aria-label="Photos">{job.photo_count ?? 0}</span>
+        </span>
+        <span className="flex items-center gap-1">
+          <Paperclip size={13} className="shrink-0" aria-hidden="true" />
+          <span aria-label="Files">{job.file_count ?? 0}</span>
+        </span>
       </div>
 
       <span className="shrink-0 text-xs text-muted-foreground">

--- a/src/lib/jobs/jobs-with-cover.test.ts
+++ b/src/lib/jobs/jobs-with-cover.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type { Photo } from "@/lib/types";
-import { loadJobsWithCover, shapeJobWithCover } from "./jobs-with-cover";
+import type { Job, Photo } from "@/lib/types";
+import {
+  attachJobCounts,
+  loadJobsWithCover,
+  shapeJobWithCover,
+} from "./jobs-with-cover";
 
 // A full photo row. The loader and shaper pass it through untouched, so
 // only `id` matters for the identity assertions below; the rest is here
@@ -35,27 +39,32 @@ function jobRow(id: string, cover_photo?: Photo | Photo[] | null) {
   return { id, cover_photo };
 }
 
-// A chainable Supabase query stub: every builder method returns the
-// builder, awaiting it resolves to the supplied result, and `from` calls
-// are counted so a test can prove the load is a single batched query.
-function fakeSupabase(result: { data: unknown; error: unknown }) {
-  let fromCalls = 0;
-  const builder: Record<string, unknown> = {};
-  for (const method of ["select", "is", "order", "eq"]) {
-    builder[method] = () => builder;
-  }
-  builder.then = (resolve: (r: unknown) => void) => resolve(result);
+// A chainable Supabase query stub. Every builder method returns the
+// builder; awaiting it resolves to the result registered for that table
+// (an unregistered table resolves to an empty list). `fromTables` records
+// the table of every `.from(...)` call, so a test can prove the load
+// batches its queries rather than running one per job.
+function fakeSupabase(
+  tables: Record<string, { data: unknown; error: unknown }>,
+) {
+  const fromTables: string[] = [];
   const client = {
-    from: () => {
-      fromCalls += 1;
+    from: (table: string) => {
+      fromTables.push(table);
+      const result = tables[table] ?? { data: [], error: null };
+      const builder: Record<string, unknown> = {};
+      for (const method of ["select", "is", "order", "eq", "in"]) {
+        builder[method] = () => builder;
+      }
+      builder.then = (resolve: (r: unknown) => void) => resolve(result);
       return builder;
     },
-    get fromCalls() {
-      return fromCalls;
+    get fromTables() {
+      return fromTables;
     },
   };
   return client as unknown as Parameters<typeof loadJobsWithCover>[0] & {
-    fromCalls: number;
+    fromTables: string[];
   };
 }
 
@@ -79,22 +88,68 @@ describe("shapeJobWithCover", () => {
   });
 });
 
+// A minimal job — attachJobCounts only reads `id` and spreads the rest,
+// so the other Job fields are irrelevant to the count-shaping behavior.
+function job(id: string): Job {
+  return { id } as Job;
+}
+
+describe("attachJobCounts", () => {
+  it("attaches each job's photo count to the matching job", () => {
+    const jobs = [job("job-A"), job("job-B")];
+    const photoRows = [
+      { job_id: "job-A" },
+      { job_id: "job-A" },
+      { job_id: "job-B" },
+    ];
+
+    const result = attachJobCounts(jobs, photoRows, []);
+
+    expect(result.map((j) => [j.id, j.photo_count])).toEqual([
+      ["job-A", 2],
+      ["job-B", 1],
+    ]);
+  });
+
+  it("keeps the file count distinct from the photo count", () => {
+    const photoRows = [{ job_id: "job-A" }, { job_id: "job-A" }];
+    const fileRows = [{ job_id: "job-A" }];
+
+    const [result] = attachJobCounts([job("job-A")], photoRows, fileRows);
+
+    expect(result.photo_count).toBe(2);
+    expect(result.file_count).toBe(1);
+  });
+
+  it("gives a job with no photos or files a count of 0, not undefined", () => {
+    const [result] = attachJobCounts([job("empty-job")], [], []);
+
+    expect(result.photo_count).toBe(0);
+    expect(result.file_count).toBe(0);
+    expect(result.photo_count).not.toBeUndefined();
+  });
+});
+
 describe("loadJobsWithCover", () => {
   it("loads jobs in one batched query, each paired with its own cover", async () => {
     const coverA = photo({ id: "cover-A" });
     const coverB = photo({ id: "cover-B" });
     const supabase = fakeSupabase({
-      data: [
-        jobRow("job-A", coverA),
-        jobRow("job-B", [coverB]),
-        jobRow("job-C", null),
-      ],
-      error: null,
+      jobs: {
+        data: [
+          jobRow("job-A", coverA),
+          jobRow("job-B", [coverB]),
+          jobRow("job-C", null),
+        ],
+        error: null,
+      },
     });
 
     const jobs = await loadJobsWithCover(supabase);
 
-    expect(supabase.fromCalls).toBe(1);
+    // The cover photo is joined into the jobs query — one `jobs` read,
+    // never one per job.
+    expect(supabase.fromTables.filter((t) => t === "jobs")).toEqual(["jobs"]);
     expect(jobs.map((j) => [j.id, j.cover_photo?.id ?? null])).toEqual([
       ["job-A", "cover-A"],
       ["job-B", "cover-B"],
@@ -103,7 +158,40 @@ describe("loadJobsWithCover", () => {
   });
 
   it("returns an empty array when the query fails", async () => {
-    const supabase = fakeSupabase({ data: null, error: { message: "boom" } });
+    const supabase = fakeSupabase({
+      jobs: { data: null, error: { message: "boom" } },
+    });
     expect(await loadJobsWithCover(supabase)).toEqual([]);
+  });
+
+  it("fetches photo and file counts batched, not one query per job", async () => {
+    const supabase = fakeSupabase({
+      jobs: {
+        data: [jobRow("job-A"), jobRow("job-B"), jobRow("job-C")],
+        error: null,
+      },
+      photos: {
+        data: [
+          { job_id: "job-A" },
+          { job_id: "job-A" },
+          { job_id: "job-B" },
+        ],
+        error: null,
+      },
+      job_files: { data: [{ job_id: "job-C" }], error: null },
+    });
+
+    const jobs = await loadJobsWithCover(supabase);
+
+    // One read of each child table covers every job — never per-job.
+    expect(supabase.fromTables.filter((t) => t === "photos")).toHaveLength(1);
+    expect(supabase.fromTables.filter((t) => t === "job_files")).toHaveLength(
+      1,
+    );
+    expect(jobs.map((j) => [j.id, j.photo_count, j.file_count])).toEqual([
+      ["job-A", 2, 0],
+      ["job-B", 1, 0],
+      ["job-C", 0, 1],
+    ]);
   });
 });

--- a/src/lib/jobs/jobs-with-cover.ts
+++ b/src/lib/jobs/jobs-with-cover.ts
@@ -18,12 +18,46 @@ export function shapeJobWithCover<
   return { ...raw, cover_photo };
 }
 
+/** Group a flat `{ job_id }` row list into a per-job occurrence count. */
+function tallyByJob(rows: Array<{ job_id: string }>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const { job_id } of rows) {
+    counts.set(job_id, (counts.get(job_id) ?? 0) + 1);
+  }
+  return counts;
+}
+
 /**
- * Load every non-deleted job together with its cover photo in a single
- * batched query. The cover is joined through `jobs.cover_photo_id`, so
- * there is no per-job follow-up query. Rows come back newest-first; an
- * optional filter narrows them to emergencies or one status, mirroring
- * the Jobs tab's filter pills. Returns `[]` if the query fails.
+ * Tally how many photos and files each job owns and attach the two
+ * counts to their jobs. The count rows arrive as flat `{ job_id }` lists
+ * — one row per photo / per file — so a job with none simply has no rows
+ * and lands on a count of 0, never `undefined`. Photo and file tallies
+ * are kept on separate keys so neither overwrites the other.
+ */
+export function attachJobCounts(
+  jobs: Job[],
+  photoRows: Array<{ job_id: string }>,
+  fileRows: Array<{ job_id: string }>,
+): Job[] {
+  const photoCounts = tallyByJob(photoRows);
+  const fileCounts = tallyByJob(fileRows);
+  return jobs.map((job) => ({
+    ...job,
+    photo_count: photoCounts.get(job.id) ?? 0,
+    file_count: fileCounts.get(job.id) ?? 0,
+  }));
+}
+
+/**
+ * Load every non-deleted job together with its cover photo, plus a photo
+ * count and a file count per job. The cover is joined through
+ * `jobs.cover_photo_id` in the jobs query itself; the two counts come
+ * from one batched read of `photos` and one of `job_files`, each scoped
+ * to the loaded jobs — so the whole load is three queries regardless of
+ * how many jobs there are, never one per job. Rows come back newest-
+ * first; an optional filter narrows them to emergencies or one status,
+ * mirroring the Jobs tab's filter pills. Returns `[]` if the jobs query
+ * fails.
  */
 export async function loadJobsWithCover(
   supabase: SupabaseClient,
@@ -46,7 +80,21 @@ export async function loadJobsWithCover(
     ascending: false,
   });
   if (error || !data) return [];
-  return (data as Array<{ cover_photo?: Photo | Photo[] | null }>).map((row) =>
-    shapeJobWithCover(row),
+  const jobs = (data as Array<{ cover_photo?: Photo | Photo[] | null }>).map(
+    (row) => shapeJobWithCover(row),
   ) as Job[];
+  if (jobs.length === 0) return jobs;
+
+  // Two batched aggregate reads, each grouped by job by attachJobCounts:
+  // one row per photo / per file, scoped to exactly the loaded jobs.
+  const jobIds = jobs.map((job) => job.id);
+  const [photoRes, fileRes] = await Promise.all([
+    supabase.from("photos").select("job_id").in("job_id", jobIds),
+    supabase.from("job_files").select("job_id").in("job_id", jobIds),
+  ]);
+  return attachJobCounts(
+    jobs,
+    (photoRes.data ?? []) as Array<{ job_id: string }>,
+    (fileRes.data ?? []) as Array<{ job_id: string }>,
+  );
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,9 @@ export interface Job {
   contact?: Contact;
   job_adjusters?: JobAdjuster[];
   cover_photo?: Photo | null;
+  // Tallied by the Comfortable-view loader (see attachJobCounts).
+  photo_count?: number;
+  file_count?: number;
 }
 
 export interface JobAdjuster {


### PR DESCRIPTION
## Summary

Completes the Comfortable row for the Jobs tab view modes (parent PRD #152) — the at-a-glance signals and counts. Builds on #162's photo-forward row.

- **`jobs-with-cover` loader** gains `attachJobCounts`. After the batched jobs+cover query, the loader runs two more batched reads — one of `photos`, one of `job_files`, each scoped to the loaded jobs via `.in("job_id", ids)` — and tallies them per job. Three queries total regardless of job count, never one per job. A job with no photos/files lands on a count of `0`, never `undefined`.
- **`Job` type** gains optional `photo_count` / `file_count`.
- **`JobComfortableRow`** renders colored status / urgency / damage-type badges (matching the cards + list views) plus a photo count and a file count. The count column is `hidden sm:flex`: on a phone-width row it collapses while the cover photo, name/address, and badges stay.

No page change needed — `jobs/page.tsx` already threads the full `Job` from the loader into the row.

## Acceptance criteria

- [x] Each Comfortable row shows colored status / urgency / damage-type badges.
- [x] Each Comfortable row shows a photo count and a file count.
- [x] Photo and file counts load via batched queries grouped by job, not one query per job.
- [x] On phone-width screens the cover photo, name/address, and badges remain; counts hide.
- [x] Unit tests cover the count row-shaping (counts attach to the correct job; no-photos job → 0 not undefined; file count distinct from photo count).

## Testing

Built via TDD (red→green): 4 new loader/shaping tests in `jobs-with-cover.test.ts` + 4 new component tests in `job-comfortable-row.test.tsx`. Full suite **759 passed (122 files)**; `tsc` + `eslint` clean on the changed surface (only the pre-existing `sync-folder-incremental.test.ts` `TS2322` and the `<img>` warning carried from #162 remain). Not browser-verified — no reachable Supabase/auth in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)