### PR TITLE
feat: insurance-company picker on the intake form (#195)

### DIFF
--- a/src/components/intake-form.test.tsx
+++ b/src/components/intake-form.test.tsx
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+
+import type { Contact, FormConfig } from "@/lib/types";
+
+// ─── Mutable mock state, seeded per test (mirrors insurance-company-picker.test.tsx) ───
+
+// The form config served by GET /api/settings/intake-form.
+let formConfigFixture: FormConfig = { sections: [] };
+// The role='insurance' rows the embedded picker's search resolves to.
+let contactsSearchResult: { data: unknown; error: unknown } = {
+  data: [],
+  error: null,
+};
+// Insert payloads captured per table, plus the row each insert reads back.
+let inserts: Record<string, Record<string, unknown>[]> = {};
+let insertResults: Record<string, { data: unknown; error: unknown }> = {};
+const routerPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+vi.mock("@/lib/config-context", () => ({
+  useConfig: () => ({ damageTypes: [] }),
+}));
+
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: () => Promise.resolve("org-test"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    from: (table: string) => {
+      const builder: Record<string, unknown> = {};
+      for (const method of ["select", "eq", "or", "limit", "order"]) {
+        builder[method] = () => builder;
+      }
+      // Awaiting the builder resolves the embedded picker's contacts search.
+      builder.then = (resolve: (r: unknown) => void) =>
+        resolve(contactsSearchResult);
+      // `.insert(payload)` records the payload and supports both a
+      // `.select().single()` read-back (contacts, jobs) and a bare await
+      // (job_custom_fields, job_activities).
+      builder.insert = (payload: Record<string, unknown>) => {
+        (inserts[table] ??= []).push(payload);
+        const result = insertResults[table] ?? {
+          data: { id: `${table}-id` },
+          error: null,
+        };
+        return {
+          select: () => ({ single: () => Promise.resolve(result) }),
+          then: (resolve: (r: unknown) => void) => resolve({ error: null }),
+        };
+      };
+      return builder;
+    },
+  }),
+}));
+
+import IntakeForm from "./intake-form";
+
+// ─── Fixtures ───
+
+function makeContact(overrides: Partial<Contact> = {}): Contact {
+  return {
+    id: "c-1",
+    full_name: "State Farm",
+    phone: null,
+    email: "claims@statefarm.com",
+    role: "insurance",
+    company: null,
+    title: null,
+    notes: null,
+    created_at: "2026-05-21T00:00:00Z",
+    updated_at: "2026-05-21T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// A form config carrying the four fields the intake submit path cares
+// about: the three fields the submit hard-requires plus the insurance
+// field mapped to job.insurance_company. Each field has a unique
+// placeholder so the test can target its plain input directly.
+function makeConfig(opts: { insuranceRequired?: boolean } = {}): FormConfig {
+  return {
+    sections: [
+      {
+        id: "s1",
+        title: "Job",
+        fields: [
+          {
+            id: "f-name",
+            type: "text",
+            label: "Full Name",
+            placeholder: "name-input",
+            maps_to: "contact.full_name",
+          },
+          {
+            id: "f-damage",
+            type: "text",
+            label: "Damage Type",
+            placeholder: "damage-input",
+            maps_to: "job.damage_type",
+          },
+          {
+            id: "f-addr",
+            type: "text",
+            label: "Property Address",
+            placeholder: "address-input",
+            maps_to: "job.property_address",
+          },
+          {
+            id: "f-ins",
+            type: "text",
+            label: "Insurance Company",
+            placeholder: "ins-input",
+            maps_to: "job.insurance_company",
+            required: opts.insuranceRequired,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  formConfigFixture = makeConfig();
+  contactsSearchResult = { data: [], error: null };
+  inserts = {};
+  insertResults = {
+    contacts: { data: { id: "contact-1" }, error: null },
+    jobs: { data: { id: "job-1", job_number: "J-100" }, error: null },
+  };
+  global.fetch = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ config: formConfigFixture }),
+    }),
+  ) as unknown as typeof fetch;
+});
+
+describe("IntakeForm — insurance-company picker swap (#195)", () => {
+  it("renders the insurance-company picker for the job.insurance_company field instead of a plain input", async () => {
+    render(<IntakeForm />);
+
+    // The picker's search box stands in for the configured plain input.
+    expect(
+      await screen.findByPlaceholderText(/search insurance companies/i),
+    ).toBeDefined();
+    // The configured plain text input is not rendered for that field.
+    expect(screen.queryByPlaceholderText("ins-input")).toBeNull();
+  });
+});
+
+describe("IntakeForm — linking the picked company to the job (#195)", () => {
+  it("writes insurance_contact_id and the company-name snapshot onto the submitted job", async () => {
+    contactsSearchResult = {
+      data: [makeContact({ id: "c-1", full_name: "State Farm" })],
+      error: null,
+    };
+
+    render(<IntakeForm />);
+
+    // Fill the three fields the intake submit path hard-requires.
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    // Pick an insurance company through the embedded picker.
+    fireEvent.change(
+      screen.getByPlaceholderText(/search insurance companies/i),
+      { target: { value: "State" } },
+    );
+    fireEvent.click(await screen.findByRole("button", { name: /State Farm/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    expect(inserts.jobs[0]).toMatchObject({
+      insurance_contact_id: "c-1",
+      insurance_company: "State Farm",
+    });
+  });
+});
+
+describe("IntakeForm — insurance company is optional (#195)", () => {
+  it("submits the job with null insurance fields when no company is picked", async () => {
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    // The picker is left untouched — no insurance company is chosen.
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    expect(inserts.jobs[0]).toMatchObject({
+      insurance_contact_id: null,
+      insurance_company: null,
+    });
+  });
+});
+
+describe("IntakeForm — required insurance field (#195)", () => {
+  it("blocks submit when the config marks the insurance field required and none is picked", async () => {
+    formConfigFixture = makeConfig({ insuranceRequired: true });
+
+    render(<IntakeForm />);
+
+    // Every field the submit would otherwise complain about is filled —
+    // only the now-required insurance field is left empty.
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    // Submit is rejected for the insurance field — no job is written.
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringMatching(/insurance company/i),
+      ),
+    );
+    expect(inserts.jobs).toBeUndefined();
+  });
+});
+
+describe("IntakeForm — typed search text is never persisted (#195)", () => {
+  it("does not persist picker search text as a loose insurance_company value", async () => {
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    // Type a company name into the picker but never select or create it.
+    fireEvent.change(
+      screen.getByPlaceholderText(/search insurance companies/i),
+      { target: { value: "Some Unlisted Insurer" } },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    // The unbacked text is not carried onto the job in any form.
+    expect(inserts.jobs[0]).toMatchObject({
+      insurance_contact_id: null,
+      insurance_company: null,
+    });
+  });
+});

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -14,7 +14,8 @@ import { useConfig } from "@/lib/config-context";
 import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "@/lib/phone";
 import { isValidPastDate } from "@/lib/date-field";
 import { DateField } from "@/components/date-field";
-import type { FormConfig, FormField } from "@/lib/types";
+import InsuranceCompanyPicker from "@/components/insurance-company-picker";
+import type { Contact, FormConfig, FormField } from "@/lib/types";
 
 export default function IntakeForm({ testMode = false }: { testMode?: boolean } = {}) {
   const router = useRouter();
@@ -23,6 +24,12 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
   const [loadingConfig, setLoadingConfig] = useState(true);
   const [formConfig, setFormConfig] = useState<FormConfig | null>(null);
   const [values, setValues] = useState<Record<string, string>>({});
+  // The field mapped to job.insurance_company is chosen with the
+  // InsuranceCompanyPicker rather than typed. This holds the picked
+  // contact so the submit can write its id; the company-name snapshot
+  // is mirrored into `values` so the existing required-field check and
+  // the insurance_company write keep working unchanged (#195).
+  const [insuranceContact, setInsuranceContact] = useState<Contact | null>(null);
 
   // Load form config
   useEffect(() => {
@@ -47,6 +54,14 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
 
   function setValue(fieldId: string, value: string) {
     setValues((prev) => ({ ...prev, [fieldId]: value }));
+  }
+
+  // The insurance picker yields a contact (or null) rather than text.
+  // Mirror its name into `values` as the company-name snapshot so the
+  // required check and insurance_company write see it like any field.
+  function setInsurance(fieldId: string, contact: Contact | null) {
+    setInsuranceContact(contact);
+    setValue(fieldId, contact?.full_name ?? "");
   }
 
   function getVal(id: string): string {
@@ -175,6 +190,7 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
           affected_areas: valueByMapsTo("job.affected_areas") || null,
           urgency: valueByMapsTo("job.urgency") || "scheduled",
           insurance_company: valueByMapsTo("job.insurance_company") || null,
+          insurance_contact_id: insuranceContact?.id ?? null,
           claim_number: valueByMapsTo("job.claim_number") || null,
           access_notes: valueByMapsTo("job.access_notes") || null,
         })
@@ -281,6 +297,8 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
                     value={getVal(field.id)}
                     onChange={(v) => setValue(field.id, v)}
                     damageTypes={damageTypes}
+                    insuranceContact={insuranceContact}
+                    onInsuranceChange={(c) => setInsurance(field.id, c)}
                   />
                 ))}
             </div>
@@ -315,11 +333,15 @@ function DynamicField({
   value,
   onChange,
   damageTypes,
+  insuranceContact,
+  onInsuranceChange,
 }: {
   field: FormField;
   value: string;
   onChange: (v: string) => void;
   damageTypes: { name: string; display_label: string; bg_color: string; text_color: string }[];
+  insuranceContact: Contact | null;
+  onInsuranceChange: (c: Contact | null) => void;
 }) {
   // Get options — from damage_types config or field.options
   let options = field.options || [];
@@ -330,6 +352,12 @@ function DynamicField({
       color: `bg-[${dt.bg_color}] text-[${dt.text_color}] border-[${dt.text_color}]/20`,
     }));
   }
+
+  // Quiet-swap: the field mapped to job.insurance_company renders the
+  // shared InsuranceCompanyPicker (search + inline create) in place of
+  // its configured plain input — same idea as the damage_types option
+  // source above, no new field type, no form-config change (#195).
+  const isInsuranceCompany = field.maps_to === "job.insurance_company";
 
   return (
     <div>
@@ -344,7 +372,15 @@ function DynamicField({
         <p className="text-xs text-muted-foreground/70 mb-1.5">{field.help_text}</p>
       )}
 
-      {(field.type === "text" || field.type === "phone" || field.type === "email") && (
+      {isInsuranceCompany && (
+        <InsuranceCompanyPicker
+          value={insuranceContact}
+          onChange={onInsuranceChange}
+        />
+      )}
+
+      {!isInsuranceCompany &&
+        (field.type === "text" || field.type === "phone" || field.type === "email") && (
         <Input
           type={field.type === "phone" ? "tel" : field.type === "email" ? "email" : "text"}
           value={value}


### PR DESCRIPTION
## What

PRD #47 slice 3 — bring the completed insurance-company picker to the intake form.

The config-driven intake form now **quiet-swaps** the field mapped to `job.insurance_company`: wherever the dynamic field renderer would draw that field's configured plain input, it renders the shared `InsuranceCompanyPicker` (search + inline create, from slices #193/#194) instead. This mirrors the existing `damage_types` option-source special-case in the same renderer — **no new field type, no form-builder change, no form-config migration.**

`IntakeForm` holds the picked `Contact` in new `insuranceContact` state; on submit the new job is written with both `insurance_contact_id` (FK) and `insurance_company` (company-name snapshot). The picked name is mirrored into the flat `values` map so the existing required-field check and the `insurance_company` write keep working unchanged.

## Acceptance criteria

- [x] The field mapped to `job.insurance_company` renders the insurance-company picker instead of a plain text input.
- [x] Selecting/creating a company links it to the new job — submitted job has `insurance_contact_id` set and `insurance_company` populated with the name snapshot.
- [x] No new field type, no form-builder change, no form-config migration.
- [x] The field stays optional unless the form config marks it required; a job with no insurance company still submits.
- [x] Typed text that is not selected or created as a contact is not persisted as a loose value on the job (the picker is contact-backed).
- [x] The intake picker behaves the same as the job-detail picker (same shared component — search, select, inline create).

## Tests

Built TDD (red→green per behavior). New `src/components/intake-form.test.tsx` — 5 tests, one per acceptance criterion:

1. Picker search box renders for the `job.insurance_company` field; configured plain input does not.
2. Selecting a company → submitted `jobs` row carries `insurance_contact_id` + `insurance_company` snapshot.
3. No company picked → job still submits with both insurance fields `null`.
4. Config marks the field required → submit blocked, no job written.
5. Search text typed but nothing selected → job's `insurance_company` stays `null`.

Full suite green: **855 tests across 130 files.** The picker's own search/select/create internals stay covered by its existing 11-test suite (`insurance-company-picker.test.tsx`).

Note: `tsc --noEmit` reports one **pre-existing** error in `src/lib/email/sync-folder-incremental.test.ts` (a vitest-4 `Mock` typing issue, unrelated to this branch — present on `main`). The two files changed here are type-clean and lint-clean.

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)