### PR TITLE
jobs: Set cover photo from the Comfortable row (#164)

### DIFF
--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
-import type { Job } from "@/lib/types";
+import type { Job, Photo } from "@/lib/types";
 
 // JobComfortableRow reads status/damage colors + labels from the config
 // context. Stub it so the row renders without a ConfigProvider; the
@@ -17,7 +17,70 @@ vi.mock("@/lib/config-context", () => ({
   }),
 }));
 
+// The row embeds JobCoverPicker, which loads the job's photos and writes
+// jobs.cover_photo_id. This stub serves one photo ("Kitchen") to the
+// picker and lets the cover write succeed, so the row's update-in-place
+// behavior can be exercised end to end.
+vi.mock("@/lib/supabase", () => {
+  const kitchenPhoto = {
+    id: "kitchen-photo",
+    job_id: "job-1",
+    storage_path: "job-1/kitchen.jpg",
+    annotated_path: null,
+    thumbnail_path: "job-1/kitchen-thumb.jpg",
+    caption: "Kitchen",
+    taken_at: null,
+    taken_by: "user-1",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-20T00:00:00Z",
+  };
+  return {
+    createClient: () => ({
+      from: (table: string) => {
+        if (table === "jobs") {
+          return {
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          };
+        }
+        const builder: Record<string, unknown> = {};
+        for (const method of ["select", "eq", "order"]) {
+          builder[method] = () => builder;
+        }
+        builder.then = (resolve: (r: unknown) => void) =>
+          resolve({ data: [kitchenPhoto], error: null });
+        return builder;
+      },
+    }),
+  };
+});
+
 import JobComfortableRow from "./job-comfortable-row";
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: "photo-1",
+    job_id: "job-1",
+    storage_path: "job-1/original.jpg",
+    annotated_path: null,
+    thumbnail_path: "job-1/thumb.jpg",
+    caption: null,
+    taken_at: null,
+    taken_by: "user-1",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
 
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
@@ -120,5 +183,55 @@ describe("JobComfortableRow — photo / file counts (#163)", () => {
     const statusBadge = screen.getByText("In Progress");
     expect(classes(statusBadge)).not.toContain("hidden");
     expect(classes(statusBadge.parentElement)).not.toContain("hidden");
+  });
+});
+
+describe("JobComfortableRow — cover picker entry point (#164)", () => {
+  it("opens the cover picker when the placeholder is clicked on a job with no cover", async () => {
+    render(<JobComfortableRow job={makeJob({ cover_photo: null })} />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /cover photo/i }));
+    expect(await screen.findByRole("dialog")).toBeDefined();
+  });
+
+  it("opens the cover picker when an existing cover thumbnail is clicked", async () => {
+    render(
+      <JobComfortableRow
+        job={makeJob({ cover_photo: makePhoto({ id: "cover-A" }) })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /cover photo/i }));
+    expect(await screen.findByRole("dialog")).toBeDefined();
+  });
+
+  it("still links the row body to the job detail page", () => {
+    render(<JobComfortableRow job={makeJob()} />);
+
+    expect(screen.getByRole("link").getAttribute("href")).toBe("/jobs/job-1");
+  });
+});
+
+describe("JobComfortableRow — cover updates in place (#164)", () => {
+  it("swaps the placeholder for the chosen cover thumbnail without a reload", async () => {
+    render(<JobComfortableRow job={makeJob({ cover_photo: null })} />);
+
+    // No cover yet — the thumbnail button offers to choose one.
+    expect(
+      screen.getByRole("button", { name: "Choose cover photo" }),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /cover photo/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Kitchen" }));
+
+    // The picker closed and the row now shows a real cover thumbnail,
+    // re-rendered from local state — no navigation, no parent refetch.
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Change cover photo" }),
+      ).toBeDefined(),
+    );
+    expect(screen.queryByRole("dialog")).toBeNull();
   });
 });

--- a/src/components/job-comfortable-row.tsx
+++ b/src/components/job-comfortable-row.tsx
@@ -1,14 +1,16 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { format } from "date-fns";
 import { ImageOff, Image as ImageIcon, Paperclip } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import JobCoverPicker from "@/components/job-cover-picker";
 import { resolveCoverPhotoUrl } from "@/lib/jobs/cover-photo";
 import { urgencyColors, urgencyLabels } from "@/lib/badge-colors";
 import { useConfig } from "@/lib/config-context";
-import type { Job } from "@/lib/types";
+import type { Job, Photo } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "";
@@ -19,8 +21,10 @@ const badgeClass = "text-[11px] font-medium px-2 py-0.5 rounded-md";
  * One roomy row in the Jobs tab Comfortable view: a square cover photo,
  * the job number and contact name, the property address, colored
  * status / urgency / damage-type badges, and a photo count plus file
- * count. The whole row links to the job. On phone-width screens the
- * counts hide while the cover, name/address, and badges stay.
+ * count. The row body links to the job; the cover thumbnail is a button —
+ * the second entry point for setting the job's cover photo (#164). On
+ * phone-width screens the counts hide while the cover, name/address, and
+ * badges stay.
  */
 export default function JobComfortableRow({ job }: { job: Job }) {
   const {
@@ -32,87 +36,120 @@ export default function JobComfortableRow({ job }: { job: Job }) {
   const isCompleted =
     job.status === "completed" || job.status === "cancelled";
   const contactName = job.contact ? job.contact.full_name : "Unknown";
-  const coverUrl = resolveCoverPhotoUrl(job.cover_photo, SUPABASE_URL);
+
+  // The row owns its cover photo so choosing a new one updates the
+  // thumbnail in place — no page reload, no parent refetch (#164).
+  const [coverPhoto, setCoverPhoto] = useState<Photo | null>(
+    job.cover_photo ?? null,
+  );
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const coverUrl = resolveCoverPhotoUrl(coverPhoto, SUPABASE_URL);
 
   return (
-    <Link
-      href={`/jobs/${job.id}`}
+    <div
       className={cn(
         "flex items-center gap-4 rounded-xl border border-border bg-card p-3 transition-all hover:border-primary/30 hover:shadow-sm",
         isCompleted && "opacity-60",
       )}
     >
-      {coverUrl ? (
-        // Plain <img> with native lazy loading: the cover is a Supabase
-        // public URL, matching how job-photos-tab.tsx renders photos.
-        <img
-          src={coverUrl}
-          alt=""
-          loading="lazy"
-          className="h-16 w-16 shrink-0 rounded-lg object-cover"
-        />
-      ) : (
-        <div
-          className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg bg-muted"
-          aria-hidden="true"
-        >
-          <ImageOff size={20} className="text-muted-foreground/40" />
-        </div>
-      )}
-
-      <div className="min-w-0 flex-1">
-        <p className="truncate font-mono text-xs text-muted-foreground">
-          {job.job_number}
-        </p>
-        <p className="truncate text-sm font-semibold text-foreground">
-          {contactName}
-        </p>
-        <p className="truncate text-sm text-muted-foreground">
-          {job.property_address}
-        </p>
-        {/* Badges sit under the address so they stay visible on a
-            phone-width row, where the count column is hidden. */}
-        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-          <Badge
-            variant="secondary"
-            className={cn(badgeClass, getStatusColor(job.status))}
-          >
-            {getStatusLabel(job.status)}
-          </Badge>
-          <Badge
-            variant="secondary"
-            className={cn(badgeClass, urgencyColors[job.urgency])}
-          >
-            {urgencyLabels[job.urgency]}
-          </Badge>
-          <Badge
-            variant="secondary"
-            className={cn(badgeClass, getDamageTypeColor(job.damage_type))}
-          >
-            {getDamageTypeLabel(job.damage_type)}
-          </Badge>
-        </div>
-      </div>
-
-      {/* Photo / file counts — an at-a-glance signal of how documented
-          the job is. */}
-      <div
-        data-testid="job-counts"
-        className="hidden shrink-0 flex-col items-end gap-1 text-xs text-muted-foreground sm:flex"
+      {/* The cover thumbnail is a button: clicking it (or the gray
+          placeholder, when no cover is set) opens the photo picker. */}
+      <button
+        type="button"
+        onClick={() => setPickerOpen(true)}
+        aria-label={coverUrl ? "Change cover photo" : "Choose cover photo"}
+        className="shrink-0 rounded-lg transition-opacity hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-primary/40"
       >
-        <span className="flex items-center gap-1">
-          <ImageIcon size={13} className="shrink-0" aria-hidden="true" />
-          <span aria-label="Photos">{job.photo_count ?? 0}</span>
-        </span>
-        <span className="flex items-center gap-1">
-          <Paperclip size={13} className="shrink-0" aria-hidden="true" />
-          <span aria-label="Files">{job.file_count ?? 0}</span>
-        </span>
-      </div>
+        {coverUrl ? (
+          // Plain <img> with native lazy loading: the cover is a Supabase
+          // public URL, matching how job-photos-tab.tsx renders photos.
+          <img
+            src={coverUrl}
+            alt=""
+            loading="lazy"
+            className="h-16 w-16 rounded-lg object-cover"
+          />
+        ) : (
+          <div
+            className="flex h-16 w-16 items-center justify-center rounded-lg bg-muted"
+            aria-hidden="true"
+          >
+            <ImageOff size={20} className="text-muted-foreground/40" />
+          </div>
+        )}
+      </button>
 
-      <span className="shrink-0 text-xs text-muted-foreground">
-        {format(new Date(job.updated_at), "MMM d, yyyy")}
-      </span>
-    </Link>
+      <Link
+        href={`/jobs/${job.id}`}
+        className="flex min-w-0 flex-1 items-center gap-4"
+      >
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-mono text-xs text-muted-foreground">
+            {job.job_number}
+          </p>
+          <p className="truncate text-sm font-semibold text-foreground">
+            {contactName}
+          </p>
+          <p className="truncate text-sm text-muted-foreground">
+            {job.property_address}
+          </p>
+          {/* Badges sit under the address so they stay visible on a
+              phone-width row, where the count column is hidden. */}
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <Badge
+              variant="secondary"
+              className={cn(badgeClass, getStatusColor(job.status))}
+            >
+              {getStatusLabel(job.status)}
+            </Badge>
+            <Badge
+              variant="secondary"
+              className={cn(badgeClass, urgencyColors[job.urgency])}
+            >
+              {urgencyLabels[job.urgency]}
+            </Badge>
+            <Badge
+              variant="secondary"
+              className={cn(badgeClass, getDamageTypeColor(job.damage_type))}
+            >
+              {getDamageTypeLabel(job.damage_type)}
+            </Badge>
+          </div>
+        </div>
+
+        {/* Photo / file counts — an at-a-glance signal of how documented
+            the job is. */}
+        <div
+          data-testid="job-counts"
+          className="hidden shrink-0 flex-col items-end gap-1 text-xs text-muted-foreground sm:flex"
+        >
+          <span className="flex items-center gap-1">
+            <ImageIcon size={13} className="shrink-0" aria-hidden="true" />
+            <span aria-label="Photos">{job.photo_count ?? 0}</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <Paperclip size={13} className="shrink-0" aria-hidden="true" />
+            <span aria-label="Files">{job.file_count ?? 0}</span>
+          </span>
+        </div>
+
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {format(new Date(job.updated_at), "MMM d, yyyy")}
+        </span>
+      </Link>
+
+      {pickerOpen && (
+        <JobCoverPicker
+          jobId={job.id}
+          currentCoverPhotoId={coverPhoto?.id ?? null}
+          supabaseUrl={SUPABASE_URL}
+          onClose={() => setPickerOpen(false)}
+          onCoverChosen={(photo) => {
+            setCoverPhoto(photo);
+            setPickerOpen(false);
+          }}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/job-cover-picker.test.tsx
+++ b/src/components/job-cover-picker.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import type { Photo } from "@/lib/types";
+
+// The picker loads the job's photos from Supabase on mount. A mutable
+// module-level result lets each test seed its own photo list.
+let photosResult: { data: unknown; error: unknown } = {
+  data: [],
+  error: null,
+};
+
+// Records the `jobs.cover_photo_id` write the picker issues when a photo
+// is chosen, so a test can assert which job and photo it targeted.
+let coverUpdate: {
+  payload: Record<string, unknown>;
+  idColumn: string;
+  idValue: string;
+} | null = null;
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      if (table === "jobs") {
+        return {
+          update: (payload: Record<string, unknown>) => ({
+            eq: (idColumn: string, idValue: string) => {
+              coverUpdate = { payload, idColumn, idValue };
+              return Promise.resolve({ error: null });
+            },
+          }),
+        };
+      }
+      // photos: a chainable query stub whose builder methods return the
+      // builder, and .then()-ing it resolves to the seeded photo result.
+      const builder: Record<string, unknown> = {};
+      for (const method of ["select", "eq", "order"]) {
+        builder[method] = () => builder;
+      }
+      builder.then = (resolve: (r: unknown) => void) => resolve(photosResult);
+      return builder;
+    },
+  }),
+}));
+
+import JobCoverPicker from "./job-cover-picker";
+
+function makePhoto(overrides: Partial<Photo> = {}): Photo {
+  return {
+    id: "photo-1",
+    job_id: "job-1",
+    storage_path: "job-1/original.jpg",
+    annotated_path: null,
+    thumbnail_path: "job-1/thumb.jpg",
+    caption: null,
+    taken_at: null,
+    taken_by: "user-1",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  photosResult = { data: [], error: null };
+  coverUpdate = null;
+});
+
+describe("JobCoverPicker — photo list (#164)", () => {
+  it("renders a choosable option for each of the job's photos", async () => {
+    photosResult = {
+      data: [
+        makePhoto({ id: "p-1", caption: "Front of house" }),
+        makePhoto({ id: "p-2", caption: "Water damage" }),
+      ],
+      error: null,
+    };
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId={null}
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={() => {}}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: "Front of house" }),
+    ).toBeDefined();
+    expect(screen.getByRole("button", { name: "Water damage" })).toBeDefined();
+  });
+});
+
+describe("JobCoverPicker — empty state (#164)", () => {
+  it("tells the user when the job has no photos to choose from", async () => {
+    photosResult = { data: [], error: null };
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId={null}
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText(/no photos/i)).toBeDefined();
+  });
+});
+
+describe("JobCoverPicker — current cover marker (#164)", () => {
+  it("marks the photo that is already the job's cover", async () => {
+    photosResult = {
+      data: [
+        makePhoto({ id: "p-1", caption: "Kitchen" }),
+        makePhoto({ id: "p-2", caption: "Bathroom" }),
+      ],
+      error: null,
+    };
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId="p-2"
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={() => {}}
+      />,
+    );
+
+    // Exactly one option — the current cover — carries the marker.
+    expect(await screen.findByText("Current cover")).toBeDefined();
+    expect(screen.getAllByText("Current cover")).toHaveLength(1);
+  });
+
+  it("shows no marker when the job has no cover set yet", async () => {
+    photosResult = {
+      data: [makePhoto({ id: "p-1", caption: "Kitchen" })],
+      error: null,
+    };
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId={null}
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={() => {}}
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: "Kitchen" })).toBeDefined();
+    expect(screen.queryByText("Current cover")).toBeNull();
+  });
+});
+
+describe("JobCoverPicker — choosing a cover (#164)", () => {
+  it("writes the chosen photo as the job's cover and reports it back", async () => {
+    photosResult = {
+      data: [makePhoto({ id: "p-9", caption: "Living room" })],
+      error: null,
+    };
+    const onCoverChosen = vi.fn();
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId={null}
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={onCoverChosen}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Living room" }));
+
+    await waitFor(() => expect(onCoverChosen).toHaveBeenCalledTimes(1));
+    // The write set this job's cover_photo_id to the chosen photo.
+    expect(coverUpdate).toEqual({
+      payload: { cover_photo_id: "p-9" },
+      idColumn: "id",
+      idValue: "job-1",
+    });
+    // The chosen photo itself is handed back so the row can update.
+    expect(onCoverChosen.mock.calls[0][0].id).toBe("p-9");
+  });
+});

--- a/src/components/job-cover-picker.tsx
+++ b/src/components/job-cover-picker.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { createClient } from "@/lib/supabase";
+import { resolveCoverPhotoUrl } from "@/lib/jobs/cover-photo";
+import type { Photo } from "@/lib/types";
+
+interface JobCoverPickerProps {
+  jobId: string;
+  currentCoverPhotoId: string | null;
+  supabaseUrl: string;
+  onClose: () => void;
+  onCoverChosen: (photo: Photo) => void;
+}
+
+/**
+ * Modal photo picker for setting a job's cover photo from the Jobs tab
+ * Comfortable view (#164) — the second entry point for a cover, alongside
+ * the "Set as cover photo" action in the Photos tab. Lists that job's
+ * photos; choosing one writes `jobs.cover_photo_id` and reports the
+ * choice back to the row so it updates without a page reload.
+ */
+export default function JobCoverPicker({
+  jobId,
+  currentCoverPhotoId,
+  supabaseUrl,
+  onClose,
+  onCoverChosen,
+}: JobCoverPickerProps) {
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [loading, setLoading] = useState(true);
+  // The id of the photo whose cover write is in flight, if any.
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    // setState lives in the .then() callback, not the effect body, so the
+    // react-hooks/set-state-in-effect lint rule stays satisfied.
+    const supabase = createClient();
+    supabase
+      .from("photos")
+      .select("*")
+      .eq("job_id", jobId)
+      .order("created_at", { ascending: false })
+      .then(({ data }: { data: Photo[] | null }) => {
+        setPhotos(data ?? []);
+        setLoading(false);
+      });
+  }, [jobId]);
+
+  // Promote the chosen photo to the job's cover. Writes jobs.cover_photo_id
+  // directly, mirroring job-photos-tab.tsx's "Set as cover" action, then
+  // hands the photo back so the Comfortable row updates without a reload.
+  async function handleChoose(photo: Photo) {
+    setSaving(photo.id);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("jobs")
+      .update({ cover_photo_id: photo.id })
+      .eq("id", jobId);
+    setSaving(null);
+    if (error) {
+      toast.error("Failed to set cover photo.");
+      return;
+    }
+    toast.success("Cover photo updated.");
+    onCoverChosen(photo);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-label="Choose cover photo"
+        className="flex max-h-[80vh] w-full max-w-2xl flex-col rounded-xl border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border p-4">
+          <h3 className="text-base font-semibold text-foreground">
+            Choose cover photo
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-accent"
+          >
+            ✕
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="flex items-center justify-center p-10">
+            <Loader2 size={22} className="animate-spin text-muted-foreground" />
+          </div>
+        ) : photos.length === 0 ? (
+          <p className="p-10 text-center text-sm text-muted-foreground">
+            No photos on this job yet. Add photos before choosing a cover.
+          </p>
+        ) : (
+          <div className="grid grid-cols-3 gap-2.5 overflow-y-auto p-4 sm:grid-cols-4">
+            {photos.map((photo) => {
+              const isCurrent = photo.id === currentCoverPhotoId;
+              return (
+                <button
+                  key={photo.id}
+                  type="button"
+                  aria-label={photo.caption ?? "Job photo"}
+                  disabled={saving !== null}
+                  onClick={() => handleChoose(photo)}
+                  className={`relative overflow-hidden rounded-lg transition-transform hover:scale-[1.03] focus:outline-none focus:ring-2 focus:ring-primary/40 disabled:opacity-60 ${
+                    isCurrent ? "ring-2 ring-[#F5A623]" : ""
+                  }`}
+                >
+                  <img
+                    src={resolveCoverPhotoUrl(photo, supabaseUrl) ?? ""}
+                    alt=""
+                    loading="lazy"
+                    className="aspect-square w-full object-cover"
+                  />
+                  {isCurrent && (
+                    <span className="absolute left-1.5 top-1.5 rounded-full bg-[#F5A623] px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                      Current cover
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What

The second entry point for a job's cover photo (parent PRD #152, blocked by #162 — now merged). The cover thumbnail on a Jobs-tab **Comfortable** row is now a button that opens a modal photo picker; choosing a photo sets it as the job's cover and the row updates in place.

## Changes

- **`job-cover-picker.tsx`** (new) — modal picker: loads the job's photos, marks the one already set as cover, writes `jobs.cover_photo_id` directly via the Supabase client (mirroring `job-photos-tab.tsx`'s "Set as cover" action from #160), and handles loading / no-photos states.
- **`job-comfortable-row.tsx`** — the cover thumbnail/placeholder becomes a `<button>` (sibling of the row `<Link>`, so no nested interactive content); the row owns local cover state so a pick re-renders the thumbnail with no parent refetch.

`jobs/page.tsx` is unchanged — #162's `loadJobsWithCover` already joins `cover_photo` onto each job.

## Acceptance criteria

- [x] Clicking the cover thumbnail or placeholder opens a picker dialog of that job's photos
- [x] Choosing a photo sets it as the job's cover photo
- [x] The row reflects the new cover without a full page reload
- [x] The picker works for a job with no cover set

## Testing

Built with `/tdd` — 9 RED→GREEN tests across `job-cover-picker.test.tsx` (5) and `job-comfortable-row.test.tsx` (4). Full suite **760 passed (123 files)**; `tsc` clean on the changed files; `eslint` clean apart from 2 pre-existing-convention `@next/next/no-img-element` warnings (`<img>` for Supabase public URLs, same as `job-comfortable-row` #162 / `job-photos-tab`).

Not browser-verified — no reachable Supabase/auth in this environment (scratch project paused), consistent with #159/#161.

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)