### PR TITLE
widgets: Emails widget UI + per-account configuration (#174)

### DIFF
--- a/ios/App/NookleusWidgets/EmailsWidget.swift
+++ b/ios/App/NookleusWidgets/EmailsWidget.swift
@@ -1,0 +1,403 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+// MARK: - Cache contract
+//
+// The Emails widget (PRD #56, slice 3, issue #174) renders the per-account
+// snapshot written by the slice 2 (#173) cache pipeline. It does NO networking
+// and NO auth — it only decodes and displays whatever the app last wrote into
+// the shared App Group container.
+//
+// The JSON schema mirrors `EmailSummarySnapshot` in
+// `src/lib/mobile/email-summary.ts`. Change one side, change the other.
+
+struct EmailSummaryPreview: Codable, Identifiable {
+    let id: String
+    let sender: String
+    let subject: String
+}
+
+struct AccountEmailSummary: Codable {
+    let accountId: String
+    let label: String
+    let unreadCount: Int
+    let previews: [EmailSummaryPreview]
+    /// ISO 8601 timestamp — when the app last wrote this account's summary.
+    let updatedAt: String
+}
+
+struct EmailSummarySnapshot: Codable {
+    let generatedAt: String
+    let accounts: [String: AccountEmailSummary]
+}
+
+// MARK: - App Group store
+
+/// Reads the email-summary snapshot the native shell writes (see
+/// `EmailWidgetBridgePlugin.swift`). Returns `nil` when no cache exists yet —
+/// the widget shows its "open the app to sync" empty state in that case.
+enum EmailSummaryStore {
+    static let appGroupID = "group.com.aaacontracting.platform"
+    static let key = "emailSummary"
+
+    static func loadSnapshot() -> EmailSummarySnapshot? {
+        guard
+            let defaults = UserDefaults(suiteName: appGroupID),
+            let json = defaults.string(forKey: key),
+            let data = json.data(using: .utf8)
+        else { return nil }
+        return try? JSONDecoder().decode(EmailSummarySnapshot.self, from: data)
+    }
+}
+
+// MARK: - Deep links
+//
+// The host/query format is parsed by `parseDeepLink` in
+// `src/lib/mobile/deep-link.ts`. `nookleus://email?account=<id>` opens that
+// account's inbox; `nookleus://email?id=<id>` opens that specific email.
+
+private func emailDeepLink(_ name: String, _ value: String) -> URL {
+    var components = URLComponents()
+    components.scheme = "nookleus"
+    components.host = "email"
+    components.queryItems = [URLQueryItem(name: name, value: value)]
+    return components.url ?? URL(string: "nookleus://email")!
+}
+
+private func accountInboxURL(_ accountId: String) -> URL {
+    emailDeepLink("account", accountId)
+}
+
+private func emailURL(_ emailId: String) -> URL {
+    emailDeepLink("id", emailId)
+}
+
+// MARK: - Freshness
+
+/// Parses an ISO 8601 string. The web side writes `Date.toISOString()`, which
+/// always carries fractional seconds, so that variant is tried first.
+private func parseISO8601(_ value: String) -> Date? {
+    let withFractional = ISO8601DateFormatter()
+    withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = withFractional.date(from: value) { return date }
+
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    return plain.date(from: value)
+}
+
+/// "Updated Xh ago" line backed by the snapshot timestamp. The timeline is
+/// refreshed hourly (see the provider) so this stays roughly current even
+/// while the app is closed.
+private func freshnessText(_ updatedAt: String) -> String {
+    guard let date = parseISO8601(updatedAt) else { return "" }
+    let seconds = max(0, Date().timeIntervalSince(date))
+    if seconds < 60 { return "Updated just now" }
+
+    let minutes = Int(seconds / 60)
+    if minutes < 60 { return "Updated \(minutes)m ago" }
+
+    let hours = minutes / 60
+    if hours < 24 { return "Updated \(hours)h ago" }
+
+    return "Updated \(hours / 24)d ago"
+}
+
+// MARK: - Configuration intent
+//
+// Each widget instance is pinned to one mailbox. The picker is sourced from
+// the cached snapshot's accounts — no networking, consistent with the
+// extension never touching auth or the API.
+
+@available(iOS 17.0, *)
+struct MailboxEntity: AppEntity {
+    let id: String
+    let label: String
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation {
+        TypeDisplayRepresentation(name: "Mailbox")
+    }
+
+    static var defaultQuery = MailboxQuery()
+
+    var displayRepresentation: DisplayRepresentation {
+        DisplayRepresentation(title: "\(label)")
+    }
+}
+
+@available(iOS 17.0, *)
+struct MailboxQuery: EntityQuery {
+    func entities(for identifiers: [MailboxEntity.ID]) async throws -> [MailboxEntity] {
+        Self.allMailboxes().filter { identifiers.contains($0.id) }
+    }
+
+    func suggestedEntities() async throws -> [MailboxEntity] {
+        Self.allMailboxes()
+    }
+
+    func defaultResult() async -> MailboxEntity? {
+        Self.allMailboxes().first
+    }
+
+    /// Every mailbox present in the cached snapshot, sorted by label.
+    static func allMailboxes() -> [MailboxEntity] {
+        guard let accounts = EmailSummaryStore.loadSnapshot()?.accounts else { return [] }
+        return accounts.values
+            .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+            .map { MailboxEntity(id: $0.accountId, label: $0.label) }
+    }
+}
+
+@available(iOS 17.0, *)
+struct SelectMailboxIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Select Mailbox"
+    static var description = IntentDescription("Choose which mailbox this widget shows.")
+
+    @Parameter(title: "Mailbox")
+    var mailbox: MailboxEntity?
+}
+
+// MARK: - Timeline
+
+@available(iOS 17.0, *)
+struct EmailsEntry: TimelineEntry {
+    let date: Date
+    /// The configured account's summary, or `nil` when no cache exists yet.
+    let summary: AccountEmailSummary?
+}
+
+@available(iOS 17.0, *)
+struct EmailsProvider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> EmailsEntry {
+        EmailsEntry(date: Date(), summary: .placeholder)
+    }
+
+    func snapshot(
+        for configuration: SelectMailboxIntent,
+        in context: Context
+    ) async -> EmailsEntry {
+        entry(for: configuration)
+    }
+
+    func timeline(
+        for configuration: SelectMailboxIntent,
+        in context: Context
+    ) async -> Timeline<EmailsEntry> {
+        // The app reloads timelines whenever it writes a fresh snapshot, so
+        // the widget never polls for data. The hourly refresh only ages the
+        // "Updated Xh ago" line while the app stays closed.
+        let nextRefresh = Calendar.current.date(byAdding: .hour, value: 1, to: Date())
+            ?? Date().addingTimeInterval(3600)
+        return Timeline(entries: [entry(for: configuration)], policy: .after(nextRefresh))
+    }
+
+    private func entry(for configuration: SelectMailboxIntent) -> EmailsEntry {
+        let snapshot = EmailSummaryStore.loadSnapshot()
+        let summary: AccountEmailSummary?
+        if let accountId = configuration.mailbox?.id {
+            summary = snapshot?.accounts[accountId]
+        } else {
+            // Not configured yet — fall back to the first available mailbox.
+            summary = snapshot?.accounts.values
+                .sorted { $0.label.localizedCaseInsensitiveCompare($1.label) == .orderedAscending }
+                .first
+        }
+        return EmailsEntry(date: Date(), summary: summary)
+    }
+}
+
+// MARK: - Views
+
+@available(iOS 17.0, *)
+struct EmailsWidgetView: View {
+    let entry: EmailsEntry
+
+    var body: some View {
+        if let summary = entry.summary {
+            EmailsContentView(summary: summary)
+        } else {
+            EmailsEmptyView()
+        }
+    }
+}
+
+/// Shown when no snapshot has been written yet (fresh install / signed out).
+/// Tapping anywhere opens the app, which writes the cache on next foreground.
+struct EmailsEmptyView: View {
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "envelope.badge")
+                .font(.largeTitle)
+                .foregroundColor(.accentColor)
+            Text("Nookleus")
+                .font(.headline)
+                .foregroundColor(.primary)
+            Text("Open the app to sync")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .widgetURL(URL(string: "nookleus://email"))
+    }
+}
+
+@available(iOS 17.0, *)
+struct EmailsContentView: View {
+    @Environment(\.widgetFamily) private var family
+    let summary: AccountEmailSummary
+
+    /// Medium has room for two previews; large fits the full three.
+    private var previewLimit: Int { family == .systemLarge ? 3 : 2 }
+
+    private var shownPreviews: [EmailSummaryPreview] {
+        Array(summary.previews.prefix(previewLimit))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            // Header — mailbox label + unread count. Opens the account inbox.
+            Link(destination: accountInboxURL(summary.accountId)) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(summary.label)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .foregroundColor(.primary)
+                    Spacer(minLength: 8)
+                    UnreadBadge(count: summary.unreadCount)
+                }
+            }
+
+            Divider()
+
+            if shownPreviews.isEmpty {
+                Spacer(minLength: 0)
+                Text("No recent messages")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer(minLength: 0)
+            } else {
+                ForEach(shownPreviews) { preview in
+                    // Each row opens that specific email.
+                    Link(destination: emailURL(preview.id)) {
+                        PreviewRow(preview: preview)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+
+            Text(freshnessText(summary.updatedAt))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // Fallback tap target for anything outside an explicit Link.
+        .widgetURL(accountInboxURL(summary.accountId))
+    }
+}
+
+struct UnreadBadge: View {
+    let count: Int
+
+    var body: some View {
+        Text(count == 0 ? "All read" : "\(count) unread")
+            .font(.caption)
+            .fontWeight(.semibold)
+            .foregroundColor(count == 0 ? .secondary : .white)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 3)
+            .background(count == 0 ? Color.clear : Color.accentColor)
+            .clipShape(Capsule())
+    }
+}
+
+struct PreviewRow: View {
+    let preview: EmailSummaryPreview
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(preview.sender)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+                .foregroundColor(.primary)
+            Text(preview.subject)
+                .font(.caption2)
+                .lineLimit(1)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+// MARK: - Widget
+
+@available(iOS 17.0, *)
+struct EmailsWidget: Widget {
+    let kind: String = "EmailsWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: kind,
+            intent: SelectMailboxIntent.self,
+            provider: EmailsProvider()
+        ) { entry in
+            EmailsWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Emails")
+        .description("Unread count and latest messages for one mailbox.")
+        .supportedFamilies([.systemMedium, .systemLarge])
+    }
+}
+
+// MARK: - Sample data
+
+@available(iOS 17.0, *)
+extension AccountEmailSummary {
+    /// Stand-in shown in the widget gallery and while the timeline loads.
+    static let placeholder = AccountEmailSummary(
+        accountId: "sample",
+        label: "Team Inbox",
+        unreadCount: 3,
+        previews: [
+            EmailSummaryPreview(
+                id: "sample-1",
+                sender: "Pat Adjuster",
+                subject: "Roof leak claim — photos attached"
+            ),
+            EmailSummaryPreview(
+                id: "sample-2",
+                sender: "scheduling@supplier.com",
+                subject: "Delivery confirmed for Thursday"
+            ),
+            EmailSummaryPreview(
+                id: "sample-3",
+                sender: "Jordan Lee",
+                subject: "Re: estimate approval"
+            ),
+        ],
+        updatedAt: ISO8601DateFormatter().string(from: Date())
+    )
+}
+
+// MARK: - Preview
+
+#if DEBUG
+@available(iOS 17.0, *)
+#Preview("Emails — medium", as: .systemMedium) {
+    EmailsWidget()
+} timeline: {
+    EmailsEntry(date: Date(), summary: .placeholder)
+    EmailsEntry(date: Date(), summary: nil)
+}
+
+@available(iOS 17.0, *)
+#Preview("Emails — large", as: .systemLarge) {
+    EmailsWidget()
+} timeline: {
+    EmailsEntry(date: Date(), summary: .placeholder)
+}
+#endif

--- a/ios/App/NookleusWidgets/NookleusWidgetsBundle.swift
+++ b/ios/App/NookleusWidgets/NookleusWidgetsBundle.swift
@@ -3,11 +3,15 @@ import WidgetKit
 
 /// Entry point for the Nookleus WidgetKit extension.
 ///
-/// Slice 1 (#172) ships only the data-free Quick Actions widget. The Emails
-/// widget (#174) is added to this bundle in a later slice.
+/// - Quick Actions (#172): a data-free deep-link widget, iOS 15+.
+/// - Emails (#174): the data-backed per-mailbox widget. It uses
+///   `AppIntentConfiguration`, so it is iOS 17+ and is included conditionally.
 @main
 struct NookleusWidgetsBundle: WidgetBundle {
     var body: some Widget {
         QuickActionsWidget()
+        if #available(iOS 17.0, *) {
+            EmailsWidget()
+        }
     }
 }

--- a/ios/App/NookleusWidgets/SETUP.md
+++ b/ios/App/NookleusWidgets/SETUP.md
@@ -36,6 +36,49 @@ Note: this is an SPM-based Capacitor project — there is **no
 - `src/lib/mobile/deep-link.ts` (parser, unit-tested) and
   `src/components/mobile/deep-link-listener.tsx` — wired into `src/app/layout.tsx`.
 
+## Slice 3 (#174) — Emails widget — needs one Xcode step
+
+Slice 3 adds the data-backed **Emails** widget. It reads the per-account
+snapshot the slice 2 (#173) cache pipeline writes into the App Group; the
+extension still does no networking and no auth.
+
+**New file — must be added to the `NookleusWidgets` target's Sources:**
+
+- `NookleusWidgets/EmailsWidget.swift` — the Codable snapshot model, the App
+  Group reader, the per-mailbox configuration intent, the timeline provider,
+  the SwiftUI views, and the `EmailsWidget`.
+
+In Xcode: select `EmailsWidget.swift` → File inspector → **Target
+Membership** → check **`NookleusWidgets`** (the same Sources phase that
+already holds `QuickActionsWidget.swift`). No other target.
+
+`NookleusWidgetsBundle.swift` was edited in this commit to register
+`EmailsWidget()` — no Xcode action, it rebuilds with the target.
+
+**iOS 17+ for the Emails widget — decision to ratify.** Per-instance
+configuration uses `AppIntentConfiguration` + `WidgetConfigurationIntent`
+(the AppIntents framework), not a legacy SiriKit `.intentdefinition` file.
+That keeps the configuration pure Swift with no generated-intent code, at the
+cost of the Emails widget requiring **iOS 17+**. The extension's deployment
+target stays **iOS 15** — `NookleusWidgetsBundle` gates the Emails widget
+behind `if #available(iOS 17.0, *)`, so Quick Actions still ships to iOS 15/16
+and the Emails widget simply does not appear in the gallery below iOS 17. No
+deployment-target change is needed. If iOS 15/16 support for the Emails
+widget is required, this must be reworked to `IntentConfiguration` with a
+SiriKit custom intent.
+
+**Web layer (slice 3 half, TDD'd, live on the next deploy):**
+
+- `src/lib/mobile/deep-link.ts` — `parseDeepLink` now handles
+  `nookleus://email?account=<id>` → `/email?account=<id>` and
+  `nookleus://email?id=<id>` → `/email?id=<id>` (bare `nookleus://email` →
+  `/email`).
+- `src/lib/mobile/email-summary.ts` — `EmailSummaryPreview` gained an `id`
+  field (the email id), so a preview tap can deep-link to that exact email.
+  The Swift `EmailSummaryPreview` in `EmailsWidget.swift` mirrors it.
+- `src/components/email-inbox.tsx` — consumes the `account` and `id` query
+  params on mount (selects the account / opens the email).
+
 ## 4. Apple Developer portal — REMAINING, needs you
 
 ⚠️ **Do not push `main` until this is done.** The commit wires
@@ -69,8 +112,17 @@ otherwise upload the profile created in §4.
 
 ## 6. Verify (slice #175)
 
-Real-device verification — adding the widget to the home screen in medium
-and large, tapping each of the four buttons, confirming the deep links land
-on the right screen — is the TestFlight slice **#175**. Acceptance criteria
-1–3 of #172 are confirmed there. AC#4 (the deep-link parser) is already
-covered by `src/lib/mobile/deep-link.test.ts`.
+Real-device verification is the TestFlight slice **#175**:
+
+- **Quick Actions (#172)** — add it in medium and large, tap each of the four
+  buttons, confirm the deep links land on the right screen (#172 AC#1–3).
+- **Emails (#174)** — add it in medium and large; configure each instance to
+  a mailbox via the widget's edit screen; confirm the unread count + previews
+  render, the "Updated Xh ago" line is present, the "Open the app to sync"
+  empty state shows with no cache, and tapping a preview / the count deep-links
+  correctly (#174 AC#1–6).
+
+The pure logic is already unit-tested off-device: `deep-link.test.ts` covers
+the parser (all `nookleus://` routes) and `email-summary.test.ts` covers
+`shapeEmailSummary` (including the preview `id`). The SwiftUI / WidgetKit /
+AppIntent code carries no automated tests — repo norm for native iOS work.

--- a/src/components/email-inbox.tsx
+++ b/src/components/email-inbox.tsx
@@ -209,7 +209,11 @@ export default function EmailInbox() {
     accountId?: string;
   } | null>(null);
 
-  // Consume compose query params (e.g. from AR aging Nudge button)
+  // Consume query params on mount:
+  // - `compose=1` opens the composer (e.g. the AR aging Nudge button).
+  // - `account` / `id` are the iOS Emails widget (#174) deep links — tapping
+  //   the unread count opens that account's inbox; tapping a preview opens
+  //   that specific email.
   const searchParams = useSearchParams();
   useEffect(() => {
     if (searchParams.get("compose") === "1") {
@@ -228,6 +232,12 @@ export default function EmailInbox() {
       });
       setComposeOpen(true);
     }
+
+    const widgetAccountId = searchParams.get("account");
+    if (widgetAccountId) setSelectedAccountId(widgetAccountId);
+
+    const widgetEmailId = searchParams.get("id");
+    if (widgetEmailId) setSelectedEmailId(widgetEmailId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/mobile/deep-link.test.ts
+++ b/src/lib/mobile/deep-link.test.ts
@@ -32,4 +32,20 @@ describe("parseDeepLink", () => {
   it("tolerates a trailing slash or path after the action", () => {
     expect(parseDeepLink("nookleus://jarvis/")).toBe("/jarvis");
   });
+
+  // Emails widget (#174) deep links — the widget emits `nookleus://email`
+  // with a query param identifying what to open.
+  it("routes a widget email link with an account to that account's inbox", () => {
+    expect(parseDeepLink("nookleus://email?account=acc-1")).toBe(
+      "/email?account=acc-1",
+    );
+  });
+
+  it("routes a widget email link with an id to that specific email", () => {
+    expect(parseDeepLink("nookleus://email?id=msg-9")).toBe("/email?id=msg-9");
+  });
+
+  it("routes a bare widget email link to the inbox", () => {
+    expect(parseDeepLink("nookleus://email")).toBe("/email");
+  });
 });

--- a/src/lib/mobile/deep-link.ts
+++ b/src/lib/mobile/deep-link.ts
@@ -19,6 +19,19 @@ const ROUTES: Record<string, string> = {
  */
 export function parseDeepLink(url: string): string | null {
   if (!url.startsWith(SCHEME)) return null;
-  const action = url.slice(SCHEME.length).split(/[/?#]/)[0];
+  const rest = url.slice(SCHEME.length);
+  const action = rest.split(/[/?#]/)[0];
+
+  // The Emails widget (#174) emits `nookleus://email` with a query param
+  // saying what to open, so its route is built dynamically.
+  if (action === "email") {
+    const params = new URLSearchParams(rest.split("?")[1] ?? "");
+    const id = params.get("id");
+    if (id) return `/email?id=${encodeURIComponent(id)}`;
+    const account = params.get("account");
+    if (account) return `/email?account=${encodeURIComponent(account)}`;
+    return "/email";
+  }
+
   return ROUTES[action] ?? null;
 }

--- a/src/lib/mobile/email-summary.test.ts
+++ b/src/lib/mobile/email-summary.test.ts
@@ -20,6 +20,7 @@ function email(
   partial: Partial<EmailSummaryEmail> & { account_id: string },
 ): EmailSummaryEmail {
   return {
+    id: "email-id",
     from_address: "sender@example.com",
     from_name: "Sender",
     subject: "A subject",
@@ -80,6 +81,7 @@ describe("shapeEmailSummary", () => {
         emails: [
           email({
             account_id: "acc-1",
+            id: "msg-1",
             from_name: "Pat Adjuster",
             subject: "Roof leak claim",
           }),
@@ -89,8 +91,20 @@ describe("shapeEmailSummary", () => {
     );
 
     expect(snapshot.accounts["acc-1"].previews).toEqual([
-      { sender: "Pat Adjuster", subject: "Roof leak claim" },
+      { id: "msg-1", sender: "Pat Adjuster", subject: "Roof leak claim" },
     ]);
+  });
+
+  it("includes each email's id in its preview so the widget can deep-link to it", () => {
+    const snapshot = shapeEmailSummary(
+      {
+        accounts: [account({ id: "acc-1" })],
+        emails: [email({ account_id: "acc-1", id: "msg-42" })],
+      },
+      "2026-05-21T12:00:00Z",
+    );
+
+    expect(snapshot.accounts["acc-1"].previews[0].id).toBe("msg-42");
   });
 
   it("caps previews at three messages per account", () => {

--- a/src/lib/mobile/email-summary.ts
+++ b/src/lib/mobile/email-summary.ts
@@ -13,7 +13,13 @@ import type { Email, EmailAccount } from "@/lib/types";
 /** The fields of an inbox `Email` the summary actually needs. */
 export type EmailSummaryEmail = Pick<
   Email,
-  "account_id" | "from_address" | "from_name" | "subject" | "is_read" | "received_at"
+  | "id"
+  | "account_id"
+  | "from_address"
+  | "from_name"
+  | "subject"
+  | "is_read"
+  | "received_at"
 >;
 
 /** The fields of an `EmailAccount` the summary actually needs. */
@@ -30,6 +36,8 @@ export const PREVIEW_LIMIT = 3;
 
 /** One message preview shown in the widget — sender + subject only. */
 export interface EmailSummaryPreview {
+  /** The email's id — the widget's deep link opens `nookleus://email?id=`. */
+  id: string;
   sender: string;
   subject: string;
 }
@@ -71,6 +79,7 @@ export function shapeEmailSummary(
       label: acc.label,
       unreadCount: accountEmails.filter((e) => !e.is_read).length,
       previews: accountEmails.slice(0, PREVIEW_LIMIT).map((e) => ({
+        id: e.id,
         // A missing or blank display name falls back to the raw address.
         sender: e.from_name || e.from_address,
         subject: e.subject,


### PR DESCRIPTION
## Summary

PRD #56 slice 3 — the data-backed **Emails** widget for the `NookleusWidgets` extension. Renders the per-account snapshot the #173 cache pipeline writes into the App Group; the extension does no networking and no auth.

- **`EmailsWidget.swift`** (new) — `AppIntentConfiguration` widget (**iOS 17+**): Codable snapshot model, App Group reader, per-mailbox configuration intent, timeline provider, SwiftUI views (unread count, up to 3 previews, "Updated Xh ago", "open the app to sync" empty state), `nookleus://` deep links.
- **`NookleusWidgetsBundle.swift`** — registers `EmailsWidget()` behind `if #available(iOS 17.0, *)`; Quick Actions stays iOS 15+.
- **`deep-link.ts`** — `parseDeepLink` now handles `nookleus://email?account=` / `?id=` (TDD'd, +3 tests).
- **`email-summary.ts`** — `EmailSummaryPreview` gains an `id` field so a preview tap can deep-link to that exact email (TDD'd, +1 test).
- **`email-inbox.tsx`** — consumes the `account` / `id` query params on mount.

**Not a `Closes`** — per the #172/#173 pattern, #174 stays open until the one Xcode step (adding `EmailsWidget.swift` to the target's Sources) lands and #175 verifies on-device.

## Decisions for review

- **iOS 17+ for the Emails widget** — per-instance config uses `AppIntentConfiguration` + `WidgetConfigurationIntent` (AppIntents framework) rather than a legacy SiriKit `.intentdefinition`, which can't be hand-authored reliably without Xcode. The extension deployment target stays iOS 15. See `NookleusWidgets/SETUP.md`.
- **`EmailSummaryPreview` extended with `id`** — #173's contract carried only `{ sender, subject }`; AC#6 ("tapping a preview opens that email") needs a routing key. `id` is not displayed, so it does not change the PRD's "sender + subject" display scope.

## Test Plan

- [x] `parseDeepLink` + `shapeEmailSummary` — Vitest, +4 tests, full suite **788 passing (125 files)**
- [x] `tsc --noEmit` clean on the changed surface (pre-existing unrelated `sync-folder-incremental.test.ts` error remains)
- [x] `eslint` clean on all 5 changed web files
- [ ] **Xcode (Mac):** add `EmailsWidget.swift` to the `NookleusWidgets` target's Sources phase, build the `App` scheme
- [ ] **#175 TestFlight:** add the widget in medium/large, configure a mailbox, verify count + previews + freshness line + empty state + deep links (AC#1–6)

> ⚠️ The Swift was written on Windows and **not compiled** — no Xcode. A human/Mac eye on `EmailsWidget.swift` is worth it before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)