### PR TITLE
widgets: email-summary cache pipeline (#173)

### DIFF
--- a/ios/App/App/EmailWidgetBridge-SETUP.md
+++ b/ios/App/App/EmailWidgetBridge-SETUP.md
@@ -1,0 +1,63 @@
+# EmailWidgetBridge — Xcode setup
+
+Issue #173 (PRD #56, slice 2) delivers the **email-summary cache pipeline**:
+the web app shapes a per-account email summary and the native shell writes it
+into the App Group container the Emails widget (slice 3, #174) will read.
+
+The web layer ships and runs on the next deploy. One native step remains and
+it needs a Mac with Xcode — this repo was authored on Windows, so the Swift
+was written but **not compiled** (same constraint as #172).
+
+## Delivered in this commit
+
+**Web layer (TDD'd, live on the next deploy):**
+
+- `src/lib/mobile/email-summary.ts` — `shapeEmailSummary`, the pure
+  inbox-data → per-account-snapshot function. 9 unit tests in
+  `email-summary.test.ts` (issue #173 AC#4).
+- `src/lib/mobile/email-widget-bridge.ts` — the `EmailWidgetBridge` Capacitor
+  plugin interface + `publishEmailSummary` (no-op off-native).
+- `src/lib/mobile/use-email-summary-cache.ts` — `useEmailSummaryCache`, the
+  web summary producer hook.
+- `src/components/email-inbox.tsx` — calls the hook once the inbox loads.
+
+**iOS native source (written, NOT compiled — no Xcode on Windows):**
+
+- `ios/App/App/EmailWidgetBridgePlugin.swift` — the Swift Capacitor plugin.
+
+## Remaining — needs Xcode
+
+Add `EmailWidgetBridgePlugin.swift` to the **`App` target's Compile Sources**:
+
+1. Open `ios/App/App.xcodeproj` in Xcode (SPM-based Capacitor project — there
+   is no `.xcworkspace`).
+2. In the Project navigator, drag `App/EmailWidgetBridgePlugin.swift` into the
+   `App` group if it is not already shown.
+3. Select the file → File inspector → **Target Membership** → check **`App`**.
+4. Build the `App` scheme. The plugin registers itself at runtime via
+   `CAPBridgedPlugin` — no Objective-C `.m` macro file and no `Podfile` entry
+   are needed.
+
+No new entitlement work: the **App Group `group.com.aaacontracting.platform`**
+was already wired onto the `App` target in #172 (`App/App.entitlements`,
+`CODE_SIGN_ENTITLEMENTS`), so `UserDefaults(suiteName:)` resolves once the
+plugin file compiles into the target.
+
+## The cache contract
+
+The widget extension (slice #174) reads the summary from:
+
+- **App Group:** `group.com.aaacontracting.platform`
+- **`UserDefaults` key:** `emailSummary`
+- **Value:** a JSON string of `EmailSummarySnapshot` (see
+  `src/lib/mobile/email-summary.ts` for the schema — `generatedAt` plus an
+  `accounts` map keyed by account id, each entry carrying `unreadCount`, up to
+  three `previews`, and `updatedAt`).
+
+## Verify (slice #175)
+
+The plugin call path — app foreground → `writeEmailSummary` → App Group →
+`reloadWidgets` → widget renders — is verified on a real device in the
+TestFlight slice **#175**, alongside the Emails widget UI (#174). AC#4 (the
+pure `shapeEmailSummary` function) is already covered by
+`src/lib/mobile/email-summary.test.ts`.

--- a/ios/App/App/EmailWidgetBridgePlugin.swift
+++ b/ios/App/App/EmailWidgetBridgePlugin.swift
@@ -1,0 +1,52 @@
+import Capacitor
+import Foundation
+import WidgetKit
+
+/// `EmailWidgetBridge` Capacitor plugin — issue #173, PRD #56 slice 2.
+///
+/// Lets the Capacitor web app hand the native shell a per-account email
+/// summary to cache for the Emails widget. Per the PRD #56 decision the
+/// WidgetKit extension does no networking and no auth: it renders whatever
+/// snapshot this plugin last wrote into the shared App Group container.
+///
+/// Registration is Swift-only via `CAPBridgedPlugin` — Capacitor discovers
+/// the plugin at runtime, so no Objective-C `.m` macro file is required. The
+/// file must be added to the `App` target's Compile Sources in Xcode; see
+/// `ios/App/App/EmailWidgetBridge-SETUP.md`.
+@objc(EmailWidgetBridgePlugin)
+public class EmailWidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "EmailWidgetBridgePlugin"
+    public let jsName = "EmailWidgetBridge"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "writeEmailSummary", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "reloadWidgets", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// App Group shared with the NookleusWidgets extension (created in #172).
+    private static let appGroupId = "group.com.aaacontracting.platform"
+
+    /// `UserDefaults` key the Emails widget (#174) reads the summary JSON from.
+    static let summaryDefaultsKey = "emailSummary"
+
+    /// Writes the summary JSON string into the shared App Group container.
+    @objc func writeEmailSummary(_ call: CAPPluginCall) {
+        guard let summary = call.getString("summary") else {
+            call.reject("writeEmailSummary requires a 'summary' JSON string")
+            return
+        }
+        guard let defaults = UserDefaults(suiteName: Self.appGroupId) else {
+            call.reject("App Group \(Self.appGroupId) is unavailable — check the entitlement")
+            return
+        }
+        defaults.set(summary, forKey: Self.summaryDefaultsKey)
+        call.resolve()
+    }
+
+    /// Reloads every widget timeline so the freshly written summary renders.
+    @objc func reloadWidgets(_ call: CAPPluginCall) {
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+        call.resolve()
+    }
+}

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -24,6 +24,7 @@ import ComposeEmailModal from "@/components/compose-email";
 import IconRail from "@/components/email/icon-rail";
 import CategoryTabs, { type CategoryFilter } from "@/components/email/category-tabs";
 import { useEmailSync } from "@/lib/email/use-email-sync";
+import { useEmailSummaryCache } from "@/lib/mobile/use-email-summary-cache";
 
 const LAZY_REFRESH_FOLDERS = new Set(["drafts", "trash", "spam", "archive"]);
 const LAZY_REFRESH_THROTTLE_MS = 30_000;
@@ -290,6 +291,11 @@ export default function EmailInbox() {
   useEffect(() => {
     loadEmails();
   }, [loadEmails]);
+
+  // Cache the loaded inbox summary for the iOS Emails widget (#173). No-op
+  // off the native shell; paused on non-inbox folders so the cache keeps its
+  // last inbox snapshot.
+  useEmailSummaryCache(emails, accounts, folder === "inbox");
 
   // Infinite scroll: bump page when sentinel enters view
   const sentinelRef = useRef<HTMLDivElement | null>(null);

--- a/src/lib/mobile/email-summary.test.ts
+++ b/src/lib/mobile/email-summary.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shapeEmailSummary,
+  type EmailSummaryAccount,
+  type EmailSummaryEmail,
+} from "./email-summary";
+
+function account(
+  partial: Partial<EmailSummaryAccount> & { id: string },
+): EmailSummaryAccount {
+  return {
+    label: partial.id,
+    email_address: `${partial.id}@example.com`,
+    ...partial,
+  };
+}
+
+function email(
+  partial: Partial<EmailSummaryEmail> & { account_id: string },
+): EmailSummaryEmail {
+  return {
+    from_address: "sender@example.com",
+    from_name: "Sender",
+    subject: "A subject",
+    is_read: true,
+    received_at: "2026-05-21T10:00:00Z",
+    ...partial,
+  };
+}
+
+describe("shapeEmailSummary", () => {
+  it("produces an empty snapshot when there are no accounts", () => {
+    const snapshot = shapeEmailSummary(
+      { accounts: [], emails: [] },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot).toEqual({
+      generatedAt: "2026-05-21T12:00:00Z",
+      accounts: {},
+    });
+  });
+
+  it("includes an account with no emails as a zero-count, empty-preview entry", () => {
+    const snapshot = shapeEmailSummary(
+      { accounts: [account({ id: "acc-1", label: "Team" })], emails: [] },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"]).toEqual({
+      accountId: "acc-1",
+      label: "Team",
+      unreadCount: 0,
+      previews: [],
+      updatedAt: "2026-05-21T12:00:00Z",
+    });
+  });
+
+  it("counts an account's unread emails", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({ account_id: "acc-1", is_read: false }),
+          email({ account_id: "acc-1", is_read: false }),
+          email({ account_id: "acc-1", is_read: true }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].unreadCount).toBe(2);
+  });
+
+  it("builds a preview with the sender name and subject for each email", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({
+            account_id: "acc-1",
+            from_name: "Pat Adjuster",
+            subject: "Roof leak claim",
+          }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews).toEqual([
+      { sender: "Pat Adjuster", subject: "Roof leak claim" },
+    ]);
+  });
+
+  it("caps previews at three messages per account", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({ account_id: "acc-1", received_at: "2026-05-21T05:00:00Z" }),
+          email({ account_id: "acc-1", received_at: "2026-05-21T06:00:00Z" }),
+          email({ account_id: "acc-1", received_at: "2026-05-21T07:00:00Z" }),
+          email({ account_id: "acc-1", received_at: "2026-05-21T08:00:00Z" }),
+          email({ account_id: "acc-1", received_at: "2026-05-21T09:00:00Z" }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews).toHaveLength(3);
+  });
+
+  it("orders previews newest first regardless of input order", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({ account_id: "acc-1", subject: "Oldest", received_at: "2026-05-21T08:00:00Z" }),
+          email({ account_id: "acc-1", subject: "Newest", received_at: "2026-05-21T11:00:00Z" }),
+          email({ account_id: "acc-1", subject: "Middle", received_at: "2026-05-21T09:30:00Z" }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews.map((p) => p.subject)).toEqual([
+      "Newest",
+      "Middle",
+      "Oldest",
+    ]);
+  });
+
+  it("falls back to the email address when a sender has no display name", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({
+            account_id: "acc-1",
+            from_name: null,
+            from_address: "claims@insurer.com",
+          }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews[0].sender).toBe(
+      "claims@insurer.com",
+    );
+  });
+
+  it("routes each email to its own account", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" }), account({ id: "acc-2" })],
+        emails: [
+          email({ account_id: "acc-1", subject: "For one", is_read: false }),
+          email({ account_id: "acc-2", subject: "For two", is_read: true }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews.map((p) => p.subject)).toEqual([
+      "For one",
+    ]);
+    expect(snapshot.accounts["acc-1"].unreadCount).toBe(1);
+    expect(snapshot.accounts["acc-2"].previews.map((p) => p.subject)).toEqual([
+      "For two",
+    ]);
+    expect(snapshot.accounts["acc-2"].unreadCount).toBe(0);
+  });
+
+  it("ignores emails whose account is not in the account list", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [
+          email({ account_id: "acc-1", is_read: false }),
+          email({ account_id: "deleted-acc", is_read: false }),
+        ],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(Object.keys(snapshot.accounts)).toEqual(["acc-1"]);
+    expect(snapshot.accounts["acc-1"].unreadCount).toBe(1);
+  });
+});

--- a/src/lib/mobile/email-summary.ts
+++ b/src/lib/mobile/email-summary.ts
@@ -1,0 +1,83 @@
+import type { Email, EmailAccount } from "@/lib/types";
+
+/**
+ * Email-summary cache pipeline (PRD #56 slice 2, issue #173).
+ *
+ * `shapeEmailSummary` is the pure heart of the pipeline: it turns the inbox
+ * data the web app already holds into the per-account snapshot the native
+ * shell writes into the shared App Group container for the Emails widget to
+ * render. It does no I/O and reads no clock — the write timestamp is passed
+ * in — so it is fully unit-testable (issue #173 AC#4).
+ */
+
+/** The fields of an inbox `Email` the summary actually needs. */
+export type EmailSummaryEmail = Pick<
+  Email,
+  "account_id" | "from_address" | "from_name" | "subject" | "is_read" | "received_at"
+>;
+
+/** The fields of an `EmailAccount` the summary actually needs. */
+export type EmailSummaryAccount = Pick<EmailAccount, "id" | "label" | "email_address">;
+
+/** The inbox data handed to the shaper. */
+export interface EmailSummaryInput {
+  accounts: EmailSummaryAccount[];
+  emails: EmailSummaryEmail[];
+}
+
+/** Most messages previewed per account — the Emails widget shows a few. */
+export const PREVIEW_LIMIT = 3;
+
+/** One message preview shown in the widget — sender + subject only. */
+export interface EmailSummaryPreview {
+  sender: string;
+  subject: string;
+}
+
+/** The per-account summary the widget renders for its configured mailbox. */
+export interface AccountEmailSummary {
+  accountId: string;
+  label: string;
+  unreadCount: number;
+  /** Latest messages, newest first, capped at {@link PREVIEW_LIMIT}. */
+  previews: EmailSummaryPreview[];
+  /** When this account's summary was written (ISO 8601). */
+  updatedAt: string;
+}
+
+/** The full snapshot written to the App Group container, keyed by account id. */
+export interface EmailSummarySnapshot {
+  /** When the snapshot was written (ISO 8601). */
+  generatedAt: string;
+  accounts: Record<string, AccountEmailSummary>;
+}
+
+export function shapeEmailSummary(
+  input: EmailSummaryInput,
+  generatedAt: string,
+): EmailSummarySnapshot {
+  const accounts: Record<string, AccountEmailSummary> = {};
+
+  for (const acc of input.accounts) {
+    // ISO 8601 timestamps sort lexicographically, so a string compare orders
+    // them chronologically — newest first. `.filter` returns a fresh array,
+    // so sorting it does not mutate the caller's `input.emails`.
+    const accountEmails = input.emails
+      .filter((e) => e.account_id === acc.id)
+      .sort((a, b) => b.received_at.localeCompare(a.received_at));
+
+    accounts[acc.id] = {
+      accountId: acc.id,
+      label: acc.label,
+      unreadCount: accountEmails.filter((e) => !e.is_read).length,
+      previews: accountEmails.slice(0, PREVIEW_LIMIT).map((e) => ({
+        // A missing or blank display name falls back to the raw address.
+        sender: e.from_name || e.from_address,
+        subject: e.subject,
+      })),
+      updatedAt: generatedAt,
+    };
+  }
+
+  return { generatedAt, accounts };
+}

--- a/src/lib/mobile/email-widget-bridge.ts
+++ b/src/lib/mobile/email-widget-bridge.ts
@@ -1,0 +1,36 @@
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+import type { EmailSummarySnapshot } from "./email-summary";
+
+/**
+ * The native `EmailWidgetBridge` Capacitor plugin (issue #173, PRD #56
+ * slice 2). Implemented in Swift in the iOS App target — see
+ * `ios/App/App/EmailWidgetBridgePlugin.swift`. There is no web
+ * implementation; {@link publishEmailSummary} short-circuits off-native.
+ */
+export interface EmailWidgetBridgePlugin {
+  /** Writes the summary JSON into the shared App Group container. */
+  writeEmailSummary(options: { summary: string }): Promise<void>;
+  /** Reloads every widget timeline so the new summary is rendered. */
+  reloadWidgets(): Promise<void>;
+}
+
+const EmailWidgetBridge =
+  registerPlugin<EmailWidgetBridgePlugin>("EmailWidgetBridge");
+
+/**
+ * Caches the email summary for the iOS Emails widget: writes the snapshot
+ * into the App Group container, then reloads the widget timelines.
+ *
+ * A no-op everywhere but the native iOS shell — the WidgetKit extension and
+ * the App Group only exist there, and the web app has no widget to feed.
+ */
+export async function publishEmailSummary(
+  snapshot: EmailSummarySnapshot,
+): Promise<void> {
+  if (!Capacitor.isNativePlatform()) return;
+  await EmailWidgetBridge.writeEmailSummary({
+    summary: JSON.stringify(snapshot),
+  });
+  await EmailWidgetBridge.reloadWidgets();
+}

--- a/src/lib/mobile/use-email-summary-cache.ts
+++ b/src/lib/mobile/use-email-summary-cache.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+
+import {
+  shapeEmailSummary,
+  type EmailSummaryAccount,
+  type EmailSummaryEmail,
+} from "./email-summary";
+import { publishEmailSummary } from "./email-widget-bridge";
+
+/**
+ * Web summary producer (issue #173, PRD #56 slice 2).
+ *
+ * Once the inbox has loaded, this hook shapes the per-account email summary
+ * and hands it to the native shell to cache for the iOS Emails widget. It is
+ * a no-op off the native iOS shell — see {@link publishEmailSummary}.
+ *
+ * @param emails   The loaded inbox emails.
+ * @param accounts The email accounts the caller can read.
+ * @param enabled  Pass `false` while a non-inbox folder is shown so the cache
+ *                 keeps its last inbox snapshot instead of being clobbered.
+ */
+export function useEmailSummaryCache(
+  emails: EmailSummaryEmail[],
+  accounts: EmailSummaryAccount[],
+  enabled: boolean,
+): void {
+  useEffect(() => {
+    // Skip until accounts have loaded — publishing an account-less snapshot
+    // would clobber a good cache with nothing.
+    if (!enabled || accounts.length === 0) return;
+
+    const snapshot = shapeEmailSummary(
+      { emails, accounts },
+      new Date().toISOString(),
+    );
+    // Fire-and-forget: a failed widget-cache write must never disrupt the
+    // inbox the user is actually looking at.
+    void publishEmailSummary(snapshot).catch(() => {});
+  }, [emails, accounts, enabled]);
+}


### PR DESCRIPTION
## Summary

PRD #56 slice 2 — the **email-summary cache pipeline**. The web app shapes a per-account email summary and the native shell caches it in the shared App Group container for the Emails widget (slice 3, #174) to render. The WidgetKit extension stays network- and auth-free (PRD #56 decision).

- **`shapeEmailSummary`** (`src/lib/mobile/email-summary.ts`) — the pure inbox-data → per-account-snapshot shaper. Per account: unread count, up to 3 latest previews (sender + subject), and a timestamp. TDD'd over 9 RED→GREEN unit tests (issue #173 AC#4).
- **`EmailWidgetBridge` Capacitor plugin** — `EmailWidgetBridgePlugin.swift` (App target) + the TS interface. `writeEmailSummary` writes the snapshot JSON into the App Group `UserDefaults`; `reloadWidgets` calls `WidgetCenter.reloadAllTimelines()`.
- **`useEmailSummaryCache` hook** — shapes + publishes once the inbox loads; wired into `email-inbox.tsx`. A no-op off the native iOS shell.

## Refs, does not close #173

This PR **refs** but does not `Fix` #173. The Swift plugin was **not compiled** — this branch was authored on Windows with no Xcode (same constraint as #172). Adding `EmailWidgetBridgePlugin.swift` to the `App` target's Compile Sources is a one-step Mac task — see `ios/App/App/EmailWidgetBridge-SETUP.md`. On-device verification of the write → reload → render path is slice #175. #173 should close once the Xcode wiring lands and #175 verifies.

## Test plan

- [x] `shapeEmailSummary` — 9 unit tests, RED→GREEN (`email-summary.test.ts`)
- [x] Full suite: **784 passed (125 files)** — baseline 775/124, +9
- [x] `tsc` clean on changed files (the lone pre-existing `sync-folder-incremental.test.ts` TS2322 is unrelated)
- [x] `eslint` clean on changed files
- [ ] Swift compiled — deferred, no Xcode on Windows
- [ ] On-device write → reload → render — slice #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)