### PR TITLE
feat: chat attachments follow routing to departments (#201)

### DIFF
--- a/src/app/api/jarvis/chat/route.test.ts
+++ b/src/app/api/jarvis/chat/route.test.ts
@@ -1,0 +1,253 @@
+// @vitest-environment node
+// Server route test — Node env so the JSON Request round-trips with
+// undici (jsdom ships no global Request).
+//
+// Issue #201 — when Jarvis Core routes a turn to a department, the Chat
+// `attachments` list (#200) rides on the internal department-call body.
+// These integration-style tests drive POST /api/jarvis/chat and assert
+// the attachment references reach the department `fetch`.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { createMock, betaCreateMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  betaCreateMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+    beta = { messages: { create: betaCreateMock } };
+  },
+  toFile: vi.fn(),
+}));
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  makeAuthedFake,
+  type SupabaseFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+const routeCtx = { params: Promise.resolve({}) };
+
+const IMAGE_ATTACHMENT = {
+  kind: "image" as const,
+  storage_path: "org-1/conv-1/photo.png",
+  media_type: "image/png",
+};
+
+function chatRequest(body: unknown): Request {
+  return new Request("http://test/api/jarvis/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// The internal department call the chat route makes — found by URL among
+// every fetch the route issued.
+function departmentCall(
+  fetchMock: ReturnType<typeof vi.fn>,
+  endpoint: string,
+): { url: string; body: Record<string, unknown> } | undefined {
+  const call = fetchMock.mock.calls.find(([url]) =>
+    String(url).includes(`/api/jarvis/${endpoint}`),
+  );
+  if (!call) return undefined;
+  return { url: String(call[0]), body: JSON.parse(call[1].body as string) };
+}
+
+// True when any message carries an image or document content block.
+function hasAttachmentBlock(messages: { content: unknown }[]): boolean {
+  return messages.some(
+    (m) =>
+      Array.isArray(m.content) &&
+      m.content.some((b) =>
+        ["image", "document"].includes((b as { type?: string }).type ?? ""),
+      ),
+  );
+}
+
+describe("POST /api/jarvis/chat — attachments follow routing (#201)", () => {
+  let service: SupabaseFake;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = "test-service-key";
+
+    service = makeSupabaseFake();
+    service.seed("user_profiles", [{ id: "user-1", full_name: "Eric" }]);
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      makeAuthedFake("user-1", { role: "admin", orgId: "org-1" }) as never,
+    );
+
+    // The department call is mocked — these tests assert on the body the
+    // chat route sends, not on a real department response.
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ content: "R&D analysed the photo." }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // The personality pass that re-renders the department answer.
+    createMock.mockResolvedValue({
+      content: [{ type: "text", text: "Here's what R&D found." }],
+    });
+    // The normal-Jarvis branch (not exercised on a routed turn).
+    betaCreateMock.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      stop_reason: "end_turn",
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("forwards attachments to the department on the @-prefix path", async () => {
+    const res = await POST(
+      chatRequest({
+        context_type: "general",
+        message: "@rnd what's wrong with this beam?",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.routed_to).toBe("rnd");
+
+    const rndCall = departmentCall(fetchMock, "rnd");
+    expect(rndCall).toBeDefined();
+    // The attachments list rode along on the internal department call.
+    expect(rndCall!.body.attachments).toEqual([IMAGE_ATTACHMENT]);
+    // ...with the caller's org id so the department can scope-check it.
+    expect(rndCall!.body.org_id).toBe("org-1");
+    // ...and the @rnd prefix is stripped from the forwarded question.
+    expect(rndCall!.body.question).toBe("what's wrong with this beam?");
+  });
+
+  it("forwards attachments when a department is selected via mode", async () => {
+    // `direct_department` is the UI department-mode field — a distinct
+    // trigger from the @marketing text prefix, same forwarding contract.
+    const res = await POST(
+      chatRequest({
+        context_type: "general",
+        direct_department: "marketing",
+        message: "Write a caption for this.",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).routed_to).toBe("marketing");
+
+    const marketingCall = departmentCall(fetchMock, "marketing");
+    expect(marketingCall).toBeDefined();
+    expect(marketingCall!.body.attachments).toEqual([IMAGE_ATTACHMENT]);
+    expect(marketingCall!.body.org_id).toBe("org-1");
+  });
+
+  it("forwards attachments when a restoration term auto-routes to Field Ops", async () => {
+    service.seed("jobs", [
+      {
+        id: "job-1",
+        organization_id: "org-1",
+        job_number: "1001",
+        property_address: "12 Main St",
+        status: "in_progress",
+        damage_type: "water",
+        created_at: "2026-05-01T00:00:00.000Z",
+      },
+    ]);
+
+    const res = await POST(
+      chatRequest({
+        context_type: "job",
+        job_id: "job-1",
+        // No @-prefix — "water damage" auto-routes the turn to Field Ops.
+        message: "there's water damage in the basement",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).routed_to).toBe("field-ops");
+
+    const fieldOpsCall = departmentCall(fetchMock, "field-ops");
+    expect(fieldOpsCall).toBeDefined();
+    // Auto-routing never silently drops the photo.
+    expect(fieldOpsCall!.body.attachments).toEqual([IMAGE_ATTACHMENT]);
+    expect(fieldOpsCall!.body.org_id).toBe("org-1");
+  });
+
+  it("forwards the full attachments list (plural integrity)", async () => {
+    // A user can attach up to five Chat attachments per turn (#200). All
+    // of them must reach the department — none silently dropped along
+    // the way to the internal call.
+    const attachments = [
+      IMAGE_ATTACHMENT,
+      {
+        kind: "image" as const,
+        storage_path: "org-1/conv-1/before.jpg",
+        media_type: "image/jpeg",
+      },
+      {
+        kind: "pdf" as const,
+        storage_path: "org-1/conv-1/scope.pdf",
+        media_type: "application/pdf",
+        filename: "scope.pdf",
+        file_id: "file_xyz",
+      },
+    ];
+
+    await POST(
+      chatRequest({
+        context_type: "general",
+        message: "@rnd review these",
+        attachments,
+      }),
+      routeCtx,
+    );
+
+    const rndCall = departmentCall(fetchMock, "rnd");
+    expect(rndCall).toBeDefined();
+    expect(rndCall!.body.attachments).toEqual(attachments);
+    expect(
+      (rndCall!.body.attachments as unknown[]).length,
+    ).toBe(3);
+  });
+
+  it("keeps the personality-pass relay text-only", async () => {
+    await POST(
+      chatRequest({
+        context_type: "general",
+        message: "@rnd what's wrong with this beam?",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    // The only Claude call the chat route makes on a routed turn is the
+    // personality pass — it relays the department's text answer in
+    // Jarvis's voice and must never carry the image or document itself.
+    expect(createMock).toHaveBeenCalledTimes(1);
+    expect(betaCreateMock).not.toHaveBeenCalled();
+    const personalityMessages = createMock.mock.calls[0][0].messages;
+    expect(hasAttachmentBlock(personalityMessages)).toBe(false);
+    expect(typeof personalityMessages[0].content).toBe("string");
+  });
+});

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -8,7 +8,7 @@ import {
 } from "@/lib/jarvis/tools";
 import { buildClaudeMessages } from "@/lib/jarvis/attachments/content-blocks";
 import {
-  loadAttachmentBase64,
+  orgScopedImageResolver,
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
@@ -249,6 +249,15 @@ export const POST = withRequestContext(
       if (departmentEndpoint === "field-ops" && job_id) {
         deptBody.job_id = job_id;
       }
+      // Chat attachments follow the turn to the department (#201) — the
+      // references ride on the internal call body, paired with the
+      // caller's org id so the department can scope-check each storage
+      // path before loading any bytes. Holds on every explicit-routing
+      // path: @-prefix, department mode, and the Field Ops auto-route.
+      if (attachments && attachments.length > 0) {
+        deptBody.attachments = attachments;
+        deptBody.org_id = ctx.orgId;
+      }
 
       const deptResponse = await fetch(`${baseUrl}/api/jarvis/${departmentEndpoint}`, {
         method: "POST",
@@ -332,25 +341,14 @@ export const POST = withRequestContext(
 
       // Beta message params — a PDF document block uses a `file` source,
       // which is a Files-API beta feature, so the Jarvis call below runs
-      // on `anthropic.beta.messages.create` (#199).
+      // on `anthropic.beta.messages.create` (#199). The org-scoped
+      // resolver refuses any attachment reference outside the caller's
+      // Organization (#201).
       const claudeMessages: Anthropic.Beta.BetaMessageParam[] =
-        await buildClaudeMessages(windowMessages, async (att) => {
-          // Defense-in-depth: an attachment path always begins with its
-          // owning org id. Refuse to load bytes from outside the caller's
-          // Organization even if a crafted reference reaches the window —
-          // buildClaudeMessages degrades the message to text on a throw.
-          if (!att.storage_path.startsWith(`${ctx.orgId}/`)) {
-            throw new Error("Attachment outside caller's organization");
-          }
-          return {
-            base64: await loadAttachmentBase64(
-              supabase as unknown as StorageClient,
-              att.storage_path,
-            ),
-            mediaType: att.media_type,
-          };
-        },
-      );
+        await buildClaudeMessages(
+          windowMessages,
+          orgScopedImageResolver(supabase as unknown as StorageClient, ctx.orgId),
+        );
 
       // Call Claude API
       const anthropic = new Anthropic({

--- a/src/app/api/jarvis/field-ops/route.test.ts
+++ b/src/app/api/jarvis/field-ops/route.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+// Server route test — Node env so the JSON Request round-trips with
+// undici (jsdom ships no global Request).
+//
+// Issue #201 — a Chat attachment follows the turn when Jarvis routes it
+// to Field Ops, including the restoration-term auto-route. The internal
+// department call carries the `attachments` list; the route resolves
+// them to Claude image / document blocks via the shared content-block
+// assembly module.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { betaCreateMock, createMock } = vi.hoisted(() => ({
+  betaCreateMock: vi.fn(),
+  createMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+    beta = { messages: { create: betaCreateMock } };
+  },
+  toFile: vi.fn(),
+}));
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/knowledge/embeddings", () => ({
+  embedQuery: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  type SupabaseFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+const SERVICE_KEY = "test-service-key";
+
+function internalRequest(body: unknown): NextRequest {
+  return new Request("http://test/api/jarvis/field-ops", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-service-key": SERVICE_KEY,
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+function blocksByType(
+  messages: { content: unknown }[],
+  type: string,
+): Array<Record<string, unknown>> {
+  const found: Array<Record<string, unknown>> = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if ((block as { type?: string }).type === type) {
+        found.push(block as Record<string, unknown>);
+      }
+    }
+  }
+  return found;
+}
+
+describe("POST /api/jarvis/field-ops — attachments follow routing (#201)", () => {
+  let service: SupabaseFake;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    service = makeSupabaseFake();
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+    const ok = {
+      content: [{ type: "text", text: "Category 2 water — get air movers in." }],
+      stop_reason: "end_turn",
+    };
+    betaCreateMock.mockResolvedValue(ok);
+    createMock.mockResolvedValue(ok);
+  });
+
+  it("forwards an attached image to the Field Ops agent as an image block", async () => {
+    service.seedBlob(
+      "jarvis-attachments/org-1/conv-7/damage.jpg",
+      new Uint8Array([5, 6, 7, 8]),
+    );
+
+    const res = await POST(
+      internalRequest({
+        question: "What category of water damage is this?",
+        org_id: "org-1",
+        attachments: [
+          {
+            kind: "image",
+            storage_path: "org-1/conv-7/damage.jpg",
+            media_type: "image/jpeg",
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(betaCreateMock).toHaveBeenCalled();
+
+    const sentMessages = betaCreateMock.mock.calls[0][0].messages;
+    const images = blocksByType(sentMessages, "image");
+    expect(images).toHaveLength(1);
+    expect(images[0].source).toEqual({
+      type: "base64",
+      media_type: "image/jpeg",
+      data: Buffer.from([5, 6, 7, 8]).toString("base64"),
+    });
+  });
+});

--- a/src/app/api/jarvis/field-ops/route.ts
+++ b/src/app/api/jarvis/field-ops/route.ts
@@ -4,6 +4,13 @@ import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { buildFieldOpsPrompt } from "@/lib/jarvis/prompts/field-ops";
 import { embedQuery } from "@/lib/knowledge/embeddings";
+import { buildClaudeMessages } from "@/lib/jarvis/attachments/content-blocks";
+import {
+  orgScopedImageResolver,
+  type StorageClient,
+} from "@/lib/jarvis/attachments/storage";
+import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import type { JarvisAttachment } from "@/lib/types";
 
 export const maxDuration = 60;
 
@@ -357,7 +364,17 @@ export async function POST(request: NextRequest) {
       question,
       context,
       job_id,
-    }: { question: string; context?: string; job_id?: string } = body;
+      attachments,
+      org_id,
+    }: {
+      question: string;
+      context?: string;
+      job_id?: string;
+      // Chat attachments that rode in with the routed turn (#201), plus
+      // the caller's org id so each storage path can be scope-checked.
+      attachments?: JarvisAttachment[];
+      org_id?: string;
+    } = body;
 
     if (!question) {
       return NextResponse.json(
@@ -433,19 +450,40 @@ export async function POST(request: NextRequest) {
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
 
-    const claudeMessages: Anthropic.MessageParam[] = [
-      { role: "user", content: userContent },
-    ];
+    // Build the Claude messages via the shared content-block assembly
+    // module — routed Chat attachments (#201) become image/document
+    // blocks on the user turn. Defense-in-depth: an attachment path
+    // always begins with its owning org id, so bytes outside the caller's
+    // Organization are never loaded (buildClaudeMessages degrades to text
+    // on a throw).
+    const claudeMessages: Anthropic.Beta.BetaMessageParam[] =
+      await buildClaudeMessages(
+        [
+          {
+            role: "user",
+            content: userContent,
+            timestamp: new Date().toISOString(),
+            ...(attachments && attachments.length > 0 ? { attachments } : {}),
+          },
+        ],
+        orgScopedImageResolver(
+          supabase as unknown as StorageClient,
+          org_id ?? null,
+        ),
+      );
 
-    let response: Anthropic.Messages.Message;
+    // Runs on the beta Messages API so a routed PDF document block (#199)
+    // is accepted alongside image blocks.
+    let response: Anthropic.Beta.BetaMessage;
     try {
-      response = await anthropic.messages.create(
+      response = await anthropic.beta.messages.create(
         {
           model: "claude-sonnet-4-20250514",
           max_tokens: 8192,
           system: systemPrompt,
           messages: claudeMessages,
           tools: fieldOpsToolDefinitions,
+          betas: [ANTHROPIC_FILES_BETA],
         },
         { timeout: CLAUDE_TIMEOUT_MS }
       );
@@ -468,10 +506,11 @@ export async function POST(request: NextRequest) {
       iterations++;
 
       const toolUseBlocks = response.content.filter(
-        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+        (block): block is Anthropic.Beta.BetaToolUseBlock =>
+          block.type === "tool_use"
       );
 
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      const toolResults: Anthropic.Beta.BetaToolResultBlockParam[] = [];
       for (const toolUse of toolUseBlocks) {
         const result = await executeFieldOpsTool(
           toolUse.name,
@@ -491,13 +530,14 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        response = await anthropic.messages.create(
+        response = await anthropic.beta.messages.create(
           {
             model: "claude-sonnet-4-20250514",
             max_tokens: 8192,
             system: systemPrompt,
             messages: claudeMessages,
             tools: fieldOpsToolDefinitions,
+            betas: [ANTHROPIC_FILES_BETA],
           },
           { timeout: CLAUDE_TIMEOUT_MS }
         );
@@ -514,7 +554,7 @@ export async function POST(request: NextRequest) {
 
     // Extract final text
     const textBlocks = response.content.filter(
-      (block): block is Anthropic.TextBlock => block.type === "text"
+      (block): block is Anthropic.Beta.BetaTextBlock => block.type === "text"
     );
     const fieldOpsResponse =
       textBlocks.map((b) => b.text).join("\n") ||

--- a/src/app/api/jarvis/marketing/route.test.ts
+++ b/src/app/api/jarvis/marketing/route.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+// Server route test — Node env so the JSON Request round-trips with
+// undici (jsdom ships no global Request).
+//
+// Issue #201 — a Chat attachment follows the turn when Jarvis routes it
+// to Marketing. The internal department call carries the `attachments`
+// list; the route resolves them to Claude image / document blocks via
+// the shared content-block assembly module.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { betaCreateMock, createMock } = vi.hoisted(() => ({
+  betaCreateMock: vi.fn(),
+  createMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+    beta = { messages: { create: betaCreateMock } };
+  },
+  toFile: vi.fn(),
+}));
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  type SupabaseFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+const SERVICE_KEY = "test-service-key";
+
+function internalRequest(body: unknown): NextRequest {
+  return new Request("http://test/api/jarvis/marketing", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-service-key": SERVICE_KEY,
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+function blocksByType(
+  messages: { content: unknown }[],
+  type: string,
+): Array<Record<string, unknown>> {
+  const found: Array<Record<string, unknown>> = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if ((block as { type?: string }).type === type) {
+        found.push(block as Record<string, unknown>);
+      }
+    }
+  }
+  return found;
+}
+
+describe("POST /api/jarvis/marketing — attachments follow routing (#201)", () => {
+  let service: SupabaseFake;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    service = makeSupabaseFake();
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+    const ok = {
+      content: [{ type: "text", text: "Strong shot — here's the caption." }],
+      stop_reason: "end_turn",
+    };
+    betaCreateMock.mockResolvedValue(ok);
+    createMock.mockResolvedValue(ok);
+  });
+
+  it("forwards an attached image to the Marketing agent as an image block", async () => {
+    service.seedBlob(
+      "jarvis-attachments/org-1/conv-3/promo.webp",
+      new Uint8Array([11, 22, 33]),
+    );
+
+    const res = await POST(
+      internalRequest({
+        question: "Write a caption for this photo.",
+        org_id: "org-1",
+        attachments: [
+          {
+            kind: "image",
+            storage_path: "org-1/conv-3/promo.webp",
+            media_type: "image/webp",
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(betaCreateMock).toHaveBeenCalled();
+
+    const sentMessages = betaCreateMock.mock.calls[0][0].messages;
+    const images = blocksByType(sentMessages, "image");
+    expect(images).toHaveLength(1);
+    expect(images[0].source).toEqual({
+      type: "base64",
+      media_type: "image/webp",
+      data: Buffer.from([11, 22, 33]).toString("base64"),
+    });
+  });
+});

--- a/src/app/api/jarvis/marketing/route.ts
+++ b/src/app/api/jarvis/marketing/route.ts
@@ -3,6 +3,13 @@ import Anthropic from "@anthropic-ai/sdk";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { MARKETING_SYSTEM_PROMPT } from "@/lib/jarvis/prompts/marketing";
+import { buildClaudeMessages } from "@/lib/jarvis/attachments/content-blocks";
+import {
+  orgScopedImageResolver,
+  type StorageClient,
+} from "@/lib/jarvis/attachments/storage";
+import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import type { JarvisAttachment } from "@/lib/types";
 
 export const maxDuration = 60;
 
@@ -219,7 +226,19 @@ async function executeMarketingTool(
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { question, context }: { question: string; context?: string } = body;
+    const {
+      question,
+      context,
+      attachments,
+      org_id,
+    }: {
+      question: string;
+      context?: string;
+      // Chat attachments that rode in with the routed turn (#201), plus
+      // the caller's org id so each storage path can be scope-checked.
+      attachments?: JarvisAttachment[];
+      org_id?: string;
+    } = body;
 
     if (!question) {
       return NextResponse.json(
@@ -257,9 +276,27 @@ export async function POST(request: NextRequest) {
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
 
-    const claudeMessages: Anthropic.MessageParam[] = [
-      { role: "user", content: userContent },
-    ];
+    // Build the Claude messages via the shared content-block assembly
+    // module — routed Chat attachments (#201) become image/document
+    // blocks on the user turn. Defense-in-depth: an attachment path
+    // always begins with its owning org id, so bytes outside the caller's
+    // Organization are never loaded (buildClaudeMessages degrades to text
+    // on a throw).
+    const claudeMessages: Anthropic.Beta.BetaMessageParam[] =
+      await buildClaudeMessages(
+        [
+          {
+            role: "user",
+            content: userContent,
+            timestamp: new Date().toISOString(),
+            ...(attachments && attachments.length > 0 ? { attachments } : {}),
+          },
+        ],
+        orgScopedImageResolver(
+          supabase as unknown as StorageClient,
+          org_id ?? null,
+        ),
+      );
 
     // Build tools array — include web_search as a native tool
     const allTools: Anthropic.Messages.Tool[] = [
@@ -270,15 +307,18 @@ export async function POST(request: NextRequest) {
       } as unknown as Anthropic.Messages.Tool,
     ];
 
-    let response: Anthropic.Messages.Message;
+    // Runs on the beta Messages API so a routed PDF document block (#199)
+    // is accepted alongside image blocks.
+    let response: Anthropic.Beta.BetaMessage;
     try {
-      response = await anthropic.messages.create(
+      response = await anthropic.beta.messages.create(
         {
           model: "claude-sonnet-4-20250514",
           max_tokens: 8192,
           system: MARKETING_SYSTEM_PROMPT,
           messages: claudeMessages,
           tools: allTools,
+          betas: [ANTHROPIC_FILES_BETA],
         },
         { timeout: CLAUDE_TIMEOUT_MS }
       );
@@ -301,10 +341,11 @@ export async function POST(request: NextRequest) {
       iterations++;
 
       const toolUseBlocks = response.content.filter(
-        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+        (block): block is Anthropic.Beta.BetaToolUseBlock =>
+          block.type === "tool_use"
       );
 
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      const toolResults: Anthropic.Beta.BetaToolResultBlockParam[] = [];
       for (const toolUse of toolUseBlocks) {
         // web_search is handled natively by Claude — skip execution
         if (toolUse.name === "web_search") continue;
@@ -327,13 +368,14 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        response = await anthropic.messages.create(
+        response = await anthropic.beta.messages.create(
           {
             model: "claude-sonnet-4-20250514",
             max_tokens: 8192,
             system: MARKETING_SYSTEM_PROMPT,
             messages: claudeMessages,
             tools: allTools,
+            betas: [ANTHROPIC_FILES_BETA],
           },
           { timeout: CLAUDE_TIMEOUT_MS }
         );
@@ -350,7 +392,7 @@ export async function POST(request: NextRequest) {
 
     // Extract final text
     const textBlocks = response.content.filter(
-      (block): block is Anthropic.TextBlock => block.type === "text"
+      (block): block is Anthropic.Beta.BetaTextBlock => block.type === "text"
     );
     const marketingResponse =
       textBlocks.map((b) => b.text).join("\n") ||

--- a/src/app/api/jarvis/rnd/route.test.ts
+++ b/src/app/api/jarvis/rnd/route.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment node
+// Server route test — Node env so the JSON Request round-trips with
+// undici (jsdom ships no global Request).
+//
+// Issue #201 — a Chat attachment follows the turn when Jarvis Core routes
+// it to a department. The internal department call carries the
+// `attachments` list (#200 — up to five images and/or PDFs, #199); the
+// department route resolves them to Claude image / document blocks via
+// the shared content-block assembly module.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+const { betaCreateMock, createMock } = vi.hoisted(() => ({
+  betaCreateMock: vi.fn(),
+  createMock: vi.fn(),
+}));
+
+vi.mock("@anthropic-ai/sdk", () => ({
+  default: class {
+    messages = { create: createMock };
+    beta = { messages: { create: betaCreateMock } };
+  },
+  toFile: vi.fn(),
+}));
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  makeSupabaseFake,
+  type SupabaseFake,
+} from "@/lib/contracts/__test-utils__/supabase-fake";
+
+const SERVICE_KEY = "test-service-key";
+
+function internalRequest(body: unknown): NextRequest {
+  return new Request("http://test/api/jarvis/rnd", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-service-key": SERVICE_KEY,
+    },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+}
+
+// Every content block of `type` found anywhere in a Claude messages array.
+function blocksByType(
+  messages: { content: unknown }[],
+  type: string,
+): Array<Record<string, unknown>> {
+  const found: Array<Record<string, unknown>> = [];
+  for (const message of messages) {
+    if (!Array.isArray(message.content)) continue;
+    for (const block of message.content) {
+      if ((block as { type?: string }).type === type) {
+        found.push(block as Record<string, unknown>);
+      }
+    }
+  }
+  return found;
+}
+
+describe("POST /api/jarvis/rnd — attachments follow routing (#201)", () => {
+  let service: SupabaseFake;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE_KEY = SERVICE_KEY;
+    service = makeSupabaseFake();
+    vi.mocked(createServiceClient).mockReturnValue(service.client as never);
+    const ok = {
+      content: [{ type: "text", text: "That's a cracked joist." }],
+      stop_reason: "end_turn",
+    };
+    // Both mocks resolve so a test failure surfaces the missing image
+    // block rather than a 500 from an undefined Anthropic response.
+    betaCreateMock.mockResolvedValue(ok);
+    createMock.mockResolvedValue(ok);
+  });
+
+  it("forwards an attached image to the R&D agent as an image block", async () => {
+    service.seedBlob(
+      "jarvis-attachments/org-1/conv-1/photo.png",
+      new Uint8Array([1, 2, 3, 4]),
+    );
+
+    const res = await POST(
+      internalRequest({
+        question: "What's wrong with this beam?",
+        org_id: "org-1",
+        attachments: [
+          {
+            kind: "image",
+            storage_path: "org-1/conv-1/photo.png",
+            media_type: "image/png",
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // Department routes run on the beta Messages API (#199) so document
+    // blocks can ride alongside image blocks.
+    expect(betaCreateMock).toHaveBeenCalled();
+
+    const sentMessages = betaCreateMock.mock.calls[0][0].messages;
+    const images = blocksByType(sentMessages, "image");
+    expect(images).toHaveLength(1);
+    expect(images[0].source).toEqual({
+      type: "base64",
+      media_type: "image/png",
+      data: Buffer.from([1, 2, 3, 4]).toString("base64"),
+    });
+  });
+
+  it("forwards an attached PDF to the R&D agent as a document block", async () => {
+    const res = await POST(
+      internalRequest({
+        question: "What does this contract say about scope?",
+        org_id: "org-1",
+        attachments: [
+          {
+            kind: "pdf",
+            storage_path: "org-1/conv-2/contract.pdf",
+            media_type: "application/pdf",
+            filename: "contract.pdf",
+            // A PDF rides by its Anthropic Files API file_id (#199) — the
+            // bytes are not re-encoded turn after turn.
+            file_id: "file_abc123",
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const sentMessages = betaCreateMock.mock.calls[0][0].messages;
+    const documents = blocksByType(sentMessages, "document");
+    expect(documents).toHaveLength(1);
+    expect(documents[0].source).toEqual({
+      type: "file",
+      file_id: "file_abc123",
+    });
+    // A PDF reference is a file_id — storage is not touched.
+    expect(service.state.storageDownloads).toHaveLength(0);
+  });
+
+  it("degrades to a text note for an image attachment outside the caller's org", async () => {
+    service.seedBlob(
+      "jarvis-attachments/org-OTHER/conv-1/secret.jpg",
+      new Uint8Array([9, 9, 9]),
+    );
+
+    const res = await POST(
+      internalRequest({
+        question: "What's in this photo?",
+        org_id: "org-1",
+        attachments: [
+          {
+            kind: "image",
+            storage_path: "org-OTHER/conv-1/secret.jpg",
+            media_type: "image/jpeg",
+          },
+        ],
+      }),
+    );
+
+    expect(res.status).toBe(200);
+
+    const sentMessages = betaCreateMock.mock.calls[0][0].messages;
+    // The cross-org reference never becomes an image block...
+    expect(blocksByType(sentMessages, "image")).toHaveLength(0);
+    // ...and the org check fires before any bytes are loaded.
+    expect(service.state.storageDownloads).toHaveLength(0);
+    // The turn still reaches R&D as a text degradation note so it can
+    // answer and explain the attachment is unavailable.
+    const texts = blocksByType(sentMessages, "text").map(
+      (b) => b.text as string,
+    );
+    expect(texts.join(" ")).toMatch(/image|attachment/i);
+  });
+});

--- a/src/app/api/jarvis/rnd/route.ts
+++ b/src/app/api/jarvis/rnd/route.ts
@@ -3,6 +3,13 @@ import Anthropic from "@anthropic-ai/sdk";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { RND_SYSTEM_PROMPT } from "@/lib/jarvis/prompts/rnd";
+import { buildClaudeMessages } from "@/lib/jarvis/attachments/content-blocks";
+import {
+  orgScopedImageResolver,
+  type StorageClient,
+} from "@/lib/jarvis/attachments/storage";
+import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import type { JarvisAttachment } from "@/lib/types";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -399,7 +406,19 @@ async function executeRndTool(
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { question, context }: { question: string; context?: string } = body;
+    const {
+      question,
+      context,
+      attachments,
+      org_id,
+    }: {
+      question: string;
+      context?: string;
+      // Chat attachments that rode in with the routed turn (#201), plus
+      // the caller's org id so each storage path can be scope-checked.
+      attachments?: JarvisAttachment[];
+      org_id?: string;
+    } = body;
 
     if (!question) {
       return NextResponse.json(
@@ -437,9 +456,27 @@ export async function POST(request: NextRequest) {
       apiKey: process.env.ANTHROPIC_API_KEY,
     });
 
-    const claudeMessages: Anthropic.MessageParam[] = [
-      { role: "user", content: userContent },
-    ];
+    // Build the Claude messages via the shared content-block assembly
+    // module — routed Chat attachments (#201) become image/document
+    // blocks on the user turn. Defense-in-depth: an attachment path
+    // always begins with its owning org id, so bytes outside the caller's
+    // Organization are never loaded (buildClaudeMessages degrades to text
+    // on a throw).
+    const claudeMessages: Anthropic.Beta.BetaMessageParam[] =
+      await buildClaudeMessages(
+        [
+          {
+            role: "user",
+            content: userContent,
+            timestamp: new Date().toISOString(),
+            ...(attachments && attachments.length > 0 ? { attachments } : {}),
+          },
+        ],
+        orgScopedImageResolver(
+          supabase as unknown as StorageClient,
+          org_id ?? null,
+        ),
+      );
 
     // Build tools array — include web_search as a native tool
     const allTools: Anthropic.Messages.Tool[] = [
@@ -450,14 +487,17 @@ export async function POST(request: NextRequest) {
       } as unknown as Anthropic.Messages.Tool,
     ];
 
-    let response: Anthropic.Messages.Message;
+    // Runs on the beta Messages API so a routed PDF document block (#199)
+    // is accepted alongside image blocks.
+    let response: Anthropic.Beta.BetaMessage;
     try {
-      response = await anthropic.messages.create({
+      response = await anthropic.beta.messages.create({
         model: "claude-opus-4-6",
         max_tokens: 16384,
         system: RND_SYSTEM_PROMPT,
         messages: claudeMessages,
         tools: allTools,
+        betas: [ANTHROPIC_FILES_BETA],
       }, { timeout: CLAUDE_TIMEOUT_MS });
     } catch (apiErr) {
       const status = (apiErr as { status?: number }).status;
@@ -475,10 +515,11 @@ export async function POST(request: NextRequest) {
       iterations++;
 
       const toolUseBlocks = response.content.filter(
-        (block): block is Anthropic.ToolUseBlock => block.type === "tool_use"
+        (block): block is Anthropic.Beta.BetaToolUseBlock =>
+          block.type === "tool_use"
       );
 
-      const toolResults: Anthropic.ToolResultBlockParam[] = [];
+      const toolResults: Anthropic.Beta.BetaToolResultBlockParam[] = [];
       for (const toolUse of toolUseBlocks) {
         // web_search is handled natively by Claude — skip execution
         if (toolUse.name === "web_search") continue;
@@ -501,12 +542,13 @@ export async function POST(request: NextRequest) {
       }
 
       try {
-        response = await anthropic.messages.create({
+        response = await anthropic.beta.messages.create({
           model: "claude-opus-4-6",
           max_tokens: 16384,
           system: RND_SYSTEM_PROMPT,
           messages: claudeMessages,
           tools: allTools,
+          betas: [ANTHROPIC_FILES_BETA],
         }, { timeout: CLAUDE_TIMEOUT_MS });
       } catch (apiErr) {
         const status = (apiErr as { status?: number }).status;
@@ -518,7 +560,7 @@ export async function POST(request: NextRequest) {
 
     // Extract final text
     const textBlocks = response.content.filter(
-      (block): block is Anthropic.TextBlock => block.type === "text"
+      (block): block is Anthropic.Beta.BetaTextBlock => block.type === "text"
     );
     const rndResponse =
       textBlocks.map((b) => b.text).join("\n") ||

--- a/src/lib/contracts/__test-utils__/supabase-fake.ts
+++ b/src/lib/contracts/__test-utils__/supabase-fake.ts
@@ -93,6 +93,17 @@ export function makeSupabaseFake(): SupabaseFake {
         );
         return { data: row ?? null, error: null };
       },
+      // `.single()` — supabase-js errors when the match is not exactly
+      // one row; the fake mirrors `.maybeSingle()` (first match or null),
+      // enough for routes that read `data?.field` off the result.
+      async single() {
+        const err = state.errors[`${table}.select`];
+        if (err) return { data: null, error: err };
+        const row = (state.rows[table] ?? []).find((r) =>
+          matchesFilters(r, filters),
+        );
+        return { data: row ?? null, error: null };
+      },
       then(
         resolve: (v: {
           data: unknown;

--- a/src/lib/jarvis/attachments/storage.ts
+++ b/src/lib/jarvis/attachments/storage.ts
@@ -6,6 +6,7 @@
 // `{organization_id}/{conversation_id}/` with a single prefix sweep.
 
 import type { SupportedImageType } from "./normalize";
+import type { AttachmentResolver } from "./content-blocks";
 
 // Media types the bucket stores — images (#198) plus PDF (#199).
 export type AttachmentMediaType = SupportedImageType | "application/pdf";
@@ -118,6 +119,30 @@ export async function loadAttachmentBase64(
   }
   const arrayBuffer = await data.arrayBuffer();
   return Buffer.from(arrayBuffer).toString("base64");
+}
+
+// An AttachmentResolver that loads image bytes from the bucket but
+// refuses any reference outside the caller's Organization — an
+// attachment path always begins with its owning org id. A cross-org or
+// org-less reference throws, so `buildClaudeMessages` degrades that
+// attachment to a text note rather than ever loading another tenant's
+// image. Shared by the chat route and the three department routes
+// (#201) so the org-scoping check lives in exactly one place. Only
+// image attachments hit the resolver — a PDF rides by its file_id and
+// never touches storage (#199).
+export function orgScopedImageResolver(
+  supabase: StorageClient,
+  orgId: string | null,
+): AttachmentResolver {
+  return async (attachment) => {
+    if (!orgId || !attachment.storage_path.startsWith(`${orgId}/`)) {
+      throw new Error("Attachment outside caller's organization");
+    }
+    return {
+      base64: await loadAttachmentBase64(supabase, attachment.storage_path),
+      mediaType: attachment.media_type,
+    };
+  };
 }
 
 // Delete every attachment under a conversation's prefix. Called when the


### PR DESCRIPTION
## What

Closes #201. A Chat attachment now travels with a turn when Jarvis Core routes it to a department agent (R&D, Marketing, Field Ops), so the department can see and reason about the attachment — not just Jarvis Core (#198, #199, #200).

## How

- The internal Jarvis-Core→department call (`POST /api/jarvis/{rnd|marketing|field-ops}`) request body gains an optional `attachments` list (#200) plus the caller's `org_id`.
- Each department route resolves the references into Claude image and document blocks via the shared `buildClaudeMessages` content-block assembly module — images and PDFs alike (#199).
- The chat route forwards the turn's `attachments` on all three explicit-routing paths: `@`-prefix (`@rnd`/`@marketing`/`@fieldops`), department mode (`direct_department`), and the Field Ops restoration-term auto-route.
- The three department routes are migrated to the beta Messages API (`anthropic.beta.messages.create` with `ANTHROPIC_FILES_BETA`), the same foundation #199 put under the chat route, so a routed PDF document block is accepted.
- The personality-pass call (department answer rendered in Jarvis's voice) stays text-only.
- **Refactor:** the org-scoped resolver — refuse any reference outside the caller's Organization — is extracted into `orgScopedImageResolver` in `storage.ts`, replacing four inline copies (the three department routes plus the chat route's #198 normal-branch resolver).

## History

This PR was opened against `main` at #198's tip, then rebuilt against current `main` after #199 and #200 merged ahead of it — the original singular-`attachment` implementation was reset and re-implemented on the new plural-`attachments[]` + PDF foundation.

## Scope

Explicit-routing paths only — the `consult_rnd`/`consult_marketing` tool-consult path is out of scope per #201's acceptance criteria.

## Acceptance criteria

- [x] Internal department-call contract accepts `attachments`
- [x] An image reaches Field Ops mode / R&D via `@rnd` / Marketing via Marketing mode
- [x] An attachment survives the Field Ops restoration-term auto-route
- [x] Each department route builds content blocks via the shared assembly module
- [x] The personality-pass relay remains text-only
- [x] An integration-style test asserts an attachment reaches the department call on the `@`-prefix path

## Testing

Built test-first (TDD, one red→green slice at a time). 10 new tests across 4 new route test files; full suite 908 pass.

- Department routes (`rnd`/`field-ops`/`marketing`): resolve an image attachment into an image block; R&D additionally pins PDF → document block and cross-org → text degradation.
- Chat route: forwards attachments on the `@`-prefix, department-mode, and Field Ops auto-route paths; pins plural-integrity (3-attachment list reaches the department intact); personality-pass relay carries no image/document block.

A `.single()` method was added to the shared `supabase-fake` test util (the chat route exercises it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
