### PR TITLE
Inline create-new-insurance-company in the picker (#194)

### DIFF
--- a/src/components/insurance-company-picker.test.tsx
+++ b/src/components/insurance-company-picker.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import type { Contact } from "@/lib/types";
 
@@ -9,17 +9,36 @@ let contactsResult: { data: unknown; error: unknown } = {
   data: [],
   error: null,
 };
+// The inline-create flow inserts a contact and reads the new row back.
+// `insertResult` seeds that row; `lastInsert` captures the payload sent.
+let insertResult: { data: unknown; error: unknown } = {
+  data: null,
+  error: null,
+};
+let lastInsert: Record<string, unknown> | null = null;
+
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: () => Promise.resolve("org-test"),
+}));
 
 vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
     // The contacts search is a chainable query whose builder methods
     // return the builder; awaiting it resolves to the seeded result.
+    // `.insert(payload).select().single()` is a separate chain that
+    // records the payload and resolves to the seeded inserted row.
     from: () => {
       const builder: Record<string, unknown> = {};
       for (const method of ["select", "eq", "or", "limit"]) {
         builder[method] = () => builder;
       }
       builder.then = (resolve: (r: unknown) => void) => resolve(contactsResult);
+      builder.insert = (payload: Record<string, unknown>) => {
+        lastInsert = payload;
+        return {
+          select: () => ({ single: () => Promise.resolve(insertResult) }),
+        };
+      };
       return builder;
     },
   }),
@@ -45,6 +64,8 @@ function makeContact(overrides: Partial<Contact> = {}): Contact {
 
 beforeEach(() => {
   contactsResult = { data: [], error: null };
+  insertResult = { data: null, error: null };
+  lastInsert = null;
 });
 
 describe("InsuranceCompanyPicker — search (#193)", () => {
@@ -154,5 +175,141 @@ describe("InsuranceCompanyPicker — clearing (#193)", () => {
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange.mock.calls[0][0]).toBeNull();
+  });
+});
+
+describe("InsuranceCompanyPicker — create affordance (#194)", () => {
+  it("offers '+ New insurance company' when no existing company matches the typed name", async () => {
+    contactsResult = { data: [], error: null };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "Geico" },
+    });
+
+    expect(
+      await screen.findByRole("button", { name: /new insurance company/i }),
+    ).toBeDefined();
+  });
+
+  it("withholds '+ New' when a company with that exact name already exists", async () => {
+    contactsResult = {
+      data: [makeContact({ id: "c-1", full_name: "State Farm" })],
+      error: null,
+    };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "state farm" },
+    });
+
+    // Wait for the search to settle on the exact match...
+    await screen.findByRole("button", { name: /^State Farm/i });
+    // ...then the create affordance must be gone.
+    expect(
+      screen.queryByRole("button", { name: /new insurance company/i }),
+    ).toBeNull();
+  });
+});
+
+describe("InsuranceCompanyPicker — inline create form (#194)", () => {
+  it("inline-expands a prefilled name + claims-email form, never a modal", async () => {
+    contactsResult = { data: [], error: null };
+
+    render(<InsuranceCompanyPicker value={null} onChange={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "Geico" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new insurance company/i }),
+    );
+
+    // Company-name field is prefilled with the typed text.
+    const nameField = screen.getByLabelText(
+      /company name/i,
+    ) as HTMLInputElement;
+    expect(nameField.value).toBe("Geico");
+    // An optional claims-email field is present.
+    expect(screen.getByLabelText(/claims email/i)).toBeDefined();
+    // The form is inline — it never opens a modal dialog.
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("creates a role='insurance' contact and auto-selects it on submit", async () => {
+    contactsResult = { data: [], error: null };
+    const created = makeContact({
+      id: "c-new",
+      full_name: "Geico",
+      email: "claims@geico.com",
+    });
+    insertResult = { data: created, error: null };
+    const onChange = vi.fn();
+
+    render(<InsuranceCompanyPicker value={null} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "Geico" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new insurance company/i }),
+    );
+    fireEvent.change(screen.getByLabelText(/claims email/i), {
+      target: { value: "claims@geico.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create company/i }));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onChange.mock.calls[0][0]).toEqual(created);
+    expect(lastInsert).toMatchObject({
+      full_name: "Geico",
+      email: "claims@geico.com",
+      role: "insurance",
+      organization_id: "org-test",
+    });
+  });
+
+  it("rejects a malformed claims email with a message and does not insert", async () => {
+    contactsResult = { data: [], error: null };
+    const onChange = vi.fn();
+
+    render(<InsuranceCompanyPicker value={null} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "Geico" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new insurance company/i }),
+    );
+    fireEvent.change(screen.getByLabelText(/claims email/i), {
+      target: { value: "not-an-email" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /create company/i }));
+
+    expect(await screen.findByText(/valid claims email/i)).toBeDefined();
+    expect(lastInsert).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("creates the company with no email when the claims email is left blank", async () => {
+    contactsResult = { data: [], error: null };
+    const created = makeContact({ id: "c-new", full_name: "Geico", email: null });
+    insertResult = { data: created, error: null };
+    const onChange = vi.fn();
+
+    render(<InsuranceCompanyPicker value={null} onChange={onChange} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search insurance/i), {
+      target: { value: "Geico" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new insurance company/i }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /create company/i }));
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(lastInsert).toMatchObject({ full_name: "Geico", email: null });
   });
 });

--- a/src/components/insurance-company-picker.tsx
+++ b/src/components/insurance-company-picker.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { X } from "lucide-react";
+import { Plus, X } from "lucide-react";
 
 import { createClient } from "@/lib/supabase";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { escapeOrFilterValue } from "@/lib/postgrest";
+import { isValidClaimsEmail, shouldOfferCreate } from "@/lib/insurance-picker";
 import { Input } from "@/components/ui/input";
 import type { Contact } from "@/lib/types";
 
@@ -18,10 +20,12 @@ interface InsuranceCompanyPickerProps {
 /**
  * Search-as-you-type picker for an insurance company — a contact with
  * role = 'insurance'. Used inside the job-detail Edit Insurance dialog
- * (PRD #47, slice 1). Select-existing-only: there is no "+ New" create
- * affordance yet (that is slice 2). Cross-organization isolation is
- * delegated to row-level security on `contacts`, exactly as the adjuster
- * search is — the query never names an organization.
+ * (PRD #47). When the typed name matches no existing insurance company,
+ * the picker offers a deliberate "+ New insurance company" action that
+ * inline-expands — never a modal — a two-field create form (PRD #47,
+ * slice 2 / issue #194). Cross-organization isolation is delegated to
+ * row-level security on `contacts`, exactly as the adjuster search is —
+ * the search query never names an organization.
  */
 export default function InsuranceCompanyPicker({
   value,
@@ -30,6 +34,14 @@ export default function InsuranceCompanyPicker({
   const [search, setSearch] = useState("");
   const [results, setResults] = useState<Contact[]>([]);
   const [searching, setSearching] = useState(false);
+  // The inline-create form: `creating` expands it in place of the
+  // search box — deliberately not a modal, since the picker can itself
+  // already live inside the job-detail Edit Insurance dialog.
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newEmail, setNewEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
 
   useEffect(() => {
     // Every setState runs inside the debounce callback, never
@@ -57,6 +69,42 @@ export default function InsuranceCompanyPicker({
     return () => clearTimeout(timer);
   }, [search]);
 
+  // Inserts the typed company as a contact (role = 'insurance') in the
+  // active organization and auto-selects it. The new company is an
+  // ordinary contact — it shows up in the Contacts tab afterwards.
+  async function handleCreate() {
+    const name = newName.trim();
+    if (!name) {
+      setFormError("Enter a company name.");
+      return;
+    }
+    if (!isValidClaimsEmail(newEmail)) {
+      setFormError("Enter a valid claims email, or leave it blank.");
+      return;
+    }
+    setSubmitting(true);
+    setFormError(null);
+    const supabase = createClient();
+    const organizationId = await getActiveOrganizationId(supabase);
+    const { data, error } = await supabase
+      .from("contacts")
+      .insert({
+        full_name: name,
+        email: newEmail.trim() || null,
+        role: "insurance",
+        organization_id: organizationId,
+      })
+      .select()
+      .single();
+    setSubmitting(false);
+    if (error || !data) {
+      setFormError("Could not create the insurance company. Please try again.");
+      return;
+    }
+    setCreating(false);
+    onChange(data as Contact);
+  }
+
   // Selected state: the job already has a linked insurance company.
   // Clearing it returns to the search state so a different company can
   // be picked, which is how "change the company" is reached.
@@ -79,6 +127,60 @@ export default function InsuranceCompanyPicker({
         >
           <X size={14} />
         </button>
+      </div>
+    );
+  }
+
+  if (creating) {
+    return (
+      <div className="space-y-3 rounded-lg border border-border bg-background/50 p-3">
+        <div>
+          <label
+            htmlFor="new-insurance-name"
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
+            Company name
+          </label>
+          <Input
+            id="new-insurance-name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="new-insurance-email"
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
+            Claims email (optional)
+          </label>
+          <Input
+            id="new-insurance-email"
+            type="email"
+            value={newEmail}
+            onChange={(e) => setNewEmail(e.target.value)}
+          />
+        </div>
+        {formError && (
+          <p className="text-sm text-destructive">{formError}</p>
+        )}
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleCreate}
+            disabled={submitting}
+            className="rounded-lg bg-primary px-3 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? "Creating…" : "Create company"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setCreating(false)}
+            className="rounded-lg border border-border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
       </div>
     );
   }
@@ -114,6 +216,25 @@ export default function InsuranceCompanyPicker({
           ))}
         </div>
       )}
+      {!searching &&
+        shouldOfferCreate(
+          search,
+          results.map((c) => c.full_name),
+        ) && (
+          <button
+            type="button"
+            onClick={() => {
+              setNewName(search.trim());
+              setNewEmail("");
+              setFormError(null);
+              setCreating(true);
+            }}
+            className="flex w-full items-center gap-2 rounded-lg border border-dashed border-border p-3 text-sm font-medium text-muted-foreground hover:bg-accent/50 hover:text-foreground transition-colors"
+          >
+            <Plus size={14} />
+            New insurance company
+          </button>
+        )}
     </div>
   );
 }

--- a/src/lib/insurance-picker.test.ts
+++ b/src/lib/insurance-picker.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidClaimsEmail, shouldOfferCreate } from "./insurance-picker";
+
+describe("shouldOfferCreate", () => {
+  it("is false for an empty query — there is nothing to create", () => {
+    expect(shouldOfferCreate("", ["State Farm"])).toBe(false);
+  });
+
+  it("is false for a query whose name already exists, regardless of case", () => {
+    expect(shouldOfferCreate("state farm", ["State Farm"])).toBe(false);
+    expect(shouldOfferCreate("  STATE FARM  ", ["State Farm"])).toBe(false);
+  });
+
+  it("is true for a near-but-not-exact match — a new company is plausible", () => {
+    expect(shouldOfferCreate("State", ["State Farm"])).toBe(true);
+  });
+
+  it("is true when no existing insurance company matches the query", () => {
+    expect(shouldOfferCreate("Geico", ["State Farm", "Allstate"])).toBe(true);
+  });
+});
+
+describe("isValidClaimsEmail", () => {
+  it("is true for a well-formed email address", () => {
+    expect(isValidClaimsEmail("claims@statefarm.com")).toBe(true);
+  });
+
+  it("is false for a malformed address", () => {
+    expect(isValidClaimsEmail("not-an-email")).toBe(false);
+    expect(isValidClaimsEmail("claims@statefarm")).toBe(false);
+    expect(isValidClaimsEmail("claims @statefarm.com")).toBe(false);
+  });
+
+  it("is true for an empty string — the claims email is optional", () => {
+    expect(isValidClaimsEmail("")).toBe(true);
+    expect(isValidClaimsEmail("   ")).toBe(true);
+  });
+});

--- a/src/lib/insurance-picker.ts
+++ b/src/lib/insurance-picker.ts
@@ -1,0 +1,43 @@
+// Pure logic behind the insurance-company picker (PRD #47, issue #194).
+//
+// Two I/O-free helpers, unit-tested in isolation exactly as the masked
+// date field is (src/lib/date-field.ts): a create-affordance guard that
+// decides whether the picker offers "+ New insurance company", and a
+// claims-email validator. No Supabase, no React — just decisions.
+
+/**
+ * Whether the picker should offer the "+ New insurance company" action.
+ *
+ * True only when the user has typed a non-empty query AND no existing
+ * insurance company matches it by exact, case-insensitive name. A
+ * near-but-not-exact match (the typed text is a substring of a company's
+ * name) still offers "+ New" — the user may genuinely want a new company.
+ * An exact match withholds it, so loose duplicates are never created.
+ *
+ * @param query         the raw text typed into the picker's search box
+ * @param existingNames names of the insurance companies currently on file
+ */
+export function shouldOfferCreate(
+  query: string,
+  existingNames: string[],
+): boolean {
+  const trimmed = query.trim();
+  if (!trimmed) return false;
+  const target = trimmed.toLowerCase();
+  return !existingNames.some((name) => name.trim().toLowerCase() === target);
+}
+
+// A pragmatic single-line email shape: a local part, an "@", and a
+// dotted domain, none containing whitespace or a second "@".
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Whether a claims email is acceptable to save. The claims email is
+ * optional, so an empty (or whitespace-only) string is valid — it means
+ * "no claims email on file". A non-empty string must be well-formed.
+ */
+export function isValidClaimsEmail(email: string): boolean {
+  const trimmed = email.trim();
+  if (!trimmed) return true;
+  return EMAIL_PATTERN.test(trimmed);
+}


### PR DESCRIPTION
## What

Slice 2 of PRD #47 (insurance-company picker). Adds the deliberate **"+ New insurance company"** inline-create affordance to the picker, plus the pure-logic module behind it.

When the typed name matches no existing insurance company, the picker offers "+ New insurance company". Choosing it **inline-expands — never a modal** — a two-field form (company name prefilled, optional claims email). Submitting creates a `contacts` row with `role = 'insurance'` in the active organization and immediately selects it. The new company is an ordinary contact — it appears in the Contacts tab and is editable there.

## Changes

- **`src/lib/insurance-picker.ts`** (new — Module M2, pure I/O-free logic):
  - `shouldOfferCreate(query, existingNames)` — create-affordance guard: true only when the trimmed query is non-empty and no existing company matches it by exact, case-insensitive name.
  - `isValidClaimsEmail(email)` — claims-email validator: empty is valid (optional), otherwise a well-formed address.
- **`src/components/insurance-company-picker.tsx`** — "+ New" affordance gated by `shouldOfferCreate`; inline non-modal create form; insert via `.insert(...).select().single()` then auto-select through the existing `onChange`; malformed email rejected inline.

No migration — #193's `jobs.insurance_contact_id` FK and the picker's job-detail wiring already cover the integration, so the affordance reaches the Edit Insurance dialog with no `job-detail.tsx` change.

## Tests

Built via `/tdd` — 13 red→green cycles. 7 unit tests for the pure module (guard across empty / exact / near / no-match; validator across valid / malformed / empty), 6 new component tests for the inline-create flow.

- Full suite **850 pass** (129 files, +13)
- `tsc` clean apart from the pre-existing, unrelated `sync-folder-incremental.test.ts` error
- ESLint **0 problems** on all four #194 files

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)