### PR TITLE
intake-form: phone format-as-you-type, E.164 storage & submit validation

### DIFF
--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/utils";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useConfig } from "@/lib/config-context";
+import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "@/lib/phone";
 import type { FormConfig, FormField } from "@/lib/types";
 
 export default function IntakeForm({ testMode = false }: { testMode?: boolean } = {}) {
@@ -76,6 +77,14 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
             toast.error(`Please fill in: ${field.label}`);
             return;
           }
+          if (
+            field.type === "phone" &&
+            getVal(field.id).trim() &&
+            !isValidUSPhone(getVal(field.id))
+          ) {
+            toast.error(`${field.label} must be a valid 10-digit US phone number.`);
+            return;
+          }
         }
       }
     }
@@ -109,7 +118,7 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
         .insert({
           organization_id: orgId,
           full_name: fullName,
-          phone: valueByMapsTo("contact.phone") || null,
+          phone: normalizePhoneToE164(valueByMapsTo("contact.phone")),
           email: valueByMapsTo("contact.email") || null,
           role: valueByMapsTo("contact.role") || "homeowner",
           notes: valueByMapsTo("contact.notes") || null,
@@ -127,7 +136,7 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
           .insert({
             organization_id: orgId,
             full_name: adjusterFullName.trim(),
-            phone: valueByMapsTo("adjuster.phone") || getVal("adjuster_phone") || null,
+            phone: normalizePhoneToE164(valueByMapsTo("adjuster.phone") || getVal("adjuster_phone")),
             role: "adjuster",
             title: valueByMapsTo("adjuster.title") || getVal("adjuster_title") || null,
           })
@@ -329,7 +338,9 @@ function DynamicField({
         <Input
           type={field.type === "phone" ? "tel" : field.type === "email" ? "email" : "text"}
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={(e) =>
+            onChange(field.type === "phone" ? formatPhoneNumber(e.target.value) : e.target.value)
+          }
           placeholder={field.placeholder}
         />
       )}

--- a/src/lib/phone.test.ts
+++ b/src/lib/phone.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "./phone";
+
+describe("formatPhoneNumber", () => {
+  it("returns an empty string for empty input", () => {
+    expect(formatPhoneNumber("")).toBe("");
+  });
+
+  it("returns an empty string when the input has no digits", () => {
+    expect(formatPhoneNumber("abc-()")).toBe("");
+  });
+
+  it("wraps one-to-three digits in an opening paren", () => {
+    expect(formatPhoneNumber("5")).toBe("(5");
+    expect(formatPhoneNumber("555")).toBe("(555");
+  });
+
+  it("adds the closing paren once the area code is complete", () => {
+    expect(formatPhoneNumber("5551")).toBe("(555) 1");
+    expect(formatPhoneNumber("555123")).toBe("(555) 123");
+  });
+
+  it("adds the hyphen for the final block", () => {
+    expect(formatPhoneNumber("5551234")).toBe("(555) 123-4");
+    expect(formatPhoneNumber("5551234567")).toBe("(555) 123-4567");
+  });
+
+  it("is stable on an already-formatted value", () => {
+    expect(formatPhoneNumber("(555) 123-4567")).toBe("(555) 123-4567");
+  });
+
+  it("ignores separator characters in the input", () => {
+    expect(formatPhoneNumber("555.123.4567")).toBe("(555) 123-4567");
+  });
+
+  it("drops a leading US country code", () => {
+    expect(formatPhoneNumber("15551234567")).toBe("(555) 123-4567");
+    expect(formatPhoneNumber("+1 555 123 4567")).toBe("(555) 123-4567");
+  });
+
+  it("formats a stored E.164 value for display", () => {
+    expect(formatPhoneNumber("+15551234567")).toBe("(555) 123-4567");
+  });
+
+  it("ignores digits typed past the tenth", () => {
+    expect(formatPhoneNumber("55512345670000")).toBe("(555) 123-4567");
+  });
+});
+
+describe("normalizePhoneToE164", () => {
+  it("returns null for empty or blank input", () => {
+    expect(normalizePhoneToE164("")).toBeNull();
+    expect(normalizePhoneToE164("   ")).toBeNull();
+  });
+
+  it("normalizes a bare 10-digit number", () => {
+    expect(normalizePhoneToE164("5551234567")).toBe("+15551234567");
+  });
+
+  it("normalizes a formatted display string", () => {
+    expect(normalizePhoneToE164("(555) 123-4567")).toBe("+15551234567");
+  });
+
+  it("normalizes an 11-digit number with a leading country code", () => {
+    expect(normalizePhoneToE164("1 (555) 123-4567")).toBe("+15551234567");
+  });
+
+  it("is idempotent on an already-canonical value", () => {
+    expect(normalizePhoneToE164("+15551234567")).toBe("+15551234567");
+  });
+
+  it("returns null for too-few digits", () => {
+    expect(normalizePhoneToE164("555123")).toBeNull();
+  });
+
+  it("returns null for too-many digits", () => {
+    expect(normalizePhoneToE164("5551234567890")).toBeNull();
+  });
+
+  it("returns null for an 11-digit number that is not country-code-prefixed", () => {
+    expect(normalizePhoneToE164("25551234567")).toBeNull();
+  });
+});
+
+describe("isValidUSPhone", () => {
+  it("is true for a complete 10-digit number", () => {
+    expect(isValidUSPhone("(555) 123-4567")).toBe(true);
+  });
+
+  it("is true for an E.164 value", () => {
+    expect(isValidUSPhone("+15551234567")).toBe(true);
+  });
+
+  it("is false for empty input", () => {
+    expect(isValidUSPhone("")).toBe(false);
+  });
+
+  it("is false for a partial number", () => {
+    expect(isValidUSPhone("(555) 12")).toBe(false);
+  });
+});

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,31 @@
+// Shared US phone-number helpers (PRD #45, issue #183). The app standardizes
+// on a `(xxx) xxx-xxxx` display string and a canonical E.164 storage value.
+
+/** Digits only, with a leading US country-code `1` dropped, capped at 10. */
+function tenDigits(input: string): string {
+  const digits = (input ?? "").replace(/\D/g, "");
+  const local = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
+  return local.slice(0, 10);
+}
+
+/** Progressively format partial or complete input into `(xxx) xxx-xxxx`. */
+export function formatPhoneNumber(input: string): string {
+  const d = tenDigits(input);
+  if (d.length === 0) return "";
+  if (d.length <= 3) return `(${d}`;
+  if (d.length <= 6) return `(${d.slice(0, 3)}) ${d.slice(3)}`;
+  return `(${d.slice(0, 3)}) ${d.slice(3, 6)}-${d.slice(6)}`;
+}
+
+/** Canonical E.164 (`+1XXXXXXXXXX`), or null when not a valid 10-digit US number. */
+export function normalizePhoneToE164(input: string): string | null {
+  const digits = (input ?? "").replace(/\D/g, "");
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  return null;
+}
+
+/** True when input can be normalized to a valid 10-digit US number. */
+export function isValidUSPhone(input: string): boolean {
+  return normalizePhoneToE164(input) !== null;
+}


### PR DESCRIPTION
Add a shared US phone util (format-as-you-type to `(xxx) xxx-xxxx`,
E.164 normalization, validation) with unit tests, and wire it into the
intake form: phone fields format live, a non-empty unparseable number
blocks submission, and contact/adjuster phones persist as E.164.

Closes #183.

https://claude.ai/code/session_01Mk3VxpduRsvukHH4pVQiHx