### PR TITLE
feat: prompt caching across the Jarvis Claude calls (#203)

### DIFF
--- a/src/app/api/jarvis/chat/route.ts
+++ b/src/app/api/jarvis/chat/route.ts
@@ -12,6 +12,7 @@ import {
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import { withPromptCache } from "@/lib/jarvis/prompt-cache";
 import type { JarvisAttachment, JarvisMessage } from "@/lib/types";
 
 export const maxDuration = 120;
@@ -355,11 +356,16 @@ export const POST = withRequestContext(
         apiKey: process.env.ANTHROPIC_API_KEY,
       });
 
+      // A cache_control breakpoint on the last content block of the last
+      // message caches the rendered prefix (tools → system → messages)
+      // before that block. A long conversation that replays many image and
+      // document blocks each turn hits the cache on follow-up turns
+      // instead of paying full input cost (#203).
       let response = await anthropic.beta.messages.create({
         model: "claude-sonnet-4-20250514",
         max_tokens: 1024,
         system: systemPrompt,
-        messages: claudeMessages,
+        messages: withPromptCache(claudeMessages),
         tools: jarvisToolDefinitions,
         betas: [ANTHROPIC_FILES_BETA],
       });
@@ -410,7 +416,7 @@ export const POST = withRequestContext(
           model: "claude-sonnet-4-20250514",
           max_tokens: 1024,
           system: systemPrompt,
-          messages: claudeMessages,
+          messages: withPromptCache(claudeMessages),
           tools: jarvisToolDefinitions,
           betas: [ANTHROPIC_FILES_BETA],
         });

--- a/src/app/api/jarvis/field-ops/route.ts
+++ b/src/app/api/jarvis/field-ops/route.ts
@@ -10,6 +10,7 @@ import {
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import { withPromptCache } from "@/lib/jarvis/prompt-cache";
 import type { JarvisAttachment } from "@/lib/types";
 
 export const maxDuration = 60;
@@ -473,7 +474,10 @@ export async function POST(request: NextRequest) {
       );
 
     // Runs on the beta Messages API so a routed PDF document block (#199)
-    // is accepted alongside image blocks.
+    // is accepted alongside image blocks. A cache_control breakpoint on
+    // the last block of the last message caches the rendered prefix
+    // (tools → system → messages) so replayed image and document blocks
+    // hit the cache on follow-up turns (#203).
     let response: Anthropic.Beta.BetaMessage;
     try {
       response = await anthropic.beta.messages.create(
@@ -481,7 +485,7 @@ export async function POST(request: NextRequest) {
           model: "claude-sonnet-4-20250514",
           max_tokens: 8192,
           system: systemPrompt,
-          messages: claudeMessages,
+          messages: withPromptCache(claudeMessages),
           tools: fieldOpsToolDefinitions,
           betas: [ANTHROPIC_FILES_BETA],
         },
@@ -535,7 +539,7 @@ export async function POST(request: NextRequest) {
             model: "claude-sonnet-4-20250514",
             max_tokens: 8192,
             system: systemPrompt,
-            messages: claudeMessages,
+            messages: withPromptCache(claudeMessages),
             tools: fieldOpsToolDefinitions,
             betas: [ANTHROPIC_FILES_BETA],
           },

--- a/src/app/api/jarvis/marketing/route.ts
+++ b/src/app/api/jarvis/marketing/route.ts
@@ -9,6 +9,7 @@ import {
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import { withPromptCache } from "@/lib/jarvis/prompt-cache";
 import type { JarvisAttachment } from "@/lib/types";
 
 export const maxDuration = 60;
@@ -308,7 +309,10 @@ export async function POST(request: NextRequest) {
     ];
 
     // Runs on the beta Messages API so a routed PDF document block (#199)
-    // is accepted alongside image blocks.
+    // is accepted alongside image blocks. A cache_control breakpoint on
+    // the last block of the last message caches the rendered prefix
+    // (tools → system → messages) so replayed image and document blocks
+    // hit the cache on follow-up turns (#203).
     let response: Anthropic.Beta.BetaMessage;
     try {
       response = await anthropic.beta.messages.create(
@@ -316,7 +320,7 @@ export async function POST(request: NextRequest) {
           model: "claude-sonnet-4-20250514",
           max_tokens: 8192,
           system: MARKETING_SYSTEM_PROMPT,
-          messages: claudeMessages,
+          messages: withPromptCache(claudeMessages),
           tools: allTools,
           betas: [ANTHROPIC_FILES_BETA],
         },
@@ -373,7 +377,7 @@ export async function POST(request: NextRequest) {
             model: "claude-sonnet-4-20250514",
             max_tokens: 8192,
             system: MARKETING_SYSTEM_PROMPT,
-            messages: claudeMessages,
+            messages: withPromptCache(claudeMessages),
             tools: allTools,
             betas: [ANTHROPIC_FILES_BETA],
           },

--- a/src/app/api/jarvis/rnd/route.ts
+++ b/src/app/api/jarvis/rnd/route.ts
@@ -9,6 +9,7 @@ import {
   type StorageClient,
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
+import { withPromptCache } from "@/lib/jarvis/prompt-cache";
 import type { JarvisAttachment } from "@/lib/types";
 import * as fs from "fs";
 import * as path from "path";
@@ -488,14 +489,17 @@ export async function POST(request: NextRequest) {
     ];
 
     // Runs on the beta Messages API so a routed PDF document block (#199)
-    // is accepted alongside image blocks.
+    // is accepted alongside image blocks. A cache_control breakpoint on
+    // the last block of the last message caches the rendered prefix
+    // (tools → system → messages) so replayed image and document blocks
+    // hit the cache on follow-up turns (#203).
     let response: Anthropic.Beta.BetaMessage;
     try {
       response = await anthropic.beta.messages.create({
         model: "claude-opus-4-6",
         max_tokens: 16384,
         system: RND_SYSTEM_PROMPT,
-        messages: claudeMessages,
+        messages: withPromptCache(claudeMessages),
         tools: allTools,
         betas: [ANTHROPIC_FILES_BETA],
       }, { timeout: CLAUDE_TIMEOUT_MS });
@@ -546,7 +550,7 @@ export async function POST(request: NextRequest) {
           model: "claude-opus-4-6",
           max_tokens: 16384,
           system: RND_SYSTEM_PROMPT,
-          messages: claudeMessages,
+          messages: withPromptCache(claudeMessages),
           tools: allTools,
           betas: [ANTHROPIC_FILES_BETA],
         }, { timeout: CLAUDE_TIMEOUT_MS });

--- a/src/lib/jarvis/prompt-cache.test.ts
+++ b/src/lib/jarvis/prompt-cache.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import { withPromptCache } from "./prompt-cache";
+
+// Issue #203 — every Jarvis Claude call places a cache_control breakpoint on
+// the replayed message history so a long conversation that re-sends many
+// images and a PDF document block each turn hits the cache on follow-up
+// turns instead of paying full input cost. The breakpoint goes on the last
+// content block of the last message — the rendered prefix
+// (tools → system → messages) before that block is the cacheable region.
+
+describe("withPromptCache", () => {
+  it("returns an empty array unchanged when the history is empty", () => {
+    const result = withPromptCache([]);
+    expect(result).toEqual([]);
+  });
+
+  it("converts a string-content last message to a text block carrying cache_control", () => {
+    const messages: Anthropic.Beta.BetaMessageParam[] = [
+      { role: "user", content: "How many active jobs?" },
+    ];
+
+    const result = withPromptCache(messages);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: "How many active jobs?",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("leaves earlier messages untouched", () => {
+    const messages: Anthropic.Beta.BetaMessageParam[] = [
+      { role: "user", content: "First turn" },
+      { role: "assistant", content: "First answer" },
+      { role: "user", content: "Second turn" },
+    ];
+
+    const result = withPromptCache(messages);
+
+    expect(result[0]).toEqual({ role: "user", content: "First turn" });
+    expect(result[1]).toEqual({ role: "assistant", content: "First answer" });
+    // Only the final message picks up the breakpoint.
+    expect(result[2]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Second turn",
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+    });
+  });
+
+  it("does not mutate the input messages or content blocks", () => {
+    const lastBlock: Anthropic.Beta.BetaTextBlockParam = {
+      type: "text",
+      text: "hi",
+    };
+    const messages: Anthropic.Beta.BetaMessageParam[] = [
+      { role: "user", content: [lastBlock] },
+    ];
+
+    withPromptCache(messages);
+
+    // Caller can re-use the same array and block on the next turn (e.g.
+    // the tool-use loop pushes onto `claudeMessages` between requests).
+    expect(messages[0].content).toEqual([{ type: "text", text: "hi" }]);
+    expect(lastBlock).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("places cache_control on the last content block of the last message", () => {
+    const messages: Anthropic.Beta.BetaMessageParam[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: "DATA",
+            },
+          },
+          { type: "text", text: "What is this?" },
+        ],
+      },
+    ];
+
+    const result = withPromptCache(messages);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: "DATA",
+            },
+          },
+          {
+            type: "text",
+            text: "What is this?",
+            cache_control: { type: "ephemeral" },
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/lib/jarvis/prompt-cache.ts
+++ b/src/lib/jarvis/prompt-cache.ts
@@ -1,0 +1,40 @@
+// Prompt caching for the Jarvis Claude calls (#203).
+//
+// Places a `cache_control: { type: "ephemeral" }` breakpoint on the last
+// content block of the last message in the history. The Messages API
+// renders `tools → system → messages` before hashing the cacheable prefix,
+// so this single breakpoint caches the tool list, the system prompt, and
+// every prior message — exactly the chunk replayed turn after turn in a
+// long conversation. On a cache hit the replayed image and PDF blocks are
+// served at ~10% of base input price; the response is byte-identical so
+// caching is a pure cost win.
+
+import type Anthropic from "@anthropic-ai/sdk";
+
+const EPHEMERAL: Anthropic.Beta.BetaCacheControlEphemeral = { type: "ephemeral" };
+
+export function withPromptCache(
+  messages: Anthropic.Beta.BetaMessageParam[],
+): Anthropic.Beta.BetaMessageParam[] {
+  if (messages.length === 0) return messages;
+
+  const lastIndex = messages.length - 1;
+  return messages.map((message, index) => {
+    if (index !== lastIndex) return message;
+    const content = message.content;
+    if (typeof content === "string") {
+      return {
+        ...message,
+        content: [{ type: "text", text: content, cache_control: EPHEMERAL }],
+      };
+    }
+    if (content.length === 0) return message;
+    const lastBlockIndex = content.length - 1;
+    return {
+      ...message,
+      content: content.map((block, i) =>
+        i === lastBlockIndex ? { ...block, cache_control: EPHEMERAL } : block,
+      ),
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a `cache_control: {type:"ephemeral"}` breakpoint on the message history of every Jarvis Claude call site — Jarvis Core chat, R&D, Marketing, and Field Ops — so a long conversation that replays many image and document blocks each turn hits the cache on follow-up turns instead of paying full input cost.
- New pure helper `src/lib/jarvis/prompt-cache.ts` (`withPromptCache`) — places `cache_control` on the last content block of the last message; converts string content to a text block; leaves earlier messages untouched; does not mutate input. 5 tests, red→green via `/tdd`.
- Wired at both call sites (initial call + tool-use loop) in each of `src/app/api/jarvis/{chat,rnd,marketing,field-ops}/route.ts`. The Jarvis Core personality-pass call is text-only and never replays attachments, so it is deliberately not wrapped.

Closes #203 — the prompt-caching slice of parent #153.

## Test plan

- [x] `npx vitest run` — 912 pass (1 pre-existing flake in `intake-form.test.tsx`, untouched on this branch)
- [x] `npx tsc --noEmit` — clean apart from the pre-existing `sync-folder-incremental.test.ts` error already noted in the #199 handoff
- [x] `npx eslint` on changed/new files — 0 problems
- [ ] **Post-merge:** browser-verify on AAA prod — multi-turn conversation with an image and a PDF should show `cache_read_input_tokens > 0` on turn 2+ via the API response's `usage` field (visible in Vercel function logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)