### PR TITLE
Backfill existing contacts.phone rows to E.164 (#186)

### DIFF
--- a/supabase/migration-186-backfill-contacts-phone-e164.sql
+++ b/supabase/migration-186-backfill-contacts-phone-e164.sql
@@ -1,0 +1,88 @@
+-- issue #186 (PRD #45) — Backfill existing contacts.phone values to E.164.
+--
+-- Purpose:    Rewrite every parseable contacts.phone value to canonical
+--             E.164 (+1XXXXXXXXXX). Rows whose value cannot be parsed as a
+--             valid 10-digit US number are left untouched. Rows already in
+--             canonical form are skipped, so updated_at is not bumped
+--             needlessly.
+--
+-- Depends on: issue #183 — the app now writes E.164 via normalizePhoneToE164()
+--             in src/lib/phone.ts. This migration brings pre-#183 rows into
+--             line so the whole app reads one phone format.
+--
+-- Normalization mirrors normalizePhoneToE164() in src/lib/phone.ts exactly:
+--             strip non-digits; 10 digits -> +1XXXXXXXXXX; 11 digits with a
+--             leading 1 -> +XXXXXXXXXXX; anything else -> unparseable (skip).
+--             The rule is verified against the TS util's test battery in
+--             supabase/migration-186-smoke-test.sql.
+--
+-- Idempotent: re-running changes nothing — the WHERE clause excludes rows
+--             already equal to their normalized form.
+--
+-- Dry run:    supabase/migration-186-dry-run.sql reports the would-change and
+--             unparseable counts; run it first and record the output on the
+--             PR before applying this migration.
+--
+-- Revert:     Not exactly reversible — see the -- ROLLBACK -- note at the end.
+
+do $$
+declare
+  v_would_change bigint;
+  v_unparseable  bigint;
+  v_changed      bigint;
+begin
+  -- Session-local helper: vanishes when the connection closes, so no
+  -- permanent schema surface is added. Declared once here and used by both
+  -- the pre-count and the UPDATE below, so the normalization rule lives in
+  -- exactly one place within this migration.
+  create or replace function pg_temp.normalize_us_phone_e164(raw text)
+    returns text language sql immutable as $fn$
+    with d as (select regexp_replace(coalesce(raw, ''), '\D', '', 'g') as digits)
+    select case
+             when length(digits) = 10 then '+1' || digits
+             when length(digits) = 11 and left(digits, 1) = '1' then '+' || digits
+           end
+    from d;
+  $fn$;
+
+  select
+    count(*) filter (
+      where pg_temp.normalize_us_phone_e164(phone) is not null
+        and phone is distinct from pg_temp.normalize_us_phone_e164(phone)),
+    count(*) filter (
+      where phone is not null and phone <> ''
+        and pg_temp.normalize_us_phone_e164(phone) is null)
+    into v_would_change, v_unparseable
+  from public.contacts;
+
+  raise notice 'migration-186: % row(s) to normalize, % unparseable (left as-is)',
+    v_would_change, v_unparseable;
+
+  update public.contacts
+     set phone = pg_temp.normalize_us_phone_e164(phone),
+         updated_at = now()
+   where pg_temp.normalize_us_phone_e164(phone) is not null
+     and phone is distinct from pg_temp.normalize_us_phone_e164(phone);
+
+  get diagnostics v_changed = row_count;
+
+  -- Safety assertion — the count and the UPDATE use an identical predicate
+  -- in one transaction, so a mismatch means a concurrent write slipped in.
+  if v_changed <> v_would_change then
+    raise exception
+      'migration-186: expected to change % row(s), changed % — aborting',
+      v_would_change, v_changed;
+  end if;
+
+  raise notice 'migration-186: backfill complete — % row(s) normalized to E.164',
+    v_changed;
+end $$;
+
+-- ROLLBACK -------------------------------------------------------------------
+-- This migration is not exactly reversible: the original pre-normalization
+-- formatting (parentheses, dashes, dots, leading "1 ") is not recorded
+-- anywhere. The change is cosmetic, though — every backfilled value still
+-- holds the same ten significant digits, only the punctuation changed. To
+-- present a stored E.164 value in the old display style, format it with
+-- formatPhoneNumber() from src/lib/phone.ts rather than reverting the data.
+-- ----------------------------------------------------------------------------

--- a/supabase/migration-186-dry-run.sql
+++ b/supabase/migration-186-dry-run.sql
@@ -1,0 +1,54 @@
+-- issue #186 (PRD #45) — Backfill contacts.phone to E.164: DRY RUN.
+--
+-- Purpose:   Read-only preview of the migration-186 backfill. Reports how
+--            many contacts.phone rows would change, how many are already
+--            canonical, and how many cannot be parsed (and so are left
+--            untouched). Run this FIRST and record the output on the PR
+--            before applying migration-186-backfill-contacts-phone-e164.sql.
+--
+-- Safety:    SELECT-only. Creates a session-local pg_temp helper that
+--            vanishes when the connection closes. Touches no real rows.
+--
+-- Normalization mirrors normalizePhoneToE164() in src/lib/phone.ts
+-- (issue #183): strip non-digits; 10 digits -> +1XXXXXXXXXX; 11 digits with
+-- a leading 1 -> +XXXXXXXXXXX; anything else is unparseable.
+--
+-- Run:       psql -f supabase/migration-186-dry-run.sql
+--            (or paste into the Supabase SQL editor).
+
+create or replace function pg_temp.normalize_us_phone_e164(raw text)
+  returns text language sql immutable as $$
+  with d as (select regexp_replace(coalesce(raw, ''), '\D', '', 'g') as digits)
+  select case
+           when length(digits) = 10 then '+1' || digits
+           when length(digits) = 11 and left(digits, 1) = '1' then '+' || digits
+         end
+  from d;
+$$;
+
+-- Summary counts — paste this row on the PR.
+with classified as (
+  select phone, pg_temp.normalize_us_phone_e164(phone) as normalized
+  from public.contacts
+)
+select
+  count(*)                                                     as total_rows,
+  count(*) filter (where phone is not null and phone <> '')     as non_empty_phone,
+  count(*) filter (where normalized is not null
+                     and phone is distinct from normalized)     as would_change,
+  count(*) filter (where normalized is not null
+                     and phone is not distinct from normalized) as already_canonical,
+  count(*) filter (where phone is not null and phone <> ''
+                     and normalized is null)                    as unparseable
+from classified;
+
+-- Why each unparseable row is unparseable — digit counts only, no raw
+-- phone values, so the PR record stays free of contact PII.
+select
+  length(regexp_replace(coalesce(phone, ''), '\D', '', 'g')) as digit_count,
+  count(*)                                                   as rows
+from public.contacts
+where phone is not null and phone <> ''
+  and pg_temp.normalize_us_phone_e164(phone) is null
+group by 1
+order by 1;

--- a/supabase/migration-186-smoke-test.sql
+++ b/supabase/migration-186-smoke-test.sql
@@ -1,0 +1,145 @@
+-- issue #186 (PRD #45) — contacts.phone E.164 backfill — migration smoke test.
+--
+-- Purpose:   Self-checking script that verifies the migration-186 backfill
+--            logic. It is *not* part of the migration. It re-creates the
+--            normalization helper, asserts it against a battery of inputs
+--            mirroring normalizePhoneToE164()'s unit tests in
+--            src/lib/phone.test.ts, then exercises the exact backfill UPDATE
+--            against a temp table. Every assertion raises an exception on
+--            failure, so a clean run prints only NOTICE lines and a failed
+--            run terminates loudly.
+--
+-- Shape:     One transaction, rolled back at the end — the DB is unchanged.
+--            No real rows are read or written; the backfill is exercised
+--            against a seeded temp table shaped like public.contacts.
+--
+-- Run:       psql -f supabase/migration-186-smoke-test.sql
+--            (or paste into the Supabase SQL editor).
+
+begin;
+
+create or replace function pg_temp.normalize_us_phone_e164(raw text)
+  returns text language sql immutable as $$
+  with d as (select regexp_replace(coalesce(raw, ''), '\D', '', 'g') as digits)
+  select case
+           when length(digits) = 10 then '+1' || digits
+           when length(digits) = 11 and left(digits, 1) = '1' then '+' || digits
+         end
+  from d;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Normalization parity — mirrors normalizePhoneToE164() in
+--    src/lib/phone.test.ts. The SQL helper and the TS util must agree, or
+--    stored data and app behavior drift apart.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_fail text;
+begin
+  select string_agg(
+           format('  %s: norm(%L) = %L, expected %L',
+                  label, input, pg_temp.normalize_us_phone_e164(input), expected),
+           e'\n')
+    into v_fail
+  from (values
+    ('null input',               null::text,         null::text),
+    ('empty string',             '',                 null),
+    ('blank / whitespace',       '   ',              null),
+    ('bare 10-digit',            '5551234567',       '+15551234567'),
+    ('formatted display string', '(555) 123-4567',   '+15551234567'),
+    ('dotted separators',        '555.123.4567',     '+15551234567'),
+    ('11-digit country code',    '1 (555) 123-4567', '+15551234567'),
+    ('already-canonical E.164',  '+15551234567',     '+15551234567'),
+    ('too few digits',           '555123',           null),
+    ('too many digits',          '5551234567890',    null),
+    ('11-digit not cc-prefixed', '25551234567',      null)
+  ) as cases(label, input, expected)
+  where pg_temp.normalize_us_phone_e164(input) is distinct from expected;
+
+  if v_fail is not null then
+    raise exception e'migration-186 smoke: normalization parity failed:\n%', v_fail;
+  end if;
+  raise notice 'migration-186 smoke: normalization parity — 11 cases pass';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill behavior — seed a temp table shaped like contacts, run the
+--    exact UPDATE from the migration, assert every row's outcome:
+--      - parseable values are rewritten to E.164;
+--      - an already-canonical value is left alone (updated_at not bumped);
+--      - unparseable values are left untouched;
+--      - a NULL phone is left untouched.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_changed bigint;
+  r record;
+begin
+  create temp table _smoke_contacts (id text, phone text, updated_at timestamptz)
+    on commit drop;
+  insert into _smoke_contacts values
+    ('parseable-bare',    '5551234567',      timestamptz '2020-01-01'),
+    ('parseable-fmt',     '(555) 987-6543',  timestamptz '2020-01-01'),
+    ('parseable-cc',      '1-555-111-2222',  timestamptz '2020-01-01'),
+    ('already-e164',      '+15553334444',    timestamptz '2020-01-01'),
+    ('unparseable-short', '555',             timestamptz '2020-01-01'),
+    ('unparseable-text',  'call the office', timestamptz '2020-01-01'),
+    ('null-phone',        null,              timestamptz '2020-01-01');
+
+  update _smoke_contacts
+     set phone = pg_temp.normalize_us_phone_e164(phone),
+         updated_at = now()
+   where pg_temp.normalize_us_phone_e164(phone) is not null
+     and phone is distinct from pg_temp.normalize_us_phone_e164(phone);
+  get diagnostics v_changed = row_count;
+
+  if v_changed <> 3 then
+    raise exception 'migration-186 smoke: expected 3 row(s) changed, got %', v_changed;
+  end if;
+
+  for r in select id, phone, updated_at from _smoke_contacts loop
+    case r.id
+      when 'parseable-bare' then
+        if r.phone is distinct from '+15551234567' then
+          raise exception 'migration-186 smoke: parseable-bare = %, expected +15551234567', r.phone;
+        end if;
+      when 'parseable-fmt' then
+        if r.phone is distinct from '+15559876543' then
+          raise exception 'migration-186 smoke: parseable-fmt = %, expected +15559876543', r.phone;
+        end if;
+      when 'parseable-cc' then
+        if r.phone is distinct from '+15551112222' then
+          raise exception 'migration-186 smoke: parseable-cc = %, expected +15551112222', r.phone;
+        end if;
+      when 'already-e164' then
+        if r.phone is distinct from '+15553334444' then
+          raise exception 'migration-186 smoke: already-e164 phone changed to %', r.phone;
+        end if;
+        if r.updated_at <> timestamptz '2020-01-01' then
+          raise exception 'migration-186 smoke: already-e164 updated_at bumped — not idempotent';
+        end if;
+      when 'unparseable-short' then
+        if r.phone is distinct from '555' then
+          raise exception 'migration-186 smoke: unparseable-short changed to %', r.phone;
+        end if;
+        if r.updated_at <> timestamptz '2020-01-01' then
+          raise exception 'migration-186 smoke: unparseable-short updated_at bumped';
+        end if;
+      when 'unparseable-text' then
+        if r.phone is distinct from 'call the office' then
+          raise exception 'migration-186 smoke: unparseable-text changed to %', r.phone;
+        end if;
+      when 'null-phone' then
+        if r.phone is not null then
+          raise exception 'migration-186 smoke: null-phone changed to %', r.phone;
+        end if;
+      else
+        raise exception 'migration-186 smoke: unexpected seed row %', r.id;
+    end case;
+  end loop;
+
+  raise notice 'migration-186 smoke: backfill behavior — 7 rows pass (3 changed, 4 untouched)';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #186. Parent: #45.

## What this does

Adds the one-time migration that normalizes existing `contacts.phone`
values to canonical E.164 (`+1XXXXXXXXXX`), best-effort. Rows whose value
can't be parsed as a valid 10-digit US number are left untouched.

The normalization mirrors `normalizePhoneToE164()` in `src/lib/phone.ts`
(#183) exactly: strip non-digits → 10 digits ⇒ `+1XXXXXXXXXX` → 11 digits
with a leading `1` ⇒ `+XXXXXXXXXXX` → anything else ⇒ unparseable.

## Files

- **`migration-186-backfill-contacts-phone-e164.sql`** — the backfill. A
  session-local `pg_temp` helper drives both the pre-count and the
  `UPDATE`, so the rule is written once and no permanent schema surface is
  added. Idempotent — already-canonical rows are skipped, so `updated_at`
  is never bumped needlessly. A safety assertion aborts the migration if
  the changed-row count drifts from the pre-count.
- **`migration-186-dry-run.sql`** — read-only preview: would-change /
  already-canonical / unparseable counts, plus a digit-count breakdown of
  the unparseable rows (counts only — no contact PII).
- **`migration-186-smoke-test.sql`** — self-checking test (transaction,
  rolled back). Asserts E.164 parity against `normalizePhoneToE164()`'s
  unit-test battery, then exercises the exact backfill `UPDATE` on a temp
  table (rewrite parseable / preserve unparseable / idempotent).

## Dry-run output — AAA prod (`rzzprgidqbnqcdupmpfe`), before apply

| total_rows | non_empty_phone | would_change | already_canonical | unparseable |
|-----------:|----------------:|-------------:|------------------:|------------:|
| 23 | 23 | **14** | 0 | **9** |

Unparseable breakdown (digit count after stripping non-digits):

| digit_count | rows |
|------------:|-----:|
| 0 | 5 |
| 6 | 2 |
| 7 | 1 |
| 12 | 1 |

The 9 unparseable rows are left exactly as-is. The migration was also
dry-applied on prod inside a rolled-back transaction: it changed 14 rows,
valid-E.164 row count went 0 → 14, the safety assertion held, and prod
`contacts` was confirmed unchanged afterward.

## How it was built

Test-driven (`/tdd`) — red→green, one behavior per cycle, each test run
against the database before the implementing code: 10-digit → `+1`;
11-digit country code → `+1`; backfill rewrites parseable rows; backfill
**preserves** unparseable rows (caught the data-loss bug where an
unguarded `UPDATE` wiped them to `NULL`); backfill stamps `updated_at` on
changed rows; backfill skips already-canonical rows.

## Not done here (intentional)

The migration is **not applied** — per the issue, the dry-run output is
reported above for review first. Applying it to prod needs explicit
sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)