### PR TITLE
widgets: NookleusWidgets Xcode target + App Group wiring (#172)

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
+		33ECFD9D8B5C4EADFD7566CB /* NookleusWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8377AF6A3FD9AD2AC1323845 /* NookleusWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
 		50379B232058CBB4000EE86E /* capacitor.config.json in Resources */ = {isa = PBXBuildFile; fileRef = 50379B222058CBB4000EE86E /* capacitor.config.json */; };
 		504EC3081FED79650016851F /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 504EC3071FED79650016851F /* AppDelegate.swift */; };
@@ -15,10 +16,39 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		BD862128CF73B88DCBA28576 /* QuickActionsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */; };
+		CC0E01018404C6330CB5EF2E /* NookleusWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4079C7114FD7E44CF0086934 /* NookleusWidgetsBundle.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		C4372C9605A384D6887E93D8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 504EC2FC1FED79650016851F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4561121111F9D091D9C54ED3;
+			remoteInfo = NookleusWidgets;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		DBBFD59A081DA4A7FD728502 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				33ECFD9D8B5C4EADFD7566CB /* NookleusWidgets.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickActionsWidget.swift; sourceTree = "<group>"; };
+		247A9A25BA193B3102812C1A /* App.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
+		4079C7114FD7E44CF0086934 /* NookleusWidgetsBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NookleusWidgetsBundle.swift; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -27,7 +57,10 @@
 		504EC3111FED79650016851F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		504EC3131FED79650016851F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		50B271D01FEDC1A000F3C39B /* public */ = {isa = PBXFileReference; lastKnownFileType = folder; path = public; sourceTree = "<group>"; };
+		8377AF6A3FD9AD2AC1323845 /* NookleusWidgets.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NookleusWidgets.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		958DCC722DB07C7200EA8C5F /* debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = debug.xcconfig; path = ../debug.xcconfig; sourceTree = SOURCE_ROOT; };
+		A46E4B974C344C093C565572 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E7079DA9F9E1E95600C6698C /* NookleusWidgets.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = NookleusWidgets.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -36,6 +69,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		70EE9B260060095444411079 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -48,6 +88,7 @@
 				958DCC722DB07C7200EA8C5F /* debug.xcconfig */,
 				504EC3061FED79650016851F /* App */,
 				504EC3051FED79650016851F /* Products */,
+				DB2F031DD5F2EA2275926466 /* NookleusWidgets */,
 			);
 			sourceTree = "<group>";
 		};
@@ -55,6 +96,7 @@
 			isa = PBXGroup;
 			children = (
 				504EC3041FED79650016851F /* App.app */,
+				8377AF6A3FD9AD2AC1323845 /* NookleusWidgets.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -70,13 +112,43 @@
 				504EC3131FED79650016851F /* Info.plist */,
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
+				247A9A25BA193B3102812C1A /* App.entitlements */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		DB2F031DD5F2EA2275926466 /* NookleusWidgets */ = {
+			isa = PBXGroup;
+			children = (
+				4079C7114FD7E44CF0086934 /* NookleusWidgetsBundle.swift */,
+				226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */,
+				A46E4B974C344C093C565572 /* Info.plist */,
+				E7079DA9F9E1E95600C6698C /* NookleusWidgets.entitlements */,
+			);
+			name = NookleusWidgets;
+			path = NookleusWidgets;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4561121111F9D091D9C54ED3 /* NookleusWidgets */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6EFA9EFBE3A61433A5FF5625 /* Build configuration list for PBXNativeTarget "NookleusWidgets" */;
+			buildPhases = (
+				05DBBB7FFEAB2898617EA0FC /* Sources */,
+				70EE9B260060095444411079 /* Frameworks */,
+				BF3D1CFC30962E6196B19FB0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = NookleusWidgets;
+			productName = NookleusWidgets;
+			productReference = 8377AF6A3FD9AD2AC1323845 /* NookleusWidgets.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		504EC3031FED79650016851F /* App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 504EC3161FED79650016851F /* Build configuration list for PBXNativeTarget "App" */;
@@ -84,10 +156,12 @@
 				504EC3001FED79650016851F /* Sources */,
 				504EC3011FED79650016851F /* Frameworks */,
 				504EC3021FED79650016851F /* Resources */,
+				DBBFD59A081DA4A7FD728502 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				9FEDD9E75B14831D3E78DABC /* PBXTargetDependency */,
 			);
 			name = App;
 			packageProductDependencies = (
@@ -107,6 +181,10 @@
 				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
+					4561121111F9D091D9C54ED3 = {
+						CreatedOnToolsVersion = 26.4.1;
+						ProvisioningStyle = Automatic;
+					};
 					504EC3031FED79650016851F = {
 						CreatedOnToolsVersion = 9.2;
 						LastSwiftMigration = 1100;
@@ -131,6 +209,7 @@
 			projectRoot = "";
 			targets = (
 				504EC3031FED79650016851F /* App */,
+				4561121111F9D091D9C54ED3 /* NookleusWidgets */,
 			);
 		};
 /* End PBXProject section */
@@ -149,9 +228,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		BF3D1CFC30962E6196B19FB0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		05DBBB7FFEAB2898617EA0FC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CC0E01018404C6330CB5EF2E /* NookleusWidgetsBundle.swift in Sources */,
+				BD862128CF73B88DCBA28576 /* QuickActionsWidget.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		504EC3001FED79650016851F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -161,6 +256,15 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		9FEDD9E75B14831D3E78DABC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = NookleusWidgets;
+			target = 4561121111F9D091D9C54ED3 /* NookleusWidgets */;
+			targetProxy = C4372C9605A384D6887E93D8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		504EC30B1FED79650016851F /* Main.storyboard */ = {
@@ -182,6 +286,34 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		3DA6085925C1EAC362ADB986 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = NookleusWidgets/NookleusWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_TEAM = QFTG9NJB7G;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = NookleusWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aaacontracting.platform.NookleusWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
 		504EC3141FED79650016851F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
@@ -308,6 +440,7 @@
 			baseConfigurationReference = 958DCC722DB07C7200EA8C5F /* debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				INFOPLIST_FILE = App/Info.plist;
@@ -331,6 +464,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = App/App.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				INFOPLIST_FILE = App/Info.plist;
@@ -346,6 +480,35 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		617FCC2A527D61465E70EB5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_ENTITLEMENTS = NookleusWidgets/NookleusWidgets.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 3;
+				DEVELOPMENT_TEAM = QFTG9NJB7G;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = NookleusWidgets/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aaacontracting.platform.NookleusWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -366,6 +529,15 @@
 			buildConfigurations = (
 				504EC3171FED79650016851F /* Debug */,
 				504EC3181FED79650016851F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		6EFA9EFBE3A61433A5FF5625 /* Build configuration list for PBXNativeTarget "NookleusWidgets" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				617FCC2A527D61465E70EB5D /* Release */,
+				3DA6085925C1EAC362ADB986 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/App/NookleusWidgets/SETUP.md
+++ b/ios/App/NookleusWidgets/SETUP.md
@@ -1,100 +1,76 @@
 # NookleusWidgets — Xcode target setup
 
-Issue #172 (PRD #56, slice 1) delivers the **source** for the Quick Actions
-widget plus all the web-side deep-link wiring. The one thing an agent cannot
-do on a non-Mac machine is create the Xcode target and configure App Store
-Connect — those steps need Xcode and the Apple Developer portal. This file is
-the checklist for that.
+Issue #172 (PRD #56, slice 1) delivers the Quick Actions widget. The Xcode
+target, source wiring, and App Group entitlements were created on a Mac
+(2026-05-21, Xcode 26.4) with the `xcodeproj` Ruby gem and verified with a
+simulator build.
 
-Everything in this folder (`ios/App/NookleusWidgets/`) is **inert** until the
-target below exists — committing it does not change the app build.
+⚠️ **One step remains and it needs a human: registering the new App ID and
+App Group in the Apple Developer portal (§4). Do NOT push `main` until that
+is done — a signed Xcode Cloud build fails without it. See §4.**
 
-## What's already done (in this branch)
+## Done — Xcode project (in this commit)
 
-- `NookleusWidgetsBundle.swift` — the `@main WidgetBundle`.
-- `QuickActionsWidget.swift` — the Quick Actions widget (medium + large, four
-  deep-link buttons).
-- `Info.plist` — the extension's Info.plist (`widgetkit-extension` point).
-- `NookleusWidgets.entitlements` — App Group `group.com.aaacontracting.platform`.
-- `ios/App/App/Info.plist` — registers the `nookleus://` URL scheme.
-- `ios/App/App/App.entitlements` — App Group on the main app target.
-- Web layer: `src/lib/mobile/deep-link.ts` (parser, unit-tested) and
-  `src/components/mobile/deep-link-listener.tsx` (handles Capacitor
-  `appUrlOpen` and routes) — already wired into `src/app/layout.tsx`.
+- **`NookleusWidgets` WidgetKit app-extension target** added to
+  `App.xcodeproj` (`com.apple.product-type.app-extension`), embedded in the
+  `App` target via an "Embed Foundation Extensions" copy-files phase plus a
+  target dependency.
+- `NookleusWidgetsBundle.swift` + `QuickActionsWidget.swift` wired into the
+  target's Sources phase; `Info.plist` set as `INFOPLIST_FILE`.
+- Bundle id `com.aaacontracting.platform.NookleusWidgets`, deployment target
+  iOS 15.0, automatic signing, team `QFTG9NJB7G`.
+- **App Group wired on both targets** via `CODE_SIGN_ENTITLEMENTS`:
+  - App → `App/App.entitlements`
+  - NookleusWidgets → `NookleusWidgets/NookleusWidgets.entitlements`
+  - both carry `group.com.aaacontracting.platform`.
+- Verified: `xcodebuild` builds the `App` scheme for the iOS Simulator with
+  `NookleusWidgets.appex` embedded in `App.app/PlugIns/`
+  (`CODE_SIGNING_ALLOWED=NO` — the Swift compiles and the project structure
+  is valid without provisioning).
 
-## 1. Create the Widget Extension target
+Note: this is an SPM-based Capacitor project — there is **no
+`App.xcworkspace`**. Open `ios/App/App.xcodeproj` directly in Xcode.
 
-1. Open **`ios/App/App.xcworkspace`** in Xcode (the workspace, not the
-   `.xcodeproj`).
-2. **File → New → Target… → iOS → Widget Extension**.
-3. Product Name: **`NookleusWidgets`**. Team: the AAA Contracting team.
-   - **Uncheck** "Include Live Activity".
-   - **Uncheck** "Include Configuration App Intent" — Quick Actions is static.
-     (The configurable Emails widget in slice #174 adds an App Intent later.)
-   - "Embed in Application" → **App**.
-4. Finish. Bundle id becomes **`com.aaacontracting.platform.NookleusWidgets`**.
-   "Activate scheme?" — either choice is fine.
+## Web layer (shipped — slice 1 web half)
 
-## 2. Swap in the provided source
+- `src/lib/mobile/deep-link.ts` (parser, unit-tested) and
+  `src/components/mobile/deep-link-listener.tsx` — wired into `src/app/layout.tsx`.
 
-Xcode scaffolds a sample widget into `ios/App/NookleusWidgets/`. Replace it
-with the files already in this folder:
+## 4. Apple Developer portal — REMAINING, needs you
 
-1. In the Project navigator, delete Xcode's generated sample widget file and
-   its generated `NookleusWidgetsBundle.swift` ("Move to Trash"). If Xcode's
-   scaffold collided with the committed files on disk (e.g. created
-   `NookleusWidgetsBundle 2.swift`), keep the committed ones.
-2. **Add Files to "App"…** → select `NookleusWidgetsBundle.swift` and
-   `QuickActionsWidget.swift` from this folder. In the dialog, **Target
-   Membership = `NookleusWidgets` only** (not the App target).
-3. Confirm `Info.plist`: the target's `INFOPLIST_FILE` build setting should
-   point at `NookleusWidgets/Info.plist`. The committed `Info.plist` matches
-   the standard WidgetKit extension layout — keep whichever single copy the
-   target references.
-
-Build the `App` scheme — the widget target compiles as part of it.
-
-## 3. App Group capability (both targets)
-
-The Quick Actions widget needs **no** data, but the App Group is the
-foundation slices #173/#174 build on, so wire it now.
-
-1. **App** target → **Signing & Capabilities → + Capability → App Groups** →
-   add **`group.com.aaacontracting.platform`**.
-2. **NookleusWidgets** target → same → add the **same** group.
-3. Xcode either uses the committed `.entitlements` files (`App/App.entitlements`,
-   `NookleusWidgets/NookleusWidgets.entitlements`) or creates its own. Either
-   way the group id must be exactly `group.com.aaacontracting.platform`. If
-   Xcode created fresh entitlements files, the committed ones are redundant —
-   delete whichever copy is not referenced by `CODE_SIGN_ENTITLEMENTS`.
-
-## 4. App Store Connect / Developer portal
+⚠️ **Do not push `main` until this is done.** The commit wires
+`CODE_SIGN_ENTITLEMENTS` with an App Group. A push triggers an Xcode Cloud
+build, and a signed build **fails** until the App Group and the new
+extension App ID exist in the portal.
 
 In the Apple Developer portal (Certificates, Identifiers & Profiles):
 
 1. **Identifiers → App Groups**: register `group.com.aaacontracting.platform`
    if it does not already exist.
-2. **Identifiers → App IDs**: register `com.aaacontracting.platform.NookleusWidgets`.
-   Enable the **App Groups** capability on it and on the existing
-   `com.aaacontracting.platform` App ID; assign the group to both.
+2. **Identifiers → App IDs**: register
+   `com.aaacontracting.platform.NookleusWidgets`. Enable the **App Groups**
+   capability on it and on the existing `com.aaacontracting.platform` App ID;
+   assign the group to both.
 3. Signing: with automatic signing, Xcode provisions both targets once the
-   App IDs + capability exist. With manual signing, create/download a
-   provisioning profile for the new extension App ID.
+   App IDs + capability exist. Opening the project in Xcode, the
+   Signing & Capabilities tab for each target should then resolve cleanly.
+
+Once §4 is done, push `main` — the Xcode Cloud build archives the app with
+the embedded widget.
 
 ## 5. Xcode Cloud
 
-No new workflow is required. The widget extension is **embedded in the App
-target**, so the existing Default workflow (set up in #143/#147) archives it
-together with the app on every push to `main`. Just confirm:
+No new workflow is required. The widget extension is embedded in the `App`
+target, so the existing Default workflow (#143/#147) archives it together
+with the app, and the `App` scheme builds `NookleusWidgets` as a dependency.
+Just confirm Xcode Cloud's signing has assets for the new
+`…NookleusWidgets` bundle id — automatic if Xcode Cloud manages signing,
+otherwise upload the profile created in §4.
 
-- The `App` scheme builds the `NookleusWidgets` target (it does once embedded).
-- Xcode Cloud's signing has assets for the new `…NookleusWidgets` bundle id —
-  automatic if Xcode Cloud manages signing; otherwise upload the profile.
+## 6. Verify (slice #175)
 
-## 6. Verify (deferred to slice #175)
-
-Real-device verification — adding the widget to the home screen in medium and
-large, tapping each of the four buttons, confirming the deep links land on the
-right screen — is the TestFlight slice **#175**. Acceptance criteria 1–3 of
-#172 are confirmed there. AC#4 (the deep-link parser) is already covered by
-`src/lib/mobile/deep-link.test.ts`.
+Real-device verification — adding the widget to the home screen in medium
+and large, tapping each of the four buttons, confirming the deep links land
+on the right screen — is the TestFlight slice **#175**. Acceptance criteria
+1–3 of #172 are confirmed there. AC#4 (the deep-link parser) is already
+covered by `src/lib/mobile/deep-link.test.ts`.


### PR DESCRIPTION
## Summary

Completes the native half of #172 (PRD #56, slice 1 — iPhone widgets) — the Xcode target the Windows session deferred because it had no Xcode.

- **`NookleusWidgets` WidgetKit app-extension target** added to `App.xcodeproj` (via the `xcodeproj` gem, not a hand-edit), embedded in the `App` target through an "Embed Foundation Extensions" copy-files phase + a target dependency.
- `NookleusWidgetsBundle.swift` + `QuickActionsWidget.swift` wired into Sources; `Info.plist`, bundle id `com.aaacontracting.platform.NookleusWidgets`, iOS 15 deployment target, automatic signing.
- **App Group `group.com.aaacontracting.platform`** wired on both targets via `CODE_SIGN_ENTITLEMENTS` (App → `App/App.entitlements`, widget → `NookleusWidgets/NookleusWidgets.entitlements`).
- `SETUP.md` rewritten to reflect the done state and drop the stale "open `App.xcworkspace`" note (this SPM-based Capacitor project has no workspace).

## Verification

- `xcodebuild` builds the `App` scheme for the iOS Simulator with `NookleusWidgets.appex` embedded in `App.app/PlugIns/` and passing `ValidateEmbeddedBinary` (`CODE_SIGNING_ALLOWED=NO`). The slice-1 Swift now genuinely compiles — it was written blind on Windows.

## Apple Developer portal (done)

Registered out-of-band in the portal: App Group `group.com.aaacontracting.platform`; App ID `com.aaacontracting.platform.NookleusWidgets` with App Groups + the group assigned; App Groups enabled on the existing `com.aaacontracting.platform` App ID. A signed Xcode Cloud build is unblocked.

Note: adding App Groups to the main App ID invalidated its provisioning profile — Xcode Cloud's managed signing regenerates it automatically on the first build after merge.

## Scope

Implementation + AC#4 (deep-link parser, already unit-tested). AC#1–3 (widget on the home screen, deep links land, signed-out render) verify on-device in slice #175 (TestFlight) — so this PR does not close #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)