### PR TITLE
Migrate existing orgs' form_config: when_happened text → date (#187)

### DIFF
--- a/supabase/migration-187-dry-run.sql
+++ b/supabase/migration-187-dry-run.sql
@@ -1,0 +1,87 @@
+-- issue #187 (PRD #45) — flip when_happened "text" -> "date": DRY RUN.
+--
+-- Purpose:   Read-only preview of migration-187. Reports how many form_config
+--            rows would change, how many already carry when_happened on
+--            "date", and how many have no when_happened field at all. Run
+--            this FIRST and record the output on the PR before applying
+--            migration-187-form-config-when-happened-date.sql.
+--
+-- Safety:    SELECT-only. Creates a session-local pg_temp helper that
+--            vanishes when the connection closes. Touches no real rows.
+--
+-- Transform rule mirrors flip_when_happened_type() in
+-- migration-187-form-config-when-happened-date.sql exactly: walk
+-- config->sections->fields, rewrite only the when_happened field's "type"
+-- to "date", preserve everything else.
+--
+-- Run:       psql -f supabase/migration-187-dry-run.sql
+--            (or paste into the Supabase SQL editor).
+
+create or replace function pg_temp.flip_when_happened_type(cfg jsonb)
+  returns jsonb language sql immutable as $$
+  select case
+    when jsonb_typeof(cfg->'sections') = 'array' then
+      jsonb_set(cfg, '{sections}', (
+        select coalesce(jsonb_agg(
+          case
+            when jsonb_typeof(section->'fields') = 'array' then
+              jsonb_set(section, '{fields}', (
+                select coalesce(jsonb_agg(
+                  case
+                    when field->>'id' = 'when_happened'
+                      then jsonb_set(field, '{type}', '"date"'::jsonb)
+                    else field
+                  end
+                  order by ford
+                ), '[]'::jsonb)
+                from jsonb_array_elements(section->'fields')
+                     with ordinality as f(field, ford)
+              ))
+            else section
+          end
+          order by sord
+        ), '[]'::jsonb)
+        from jsonb_array_elements(cfg->'sections')
+             with ordinality as s(section, sord)
+      ))
+    else cfg
+  end;
+$$;
+
+-- Summary counts — paste this row on the PR.
+with classified as (
+  select
+    config is distinct from pg_temp.flip_when_happened_type(config) as would_change,
+    exists (
+      select 1
+      from jsonb_array_elements(
+             case when jsonb_typeof(config->'sections') = 'array'
+                  then config->'sections' else '[]'::jsonb end) s
+      cross join lateral jsonb_array_elements(
+             case when jsonb_typeof(s->'fields') = 'array'
+                  then s->'fields' else '[]'::jsonb end) f
+      where f->>'id' = 'when_happened'
+    ) as has_when_happened
+  from public.form_config
+)
+select
+  count(*)                                                        as total_rows,
+  count(*) filter (where has_when_happened)                       as has_when_happened,
+  count(*) filter (where would_change)                            as would_change,
+  count(*) filter (where has_when_happened and not would_change)  as already_date,
+  count(*) filter (where not has_when_happened)                   as no_when_happened
+from classified;
+
+-- when_happened.type breakdown across every row that carries the field.
+-- Expected before applying: all rows on "text"; after: all on "date".
+select f->>'type' as when_happened_type, count(*) as rows
+from public.form_config fc
+cross join lateral jsonb_array_elements(
+  case when jsonb_typeof(fc.config->'sections') = 'array'
+       then fc.config->'sections' else '[]'::jsonb end) s
+cross join lateral jsonb_array_elements(
+  case when jsonb_typeof(s->'fields') = 'array'
+       then s->'fields' else '[]'::jsonb end) f
+where f->>'id' = 'when_happened'
+group by 1
+order by 2 desc;

--- a/supabase/migration-187-form-config-when-happened-date.sql
+++ b/supabase/migration-187-form-config-when-happened-date.sql
@@ -1,0 +1,108 @@
+-- issue #187 (PRD #45) — flip when_happened "text" -> "date" in every existing
+-- organization's saved form_config.
+--
+-- Purpose:    The intake-form builder seed was updated in issue #184 so newly
+--             seeded orgs render the "When Did It Happen?" field with the new
+--             masked-date component (form-config field type "date"). Orgs
+--             created before #184 still carry the old type: "text" in their
+--             stored form_config.config JSONB and would never get the date
+--             renderer. This migration flips when_happened's "type" to "date"
+--             in every existing form_config row that has the field.
+--
+-- Scope:      Only the when_happened field's "type" key is rewritten. Every
+--             other field, every other key within when_happened, and the
+--             section / field ordering are preserved. Rows with no
+--             when_happened field are left untouched. The transform rule is
+--             verified test-first in supabase/migration-187-smoke-test.sql.
+--
+-- Idempotent: re-running changes nothing — the WHERE clause excludes rows
+--             that already equal their transformed form, so updated_at is
+--             not bumped on rows already on "date" or with no when_happened.
+--
+-- Dry run:    supabase/migration-187-dry-run.sql reports the would-change
+--             count; run it first and record the output on the PR before
+--             applying this migration.
+--
+-- Revert:     Not cleanly auto-reversible — see the -- ROLLBACK -- note below.
+
+do $$
+declare
+  v_would_change bigint;
+  v_changed      bigint;
+begin
+  -- Session-local helper: vanishes when the connection closes, so no
+  -- permanent schema surface is added. Declared once and used by both the
+  -- pre-count and the UPDATE below, so the transform rule lives in exactly
+  -- one place within this migration. It walks config->sections->fields,
+  -- rewrites only the when_happened field's "type" to "date", and rebuilds
+  -- both arrays in their original order. Identical to the helper in
+  -- migration-187-smoke-test.sql and migration-187-dry-run.sql.
+  create or replace function pg_temp.flip_when_happened_type(cfg jsonb)
+    returns jsonb language sql immutable as $fn$
+    select case
+      when jsonb_typeof(cfg->'sections') = 'array' then
+        jsonb_set(cfg, '{sections}', (
+          select coalesce(jsonb_agg(
+            case
+              when jsonb_typeof(section->'fields') = 'array' then
+                jsonb_set(section, '{fields}', (
+                  select coalesce(jsonb_agg(
+                    case
+                      when field->>'id' = 'when_happened'
+                        then jsonb_set(field, '{type}', '"date"'::jsonb)
+                      else field
+                    end
+                    order by ford
+                  ), '[]'::jsonb)
+                  from jsonb_array_elements(section->'fields')
+                       with ordinality as f(field, ford)
+                ))
+              else section
+            end
+            order by sord
+          ), '[]'::jsonb)
+          from jsonb_array_elements(cfg->'sections')
+               with ordinality as s(section, sord)
+        ))
+      else cfg
+    end;
+  $fn$;
+
+  select count(*) filter (
+           where config is distinct from pg_temp.flip_when_happened_type(config))
+    into v_would_change
+  from public.form_config;
+
+  raise notice 'migration-187: % form_config row(s) to flip when_happened text -> date',
+    v_would_change;
+
+  update public.form_config
+     set config = pg_temp.flip_when_happened_type(config),
+         updated_at = now()
+   where config is distinct from pg_temp.flip_when_happened_type(config);
+
+  get diagnostics v_changed = row_count;
+
+  -- Safety assertion — the pre-count and the UPDATE use an identical
+  -- predicate within one transaction, so a mismatch means a concurrent write
+  -- slipped in.
+  if v_changed <> v_would_change then
+    raise exception
+      'migration-187: expected to change % row(s), changed % — aborting',
+      v_would_change, v_changed;
+  end if;
+
+  raise notice 'migration-187: complete — % form_config row(s) updated to date',
+    v_changed;
+end $$;
+
+-- ROLLBACK -------------------------------------------------------------------
+-- Not cleanly auto-reversible. A blanket "flip when_happened date -> text"
+-- would also downgrade orgs seeded *after* issue #184, whose form_config seed
+-- already produces type: "date" — those were never "text" and must stay
+-- "date". This migration does not record which rows it touched.
+--
+-- The change is config-only and low-risk: it swaps a single string within a
+-- builder field. If a specific org's config must be reverted, edit that one
+-- form_config row's when_happened.type back to "text" by id.
+-- ----------------------------------------------------------------------------

--- a/supabase/migration-187-smoke-test.sql
+++ b/supabase/migration-187-smoke-test.sql
@@ -1,0 +1,211 @@
+-- issue #187 (PRD #45) — form_config when_happened text->date — migration smoke test.
+--
+-- Purpose:   Self-checking script that verifies the migration-187 transform.
+--            It is *not* part of the migration. It re-creates the transform
+--            helper, asserts it against a battery of config shapes, then
+--            exercises the exact migration UPDATE against a temp table shaped
+--            like public.form_config. Every assertion raises an exception on
+--            failure, so a clean run prints only NOTICE lines and a failed
+--            run terminates loudly.
+--
+-- Shape:     One transaction, rolled back at the end — the DB is unchanged.
+--            No real rows are read or written; the migration is exercised
+--            against a seeded temp table.
+--
+-- Run:       psql -f supabase/migration-187-smoke-test.sql
+--            (or paste into the Supabase SQL editor).
+
+begin;
+
+-- The transform helper, identical to the one in
+-- migration-187-form-config-when-happened-date.sql and migration-187-dry-run.sql.
+create or replace function pg_temp.flip_when_happened_type(cfg jsonb)
+  returns jsonb language sql immutable as $$
+  select case
+    when jsonb_typeof(cfg->'sections') = 'array' then
+      jsonb_set(cfg, '{sections}', (
+        select coalesce(jsonb_agg(
+          case
+            when jsonb_typeof(section->'fields') = 'array' then
+              jsonb_set(section, '{fields}', (
+                select coalesce(jsonb_agg(
+                  case
+                    when field->>'id' = 'when_happened'
+                      then jsonb_set(field, '{type}', '"date"'::jsonb)
+                    else field
+                  end
+                  order by ford
+                ), '[]'::jsonb)
+                from jsonb_array_elements(section->'fields')
+                     with ordinality as f(field, ford)
+              ))
+            else section
+          end
+          order by sord
+        ), '[]'::jsonb)
+        from jsonb_array_elements(cfg->'sections')
+             with ordinality as s(section, sord)
+      ))
+    else cfg
+  end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 1. Transform parity — flip_when_happened_type() flips when_happened's type
+--    to "date" and changes nothing else.
+-- ---------------------------------------------------------------------------
+
+-- C1: when_happened text -> date.
+do $$
+declare
+  v_in  jsonb := '{"sections":[{"id":"damage_info","title":"Damage Information","fields":[
+    {"id":"when_happened","type":"text","label":"When Did It Happen?","required":false}
+  ]}]}';
+  v_out jsonb := pg_temp.flip_when_happened_type(v_in);
+begin
+  if v_out #>> '{sections,0,fields,0,type}' is distinct from 'date' then
+    raise exception 'smoke C1: when_happened type = %, expected "date"',
+      v_out #>> '{sections,0,fields,0,type}';
+  end if;
+  raise notice 'smoke C1: when_happened text -> date — PASS';
+end $$;
+
+-- C2: sibling fields in the same section keep their own type.
+do $$
+declare
+  v_in  jsonb := '{"sections":[{"id":"damage_info","title":"Damage Information","fields":[
+    {"id":"damage_type","type":"pill","label":"Type of Damage"},
+    {"id":"damage_source","type":"text","label":"Source of Damage"},
+    {"id":"when_happened","type":"text","label":"When Did It Happen?"},
+    {"id":"affected_areas","type":"text","label":"Affected Areas"}
+  ]}]}';
+  v_out jsonb := pg_temp.flip_when_happened_type(v_in);
+begin
+  if v_out #>> '{sections,0,fields,0,type}' is distinct from 'pill'
+     or v_out #>> '{sections,0,fields,1,type}' is distinct from 'text'
+     or v_out #>> '{sections,0,fields,2,type}' is distinct from 'date'
+     or v_out #>> '{sections,0,fields,3,type}' is distinct from 'text' then
+    raise exception 'smoke C2: sibling field types = %',
+      (select jsonb_agg(f->>'type') from jsonb_array_elements(v_out#>'{sections,0,fields}') f);
+  end if;
+  raise notice 'smoke C2: sibling fields keep their type — PASS';
+end $$;
+
+-- C3: every other key inside the when_happened object is preserved — only
+--     "type" changes.
+do $$
+declare
+  v_field jsonb := '{"id":"when_happened","type":"text","label":"When Did It Happen?",
+    "required":false,"is_default":true,"visible":true}';
+  v_in  jsonb := jsonb_build_object('sections', jsonb_build_array(
+    jsonb_build_object('id','damage_info','fields', jsonb_build_array(v_field))));
+  v_out_field jsonb := pg_temp.flip_when_happened_type(v_in) #> '{sections,0,fields,0}';
+begin
+  if v_out_field is distinct from (v_field || '{"type":"date"}'::jsonb) then
+    raise exception 'smoke C3: when_happened object = %, expected only type flipped',
+      v_out_field;
+  end if;
+  raise notice 'smoke C3: when_happened other keys preserved — PASS';
+end $$;
+
+-- C4: a config with no when_happened field is returned byte-for-byte unchanged.
+do $$
+declare
+  v_in jsonb := '{"sections":[
+    {"id":"caller_info","title":"Caller Information","fields":[
+      {"id":"first_name","type":"text","label":"First Name"},
+      {"id":"phone","type":"phone","label":"Phone"}]},
+    {"id":"property","title":"Property Details","fields":[
+      {"id":"property_address","type":"text","label":"Property Address"}]}
+  ]}';
+begin
+  if pg_temp.flip_when_happened_type(v_in) is distinct from v_in then
+    raise exception 'smoke C4: config without when_happened was modified — got %',
+      pg_temp.flip_when_happened_type(v_in);
+  end if;
+  raise notice 'smoke C4: config without when_happened unchanged — PASS';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Migration behavior — seed a temp table shaped like public.form_config,
+--    run the exact UPDATE from migration-187, and assert each row's outcome:
+--      - a row whose when_happened is "text" is flipped to "date" and its
+--        updated_at is bumped;
+--      - a row whose when_happened is already "date" is left untouched
+--        (config unchanged, updated_at NOT bumped);
+--      - a row with no when_happened field is left untouched;
+--    then re-run the UPDATE and assert it changes zero rows (idempotent).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_seed_ts constant timestamptz := timestamptz '2020-01-01';
+  v_changed bigint;
+  r record;
+begin
+  create temp table _smoke_form_config (id text, config jsonb, updated_at timestamptz)
+    on commit drop;
+  insert into _smoke_form_config values
+    ('text-row', '{"sections":[
+        {"id":"caller_info","fields":[{"id":"phone","type":"phone"}]},
+        {"id":"damage_info","fields":[
+          {"id":"damage_source","type":"text"},
+          {"id":"when_happened","type":"text","label":"When Did It Happen?"}]}
+      ]}', v_seed_ts),
+    ('already-date', '{"sections":[
+        {"id":"damage_info","fields":[{"id":"when_happened","type":"date"}]}
+      ]}', v_seed_ts),
+    ('no-when-happened', '{"sections":[
+        {"id":"caller_info","fields":[{"id":"first_name","type":"text"}]}
+      ]}', v_seed_ts);
+
+  -- The exact UPDATE from migration-187-form-config-when-happened-date.sql.
+  update _smoke_form_config
+     set config = pg_temp.flip_when_happened_type(config),
+         updated_at = now()
+   where config is distinct from pg_temp.flip_when_happened_type(config);
+  get diagnostics v_changed = row_count;
+
+  -- C5: exactly the one text-row is flipped; the other two are untouched.
+  if v_changed <> 1 then
+    raise exception 'smoke C5: expected 1 row changed, got %', v_changed;
+  end if;
+  for r in select id, config, updated_at from _smoke_form_config loop
+    case r.id
+      when 'text-row' then
+        if r.config #>> '{sections,1,fields,1,type}' is distinct from 'date' then
+          raise exception 'smoke C5: text-row when_happened type = %, expected date',
+            r.config #>> '{sections,1,fields,1,type}';
+        end if;
+        if r.updated_at <= v_seed_ts then
+          raise exception 'smoke C5: text-row updated_at was not bumped';
+        end if;
+      when 'already-date' then
+        if r.config #>> '{sections,0,fields,0,type}' is distinct from 'date' then
+          raise exception 'smoke C5: already-date row config was corrupted';
+        end if;
+        if r.updated_at <> v_seed_ts then
+          raise exception 'smoke C5: already-date updated_at was bumped — not idempotent';
+        end if;
+      when 'no-when-happened' then
+        if r.updated_at <> v_seed_ts then
+          raise exception 'smoke C5: no-when-happened updated_at was bumped';
+        end if;
+      else
+        raise exception 'smoke C5: unexpected seed row %', r.id;
+    end case;
+  end loop;
+  raise notice 'smoke C5: migration UPDATE — 3 rows (1 flipped, 2 untouched) — PASS';
+
+  -- C6: re-running the migration changes nothing.
+  update _smoke_form_config
+     set config = pg_temp.flip_when_happened_type(config),
+         updated_at = now()
+   where config is distinct from pg_temp.flip_when_happened_type(config);
+  get diagnostics v_changed = row_count;
+  if v_changed <> 0 then
+    raise exception 'smoke C6: re-run changed % row(s), expected 0', v_changed;
+  end if;
+  raise notice 'smoke C6: migration UPDATE is idempotent on re-run — PASS';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #187 — slice 4 of PRD #45.

## What this does

Issue #184 updated the intake-form builder **seed** so newly seeded orgs render "When Did It Happen?" with the masked-date component (form-config field type `date`). Orgs created **before** #184 still carry `type: "text"` in their stored `form_config.config` JSONB and would never get the date renderer.

This migration flips `when_happened`'s `type` to `"date"` in every existing `form_config` row that has the field — and nothing else.

## Files

| File | Role |
|---|---|
| `migration-187-form-config-when-happened-date.sql` | The migration |
| `migration-187-dry-run.sql` | Read-only preview — run first, output below |
| `migration-187-smoke-test.sql` | Built test-first (TDD), self-checking, rolled back |

A session-local `pg_temp` transform helper walks `config→sections→fields`, rewrites only `when_happened`'s `type`, and rebuilds both arrays in their original order. Identical helper text in all three files (the #186 pattern — no permanent schema surface). Idempotent: rows already on `date` or without the field are skipped, so `updated_at` is not bumped; a safety assertion aborts if the changed count drifts from the pre-count.

## Dry run — AAA prod

\`\`\`
total_rows | has_when_happened | would_change | already_date | no_when_happened
-----------+-------------------+--------------+--------------+------------------
       110 |                 8 |            8 |            0 |              102
\`\`\`

`when_happened.type` breakdown: **8 rows on `text`**, 0 on `date`. The migration flips exactly those 8; the other 102 rows have no `when_happened` field and are untouched.

## TDD

Built with `/tdd` — 6 red→green cycles run via the Supabase MCP against a seeded **temp table** (no real data touched):

1. `when_happened` `text` → `date` (tracer)
2. sibling fields keep their own type
3. other keys within the `when_happened` object preserved
4. a config with no `when_happened` returned unchanged
5. migration UPDATE — multi-row flip, `updated_at` bumped only on changed rows
6. migration UPDATE is idempotent on re-run

All 6 green. RED was demonstrated for C1 (stub helper) and C5 (UPDATE without the `WHERE` predicate bumps all rows).

## Acceptance criteria

- [x] A migration updates `when_happened.type` to `"date"` in every existing `form_config` row that contains the field
- [x] All other fields within each org's `config` JSONB are unchanged
- [x] Orgs without a `when_happened` field are unaffected
- [ ] After the migration, existing orgs render the masked date field — verified once the migration is applied to prod

## Not yet applied

The migration has **not** been run against prod. Apply `migration-187-form-config-when-happened-date.sql`, expect `8 form_config row(s) updated to date`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)