### PR TITLE
widgets: wire EmailWidgetBridgePlugin into the App target (#173)

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		504EC30F1FED79650016851F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 504EC30E1FED79650016851F /* Assets.xcassets */; };
 		504EC3121FED79650016851F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 504EC3101FED79650016851F /* LaunchScreen.storyboard */; };
 		50B271D11FEDC1A000F3C39B /* public in Resources */ = {isa = PBXBuildFile; fileRef = 50B271D01FEDC1A000F3C39B /* public */; };
+		A6116D307648E2DA2E074510 /* EmailWidgetBridgePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097481F43003B2C7999C9BDF /* EmailWidgetBridgePlugin.swift */; };
 		BD862128CF73B88DCBA28576 /* QuickActionsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */; };
 		CC0E01018404C6330CB5EF2E /* NookleusWidgetsBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4079C7114FD7E44CF0086934 /* NookleusWidgetsBundle.swift */; };
 /* End PBXBuildFile section */
@@ -45,6 +46,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		097481F43003B2C7999C9BDF /* EmailWidgetBridgePlugin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EmailWidgetBridgePlugin.swift; sourceTree = "<group>"; };
 		226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickActionsWidget.swift; sourceTree = "<group>"; };
 		247A9A25BA193B3102812C1A /* App.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 				2FAD9762203C412B000D30F8 /* config.xml */,
 				50B271D01FEDC1A000F3C39B /* public */,
 				247A9A25BA193B3102812C1A /* App.entitlements */,
+				097481F43003B2C7999C9BDF /* EmailWidgetBridgePlugin.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -252,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				504EC3081FED79650016851F /* AppDelegate.swift in Sources */,
+				A6116D307648E2DA2E074510 /* EmailWidgetBridgePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/App/EmailWidgetBridge-SETUP.md
+++ b/ios/App/App/EmailWidgetBridge-SETUP.md
@@ -4,9 +4,9 @@ Issue #173 (PRD #56, slice 2) delivers the **email-summary cache pipeline**:
 the web app shapes a per-account email summary and the native shell writes it
 into the App Group container the Emails widget (slice 3, #174) will read.
 
-The web layer ships and runs on the next deploy. One native step remains and
-it needs a Mac with Xcode — this repo was authored on Windows, so the Swift
-was written but **not compiled** (same constraint as #172).
+The web layer ships and runs on the deploy. The one native step — adding the
+Swift plugin to the `App` target — is now **done** (see "Xcode wiring" below);
+it needed a Mac with Xcode because the file was authored on Windows.
 
 ## Delivered in this commit
 
@@ -25,22 +25,27 @@ was written but **not compiled** (same constraint as #172).
 
 - `ios/App/App/EmailWidgetBridgePlugin.swift` — the Swift Capacitor plugin.
 
-## Remaining — needs Xcode
+## Xcode wiring — done
 
-Add `EmailWidgetBridgePlugin.swift` to the **`App` target's Compile Sources**:
+`EmailWidgetBridgePlugin.swift` is in the **`App` target's Compile Sources**
+phase (`ios/App/App.xcodeproj/project.pbxproj`). It was added programmatically
+with the `xcodeproj` Ruby gem — the same approach #172 used for the
+`NookleusWidgets` target — not a hand-edit of `project.pbxproj`.
 
-1. Open `ios/App/App.xcodeproj` in Xcode (SPM-based Capacitor project — there
-   is no `.xcworkspace`).
-2. In the Project navigator, drag `App/EmailWidgetBridgePlugin.swift` into the
-   `App` group if it is not already shown.
-3. Select the file → File inspector → **Target Membership** → check **`App`**.
-4. Build the `App` scheme. The plugin registers itself at runtime via
-   `CAPBridgedPlugin` — no Objective-C `.m` macro file and no `Podfile` entry
-   are needed.
+Verified: `xcodebuild` builds the **`App` scheme** for the iOS Simulator
+(`CODE_SIGNING_ALLOWED=NO`) with `EmailWidgetBridgePlugin.swift` compiled into
+the `App` target and `NookleusWidgets.appex` embedded.
+
+> Build the **`App` scheme**, not `-target App`. A bare `-target` build does
+> not order transitive SPM package dependencies, so `SecureStoragePlugin`
+> fails with `unable to resolve module dependency: 'SwiftKeychainWrapper'`.
+
+The plugin registers itself at runtime via `CAPBridgedPlugin` — no Objective-C
+`.m` macro file and no `Podfile` entry are needed.
 
 No new entitlement work: the **App Group `group.com.aaacontracting.platform`**
 was already wired onto the `App` target in #172 (`App/App.entitlements`,
-`CODE_SIGN_ENTITLEMENTS`), so `UserDefaults(suiteName:)` resolves once the
+`CODE_SIGN_ENTITLEMENTS`), so `UserDefaults(suiteName:)` resolves now that the
 plugin file compiles into the target.
 
 ## The cache contract


### PR DESCRIPTION
## Summary

Completes the one native step issue #173 (PRD #56, slice 2 — email-summary cache pipeline) deferred: `EmailWidgetBridgePlugin.swift` — the Swift Capacitor plugin committed in #173 (`f956399`) — was authored on Windows but never wired into the Xcode project. This adds it to the **`App` target's Compile Sources** phase.

- `project.pbxproj` — `PBXFileReference` + `PBXBuildFile` for `EmailWidgetBridgePlugin.swift`, added to the `App` group and the `App` target's Sources build phase. Done programmatically with the `xcodeproj` Ruby gem, mirroring how #172 created the `NookleusWidgets` target — not a hand-edit.
- `EmailWidgetBridge-SETUP.md` — updated to the done state.

## Verification

`xcodebuild` builds the **`App` scheme** for the iOS Simulator (`CODE_SIGNING_ALLOWED=NO`): **`** BUILD SUCCEEDED **`** — `EmailWidgetBridgePlugin.swift` compiles into the `App` target (arm64 + x86_64), 0 errors / 0 warnings, `App.app` produced with `PlugIns/NookleusWidgets.appex` embedded.

> Build the **`App` scheme**, not `-target App` — a bare `-target` build does not order transitive SPM package dependencies, so `SecureStoragePlugin` fails to resolve `SwiftKeychainWrapper`.

## Notes

Refs #173 — **does not close it**. On-device verification of the full plugin call path (app foreground → `writeEmailSummary` → App Group → widget render) is slice #175, mirroring how #172/#178 were left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)