### PR TITLE
feat: PDF support for Jarvis Chat attachments (#199)

### DIFF
--- a/src/app/api/jarvis/attachments/route.test.ts
+++ b/src/app/api/jarvis/attachments/route.test.ts
@@ -12,6 +12,20 @@ vi.mock("@/lib/supabase-api", () => ({
   createServiceClient: vi.fn(),
 }));
 
+// The Anthropic SDK is the integration boundary for the PDF path (#199):
+// a PDF is uploaded to the Files API and the route records the file_id.
+const anthropicFilesUpload = vi
+  .fn()
+  .mockResolvedValue({ id: "file_test123", type: "file" });
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: vi.fn(function MockAnthropic() {
+    return { beta: { files: { upload: anthropicFilesUpload } } };
+  }),
+  toFile: vi.fn(async (_bytes: unknown, filename: string) => ({
+    name: filename,
+  })),
+}));
+
 import { POST, GET } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
@@ -45,6 +59,13 @@ async function pngFile(name = "photo.png"): Promise<File> {
   return new File([new Uint8Array(bytes)], name, { type: "image/png" });
 }
 
+function pdfFile(name = "contract.pdf"): File {
+  // A minimal PDF byte sequence — the route stores bytes verbatim and does
+  // not parse them, so a valid header is enough.
+  const bytes = new TextEncoder().encode("%PDF-1.4\n%minimal\n");
+  return new File([bytes], name, { type: "application/pdf" });
+}
+
 describe("POST /api/jarvis/attachments (#198)", () => {
   let service: SupabaseFake;
 
@@ -73,8 +94,8 @@ describe("POST /api/jarvis/attachments (#198)", () => {
     const form = new FormData();
     form.append(
       "file",
-      new File([new Uint8Array([1, 2, 3])], "notes.pdf", {
-        type: "application/pdf",
+      new File([new Uint8Array([1, 2, 3])], "notes.docx", {
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       }),
     );
     form.append("conversation_id", "conv-1");
@@ -82,7 +103,7 @@ describe("POST /api/jarvis/attachments (#198)", () => {
     const res = await POST(postRequest(form), routeCtx);
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/image/i);
+    expect(body.error).toMatch(/image|pdf/i);
     // Nothing should have been written to the bucket.
     expect(service.state.storageUploads).toHaveLength(0);
   });
@@ -124,6 +145,47 @@ describe("POST /api/jarvis/attachments (#198)", () => {
     expect(service.state.storageUploads[0].path).toBe(
       body.attachment.storage_path,
     );
+  });
+
+  it("stores a valid PDF and records the Anthropic file_id (#199)", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    const form = new FormData();
+    form.append("file", pdfFile());
+    form.append("conversation_id", "conv-pdf");
+
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.attachment.kind).toBe("pdf");
+    expect(body.attachment.media_type).toBe("application/pdf");
+    // The PDF is uploaded to the Anthropic Files API and its file_id is
+    // recorded on the reference so a replayed PDF is not re-encoded.
+    expect(body.attachment.file_id).toBe("file_test123");
+    expect(body.attachment.storage_path).toMatch(
+      /^org-1\/conv-pdf\/.+\.pdf$/,
+    );
+
+    expect(service.state.storageUploads).toHaveLength(1);
+    expect(service.state.storageUploads[0].bucket).toBe("jarvis-attachments");
+  });
+
+  it("rejects the attachment when the Anthropic Files API upload fails (#199)", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin" }) as never,
+    );
+    anthropicFilesUpload.mockRejectedValueOnce(new Error("Files API down"));
+
+    const form = new FormData();
+    form.append("file", pdfFile());
+    form.append("conversation_id", "conv-pdf");
+
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
   });
 });
 

--- a/src/app/api/jarvis/attachments/route.ts
+++ b/src/app/api/jarvis/attachments/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import {
   validateAttachment,
@@ -9,13 +10,16 @@ import {
   JARVIS_ATTACHMENTS_BUCKET,
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
+import { uploadPdfToAnthropic } from "@/lib/jarvis/attachments/anthropic-files";
 import type { JarvisAttachment } from "@/lib/types";
 
-// Issue #198 — Jarvis Chat attachments.
+// Issue #198, #199 — Jarvis Chat attachments.
 //
-// POST: accepts a single image, validates type/size, resizes large images,
-// stores it in the private `jarvis-attachments` bucket, and returns an
-// attachment reference for the client to attach to its message.
+// POST: accepts a single image or PDF, validates type/size, resizes large
+// images, stores the bytes in the private `jarvis-attachments` bucket, and
+// returns an attachment reference for the client to attach to its message.
+// A PDF is additionally uploaded to the Anthropic Files API so it can be
+// referenced by file_id on every replay (#199).
 //
 // GET: returns a short-lived signed URL for rendering a stored attachment.
 //
@@ -61,35 +65,67 @@ export const POST = withRequestContext(
       return NextResponse.json({ error: validation.error }, { status: 400 });
     }
 
-    let stored: { storagePath: string };
-    let mediaType = validation.mediaType;
+    let attachment: JarvisAttachment;
     try {
       const original = Buffer.from(await file.arrayBuffer());
-      const resized = await resizeImage(original, validation.mediaType);
-      mediaType = resized.mediaType;
-      stored = await uploadAttachment(ctx.serviceClient as StorageClient, {
-        orgId: ctx.orgId,
-        conversationId,
-        mediaType: resized.mediaType,
-        bytes: resized.bytes,
-      });
+
+      if (validation.kind === "pdf") {
+        // PDFs are not resized. Store the bytes, then upload to the
+        // Anthropic Files API — a failed Files upload throws, so the catch
+        // below rejects the whole attachment (a PDF with no file_id can
+        // never reach Claude).
+        const stored = await uploadAttachment(
+          ctx.serviceClient as StorageClient,
+          {
+            orgId: ctx.orgId,
+            conversationId,
+            mediaType: validation.mediaType,
+            bytes: original,
+          },
+        );
+        const anthropic = new Anthropic({
+          apiKey: process.env.ANTHROPIC_API_KEY,
+        });
+        const fileId = await uploadPdfToAnthropic(anthropic, {
+          bytes: original,
+          filename: file.name || "document.pdf",
+        });
+        attachment = {
+          kind: "pdf",
+          storage_path: stored.storagePath,
+          media_type: validation.mediaType,
+          filename: file.name || undefined,
+          file_id: fileId,
+        };
+      } else {
+        const resized = await resizeImage(original, validation.mediaType);
+        const stored = await uploadAttachment(
+          ctx.serviceClient as StorageClient,
+          {
+            orgId: ctx.orgId,
+            conversationId,
+            mediaType: resized.mediaType,
+            bytes: resized.bytes,
+          },
+        );
+        attachment = {
+          kind: "image",
+          storage_path: stored.storagePath,
+          media_type: resized.mediaType,
+          filename: file.name || undefined,
+        };
+      }
     } catch (err) {
       console.error("Jarvis attachment upload failed:", err);
       return NextResponse.json(
         {
           error:
-            "Couldn't process that image — try again, or pick a different file.",
+            "Couldn't process that file — try again, or pick a different one.",
         },
         { status: 500 },
       );
     }
 
-    const attachment: JarvisAttachment = {
-      kind: "image",
-      storage_path: stored.storagePath,
-      media_type: mediaType,
-      filename: file.name || undefined,
-    };
     return NextResponse.json({ attachment });
   },
 );

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -11,6 +11,7 @@ import {
   loadAttachmentBase64,
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
+import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
 import type { JarvisAttachment, JarvisMessage } from "@/lib/types";
 
 export const maxDuration = 120;
@@ -329,9 +330,11 @@ export const POST = withRequestContext(
         incomingUserMessage,
       ].slice(-MAX_CONVERSATION_MESSAGES);
 
-      const claudeMessages: Anthropic.MessageParam[] = await buildClaudeMessages(
-        windowMessages,
-        async (att) => {
+      // Beta message params — a PDF document block uses a `file` source,
+      // which is a Files-API beta feature, so the Jarvis call below runs
+      // on `anthropic.beta.messages.create` (#199).
+      const claudeMessages: Anthropic.Beta.BetaMessageParam[] =
+        await buildClaudeMessages(windowMessages, async (att) => {
           // Defense-in-depth: an attachment path always begins with its
           // owning org id. Refuse to load bytes from outside the caller's
           // Organization even if a crafted reference reaches the window —
@@ -354,12 +357,13 @@ export const POST = withRequestContext(
         apiKey: process.env.ANTHROPIC_API_KEY,
       });
 
-      let response = await anthropic.messages.create({
+      let response = await anthropic.beta.messages.create({
         model: "claude-sonnet-4-20250514",
         max_tokens: 1024,
         system: systemPrompt,
         messages: claudeMessages,
         tools: jarvisToolDefinitions,
+        betas: [ANTHROPIC_FILES_BETA],
       });
 
       // Tool use loop
@@ -369,11 +373,12 @@ export const POST = withRequestContext(
 
         // Extract tool use blocks
         const toolUseBlocks = response.content.filter(
-          (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+          (block): block is Anthropic.Beta.BetaToolUseBlock =>
+            block.type === "tool_use"
         );
 
         // Execute each tool
-        const toolResults: Anthropic.ToolResultBlockParam[] = [];
+        const toolResults: Anthropic.Beta.BetaToolResultBlockParam[] = [];
         for (const toolUse of toolUseBlocks) {
           if (toolUse.name === "consult_rnd") {
             routedTo = "rnd";
@@ -403,18 +408,20 @@ export const POST = withRequestContext(
         claudeMessages.push({ role: "assistant", content: response.content });
         claudeMessages.push({ role: "user", content: toolResults });
 
-        response = await anthropic.messages.create({
+        response = await anthropic.beta.messages.create({
           model: "claude-sonnet-4-20250514",
           max_tokens: 1024,
           system: systemPrompt,
           messages: claudeMessages,
           tools: jarvisToolDefinitions,
+          betas: [ANTHROPIC_FILES_BETA],
         });
       }
 
       // Extract final text response
       const textBlocks = response.content.filter(
-        (block): block is Anthropic.TextBlock => block.type === "text"
+        (block): block is Anthropic.Beta.BetaTextBlock =>
+          block.type === "text"
       );
       assistantContent =
         textBlocks.map((b) => b.text).join("\n") ||

--- a/src/components/jarvis/JarvisInput.tsx
+++ b/src/components/jarvis/JarvisInput.tsx
@@ -7,8 +7,11 @@ import {
   useEffect,
   type KeyboardEvent,
 } from "react";
-import { ArrowUp, Paperclip, X, Loader2 } from "lucide-react";
+import { ArrowUp, Paperclip, X, Loader2, FileText } from "lucide-react";
 import type { JarvisAttachment } from "@/lib/types";
+
+// Accepted attachment types — images and PDF (#198, #199).
+const ACCEPTED_ATTACHMENT_TYPES = "image/*,application/pdf";
 
 interface JarvisInputProps {
   onSend: (message: string, attachment?: JarvisAttachment) => void;
@@ -32,6 +35,8 @@ export default function JarvisInput({
   const [value, setValue] = useState("");
   const [attachment, setAttachment] = useState<JarvisAttachment | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  // A picked PDF has no image preview — it shows as a labelled chip (#199).
+  const [pdfName, setPdfName] = useState<string | null>(null);
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -102,21 +107,31 @@ export default function JarvisInput({
     e.target.value = "";
     if (!file) return;
 
-    if (!file.type.startsWith("image/")) {
+    const isImage = file.type.startsWith("image/");
+    const isPdf = file.type === "application/pdf";
+    if (!isImage && !isPdf) {
       setUploadError(
-        "That isn't an image — attach a JPEG, PNG, GIF, or WebP.",
+        "That isn't a supported file — attach an image (JPEG, PNG, GIF, WebP) or a PDF.",
       );
       return;
     }
 
     if (previewUrl) URL.revokeObjectURL(previewUrl);
-    setPreviewUrl(URL.createObjectURL(file));
+    if (isPdf) {
+      // A PDF gets a labelled chip, not an image thumbnail.
+      setPreviewUrl(null);
+      setPdfName(file.name || "PDF document");
+    } else {
+      setPdfName(null);
+      setPreviewUrl(URL.createObjectURL(file));
+    }
     runUpload(file);
   }
 
   function clearAttachment() {
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     setPreviewUrl(null);
+    setPdfName(null);
     setAttachment(null);
     setUploadError(null);
     setUploading(false);
@@ -152,7 +167,7 @@ export default function JarvisInput({
   return (
     <div className="px-4 pb-4 pt-2">
       {/* Attachment preview / upload state */}
-      {(previewUrl || uploadError) && (
+      {(previewUrl || pdfName || uploadError) && (
         <div className="mb-2 flex items-center gap-2">
           {previewUrl && (
             <div className="relative">
@@ -166,6 +181,33 @@ export default function JarvisInput({
                 <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-black/40">
                   <Loader2 size={18} className="animate-spin text-white" />
                 </div>
+              )}
+              {!uploading && (
+                <button
+                  type="button"
+                  onClick={clearAttachment}
+                  aria-label="Remove attachment"
+                  className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-foreground text-background shadow"
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </div>
+          )}
+          {pdfName && (
+            <div className="relative flex items-center gap-2 rounded-lg border border-border bg-muted py-2 pl-3 pr-8">
+              <FileText
+                size={16}
+                className="flex-shrink-0 text-muted-foreground"
+              />
+              <span className="max-w-[160px] truncate text-xs text-foreground">
+                {pdfName}
+              </span>
+              {uploading && (
+                <Loader2
+                  size={14}
+                  className="animate-spin text-muted-foreground"
+                />
               )}
               {!uploading && (
                 <button
@@ -205,7 +247,7 @@ export default function JarvisInput({
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/*"
+              accept={ACCEPTED_ATTACHMENT_TYPES}
               onChange={handleFilePicked}
               className="hidden"
             />
@@ -213,7 +255,7 @@ export default function JarvisInput({
               type="button"
               onClick={() => fileInputRef.current?.click()}
               disabled={disabled || uploading}
-              aria-label="Attach image"
+              aria-label="Attach image or PDF"
               className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 text-muted-foreground transition-all hover:bg-muted disabled:opacity-30 disabled:cursor-not-allowed"
             >
               <Paperclip size={16} />

--- a/src/components/jarvis/JarvisMessage.tsx
+++ b/src/components/jarvis/JarvisMessage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import { FileText } from "lucide-react";
 import type {
   JarvisAttachment,
   JarvisMessage as JarvisMessageType,
@@ -62,6 +63,53 @@ function JarvisAttachmentImage({
   );
 }
 
+// Renders a PDF attachment inside a message bubble as a labelled chip
+// (#199). A short-lived signed URL is fetched on mount so the chip opens
+// the PDF in a new tab; if the fetch fails the chip is still shown, just
+// not linked.
+function JarvisAttachmentPdf({
+  attachment,
+}: {
+  attachment: JarvisAttachment;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/jarvis/attachments?path=${encodeURIComponent(attachment.storage_path)}`,
+        );
+        const data = await res.json();
+        if (!cancelled && res.ok && data.url) setUrl(data.url);
+      } catch {
+        // Leave the chip unlinked — the filename is still informative.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.storage_path]);
+
+  const label = attachment.filename || "PDF document";
+  const chip = (
+    <div className="flex items-center gap-2 rounded-xl bg-white/10 px-3 py-2">
+      <FileText size={16} className="flex-shrink-0 text-white/80" />
+      <span className="max-w-[200px] truncate text-xs text-white">
+        {label}
+      </span>
+    </div>
+  );
+
+  if (!url) return chip;
+  return (
+    <a href={url} target="_blank" rel="noopener noreferrer">
+      {chip}
+    </a>
+  );
+}
+
 function formatRelativeTime(timestamp: string): string {
   const now = Date.now();
   const then = new Date(timestamp).getTime();
@@ -108,6 +156,9 @@ export default function JarvisMessage({ message }: { message: JarvisMessageType 
             <div className="space-y-2">
               {message.attachment?.kind === "image" && (
                 <JarvisAttachmentImage attachment={message.attachment} />
+              )}
+              {message.attachment?.kind === "pdf" && (
+                <JarvisAttachmentPdf attachment={message.attachment} />
               )}
               {message.content && (
                 <p className="text-sm whitespace-pre-wrap">

--- a/src/lib/jarvis/attachments/anthropic-files.ts
+++ b/src/lib/jarvis/attachments/anthropic-files.ts
@@ -1,0 +1,29 @@
+// Anthropic Files API integration for Jarvis Chat attachments (#199).
+//
+// A PDF is uploaded to the Anthropic Files API once, on attach. The
+// returned file_id is stored inline on the attachment reference and
+// reused as a document `file` source on every replay — so a PDF is
+// encoded and uploaded exactly once, never re-sent byte-for-byte.
+
+import Anthropic, { toFile } from "@anthropic-ai/sdk";
+
+// Beta required for the Anthropic Files API: file uploads, and `file`
+// document sources on the Messages API. Both the attachments route (which
+// uploads) and the Jarvis chat route (which references file_ids) send it.
+export const ANTHROPIC_FILES_BETA = "files-api-2025-04-14";
+
+// Upload a PDF's bytes to the Anthropic Files API and return its file_id.
+// Throws if the upload fails — the caller treats that as a failed attach.
+export async function uploadPdfToAnthropic(
+  anthropic: Anthropic,
+  pdf: { bytes: Buffer | Uint8Array; filename: string },
+): Promise<string> {
+  const uploadable = await toFile(pdf.bytes, pdf.filename, {
+    type: "application/pdf",
+  });
+  const result = await anthropic.beta.files.upload({
+    file: uploadable,
+    betas: [ANTHROPIC_FILES_BETA],
+  });
+  return result.id;
+}

--- a/src/lib/jarvis/attachments/content-blocks.test.ts
+++ b/src/lib/jarvis/attachments/content-blocks.test.ts
@@ -66,6 +66,40 @@ describe("buildClaudeMessages", () => {
     ]);
   });
 
+  it("maps a user message with a PDF attachment to a document + text block (#199)", async () => {
+    const history: JarvisMessage[] = [
+      msg({
+        role: "user",
+        content: "What does this contract say?",
+        attachment: {
+          kind: "pdf",
+          storage_path: "org-1/conv-9/contract.pdf",
+          media_type: "application/pdf",
+          file_id: "file_abc123",
+        },
+      }),
+    ];
+
+    // A PDF carries its Anthropic Files API file_id on the reference, so the
+    // resolver — which fetches image bytes — is never called for it.
+    const result = await buildClaudeMessages(history, async () => {
+      throw new Error("resolver should not be called for a PDF");
+    });
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: { type: "file", file_id: "file_abc123" },
+          },
+          { type: "text", text: "What does this contract say?" },
+        ],
+      },
+    ]);
+  });
+
   it("omits the text block when an attachment message has no text", async () => {
     const history: JarvisMessage[] = [
       msg({
@@ -169,5 +203,95 @@ describe("buildClaudeMessages", () => {
     expect(typeof result[0].content).toBe("string");
     expect(result[0].content).toMatch(/What's wrong here\?/);
     expect(result[0].content).toMatch(/image|attachment/i);
+  });
+
+  it("omits the text block for a PDF attachment with no caption (#199)", async () => {
+    const history: JarvisMessage[] = [
+      msg({
+        role: "user",
+        content: "",
+        attachment: {
+          kind: "pdf",
+          storage_path: "org-1/conv-9/report.pdf",
+          media_type: "application/pdf",
+          file_id: "file_nocaption",
+        },
+      }),
+    ];
+
+    const result = await buildClaudeMessages(history, async () => {
+      throw new Error("resolver should not be called for a PDF");
+    });
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "document",
+            source: { type: "file", file_id: "file_nocaption" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("replays a PDF by its file_id on a later turn (#199)", async () => {
+    // The PDF was attached on an earlier turn; a follow-up turn carries
+    // only text. On replay the PDF is re-sent as a document block that
+    // reuses the stored file_id — it is never re-encoded.
+    const history: JarvisMessage[] = [
+      msg({
+        role: "user",
+        content: "review this contract",
+        attachment: {
+          kind: "pdf",
+          storage_path: "org-1/conv-9/contract.pdf",
+          media_type: "application/pdf",
+          file_id: "file_replay",
+        },
+      }),
+      msg({ role: "assistant", content: "It looks standard." }),
+      msg({ role: "user", content: "any liability risks?" }),
+    ];
+
+    const result = await buildClaudeMessages(history, async () => {
+      throw new Error("resolver should not be called for a PDF");
+    });
+
+    const documentFileIds: string[] = [];
+    for (const message of result) {
+      if (!Array.isArray(message.content)) continue;
+      for (const block of message.content) {
+        if (block.type === "document" && block.source.type === "file") {
+          documentFileIds.push(block.source.file_id);
+        }
+      }
+    }
+    expect(documentFileIds).toEqual(["file_replay"]);
+  });
+
+  it("degrades a PDF with no file_id to a text note (#199)", async () => {
+    // A failed Files API upload leaves a PDF reference with no file_id.
+    const history: JarvisMessage[] = [
+      msg({
+        role: "user",
+        content: "what does this say?",
+        attachment: {
+          kind: "pdf",
+          storage_path: "org-1/conv-9/broken.pdf",
+          media_type: "application/pdf",
+        },
+      }),
+    ];
+
+    const result = await buildClaudeMessages(history, async () => {
+      throw new Error("resolver should not be called for a PDF");
+    });
+
+    expect(result).toHaveLength(1);
+    expect(typeof result[0].content).toBe("string");
+    expect(result[0].content).toMatch(/what does this say\?/);
+    expect(result[0].content).toMatch(/pdf|document/i);
   });
 });

--- a/src/lib/jarvis/attachments/content-blocks.ts
+++ b/src/lib/jarvis/attachments/content-blocks.ts
@@ -1,9 +1,16 @@
-// Claude content-block assembly for Jarvis Chat attachments (#198).
+// Claude content-block assembly for Jarvis Chat attachments (#198, #199).
 //
 // Turns the JarvisMessage history into the Anthropic message-params
 // array: text stays text, an attached image becomes a base64 image
-// content block. A reference-to-source resolver is injected so this is
-// testable without touching storage.
+// content block, and an attached PDF becomes a document block that
+// references its Anthropic Files API file_id. A reference-to-source
+// resolver is injected for images so this is testable without touching
+// storage; a PDF needs no resolver because its file_id rides inline on
+// the reference (so a replayed PDF is never re-encoded).
+//
+// The result is typed against the beta message params: a document block
+// with a `file` source is a beta-only feature, so the Jarvis routes call
+// `anthropic.beta.messages.create` with the files-api beta.
 
 import type Anthropic from "@anthropic-ai/sdk";
 import type { JarvisAttachment, JarvisMessage } from "@/lib/types";
@@ -13,7 +20,8 @@ export interface ResolvedImage {
   mediaType: string;
 }
 
-// Resolves a stored attachment reference to the base64 bytes Claude needs.
+// Resolves a stored image attachment reference to the base64 bytes Claude
+// needs. Only images are resolved — a PDF carries its file_id inline.
 export type AttachmentResolver = (
   attachment: JarvisAttachment,
 ) => Promise<ResolvedImage>;
@@ -21,43 +29,72 @@ export type AttachmentResolver = (
 export async function buildClaudeMessages(
   history: JarvisMessage[],
   resolveImage: AttachmentResolver,
-): Promise<Anthropic.MessageParam[]> {
+): Promise<Anthropic.Beta.BetaMessageParam[]> {
   return Promise.all(
     history.map(async (message) => {
-      if (!message.attachment) {
+      const attachment = message.attachment;
+      if (!attachment) {
         return { role: message.role, content: message.content };
       }
 
-      let resolved: ResolvedImage;
+      let attachmentBlock: Anthropic.Beta.BetaContentBlockParam;
       try {
-        resolved = await resolveImage(message.attachment);
+        attachmentBlock =
+          attachment.kind === "pdf"
+            ? documentBlock(attachment)
+            : imageBlock(await resolveImage(attachment));
       } catch {
-        // The image is gone or unreadable — degrade to text so Jarvis can
-        // still respond and tell the user the attachment is unavailable.
-        const note = "[An image was attached here but could not be loaded.]";
-        const text = message.content.trim()
-          ? `${message.content}\n\n${note}`
-          : note;
-        return { role: message.role, content: text };
+        // The image or PDF is gone or unreadable — degrade to text so
+        // Jarvis can still respond and tell the user it is unavailable.
+        return {
+          role: message.role,
+          content: degradedText(message.content, attachment.kind),
+        };
       }
 
-      const content: Anthropic.ContentBlockParam[] = [
-        {
-          type: "image",
-          source: {
-            type: "base64",
-            media_type:
-              resolved.mediaType as Anthropic.Base64ImageSource["media_type"],
-            data: resolved.base64,
-          },
-        },
-      ];
+      const content: Anthropic.Beta.BetaContentBlockParam[] = [attachmentBlock];
       // An empty text block is rejected by the API — a message may carry
-      // just an image with no caption.
+      // just an attachment with no caption.
       if (message.content.trim().length > 0) {
         content.push({ type: "text", text: message.content });
       }
       return { role: message.role, content };
     }),
   );
+}
+
+function imageBlock(resolved: ResolvedImage): Anthropic.Beta.BetaImageBlockParam {
+  return {
+    type: "image",
+    source: {
+      type: "base64",
+      media_type:
+        resolved.mediaType as Anthropic.Beta.BetaBase64ImageSource["media_type"],
+      data: resolved.base64,
+    },
+  };
+}
+
+// A PDF is referenced by its Anthropic Files API file_id, so a replayed
+// PDF is never re-encoded turn after turn. A reference with no file_id (a
+// failed upload) throws, degrading the message to text.
+function documentBlock(
+  attachment: JarvisAttachment,
+): Anthropic.Beta.BetaRequestDocumentBlock {
+  if (!attachment.file_id) {
+    throw new Error("PDF attachment has no file_id");
+  }
+  return {
+    type: "document",
+    source: { type: "file", file_id: attachment.file_id },
+  };
+}
+
+function degradedText(
+  content: string,
+  kind: JarvisAttachment["kind"],
+): string {
+  const noun = kind === "pdf" ? "A PDF" : "An image";
+  const note = `[${noun} was attached here but could not be loaded.]`;
+  return content.trim() ? `${content}\n\n${note}` : note;
 }

--- a/src/lib/jarvis/attachments/normalize.test.ts
+++ b/src/lib/jarvis/attachments/normalize.test.ts
@@ -4,29 +4,66 @@ import {
   validateAttachment,
   resizeImage,
   MAX_ATTACHMENT_BYTES,
+  MAX_PDF_BYTES,
   MAX_IMAGE_EDGE_PX,
 } from "./normalize";
 
 // Issue #198 — a user attaches one image to a Jarvis Core message. The
 // normalization module is the gate: it decides what counts as an
 // attachable image before anything reaches storage or Claude.
+//
+// Issue #199 extends the gate to PDFs (up to 32 MB, no resize).
 
 describe("validateAttachment", () => {
   it("accepts a supported image type", () => {
     const result = validateAttachment({ type: "image/jpeg", size: 1024 });
     expect(result.ok).toBe(true);
+    if (result.ok) expect(result.kind).toBe("image");
   });
 
   it("rejects an unsupported type with a clear error", () => {
     const result = validateAttachment({
-      type: "application/pdf",
+      type: "text/plain",
       size: 1024,
     });
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.error).toMatch(/pdf/i);
-      expect(result.error).toMatch(/image/i);
+      expect(result.error).toMatch(/text\/plain/i);
+      expect(result.error).toMatch(/image|pdf/i);
     }
+  });
+
+  it("accepts a PDF", () => {
+    const result = validateAttachment({
+      type: "application/pdf",
+      size: 1024,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.kind).toBe("pdf");
+      expect(result.mediaType).toBe("application/pdf");
+    }
+  });
+
+  it("rejects a PDF over the 32MB limit", () => {
+    const result = validateAttachment({
+      type: "application/pdf",
+      size: MAX_PDF_BYTES + 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/large|size|limit/i);
+      expect(result.error).toMatch(/pdf/i);
+    }
+  });
+
+  it("accepts a PDF at exactly the 32MB limit", () => {
+    const result = validateAttachment({
+      type: "application/pdf",
+      size: MAX_PDF_BYTES,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.kind).toBe("pdf");
   });
 
   it("rejects a file over the size limit", () => {

--- a/src/lib/jarvis/attachments/normalize.ts
+++ b/src/lib/jarvis/attachments/normalize.ts
@@ -1,8 +1,9 @@
-// Attachment normalization for Jarvis Chat attachments (#198).
+// Attachment normalization for Jarvis Chat attachments (#198, #199).
 //
 // The gate between a user-picked file and the rest of the pipeline:
-// it validates the file is an attachable image and resizes large
-// images so they sit within Claude's vision sweet spot.
+// it validates the file is an attachable image or PDF and resizes large
+// images so they sit within Claude's vision sweet spot. PDFs are passed
+// through unresized (#199).
 
 import sharp from "sharp";
 
@@ -15,10 +16,16 @@ export const SUPPORTED_IMAGE_TYPES = [
 
 export type SupportedImageType = (typeof SUPPORTED_IMAGE_TYPES)[number];
 
-// Upload ceiling. Resizing brings the long edge down to MAX_IMAGE_EDGE_PX,
-// so anything that clears this cap ends up comfortably inside Claude's
-// per-image limit by the time it is sent.
+export const PDF_MEDIA_TYPE = "application/pdf";
+
+// Image upload ceiling. Resizing brings the long edge down to
+// MAX_IMAGE_EDGE_PX, so anything that clears this cap ends up comfortably
+// inside Claude's per-image limit by the time it is sent.
 export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10 MB
+
+// PDF upload ceiling — Claude's document limit (#199). PDFs are not
+// resized, so this cap is the only size gate they get.
+export const MAX_PDF_BYTES = 32 * 1024 * 1024; // 32 MB
 
 // Claude's vision models read an image at full detail up to ~1568px on the
 // long edge; past that the image is downsampled anyway. Resizing here keeps
@@ -26,30 +33,45 @@ export const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024; // 10 MB
 export const MAX_IMAGE_EDGE_PX = 1568;
 
 export type ValidationResult =
-  | { ok: true; mediaType: SupportedImageType }
+  | { ok: true; kind: "image"; mediaType: SupportedImageType }
+  | { ok: true; kind: "pdf"; mediaType: typeof PDF_MEDIA_TYPE }
   | { ok: false; error: string };
 
 export function validateAttachment(file: {
   type: string;
   size: number;
 }): ValidationResult {
-  if (
-    !(SUPPORTED_IMAGE_TYPES as readonly string[]).includes(file.type)
-  ) {
-    const label = file.type || "that file";
+  if ((SUPPORTED_IMAGE_TYPES as readonly string[]).includes(file.type)) {
+    if (file.size > MAX_ATTACHMENT_BYTES) {
+      const mb = Math.round(MAX_ATTACHMENT_BYTES / (1024 * 1024));
+      return {
+        ok: false,
+        error: `That image is too large — keep images under ${mb} MB.`,
+      };
+    }
     return {
-      ok: false,
-      error: `${label} isn't a supported image — attach a JPEG, PNG, GIF, or WebP.`,
+      ok: true,
+      kind: "image",
+      mediaType: file.type as SupportedImageType,
     };
   }
-  if (file.size > MAX_ATTACHMENT_BYTES) {
-    const mb = Math.round(MAX_ATTACHMENT_BYTES / (1024 * 1024));
-    return {
-      ok: false,
-      error: `That image is too large — keep attachments under ${mb} MB.`,
-    };
+
+  if (file.type === PDF_MEDIA_TYPE) {
+    if (file.size > MAX_PDF_BYTES) {
+      const mb = Math.round(MAX_PDF_BYTES / (1024 * 1024));
+      return {
+        ok: false,
+        error: `That PDF is too large — keep PDFs under ${mb} MB.`,
+      };
+    }
+    return { ok: true, kind: "pdf", mediaType: PDF_MEDIA_TYPE };
   }
-  return { ok: true, mediaType: file.type as SupportedImageType };
+
+  const label = file.type || "that file";
+  return {
+    ok: false,
+    error: `${label} isn't a supported attachment — attach a JPEG, PNG, GIF, or WebP image, or a PDF.`,
+  };
 }
 
 // Resize an image so its long edge is at most MAX_IMAGE_EDGE_PX. Smaller

--- a/src/lib/jarvis/attachments/storage.test.ts
+++ b/src/lib/jarvis/attachments/storage.test.ts
@@ -67,6 +67,10 @@ describe("extensionForMediaType", () => {
     expect(extensionForMediaType("image/gif")).toBe("gif");
     expect(extensionForMediaType("image/webp")).toBe("webp");
   });
+
+  it("maps application/pdf to the pdf extension (#199)", () => {
+    expect(extensionForMediaType("application/pdf")).toBe("pdf");
+  });
 });
 
 describe("deleteConversationAttachments", () => {

--- a/src/lib/jarvis/attachments/storage.ts
+++ b/src/lib/jarvis/attachments/storage.ts
@@ -1,4 +1,4 @@
-// Attachment storage for Jarvis Chat attachments (#198).
+// Attachment storage for Jarvis Chat attachments (#198, #199).
 //
 // Owns the `jarvis-attachments` bucket: the object path shape, plus
 // upload / load / conversation-prefix delete. Keeping the path shape in
@@ -6,6 +6,9 @@
 // `{organization_id}/{conversation_id}/` with a single prefix sweep.
 
 import type { SupportedImageType } from "./normalize";
+
+// Media types the bucket stores — images (#198) plus PDF (#199).
+export type AttachmentMediaType = SupportedImageType | "application/pdf";
 
 export const JARVIS_ATTACHMENTS_BUCKET = "jarvis-attachments";
 
@@ -58,6 +61,7 @@ const EXTENSION_BY_MEDIA_TYPE: Record<string, string> = {
   "image/png": "png",
   "image/gif": "gif",
   "image/webp": "webp",
+  "application/pdf": "pdf",
 };
 
 // File extension for an attachment's media type — used to name the stored
@@ -66,14 +70,15 @@ export function extensionForMediaType(mediaType: string): string {
   return EXTENSION_BY_MEDIA_TYPE[mediaType] ?? "bin";
 }
 
-// Upload one normalized image into the bucket under the conversation's
-// prefix. Returns the object path to store inline on the message.
+// Upload one normalized image or PDF into the bucket under the
+// conversation's prefix. Returns the object path to store inline on the
+// message.
 export async function uploadAttachment(
   supabase: StorageClient,
   params: {
     orgId: string;
     conversationId: string;
-    mediaType: SupportedImageType;
+    mediaType: AttachmentMediaType;
     bytes: Buffer | Uint8Array;
   },
 ): Promise<{ storagePath: string }> {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -369,14 +369,18 @@ export interface JobCustomField {
 
 // Jarvis
 
-// An image attached to a Jarvis message (#198). Stored inline in the
-// conversation's `messages` JSONB — there is no `jarvis_attachments` table.
-// `storage_path` points into the private `jarvis-attachments` bucket.
+// An image or PDF attached to a Jarvis message (#198, #199). Stored inline
+// in the conversation's `messages` JSONB — there is no `jarvis_attachments`
+// table. `storage_path` points into the private `jarvis-attachments` bucket.
 export interface JarvisAttachment {
-  kind: "image";
+  kind: "image" | "pdf";
   storage_path: string;
   media_type: string;
   filename?: string;
+  // Anthropic Files API id — set for PDFs (#199). A PDF is uploaded to the
+  // Files API once on attach and referenced by `file_id` on every replay,
+  // so it is never re-encoded turn after turn.
+  file_id?: string;
 }
 
 export interface JarvisMessage {


### PR DESCRIPTION
## What this does

Implements [#199](https://github.com/ericdaniels22/Nookleus/issues/199) — **PDF support** for Jarvis Chat attachments, the next slice of parent PRD [#153](https://github.com/ericdaniels22/Nookleus/issues/153). Built test-first via `/tdd` in an isolated worktree, on top of the #198 image spine.

A user in Jarvis Core can attach a **PDF (up to 32 MB)** from the chat box. The PDF is validated, stored in the `jarvis-attachments` bucket, and uploaded **once** to the Anthropic Files API — referenced by `file_id` on every replay so it is never re-encoded. It renders as a labelled chip (not a thumbnail) in the input and in the user's message bubble.

## Acceptance criteria

- [x] `POST /api/jarvis/attachments` accepts PDFs; PDFs over 32 MB are rejected with a clear message.
- [x] An attached PDF is uploaded to the Anthropic Files API and its `file_id` is recorded on the reference.
- [x] The content-block assembly module emits a document block for PDFs (`file` source) so Jarvis Core can answer questions about an attached PDF.
- [x] A replayed PDF on a follow-up turn reuses the stored `file_id` rather than re-encoding.
- [x] A PDF shows as a labelled chip in the input before send and in the user's message bubble after send.
- [x] Unit tests cover PDF validation (accept valid, reject oversize) and the assembly module's document-block output.

## Changes

- **`normalize.ts`** — `validateAttachment` accepts `application/pdf` up to `MAX_PDF_BYTES` (32 MB), returns a `kind` discriminant; PDFs skip the image resize.
- **`storage.ts`** — `application/pdf` → `.pdf`; `uploadAttachment` takes a broadened `AttachmentMediaType`.
- **`anthropic-files.ts`** (new) — `uploadPdfToAnthropic` uploads a PDF to the Anthropic Files API; `ANTHROPIC_FILES_BETA` shared by the attachments and chat routes.
- **`content-blocks.ts`** — a PDF becomes a document block with a `file` source; `buildClaudeMessages` now returns beta message params. Replayed PDFs reuse the stored `file_id`; a missing `file_id` degrades to a text note.
- **`attachments/route.ts`** — stores a PDF and records its `file_id`; a failed Files API upload rejects the whole attachment.
- **`chat/route.ts`** — switched to `anthropic.beta.messages.create` with the `files-api` beta so PDF document blocks are accepted.
- **UI** — `JarvisInput` accepts PDFs (labelled chip + upload state); `JarvisMessage` renders a PDF as a labelled, openable chip.

## Decisions

- **Failed Files API upload → reject the attachment** (AskUserQuestion). A PDF with no `file_id` can never reach Claude, so a half-stored PDF is never useful — the user gets an error and retries.
- **Beta Messages API** — a document `file` source is a Files-API beta feature, so the Jarvis chat route moved from `anthropic.messages.create` to `anthropic.beta.messages.create`. Required by the `file_id` acceptance criterion.

## Out of scope (separate #153 slices)

Prompt caching, multiple files per message, department routing for attachments, deleting Anthropic-side files on conversation delete (the bucket prefix is already swept; Anthropic files expire per retention).

## Verification

- Full suite **887 tests pass** (134 files); **+10 attachment tests** added test-first.
- `tsc` clean apart from the pre-existing, unrelated `sync-folder-incremental.test.ts` error.
- ESLint **0 problems** on all changed files.
- Not yet browser-verified against the live Anthropic API.

Closes #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
