### PR TITLE
Masked MM/DD/YYYY date field with calendar popover (#184)

### DIFF
--- a/src/components/date-field.tsx
+++ b/src/components/date-field.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  addMonths,
+  format,
+  getDay,
+  getDaysInMonth,
+  isAfter,
+  isSameDay,
+  isSameMonth,
+  startOfMonth,
+  startOfToday,
+  subMonths,
+} from "date-fns";
+import { CalendarIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { isValidPastDate, maskDateInput, parseMaskedDate } from "@/lib/date-field";
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+interface DateFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  id?: string;
+}
+
+/**
+ * Masked MM/DD/YYYY text input paired with a hand-rolled month-grid calendar
+ * popover. Future dates are rejected: the calendar disables future days, and a
+ * complete typed value that is in the future (or non-existent) is flagged.
+ */
+export function DateField({ value, onChange, placeholder, id }: DateFieldProps) {
+  const today = startOfToday();
+  const [open, setOpen] = useState(false);
+  const [viewMonth, setViewMonth] = useState(() =>
+    startOfMonth(pastOrToday(parseMaskedDate(value), today)),
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close the popover on an outside click or Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onPointerDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const selected = parseMaskedDate(value);
+  const complete = value.length === 10;
+  const invalidMessage =
+    !complete || isValidPastDate(value)
+      ? null
+      : !selected
+        ? "Enter a real calendar date."
+        : "The date can’t be in the future.";
+
+  function toggleCalendar() {
+    setViewMonth(startOfMonth(pastOrToday(parseMaskedDate(value), today)));
+    setOpen((o) => !o);
+  }
+
+  function pickDay(day: Date) {
+    onChange(format(day, "MM/dd/yyyy"));
+    setOpen(false);
+  }
+
+  const monthStart = startOfMonth(viewMonth);
+  const cells: (Date | null)[] = [
+    ...Array<null>(getDay(monthStart)).fill(null),
+    ...Array.from(
+      { length: getDaysInMonth(viewMonth) },
+      (_, i) => new Date(viewMonth.getFullYear(), viewMonth.getMonth(), i + 1),
+    ),
+  ];
+  const canGoNext = !isSameMonth(viewMonth, today);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <div className="relative">
+        <Input
+          id={id}
+          type="text"
+          inputMode="numeric"
+          value={value}
+          onChange={(e) => onChange(maskDateInput(e.target.value))}
+          placeholder={placeholder || "MM/DD/YYYY"}
+          aria-invalid={invalidMessage ? true : undefined}
+          className="pr-9"
+        />
+        <button
+          type="button"
+          onClick={toggleCalendar}
+          aria-label="Open calendar"
+          className="absolute inset-y-0 right-0 flex w-9 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <CalendarIcon className="size-4" />
+        </button>
+      </div>
+
+      {invalidMessage && <p className="mt-1 text-xs text-destructive">{invalidMessage}</p>}
+
+      {open && (
+        <div className="absolute left-0 z-50 mt-1 w-[17rem] rounded-lg border border-border bg-card p-3 shadow-lg">
+          <div className="mb-2 flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setViewMonth((m) => subMonths(m, 1))}
+              aria-label="Previous month"
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <ChevronLeftIcon className="size-4" />
+            </button>
+            <span className="text-sm font-semibold text-foreground">
+              {format(viewMonth, "MMMM yyyy")}
+            </span>
+            <button
+              type="button"
+              onClick={() => canGoNext && setViewMonth((m) => addMonths(m, 1))}
+              disabled={!canGoNext}
+              aria-label="Next month"
+              className="flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+            >
+              <ChevronRightIcon className="size-4" />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-7 gap-0.5">
+            {WEEKDAYS.map((wd) => (
+              <div
+                key={wd}
+                className="flex h-7 items-center justify-center text-xs font-medium text-muted-foreground"
+              >
+                {wd}
+              </div>
+            ))}
+            {cells.map((day, i) => {
+              if (!day) return <div key={`blank-${i}`} className="size-8" />;
+              const isFuture = isAfter(day, today);
+              const isSelected = !!selected && isSameDay(day, selected);
+              const isToday = isSameDay(day, today);
+              return (
+                <button
+                  key={day.toISOString()}
+                  type="button"
+                  disabled={isFuture}
+                  onClick={() => pickDay(day)}
+                  className={cn(
+                    "flex size-8 items-center justify-center rounded-md text-sm transition-colors",
+                    isFuture && "cursor-not-allowed text-muted-foreground/30",
+                    !isFuture && !isSelected && "text-foreground hover:bg-accent",
+                    isSelected && "bg-[image:var(--gradient-primary)] font-semibold text-white",
+                    isToday && !isSelected && "font-semibold ring-1 ring-inset ring-[var(--brand-primary)]/40",
+                  )}
+                >
+                  {day.getDate()}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The given date when it exists and is not in the future, otherwise `today`. */
+function pastOrToday(date: Date | null, today: Date): Date {
+  return date && !isAfter(date, today) ? date : today;
+}

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -12,6 +12,8 @@ import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { useConfig } from "@/lib/config-context";
 import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "@/lib/phone";
+import { isValidPastDate } from "@/lib/date-field";
+import { DateField } from "@/components/date-field";
 import type { FormConfig, FormField } from "@/lib/types";
 
 export default function IntakeForm({ testMode = false }: { testMode?: boolean } = {}) {
@@ -83,6 +85,14 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
             !isValidUSPhone(getVal(field.id))
           ) {
             toast.error(`${field.label} must be a valid 10-digit US phone number.`);
+            return;
+          }
+          if (
+            field.type === "date" &&
+            getVal(field.id).trim() &&
+            !isValidPastDate(getVal(field.id))
+          ) {
+            toast.error(`${field.label} must be a valid date that is not in the future.`);
             return;
           }
         }
@@ -355,10 +365,10 @@ function DynamicField({
       )}
 
       {field.type === "date" && (
-        <Input
-          type="date"
+        <DateField
           value={value}
-          onChange={(e) => onChange(e.target.value)}
+          onChange={onChange}
+          placeholder={field.placeholder}
         />
       )}
 

--- a/src/lib/date-field.test.ts
+++ b/src/lib/date-field.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidPastDate, maskDateInput, parseMaskedDate } from "./date-field";
+
+describe("maskDateInput", () => {
+  it("formats eight digits into MM/DD/YYYY", () => {
+    expect(maskDateInput("12252024")).toBe("12/25/2024");
+  });
+
+  it("leaves a one-or-two-digit month bare, with no trailing slash", () => {
+    expect(maskDateInput("1")).toBe("1");
+    expect(maskDateInput("12")).toBe("12");
+  });
+
+  it("opens the day block once the month is complete", () => {
+    expect(maskDateInput("123")).toBe("12/3");
+    expect(maskDateInput("1225")).toBe("12/25");
+  });
+
+  it("opens the year block once the day is complete", () => {
+    expect(maskDateInput("12252")).toBe("12/25/2");
+  });
+
+  it("strips separators so an already-masked value re-masks unchanged", () => {
+    expect(maskDateInput("12/25/2024")).toBe("12/25/2024");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(maskDateInput("")).toBe("");
+  });
+
+  it("ignores digits typed past the eighth", () => {
+    expect(maskDateInput("122520249999")).toBe("12/25/2024");
+  });
+});
+
+describe("parseMaskedDate", () => {
+  it("parses a complete MM/DD/YYYY string into a Date", () => {
+    expect(parseMaskedDate("12/25/2024")).toEqual(new Date(2024, 11, 25));
+  });
+
+  it("returns null for an incomplete string", () => {
+    expect(parseMaskedDate("12/25")).toBeNull();
+    expect(parseMaskedDate("")).toBeNull();
+  });
+
+  it("returns null for a non-existent calendar date", () => {
+    expect(parseMaskedDate("02/30/2024")).toBeNull();
+    expect(parseMaskedDate("13/01/2024")).toBeNull();
+  });
+});
+
+describe("isValidPastDate", () => {
+  it("is true for a complete, real, past date", () => {
+    expect(isValidPastDate("01/15/2020")).toBe(true);
+  });
+
+  it("is false for a future date", () => {
+    const nextYear = new Date().getFullYear() + 1;
+    expect(isValidPastDate(`06/15/${nextYear}`)).toBe(false);
+  });
+
+  it("is true for today (an incident can have happened today)", () => {
+    const now = new Date();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    expect(isValidPastDate(`${mm}/${dd}/${now.getFullYear()}`)).toBe(true);
+  });
+
+  it("is false for an incomplete or non-existent date", () => {
+    expect(isValidPastDate("12/25")).toBe(false);
+    expect(isValidPastDate("02/30/2020")).toBe(false);
+    expect(isValidPastDate("")).toBe(false);
+  });
+});

--- a/src/lib/date-field.ts
+++ b/src/lib/date-field.ts
@@ -1,0 +1,31 @@
+// Pure date helpers for the masked MM/DD/YYYY intake field (PRD #45, issue #184).
+
+/** Strip non-digits and progressively format input into `MM/DD/YYYY`. */
+export function maskDateInput(input: string): string {
+  const d = (input ?? "").replace(/\D/g, "").slice(0, 8);
+  if (d.length <= 2) return d;
+  if (d.length <= 4) return `${d.slice(0, 2)}/${d.slice(2)}`;
+  return `${d.slice(0, 2)}/${d.slice(2, 4)}/${d.slice(4)}`;
+}
+
+/** Parse a complete `MM/DD/YYYY` string into a local-midnight Date, or null. */
+export function parseMaskedDate(input: string): Date | null {
+  const m = (input ?? "").match(/^(\d{2})\/(\d{2})\/(\d{4})$/);
+  if (!m) return null;
+  const month = Number(m[1]);
+  const day = Number(m[2]);
+  const year = Number(m[3]);
+  const date = new Date(year, month - 1, day);
+  // Reject roll-over from non-existent dates (e.g. 02/30 → Mar 1).
+  if (date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+  return date;
+}
+
+/** True when input is a complete, real `MM/DD/YYYY` date that is not in the future. */
+export function isValidPastDate(input: string): boolean {
+  const date = parseMaskedDate(input);
+  if (!date) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return date.getTime() <= today.getTime();
+}

--- a/supabase/migration-build14f.sql
+++ b/supabase/migration-build14f.sql
@@ -68,7 +68,7 @@ INSERT INTO form_config (config, version, created_by) VALUES (
       "fields": [
         {"id": "damage_type", "type": "pill", "label": "Type of Damage", "required": true, "is_default": true, "visible": true, "maps_to": "job.damage_type", "options_source": "damage_types"},
         {"id": "damage_source", "type": "text", "label": "Source of Damage", "required": false, "is_default": true, "visible": true, "maps_to": "job.damage_source"},
-        {"id": "when_happened", "type": "text", "label": "When Did It Happen?", "required": false, "is_default": true, "visible": true},
+        {"id": "when_happened", "type": "date", "label": "When Did It Happen?", "required": false, "is_default": true, "visible": true},
         {"id": "affected_areas", "type": "text", "label": "Affected Areas", "required": false, "is_default": true, "visible": true, "maps_to": "job.affected_areas"}
       ]
     },


### PR DESCRIPTION
Closes #184 — slice 3 of PRD #45.

## What this adds

A reusable date field for the intake form's `date` field type: a text input that masks keystrokes into `MM/DD/YYYY`, paired with a hand-rolled month-grid calendar popover. **No new npm dependency** — reuses the already-installed `date-fns`.

## Changes

- **`src/lib/date-field.ts`** — pure logic, built TDD red→green (14 Vitest tests):
  - `maskDateInput` — progressive `MM/DD/YYYY` masking, 8-digit cap
  - `parseMaskedDate` — `MM/DD/YYYY` → `Date | null`, rejects non-existent dates (`02/30`, `13/01`)
  - `isValidPastDate` — complete + real + not-future (today is allowed)
- **`src/components/date-field.tsx`** — `"use client"` component: masked input + calendar popover (month nav, today/selected highlighted, future days disabled, click-outside/Escape to close)
- **`src/components/intake-form.tsx`** — `date` field type renders `<DateField>`; submit blocks an invalid/future date (mirrors the existing `phone` validation)
- **`supabase/migration-build14f.sql`** — `when_happened` flipped `text` → `date`

## Future-date rejection

The calendar disables future days (can't be selected); a complete typed future or non-existent date is flagged inline and blocks form submission.

## Verification

- 14/14 Vitest tests pass (`src/lib/date-field.test.ts`)
- `tsc` + ESLint clean on all touched files
- Per the PRD, the component itself is **browser-verified** — that QA step is still pending.

> Follow-up: slice 4 of PRD #45 (migrate existing orgs' saved `form_config` to flip `when_happened`) is a separate issue, blocked by this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)