### PR TITLE
feat: tool-consult forwards attachments to departments (#202)

### DIFF
--- a/src/app/api/jarvis/chat/route.test.ts
+++ b/src/app/api/jarvis/chat/route.test.ts
@@ -231,6 +231,88 @@ describe("POST /api/jarvis/chat — attachments follow routing (#201)", () => {
     ).toBe(3);
   });
 
+  it("forwards attachments to R&D on the tool-consult path (#202)", async () => {
+    // Jarvis Core delegates mid-answer through the `consult_rnd` tool —
+    // not an @-prefix. A tool call's input is model-generated text and
+    // cannot carry image bytes, so the turn's attachments must travel
+    // through the executor context, not the tool input.
+    betaCreateMock.mockReset();
+    betaCreateMock.mockResolvedValueOnce({
+      stop_reason: "tool_use",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_1",
+          name: "consult_rnd",
+          input: { question: "what's wrong with this beam?" },
+        },
+      ],
+    });
+    betaCreateMock.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "Here's what R&D found." }],
+    });
+
+    const res = await POST(
+      chatRequest({
+        context_type: "general",
+        // No @-prefix — Jarvis Core decides to consult R&D itself.
+        message: "what's wrong with this beam?",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(200);
+
+    const rndCall = departmentCall(fetchMock, "rnd");
+    expect(rndCall).toBeDefined();
+    // The attachment reference rode the tool-consult call to the
+    // department — the model-generated tool input never carried it.
+    expect(rndCall!.body.attachments).toEqual([IMAGE_ATTACHMENT]);
+    // ...paired with the caller's org id so the department can scope-
+    // check the storage path before loading any bytes (#201 contract).
+    expect(rndCall!.body.org_id).toBe("org-1");
+  });
+
+  it("forwards attachments to Marketing on the tool-consult path (#202)", async () => {
+    // Same contract as `consult_rnd` but routed through the
+    // `consult_marketing` tool, which uses a `query` input field. The
+    // attachment still travels via the executor context, not the input.
+    betaCreateMock.mockReset();
+    betaCreateMock.mockResolvedValueOnce({
+      stop_reason: "tool_use",
+      content: [
+        {
+          type: "tool_use",
+          id: "tu_m1",
+          name: "consult_marketing",
+          input: { query: "write a caption for this" },
+        },
+      ],
+    });
+    betaCreateMock.mockResolvedValueOnce({
+      stop_reason: "end_turn",
+      content: [{ type: "text", text: "Caption ready." }],
+    });
+
+    const res = await POST(
+      chatRequest({
+        context_type: "general",
+        message: "write a caption for this",
+        attachments: [IMAGE_ATTACHMENT],
+      }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(200);
+
+    const marketingCall = departmentCall(fetchMock, "marketing");
+    expect(marketingCall).toBeDefined();
+    expect(marketingCall!.body.attachments).toEqual([IMAGE_ATTACHMENT]);
+    expect(marketingCall!.body.org_id).toBe("org-1");
+  });
+
   it("keeps the personality-pass relay text-only", async () => {
     await POST(
       chatRequest({

--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -393,6 +393,11 @@ export const POST = withRequestContext(
               jobId: job_id,
               supabase,
               orgId: ctx.orgId,
+              // Tool-consult attachment forwarding (#202): the turn's
+              // attachments reach `consult_rnd` / `consult_marketing` via
+              // the executor context, never via the model-generated
+              // `toolInput` (which is text and cannot carry image bytes).
+              attachments,
             }
           );
           toolResults.push({

--- a/src/lib/jarvis/tools.ts
+++ b/src/lib/jarvis/tools.ts
@@ -1,6 +1,7 @@
 import type { Tool } from "@anthropic-ai/sdk/resources/messages";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import type { JarvisAttachment } from "@/lib/types";
 
 // --- Types ---
 
@@ -16,6 +17,11 @@ export interface ToolExecutionContext {
   // the Active Organization — scoping by null then matches nothing, which is
   // the safe outcome.
   orgId: string | null;
+  // The turn's Chat attachments, if any. A tool call's input is model-
+  // generated text and cannot carry image bytes, so the consult_rnd /
+  // consult_marketing executors forward attachments to the department via
+  // this context — never via `toolInput` (#202).
+  attachments?: JarvisAttachment[];
 }
 
 // --- Tool Definitions for Claude API ---
@@ -257,12 +263,14 @@ export async function executeJarvisTool(
         break;
       case "consult_rnd":
         result = await toolConsultRnd(
-          toolInput as { question: string; context?: string }
+          toolInput as { question: string; context?: string },
+          context
         );
         break;
       case "consult_marketing":
         result = await toolConsultMarketing(
-          toolInput as { query: string }
+          toolInput as { query: string },
+          context
         );
         break;
       default:
@@ -672,7 +680,8 @@ async function toolLogActivity(
 }
 
 async function toolConsultRnd(
-  input: { question: string; context?: string }
+  input: { question: string; context?: string },
+  ctx: ToolExecutionContext
 ): Promise<{ content: string } | { error: string }> {
   try {
     const baseUrl = process.env.NEXT_PUBLIC_SITE_URL
@@ -682,16 +691,26 @@ async function toolConsultRnd(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 120_000);
 
+    // The turn's Chat attachments ride along on the internal call via the
+    // executor context — the model-generated `toolInput` cannot carry image
+    // bytes. Pairs with `org_id` so R&D scope-checks each storage path
+    // before loading any bytes (#201/#202 contract).
+    const reqBody: Record<string, unknown> = {
+      question: input.question,
+      context: input.context,
+    };
+    if (ctx.attachments && ctx.attachments.length > 0) {
+      reqBody.attachments = ctx.attachments;
+      reqBody.org_id = ctx.orgId;
+    }
+
     const response = await fetch(`${baseUrl}/api/jarvis/rnd`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "x-service-key": process.env.SUPABASE_SERVICE_ROLE_KEY || "",
       },
-      body: JSON.stringify({
-        question: input.question,
-        context: input.context,
-      }),
+      body: JSON.stringify(reqBody),
       signal: controller.signal,
     });
 
@@ -710,7 +729,8 @@ async function toolConsultRnd(
 }
 
 async function toolConsultMarketing(
-  input: { query: string }
+  input: { query: string },
+  ctx: ToolExecutionContext
 ): Promise<{ content: string } | { error: string }> {
   try {
     const baseUrl = process.env.NEXT_PUBLIC_SITE_URL
@@ -720,15 +740,22 @@ async function toolConsultMarketing(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 60_000);
 
+    // Same attachment-via-context contract as `consult_rnd` (#202).
+    const reqBody: Record<string, unknown> = {
+      question: input.query,
+    };
+    if (ctx.attachments && ctx.attachments.length > 0) {
+      reqBody.attachments = ctx.attachments;
+      reqBody.org_id = ctx.orgId;
+    }
+
     const response = await fetch(`${baseUrl}/api/jarvis/marketing`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "x-service-key": process.env.SUPABASE_SERVICE_ROLE_KEY || "",
       },
-      body: JSON.stringify({
-        question: input.query,
-      }),
+      body: JSON.stringify(reqBody),
       signal: controller.signal,
     });
 


### PR DESCRIPTION
## Summary

- Next slice of parent **#153** ("Chat attachments for Jarvis"). When Jarvis Core delegates mid-answer via the `consult_rnd` / `consult_marketing` tools (not an `@`-prefix or department mode), the turn's attachments now reach the consulted department.
- A tool call's input is model-generated text and cannot carry image bytes, so attachments travel through the **tool-executor context** — not the tool input. Reuses the `attachments` + `org_id` contract from #201; each department continues to scope-check the storage path before loading bytes.

## What changed

- `ToolExecutionContext` gains `attachments?: JarvisAttachment[]`.
- `consult_rnd` / `consult_marketing` executors take the context and include `attachments` + `org_id` on the internal department call body when present.
- The chat route's tool-use loop passes the turn's `attachments` into the executor context.

## Test plan

- [x] Vitest: 910 / 910 pass (140 files). Two new integration-style tests in `src/app/api/jarvis/chat/route.test.ts` drive `POST /api/jarvis/chat` with a tool-use response, then assert the attachment reference (and `org_id`) reach the internal `/api/jarvis/rnd` and `/api/jarvis/marketing` calls.
- [x] `tsc --noEmit` — clean on changed files (one pre-existing error in `sync-folder-incremental.test.ts`, unrelated).
- [x] ESLint — clean on changed files (one pre-existing `any` on `tools.ts:363`, untouched by this diff).
- [ ] Browser-verify on AAA prod: attach an image, ask a question Jarvis Core decides to consult R&D about (no `@rnd`), confirm R&D answer references the image.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)