### PR TITLE
Insurance-company picker on job detail (PRD #47 slice 1)

### DIFF
--- a/src/components/insurance-company-picker.test.tsx
+++ b/src/components/insurance-company-picker.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import type { Contact } from "@/lib/types";
+
+// The picker searches role='insurance' contacts as the user types. A
+// mutable module-level result lets each test seed its own match list.
+let contactsResult: { data: unknown; error: unknown } = {
+  data: [],
+  error: null,
+};
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    // The contacts search is a chainable query whose builder methods
+    // return the builder; awaiting it resolves to the seeded result.
+    from: () => {
+      const builder: Record<string, unknown> = {};
+      for (const method of ["select", "eq", "or", "limit"]) {
+        builder[method] = () => builder;
+      }
+      builder.then = (resolve: (r: unknown) => void) => resolve(contactsResult);
+      return builder;
+    },
+  }),
+}));
+
+import InsuranceCompanyPicker from "./insurance-company-picker";
+
+function makeContact(overrides: Partial<Contact> = {}): Contact {
+  return {
+    id: "c-1",
+    full_name: "State Farm",
+    phone: null,
+    email: "claims@statefarm.com",
+    role: "insurance",
+    company: null,
+    title: null,
+    notes: null,
+    created_at: "2026-05-20T00:00:00Z",
+    updated_at: "2026-05-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  contactsResult = { data: [], error: null };
+});
+
+describe("InsuranceCompanyPicker — search (#193)", () => {
+  it("renders a matching insurance company as the user types", async () => {
+    contactsResult = {
+      data: [makeContact({ id: "c-1", full_name: "State Farm" })],
+      error: null,
+    };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "state" },
+    });
+
+    expect(
+      await screen.findByRole("button", { name: /State Farm/i }),
+    ).toBeDefined();
+  });
+});
+
+describe("InsuranceCompanyPicker — claims email (#193)", () => {
+  it("shows each matching company's claims email alongside its name", async () => {
+    contactsResult = {
+      data: [
+        makeContact({
+          id: "c-1",
+          full_name: "Allstate",
+          email: "claims@allstate.com",
+        }),
+      ],
+      error: null,
+    };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "all" },
+    });
+
+    expect(await screen.findByText("Allstate")).toBeDefined();
+    expect(screen.getByText("claims@allstate.com")).toBeDefined();
+  });
+});
+
+describe("InsuranceCompanyPicker — selecting (#193)", () => {
+  it("fires onChange with the chosen company when a match is selected", async () => {
+    const chosen = makeContact({ id: "c-9", full_name: "Liberty Mutual" });
+    contactsResult = { data: [chosen], error: null };
+    const onChange = vi.fn();
+
+    render(<InsuranceCompanyPicker value={null} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "liberty" },
+    });
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Liberty Mutual/i }),
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(chosen);
+  });
+});
+
+describe("InsuranceCompanyPicker — no matches (#193)", () => {
+  it("tells the user when a search turns up no insurance companies", async () => {
+    contactsResult = { data: [], error: null };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "nonesuch" },
+    });
+
+    expect(await screen.findByText(/no matching insurance/i)).toBeDefined();
+  });
+});
+
+describe("InsuranceCompanyPicker — linked company (#193)", () => {
+  it("shows the company already linked to the job", () => {
+    render(
+      <InsuranceCompanyPicker
+        value={makeContact({ id: "c-1", full_name: "Travelers" })}
+        onChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Travelers")).toBeDefined();
+  });
+});
+
+describe("InsuranceCompanyPicker — clearing (#193)", () => {
+  it("fires onChange with null when the linked company is cleared", () => {
+    const onChange = vi.fn();
+    render(
+      <InsuranceCompanyPicker
+        value={makeContact({ id: "c-1", full_name: "Travelers" })}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /clear insurance company/i }),
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toBeNull();
+  });
+});

--- a/src/components/insurance-company-picker.tsx
+++ b/src/components/insurance-company-picker.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+
+import { createClient } from "@/lib/supabase";
+import { escapeOrFilterValue } from "@/lib/postgrest";
+import { Input } from "@/components/ui/input";
+import type { Contact } from "@/lib/types";
+
+interface InsuranceCompanyPickerProps {
+  /** The insurance contact currently linked to the job, or null if none. */
+  value: Contact | null;
+  /** Fires when the user picks a company or clears the selection. */
+  onChange: (contact: Contact | null) => void;
+}
+
+/**
+ * Search-as-you-type picker for an insurance company — a contact with
+ * role = 'insurance'. Used inside the job-detail Edit Insurance dialog
+ * (PRD #47, slice 1). Select-existing-only: there is no "+ New" create
+ * affordance yet (that is slice 2). Cross-organization isolation is
+ * delegated to row-level security on `contacts`, exactly as the adjuster
+ * search is — the query never names an organization.
+ */
+export default function InsuranceCompanyPicker({
+  value,
+  onChange,
+}: InsuranceCompanyPickerProps) {
+  const [search, setSearch] = useState("");
+  const [results, setResults] = useState<Contact[]>([]);
+  const [searching, setSearching] = useState(false);
+
+  useEffect(() => {
+    // Every setState runs inside the debounce callback, never
+    // synchronously in the effect body — the react-hooks/set-state-in-effect
+    // avoidance also used in job-cover-picker.tsx.
+    const timer = setTimeout(async () => {
+      const query = search.trim();
+      if (!query) {
+        setResults([]);
+        setSearching(false);
+        return;
+      }
+      setSearching(true);
+      const supabase = createClient();
+      const term = escapeOrFilterValue(`%${query}%`);
+      const { data } = await supabase
+        .from("contacts")
+        .select("*")
+        .eq("role", "insurance")
+        .or(`full_name.ilike.${term},company.ilike.${term}`)
+        .limit(10);
+      setResults((data as Contact[] | null) ?? []);
+      setSearching(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  // Selected state: the job already has a linked insurance company.
+  // Clearing it returns to the search state so a different company can
+  // be picked, which is how "change the company" is reached.
+  if (value) {
+    return (
+      <div className="flex items-start justify-between gap-2 rounded-lg border border-border bg-background/50 p-3">
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            {value.full_name}
+          </p>
+          {value.email && (
+            <p className="text-xs text-muted-foreground">{value.email}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          aria-label="Clear insurance company"
+          onClick={() => onChange(null)}
+          className="rounded-md p-1 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Input
+        placeholder="Search insurance companies..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {!searching && search.trim() && results.length === 0 && (
+        <p className="text-sm text-muted-foreground/60 text-center py-4">
+          No matching insurance companies found
+        </p>
+      )}
+      {results.length > 0 && (
+        <div className="space-y-2 max-h-60 overflow-y-auto">
+          {results.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => onChange(c)}
+              className="w-full text-left rounded-lg border border-border p-3 hover:bg-accent/50 transition-colors"
+            >
+              <p className="text-sm font-medium text-foreground">
+                {c.full_name}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {c.email ?? "No claims email on file"}
+              </p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -97,6 +97,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
     property_stories: null,
     affected_areas: null,
     insurance_company: null,
+    insurance_contact_id: null,
     claim_number: null,
     policy_number: null,
     payer_type: null,

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -28,6 +28,7 @@ import JarvisJobPanel from "@/components/jarvis/JarvisJobPanel";
 import JobFiles from "@/components/job-files";
 import ContractsSection from "@/components/contracts/contracts-section";
 import CaptureFab from "@/components/mobile/capture-fab";
+import InsuranceCompanyPicker from "@/components/insurance-company-picker";
 import {
   MapPin,
   Home,
@@ -127,7 +128,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
     const [jobRes, activitiesRes, paymentsRes, invoicesRes, photosRes, photoCountRes, tagsRes, reportsRes, emailsRes] = await Promise.all([
       supabase
         .from("jobs")
-        .select("*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
+        .select("*, contact:contacts!contact_id(*), insurance_contact:contacts!insurance_contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
         .eq("id", jobId)
         .single(),
       supabase
@@ -664,6 +665,14 @@ export default function JobDetail({ jobId }: { jobId: string }) {
               <div className="rounded-lg border border-border bg-background/50 p-3 mb-3">
                 {job.insurance_company && (
                   <p className="text-sm font-medium text-foreground mb-1">{job.insurance_company}</p>
+                )}
+                {job.insurance_contact?.email && (
+                  <a
+                    href={`mailto:${job.insurance_contact.email}`}
+                    className="block text-xs text-primary hover:underline mb-1"
+                  >
+                    {job.insurance_contact.email}
+                  </a>
                 )}
                 <p className="text-xs text-muted-foreground">
                   {[
@@ -1446,8 +1455,13 @@ function EditInsuranceDialog({
   onSaved: () => void;
 }) {
   const [saving, setSaving] = useState(false);
+  // The linked insurance company is chosen with InsuranceCompanyPicker
+  // rather than typed. `insuranceTouched` records whether the picker was
+  // actually used this session — when it was not, the save leaves a
+  // legacy job's free-text insurance_company name untouched (#193).
+  const [insuranceContact, setInsuranceContact] = useState<Contact | null>(null);
+  const [insuranceTouched, setInsuranceTouched] = useState(false);
   const [form, setForm] = useState({
-    insurance_company: "",
     claim_number: "",
     policy_number: "",
     date_of_loss: "",
@@ -1460,8 +1474,9 @@ function EditInsuranceDialog({
 
   useEffect(() => {
     if (open) {
+      setInsuranceContact(job.insurance_contact ?? null);
+      setInsuranceTouched(false);
       setForm({
-        insurance_company: job.insurance_company || "",
         claim_number: job.claim_number || "",
         policy_number: job.policy_number || "",
         date_of_loss: job.date_of_loss || "",
@@ -1477,19 +1492,28 @@ function EditInsuranceDialog({
   async function handleSave() {
     setSaving(true);
     const supabase = createClient();
+    const jobUpdate: Record<string, unknown> = {
+      claim_number: form.claim_number.trim() || null,
+      policy_number: form.policy_number.trim() || null,
+      date_of_loss: form.date_of_loss || null,
+      deductible: form.deductible ? Number(form.deductible) : null,
+      hoa_name: form.hoa_name.trim() || null,
+      hoa_contact_name: form.hoa_contact_name.trim() || null,
+      hoa_contact_phone: normalizePhoneToE164(form.hoa_contact_phone) ?? (form.hoa_contact_phone.trim() || null),
+      hoa_contact_email: form.hoa_contact_email.trim() || null,
+    };
+    // Only rewrite the insurance link when the picker was actually used.
+    // A legacy job carries a free-text insurance_company name and no
+    // insurance_contact_id; saving unrelated fields must not erase it.
+    // When the picker is used, insurance_company is snapshotted from the
+    // selected contact's name so existing free-text readers stay valid.
+    if (insuranceTouched) {
+      jobUpdate.insurance_contact_id = insuranceContact?.id ?? null;
+      jobUpdate.insurance_company = insuranceContact?.full_name ?? null;
+    }
     const { error } = await supabase
       .from("jobs")
-      .update({
-        insurance_company: form.insurance_company.trim() || null,
-        claim_number: form.claim_number.trim() || null,
-        policy_number: form.policy_number.trim() || null,
-        date_of_loss: form.date_of_loss || null,
-        deductible: form.deductible ? Number(form.deductible) : null,
-        hoa_name: form.hoa_name.trim() || null,
-        hoa_contact_name: form.hoa_contact_name.trim() || null,
-        hoa_contact_phone: normalizePhoneToE164(form.hoa_contact_phone) ?? (form.hoa_contact_phone.trim() || null),
-        hoa_contact_email: form.hoa_contact_email.trim() || null,
-      })
+      .update(jobUpdate)
       .eq("id", jobId);
 
     if (error) {
@@ -1515,7 +1539,18 @@ function EditInsuranceDialog({
         <div className="space-y-4 pt-2 max-h-[70vh] overflow-y-auto">
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">Insurance Company</label>
-            <Input value={form.insurance_company} onChange={(e) => update("insurance_company", e.target.value)} placeholder="e.g. State Farm" />
+            {job.insurance_company && !job.insurance_contact_id && !insuranceTouched && (
+              <p className="text-xs text-muted-foreground/70 mb-1.5">
+                Currently: {job.insurance_company} &middot; not linked to a contact
+              </p>
+            )}
+            <InsuranceCompanyPicker
+              value={insuranceContact}
+              onChange={(c) => {
+                setInsuranceContact(c);
+                setInsuranceTouched(true);
+              }}
+            />
           </div>
           <div className="grid grid-cols-2 gap-3">
             <div>

--- a/src/components/job-list-row.test.tsx
+++ b/src/components/job-list-row.test.tsx
@@ -33,6 +33,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
     property_stories: null,
     affected_areas: null,
     insurance_company: null,
+    insurance_contact_id: null,
     claim_number: null,
     policy_number: null,
     payer_type: null,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,10 @@ export interface Job {
   property_stories: number | null;
   affected_areas: string | null;
   insurance_company: string | null;
+  /** FK to a `contacts` row with role = 'insurance' (PRD #47). When set,
+   *  the linked company's name is also snapshotted into `insurance_company`
+   *  above so existing free-text readers stay untouched. */
+  insurance_contact_id: string | null;
   claim_number: string | null;
   policy_number: string | null;
   payer_type: "insurance" | "homeowner" | "mixed" | null;
@@ -45,6 +49,7 @@ export interface Job {
   deleted_at?: string | null;
   // Joined fields
   contact?: Contact;
+  insurance_contact?: Contact | null;
   job_adjusters?: JobAdjuster[];
   cover_photo?: Photo | null;
   // Tallied by the Comfortable-view loader (see attachJobCounts).

--- a/supabase/migration-193-jobs-insurance-contact-id.sql
+++ b/supabase/migration-193-jobs-insurance-contact-id.sql
@@ -1,0 +1,30 @@
+-- issue #193 (PRD #47, slice 1) — link a job to its insurance company.
+--
+-- Insurance companies are contacts with role = 'insurance', a role the
+-- schema already supports and that the Contacts page already creates.
+-- This migration adds the job -> insurance contact link as a nullable
+-- foreign key, mirroring the homeowner link (jobs.contact_id) rather
+-- than a junction table: one insurer per job.
+--
+-- insurance_contact_id is nullable and references contacts(id)
+-- ON DELETE SET NULL: deleting the linked contact reverts the job to
+-- having no linked insurer rather than blocking the contact delete.
+-- The job keeps its free-text insurance_company name snapshot
+-- regardless, so the link can always be re-established.
+--
+-- No backfill: insurance_contact_id starts NULL for every existing job.
+-- The existing free-text jobs.insurance_company column is untouched and
+-- continues to serve every current reader (Jarvis context, CSV export,
+-- report builder, report PDF, job card). Once a company is picked, that
+-- column is written as a denormalized name snapshot of the contact.
+
+ALTER TABLE public.jobs
+  ADD COLUMN IF NOT EXISTS insurance_contact_id uuid
+    REFERENCES public.contacts(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_jobs_insurance_contact_id
+  ON public.jobs (insurance_contact_id);
+
+-- ROLLBACK ---
+-- DROP INDEX IF EXISTS public.idx_jobs_insurance_contact_id;
+-- ALTER TABLE public.jobs DROP COLUMN IF EXISTS insurance_contact_id;


### PR DESCRIPTION
Closes #193.

## What this does

Slice 1 of PRD #47 — the insurance-company picker on the job-detail screen, in its **select-existing-only** form. Insurance companies are `contacts` with `role = 'insurance'`; this slice adds the job → insurance link and a shared search-as-you-type picker used inside the job-detail "Edit Insurance" dialog.

## Changes

- **`supabase/migration-193-jobs-insurance-contact-id.sql`** — nullable `jobs.insurance_contact_id` uuid FK → `contacts(id)` `ON DELETE SET NULL`, plus index. **Already applied to AAA prod** (`migration_193_jobs_insurance_contact_id`) — merging just lands the source-of-truth file.
- **`src/components/insurance-company-picker.tsx`** (new) — shared picker over `role = 'insurance'` contacts; pure `value`/`onChange` interface; select-existing-only (the "+ New" affordance is slice 2); cross-org isolation via RLS on `contacts`, like the existing adjuster search.
- **`src/components/insurance-company-picker.test.tsx`** (new) — 6 component tests, built test-first as 6 red→green cycles.
- **`src/lib/types.ts`** — `Job` gains `insurance_contact_id` + joined `insurance_contact`.
- **`src/components/job-detail.tsx`** — `fetchData` joins the insurance contact; the Edit Insurance dialog uses the picker; save writes the FK + `insurance_company` name snapshot **only when the picker is touched** (legacy free-text names survive untouched, surfaced via a "Currently: … not linked" note); the read-only card shows the claims email as a `mailto:` link.

## Testing

- Full suite: **837 tests pass** (128 files, +6).
- `tsc` clean apart from a pre-existing unrelated error (`sync-folder-incremental.test.ts`).
- ESLint: 0 new problems.

All 9 acceptance criteria on #193 are met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)