### PR TITLE
phone: roll out (xxx) xxx-xxxx display & E.164 storage app-wide (#185)

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Contact } from "@/lib/types";
+import { formatPhoneNumber, normalizePhoneToE164, phoneMatchesQuery } from "@/lib/phone";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -137,7 +138,7 @@ export default function ContactsPage() {
       return (
         fullName.includes(q) ||
         c.email?.toLowerCase().includes(q) ||
-        c.phone?.toLowerCase().includes(q) ||
+        phoneMatchesQuery(c.phone, search) ||
         c.company?.toLowerCase().includes(q)
       );
     }
@@ -159,7 +160,7 @@ export default function ContactsPage() {
     setEditingContact(contact);
     setForm({
       full_name: contact.full_name,
-      phone: contact.phone || "",
+      phone: formatPhoneNumber(contact.phone || ""),
       email: contact.email || "",
       role: contact.role,
       company: contact.company || "",
@@ -179,7 +180,7 @@ export default function ContactsPage() {
 
     const payload = {
       full_name: form.full_name.trim(),
-      phone: form.phone.trim() || null,
+      phone: normalizePhoneToE164(form.phone) ?? (form.phone.trim() || null),
       email: form.email.trim() || null,
       role: form.role,
       company: form.company.trim() || null,
@@ -359,7 +360,7 @@ export default function ContactsPage() {
                     {contact.phone && (
                       <span className="inline-flex items-center gap-1">
                         <Phone size={12} className="text-muted-foreground/60" />
-                        {contact.phone}
+                        {formatPhoneNumber(contact.phone)}
                       </span>
                     )}
                     {contact.email && (
@@ -472,7 +473,7 @@ export default function ContactsPage() {
                 </label>
                 <Input
                   value={form.phone}
-                  onChange={(e) => setForm({ ...form, phone: e.target.value })}
+                  onChange={(e) => setForm({ ...form, phone: formatPhoneNumber(e.target.value) })}
                   placeholder="(555) 123-4567"
                 />
               </div>

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -5,6 +5,7 @@ import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
 import { getEstimateWithContents } from "@/lib/estimates";
 import { formatCurrency } from "@/lib/format";
+import { formatPhoneNumber } from "@/lib/phone";
 import { STATUS_BADGE_CLASSES, formatStatusLabel } from "@/lib/estimate-status";
 import { ExportPdfButton } from "@/components/export-pdf-modal/button";
 import { SendButton } from "@/components/send-modal/button";
@@ -259,7 +260,7 @@ export default async function EstimateViewPage({
             <p className="text-sm text-muted-foreground">{contact.email}</p>
           )}
           {contact.phone && (
-            <p className="text-sm text-muted-foreground">{contact.phone}</p>
+            <p className="text-sm text-muted-foreground">{formatPhoneNumber(contact.phone)}</p>
           )}
         </div>
       )}

--- a/src/app/settings/users/page.tsx
+++ b/src/app/settings/users/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { Input } from "@/components/ui/input";
+import { formatPhoneNumber } from "@/lib/phone";
 import {
   Dialog,
   DialogContent,
@@ -256,7 +257,7 @@ export default function UsersSettingsPage() {
                       )}
                       {user.phone && (
                         <span className="inline-flex items-center gap-1">
-                          <Phone size={11} /> {user.phone}
+                          <Phone size={11} /> {formatPhoneNumber(user.phone)}
                         </span>
                       )}
                       {user.last_login_at && (

--- a/src/components/estimate-builder/customer-block.tsx
+++ b/src/components/estimate-builder/customer-block.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, User } from "lucide-react";
 import type { BuilderMode, Contact, Job } from "@/lib/types";
+import { formatPhoneNumber } from "@/lib/phone";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CustomerBlock — read-only display of customer info pulled from the job.
@@ -56,7 +57,7 @@ export function CustomerBlock({ job, mode = "estimate" }: CustomerBlockProps) {
             <div className="text-muted-foreground">{contact.email}</div>
           )}
           {contact?.phone && (
-            <div className="text-muted-foreground">{contact.phone}</div>
+            <div className="text-muted-foreground">{formatPhoneNumber(contact.phone)}</div>
           )}
         </div>
       )}

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase";
 import { escapeOrFilterValue } from "@/lib/postgrest";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
+import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
 import { Badge } from "@/components/ui/badge";
@@ -611,7 +612,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                   </span>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  {[job.contact.phone, job.contact.email].filter(Boolean).join(" \u00b7 ")}
+                  {[formatPhoneNumber(job.contact.phone || ""), job.contact.email].filter(Boolean).join(" \u00b7 ")}
                 </p>
               </div>
             )}
@@ -699,7 +700,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                   )}
                   {job.hoa_contact_name && (
                     <p className="text-xs text-muted-foreground">
-                      {[job.hoa_contact_name, job.hoa_contact_phone].filter(Boolean).join(" \u00b7 ")}
+                      {[job.hoa_contact_name, formatPhoneNumber(job.hoa_contact_phone || "")].filter(Boolean).join(" \u00b7 ")}
                     </p>
                   )}
                   {job.hoa_contact_email && (
@@ -1087,7 +1088,7 @@ function AdjusterCard({
         </div>
       </div>
       <p className="text-xs text-muted-foreground">{[adj.title, adj.company].filter(Boolean).join(" \u00b7 ")}</p>
-      <p className="text-xs text-muted-foreground mt-0.5">{[adj.phone, adj.email].filter(Boolean).join(" \u00b7 ")}</p>
+      <p className="text-xs text-muted-foreground mt-0.5">{[formatPhoneNumber(adj.phone || ""), adj.email].filter(Boolean).join(" \u00b7 ")}</p>
     </div>
   );
 }
@@ -1340,7 +1341,7 @@ function EditContactDialog({
     if (open && job.contact) {
       setForm({
         full_name: job.contact.full_name || "",
-        phone: job.contact.phone || "",
+        phone: formatPhoneNumber(job.contact.phone || ""),
         email: job.contact.email || "",
         role: job.contact.role || "homeowner",
       });
@@ -1362,7 +1363,7 @@ function EditContactDialog({
       .from("contacts")
       .update({
         full_name: form.full_name.trim(),
-        phone: form.phone.trim() || null,
+        phone: normalizePhoneToE164(form.phone) ?? (form.phone.trim() || null),
         email: form.email.trim() || null,
         role: form.role,
       })
@@ -1397,7 +1398,7 @@ function EditContactDialog({
           </div>
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">Phone</label>
-            <Input type="tel" value={form.phone} onChange={(e) => update("phone", e.target.value)} placeholder="(512) 555-0101" />
+            <Input type="tel" value={form.phone} onChange={(e) => update("phone", formatPhoneNumber(e.target.value))} placeholder="(512) 555-0101" />
           </div>
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">Email</label>
@@ -1467,7 +1468,7 @@ function EditInsuranceDialog({
         deductible: job.deductible != null ? String(job.deductible) : "",
         hoa_name: job.hoa_name || "",
         hoa_contact_name: job.hoa_contact_name || "",
-        hoa_contact_phone: job.hoa_contact_phone || "",
+        hoa_contact_phone: formatPhoneNumber(job.hoa_contact_phone || ""),
         hoa_contact_email: job.hoa_contact_email || "",
       });
     }
@@ -1486,7 +1487,7 @@ function EditInsuranceDialog({
         deductible: form.deductible ? Number(form.deductible) : null,
         hoa_name: form.hoa_name.trim() || null,
         hoa_contact_name: form.hoa_contact_name.trim() || null,
-        hoa_contact_phone: form.hoa_contact_phone.trim() || null,
+        hoa_contact_phone: normalizePhoneToE164(form.hoa_contact_phone) ?? (form.hoa_contact_phone.trim() || null),
         hoa_contact_email: form.hoa_contact_email.trim() || null,
       })
       .eq("id", jobId);
@@ -1549,7 +1550,7 @@ function EditInsuranceDialog({
               </div>
               <div>
                 <label className="block text-sm font-medium text-muted-foreground mb-1">Contact Phone</label>
-                <Input type="tel" value={form.hoa_contact_phone} onChange={(e) => update("hoa_contact_phone", e.target.value)} />
+                <Input type="tel" value={form.hoa_contact_phone} onChange={(e) => update("hoa_contact_phone", formatPhoneNumber(e.target.value))} />
               </div>
             </div>
             <div className="mt-3">
@@ -1664,7 +1665,7 @@ function AddAdjusterDialog({
         full_name: createForm.full_name.trim(),
         title: createForm.title.trim() || null,
         company: createForm.company.trim() || null,
-        phone: createForm.phone.trim() || null,
+        phone: normalizePhoneToE164(createForm.phone) ?? (createForm.phone.trim() || null),
         email: createForm.email.trim() || null,
         role: "adjuster",
       })
@@ -1746,7 +1747,7 @@ function AddAdjusterDialog({
                   >
                     <p className="text-sm font-medium text-foreground">{c.full_name}</p>
                     <p className="text-xs text-muted-foreground">{[c.title, c.company].filter(Boolean).join(" \u00b7 ")}</p>
-                    <p className="text-xs text-muted-foreground">{[c.phone, c.email].filter(Boolean).join(" \u00b7 ")}</p>
+                    <p className="text-xs text-muted-foreground">{[formatPhoneNumber(c.phone || ""), c.email].filter(Boolean).join(" \u00b7 ")}</p>
                   </button>
                 ))}
               </div>
@@ -1773,7 +1774,7 @@ function AddAdjusterDialog({
             </div>
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">Phone</label>
-              <Input type="tel" value={createForm.phone} onChange={(e) => updateCreate("phone", e.target.value)} placeholder="(512) 555-0101" />
+              <Input type="tel" value={createForm.phone} onChange={(e) => updateCreate("phone", formatPhoneNumber(e.target.value))} placeholder="(512) 555-0101" />
             </div>
             <div>
               <label className="block text-sm font-medium text-muted-foreground mb-1">Email</label>

--- a/src/lib/phone.test.ts
+++ b/src/lib/phone.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "./phone";
+import {
+  formatPhoneNumber,
+  isValidUSPhone,
+  normalizePhoneToE164,
+  phoneMatchesQuery,
+} from "./phone";
 
 describe("formatPhoneNumber", () => {
   it("returns an empty string for empty input", () => {
@@ -80,6 +85,38 @@ describe("normalizePhoneToE164", () => {
 
   it("returns null for an 11-digit number that is not country-code-prefixed", () => {
     expect(normalizePhoneToE164("25551234567")).toBeNull();
+  });
+});
+
+describe("phoneMatchesQuery", () => {
+  it("matches a stored E.164 number against a formatted query", () => {
+    expect(phoneMatchesQuery("+15551234567", "(555) 123-4567")).toBe(true);
+  });
+
+  it("does not match when the query has no digits", () => {
+    expect(phoneMatchesQuery("+15551234567", "john")).toBe(false);
+  });
+
+  it("matches a raw-digit query", () => {
+    expect(phoneMatchesQuery("+15551234567", "5551234567")).toBe(true);
+  });
+
+  it("matches a partial query against the area code or any digit run", () => {
+    expect(phoneMatchesQuery("+15551234567", "555")).toBe(true);
+    expect(phoneMatchesQuery("+15551234567", "234")).toBe(true);
+  });
+
+  it("does not match when the query digits are absent from the number", () => {
+    expect(phoneMatchesQuery("+15551234567", "999")).toBe(false);
+  });
+
+  it("does not match a null or undefined stored phone", () => {
+    expect(phoneMatchesQuery(null, "555")).toBe(false);
+    expect(phoneMatchesQuery(undefined, "555")).toBe(false);
+  });
+
+  it("matches across formats — a country-code query against a 10-digit stored value", () => {
+    expect(phoneMatchesQuery("5551234567", "1 (555) 123-4567")).toBe(true);
   });
 });
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -29,3 +29,14 @@ export function normalizePhoneToE164(input: string): string | null {
 export function isValidUSPhone(input: string): boolean {
   return normalizePhoneToE164(input) !== null;
 }
+
+/**
+ * True when `query`'s digits appear within `phone`'s digits — used by the
+ * contacts search so a stored E.164 number matches whether the query was
+ * typed formatted, as raw digits, or partially.
+ */
+export function phoneMatchesQuery(phone: string | null | undefined, query: string): boolean {
+  const queryDigits = tenDigits(query);
+  if (queryDigits.length === 0) return false;
+  return tenDigits(phone ?? "").includes(queryDigits);
+}


### PR DESCRIPTION
Closes #185 — (slice of PRD #45) — applies the shared phone util (`src/lib/phone.ts`, from #183) to every contact/adjuster phone surface so the whole app reads and writes one consistent format.

## Changes

**Display sites** — stored value rendered via `formatPhoneNumber`:
- `job-detail.tsx` — contact, HOA contact, adjuster card, adjuster-search results
- `contacts/page.tsx` — contact list
- `estimate-builder/customer-block.tsx` — customer block
- `estimates/[id]/page.tsx` — estimate detail
- `settings/users/page.tsx` — user list

**Editors** — format-as-you-type `onChange`, the loaded value formatted on open, E.164 written on save:
- `job-detail.tsx` — Edit Contact, Edit Insurance/HOA, Add Adjuster dialogs
- `contacts/page.tsx` — add/edit contact dialog

Save behavior is **best-effort, never block** (confirmed with the user): a valid number stores E.164; a non-empty value that won't normalize is stored as typed rather than silently dropped. Empty stays `null`. #185 lists no submit-validation criteria — that was #183's job, scoped to the intake form.

**Contacts search** — new `phoneMatchesQuery()` in `phone.ts` backs the phone search clause: it digit-normalizes both the stored number and the query (dropping a leading `1`) so an E.164-stored number matches whether the query is typed formatted, as raw digits, or partially. A query with no digits never matches, so name searches don't false-match phones.

## Tests

`phoneMatchesQuery` built TDD (red→green), 7 new cases in `phone.test.ts`. The display/editor wiring is mechanical and verified by type-check + build.

- `vitest` — 817 passed (126 files), +7
- `tsc --noEmit` — clean except the pre-existing `sync-folder-incremental.test.ts` error
- `eslint` — 0 new problems vs. baseline on the changed files

## Acceptance criteria

- [x] Every contact/adjuster phone display renders as `(xxx) xxx-xxxx`
- [x] Every phone editor formats-as-you-type and stores E.164
- [x] Contacts search matches phone numbers regardless of query format
- [x] No listed surface displays a raw/unformatted phone string

🤖 Generated with [Claude Code](https://claude.com/claude-code)