### PR TITLE
widgets: wire EmailsWidget into the NookleusWidgets target (#174)

### DIFF
--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0F7E5D1D7C9E759F783E1AC0 /* EmailsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1EF968205ABDE2CDA1181B /* EmailsWidget.swift */; };
 		2FAD9763203C412B000D30F8 /* config.xml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAD9762203C412B000D30F8 /* config.xml */; };
 		33ECFD9D8B5C4EADFD7566CB /* NookleusWidgets.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8377AF6A3FD9AD2AC1323845 /* NookleusWidgets.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4D22ABE92AF431CB00220026 /* CapApp-SPM in Frameworks */ = {isa = PBXBuildFile; productRef = 4D22ABE82AF431CB00220026 /* CapApp-SPM */; };
@@ -51,6 +52,7 @@
 		247A9A25BA193B3102812C1A /* App.entitlements */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.entitlements; path = App.entitlements; sourceTree = "<group>"; };
 		2FAD9762203C412B000D30F8 /* config.xml */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = config.xml; sourceTree = "<group>"; };
 		4079C7114FD7E44CF0086934 /* NookleusWidgetsBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NookleusWidgetsBundle.swift; sourceTree = "<group>"; };
+		4C1EF968205ABDE2CDA1181B /* EmailsWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EmailsWidget.swift; sourceTree = "<group>"; };
 		50379B222058CBB4000EE86E /* capacitor.config.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = capacitor.config.json; sourceTree = "<group>"; };
 		504EC3041FED79650016851F /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		504EC3071FED79650016851F /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				226D62D47842E4E0D66FD88B /* QuickActionsWidget.swift */,
 				A46E4B974C344C093C565572 /* Info.plist */,
 				E7079DA9F9E1E95600C6698C /* NookleusWidgets.entitlements */,
+				4C1EF968205ABDE2CDA1181B /* EmailsWidget.swift */,
 			);
 			name = NookleusWidgets;
 			path = NookleusWidgets;
@@ -247,6 +250,7 @@
 			files = (
 				CC0E01018404C6330CB5EF2E /* NookleusWidgetsBundle.swift in Sources */,
 				BD862128CF73B88DCBA28576 /* QuickActionsWidget.swift in Sources */,
+				0F7E5D1D7C9E759F783E1AC0 /* EmailsWidget.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/App/NookleusWidgets/SETUP.md
+++ b/ios/App/NookleusWidgets/SETUP.md
@@ -5,9 +5,9 @@ target, source wiring, and App Group entitlements were created on a Mac
 (2026-05-21, Xcode 26.4) with the `xcodeproj` Ruby gem and verified with a
 simulator build.
 
-⚠️ **One step remains and it needs a human: registering the new App ID and
-App Group in the Apple Developer portal (§4). Do NOT push `main` until that
-is done — a signed Xcode Cloud build fails without it. See §4.**
+✅ **Apple Developer portal setup (§4) is complete** — the App Group and the
+`…NookleusWidgets` App ID were registered on 2026-05-21 (#172 native half).
+`main` has shipped signed Xcode Cloud builds since; no portal blocker remains.
 
 ## Done — Xcode project (in this commit)
 
@@ -36,24 +36,31 @@ Note: this is an SPM-based Capacitor project — there is **no
 - `src/lib/mobile/deep-link.ts` (parser, unit-tested) and
   `src/components/mobile/deep-link-listener.tsx` — wired into `src/app/layout.tsx`.
 
-## Slice 3 (#174) — Emails widget — needs one Xcode step
+## Slice 3 (#174) — Emails widget — Xcode wiring done
 
 Slice 3 adds the data-backed **Emails** widget. It reads the per-account
 snapshot the slice 2 (#173) cache pipeline writes into the App Group; the
 extension still does no networking and no auth.
 
-**New file — must be added to the `NookleusWidgets` target's Sources:**
-
 - `NookleusWidgets/EmailsWidget.swift` — the Codable snapshot model, the App
   Group reader, the per-mailbox configuration intent, the timeline provider,
   the SwiftUI views, and the `EmailsWidget`.
 
-In Xcode: select `EmailsWidget.swift` → File inspector → **Target
-Membership** → check **`NookleusWidgets`** (the same Sources phase that
-already holds `QuickActionsWidget.swift`). No other target.
+**Done (2026-05-21, Xcode 26.4.1):** `EmailsWidget.swift` was added to the
+`NookleusWidgets` target's Compile Sources phase — the same phase that holds
+`QuickActionsWidget.swift`. Done programmatically with the `xcodeproj` Ruby
+gem (not a hand-edit of `project.pbxproj`), mirroring #172/#173.
+`NookleusWidgetsBundle.swift` (committed with the #174 web PR) already
+registers `EmailsWidget()` behind `if #available(iOS 17.0, *)` — no Xcode
+action, it rebuilds with the target.
 
-`NookleusWidgetsBundle.swift` was edited in this commit to register
-`EmailsWidget()` — no Xcode action, it rebuilds with the target.
+**Verified:** `xcodebuild` builds the **`App` scheme** for the iOS Simulator
+(`CODE_SIGNING_ALLOWED=NO`) — `** BUILD SUCCEEDED **`, `EmailsWidget.swift`
+compiled into `NookleusWidgets` (arm64 + x86_64), AppIntents metadata
+extracted, `NookleusWidgets.appex` embedded in `App.app/PlugIns/` and passing
+`ValidateEmbeddedBinary`, 0 errors / 0 warnings. Build the **`App` scheme**,
+not `-target App` — a bare `-target` build fails to order the SPM package
+graph (`SwiftKeychainWrapper`).
 
 **iOS 17+ for the Emails widget — decision to ratify.** Per-instance
 configuration uses `AppIntentConfiguration` + `WidgetConfigurationIntent`
@@ -79,27 +86,21 @@ SiriKit custom intent.
 - `src/components/email-inbox.tsx` — consumes the `account` and `id` query
   params on mount (selects the account / opens the email).
 
-## 4. Apple Developer portal — REMAINING, needs you
+## 4. Apple Developer portal — DONE (2026-05-21, #172 native half)
 
-⚠️ **Do not push `main` until this is done.** The commit wires
-`CODE_SIGN_ENTITLEMENTS` with an App Group. A push triggers an Xcode Cloud
-build, and a signed build **fails** until the App Group and the new
-extension App ID exist in the portal.
+The entitlements wiring (`CODE_SIGN_ENTITLEMENTS` + App Group) needed portal
+registration before a signed Xcode Cloud build could succeed. That was
+completed when the #172 native half landed:
 
-In the Apple Developer portal (Certificates, Identifiers & Profiles):
+1. **App Group** `group.com.aaacontracting.platform` — registered.
+2. **App ID** `com.aaacontracting.platform.NookleusWidgets` — registered with
+   the **App Groups** capability; the same capability + group were also added
+   to the existing `com.aaacontracting.platform` App ID.
+3. Signing — automatic; Xcode Cloud's managed signing provisions both
+   targets. Signed builds have shipped to TestFlight since.
 
-1. **Identifiers → App Groups**: register `group.com.aaacontracting.platform`
-   if it does not already exist.
-2. **Identifiers → App IDs**: register
-   `com.aaacontracting.platform.NookleusWidgets`. Enable the **App Groups**
-   capability on it and on the existing `com.aaacontracting.platform` App ID;
-   assign the group to both.
-3. Signing: with automatic signing, Xcode provisions both targets once the
-   App IDs + capability exist. Opening the project in Xcode, the
-   Signing & Capabilities tab for each target should then resolve cleanly.
-
-Once §4 is done, push `main` — the Xcode Cloud build archives the app with
-the embedded widget.
+No portal action remains for the Emails widget — `EmailsWidget.swift` is a
+source file on an existing target, with no new entitlement or App ID.
 
 ## 5. Xcode Cloud
 


### PR DESCRIPTION
The remaining **Mac Xcode step** for slice [#174](https://github.com/ericdaniels22/Nookleus/issues/174) (PRD [#56](https://github.com/ericdaniels22/Nookleus/issues/56), iPhone widgets) — the part the web-only sessions that built #174 ([PR #179](https://github.com/ericdaniels22/Nookleus/pull/179)) explicitly deferred. Mirrors how #172's and #173's Xcode steps landed ([PR #177](https://github.com/ericdaniels22/Nookleus/pull/177)/[#180](https://github.com/ericdaniels22/Nookleus/pull/180)).

## What this does

- Adds `ios/App/NookleusWidgets/EmailsWidget.swift` to the **`NookleusWidgets` target's Compile Sources phase** — the same phase that holds `QuickActionsWidget.swift`. Done **programmatically** with the `xcodeproj` Ruby gem (1.27.0), not a hand-edit of `project.pbxproj`: a `PBXFileReference` + `PBXBuildFile` wired into the `NookleusWidgets` group and Sources build phase (`project.pbxproj` +4 lines).
- `NookleusWidgetsBundle.swift` already registers `EmailsWidget()` behind `if #available(iOS 17.0, *)` (committed with PR #179) — no Xcode action needed, it rebuilds with the target.
- `NookleusWidgets/SETUP.md` — marks the #174 Xcode step done; refreshes the stale §4 portal warning (that registration completed with the #172 native half).

## Verification

`xcodebuild` builds the **`App` scheme** for the iOS Simulator (`CODE_SIGNING_ALLOWED=NO`) — `** BUILD SUCCEEDED **`, `EmailsWidget.swift` compiled into the `NookleusWidgets` target (arm64 + x86_64), AppIntents metadata extracted, `NookleusWidgets.appex` embedded in `App.app/PlugIns/` and passing `ValidateEmbeddedBinary`, **0 errors / 0 warnings**. Xcode 26.4.1.

## Not closing #174

This PR refs but does **not** `Close` #174 — `EmailsWidget.swift` now compiles into the widget extension, but the per-mailbox config + render path has never run on a device. On-device verification is slice [#175](https://github.com/ericdaniels22/Nookleus/issues/175) (TestFlight), the last slice of PRD #56. Mirrors #172/#173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)