### PR TITLE
fix: render email body html + attachments in job view (#212)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -13,6 +13,7 @@ import { Loader2, Send, ChevronDown, ChevronUp, Paperclip, X, FileIcon, Save } f
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
+import { htmlToText } from "@/lib/email/html-to-text";
 
 interface EmailAccountData {
   id: string;
@@ -240,9 +241,7 @@ export default function ComposeEmailModal({
     const currentCc = ccRecipientsRef.current;
     const currentBcc = bccRecipientsRef.current;
 
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = bodyHtml;
-    const bodyText = tempDiv.textContent || tempDiv.innerText || "";
+    const bodyText = htmlToText(bodyHtml);
 
     setSavingDraft(true);
     try {
@@ -302,10 +301,7 @@ export default function ComposeEmailModal({
       return;
     }
 
-    // Extract plain text from HTML for body_text
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = bodyHtml;
-    const bodyText = tempDiv.textContent || tempDiv.innerText || "";
+    const bodyText = htmlToText(bodyHtml);
 
     if (!bodyText.trim()) {
       toast.error("Please write a message.");

--- a/src/components/email-reader.tsx
+++ b/src/components/email-reader.tsx
@@ -12,58 +12,14 @@ import {
   Briefcase,
   ChevronDown,
   ChevronUp,
-  Download,
-  FileIcon,
   Trash2,
   ShieldAlert,
   Search,
 } from "lucide-react";
 import { toast } from "sonner";
 import type { Email } from "@/lib/types";
-
-function EmailBodyFrame({ html }: { html: string }) {
-  const ref = useRef<HTMLIFrameElement>(null);
-  const [height, setHeight] = useState(200);
-
-  useEffect(() => {
-    const iframe = ref.current;
-    if (!iframe) return;
-    const doc = iframe.contentDocument;
-    if (!doc) return;
-
-    const baseStyles = `
-      :root { color-scheme: light; }
-      html, body { margin: 0; padding: 0; background: #fff; color: #333;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        font-size: 14px; line-height: 1.5; word-wrap: break-word; }
-      img { max-width: 100%; height: auto; }
-      a { color: #2B5EA7; }
-      table { max-width: 100%; }
-    `;
-
-    doc.open();
-    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8"><base target="_blank"><style>${baseStyles}</style></head><body>${html}</body></html>`);
-    doc.close();
-
-    const resize = () => {
-      if (!doc.body) return;
-      setHeight(doc.body.scrollHeight + 16);
-    };
-    resize();
-    const obs = new ResizeObserver(resize);
-    if (doc.body) obs.observe(doc.body);
-    return () => obs.disconnect();
-  }, [html]);
-
-  return (
-    <iframe
-      ref={ref}
-      title="Email body"
-      sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
-      style={{ width: "100%", height, border: 0, display: "block" }}
-    />
-  );
-}
+import { EmailBodyFrame } from "@/components/email/email-body-frame";
+import { EmailAttachments } from "@/components/email/email-attachments";
 
 interface EmailReaderProps {
   emailId: string;
@@ -467,48 +423,12 @@ export default function EmailReader({
                     )}
                   </div>
 
-                  {/* Attachments — list when uploaded, "Downloading…" placeholder
-                       briefly while after() finishes the post-response upload. */}
                   {email.has_attachments && (
                     <div className="px-4 py-3 border-t border-gray-100">
-                      {email.attachments && email.attachments.length > 0 ? (
-                        <>
-                          <p className="text-xs font-medium text-[#666] mb-2 flex items-center gap-1">
-                            <Paperclip size={12} />
-                            {email.attachments.length} attachment{email.attachments.length !== 1 ? "s" : ""}
-                          </p>
-                          <div className="flex flex-wrap gap-2">
-                            {email.attachments.map((att) => (
-                              <a
-                                key={att.id}
-                                href={`/api/email/attachments/${att.id}`}
-                                download={att.filename}
-                                className="inline-flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors group"
-                              >
-                                <FileIcon size={16} className="text-[#2B5EA7] shrink-0" />
-                                <div className="min-w-0">
-                                  <p className="text-sm text-[#333] truncate max-w-[200px]">
-                                    {att.filename}
-                                  </p>
-                                  {att.file_size && (
-                                    <p className="text-[10px] text-[#999]">
-                                      {att.file_size > 1024 * 1024
-                                        ? `${(att.file_size / (1024 * 1024)).toFixed(1)}MB`
-                                        : `${(att.file_size / 1024).toFixed(0)}KB`}
-                                    </p>
-                                  )}
-                                </div>
-                                <Download size={14} className="text-[#999] group-hover:text-[#2B5EA7] shrink-0" />
-                              </a>
-                            ))}
-                          </div>
-                        </>
-                      ) : (
-                        <p className="text-xs text-[#999] flex items-center gap-2">
-                          <Paperclip size={12} />
-                          Downloading…
-                        </p>
-                      )}
+                      <EmailAttachments
+                        attachments={email.attachments}
+                        hasAttachments={email.has_attachments}
+                      />
                     </div>
                   )}
                 </div>

--- a/src/components/email/email-attachments.tsx
+++ b/src/components/email/email-attachments.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Paperclip, Download, FileIcon } from "lucide-react";
+import type { EmailAttachment } from "@/lib/types";
+
+// Attachment list with download links via /api/email/attachments/{id}.
+// Shared by the inbox reader and the Job View email row (#212).
+//
+// When `hasAttachments` is true but `attachments` is empty/undefined, the
+// row is still mid-upload (sync's after() hook hasn't landed the files yet)
+// — show a placeholder so the user knows attachments are coming.
+export function EmailAttachments({
+  attachments,
+  hasAttachments,
+}: {
+  attachments: EmailAttachment[] | undefined;
+  hasAttachments: boolean;
+}) {
+  if (!hasAttachments) return null;
+
+  if (!attachments || attachments.length === 0) {
+    return (
+      <p className="text-xs text-[#999] flex items-center gap-2">
+        <Paperclip size={12} />
+        Downloading…
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <p className="text-xs font-medium text-[#666] mb-2 flex items-center gap-1">
+        <Paperclip size={12} />
+        {attachments.length} attachment{attachments.length !== 1 ? "s" : ""}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {attachments.map((att) => (
+          <a
+            key={att.id}
+            href={`/api/email/attachments/${att.id}`}
+            download={att.filename}
+            className="inline-flex items-center gap-2 px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg hover:bg-gray-100 transition-colors group"
+          >
+            <FileIcon size={16} className="text-[#2B5EA7] shrink-0" />
+            <div className="min-w-0">
+              <p className="text-sm text-[#333] truncate max-w-[200px]">
+                {att.filename}
+              </p>
+              {att.file_size && (
+                <p className="text-[10px] text-[#999]">
+                  {att.file_size > 1024 * 1024
+                    ? `${(att.file_size / (1024 * 1024)).toFixed(1)}MB`
+                    : `${(att.file_size / 1024).toFixed(0)}KB`}
+                </p>
+              )}
+            </div>
+            <Download size={14} className="text-[#999] group-hover:text-[#2B5EA7] shrink-0" />
+          </a>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/email/email-body-frame.tsx
+++ b/src/components/email/email-body-frame.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+// Sandboxed iframe for rendering an email's HTML body. Scripts are disabled
+// (no `allow-scripts` in sandbox); links open in a new tab via `<base target>`.
+// Shared by the inbox reader and the Job View email row so paragraph spacing
+// and inline formatting render identically in both surfaces (#212).
+export function EmailBodyFrame({ html }: { html: string }) {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [height, setHeight] = useState(200);
+
+  useEffect(() => {
+    const iframe = ref.current;
+    if (!iframe) return;
+    const doc = iframe.contentDocument;
+    if (!doc) return;
+
+    const baseStyles = `
+      :root { color-scheme: light; }
+      html, body { margin: 0; padding: 0; background: #fff; color: #333;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 14px; line-height: 1.5; word-wrap: break-word; }
+      img { max-width: 100%; height: auto; }
+      a { color: #2B5EA7; }
+      table { max-width: 100%; }
+    `;
+
+    doc.open();
+    doc.write(`<!DOCTYPE html><html><head><meta charset="utf-8"><base target="_blank"><style>${baseStyles}</style></head><body>${html}</body></html>`);
+    doc.close();
+
+    const resize = () => {
+      if (!doc.body) return;
+      setHeight(doc.body.scrollHeight + 16);
+    };
+    resize();
+    const obs = new ResizeObserver(resize);
+    if (doc.body) obs.observe(doc.body);
+    return () => obs.disconnect();
+  }, [html]);
+
+  return (
+    <iframe
+      ref={ref}
+      title="Email body"
+      sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+      style={{ width: "100%", height, border: 0, display: "block" }}
+    />
+  );
+}

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -24,6 +24,8 @@ import PhotoUploadModal from "@/components/photo-upload";
 import PhotoDetailModal from "@/components/photo-detail";
 import PhotoAnnotator from "@/components/photo-annotator";
 import ComposeEmailModal from "@/components/compose-email";
+import { EmailBodyFrame } from "@/components/email/email-body-frame";
+import { EmailAttachments } from "@/components/email/email-attachments";
 import JarvisJobPanel from "@/components/jarvis/JarvisJobPanel";
 import JobFiles from "@/components/job-files";
 import ContractsSection from "@/components/contracts/contracts-section";
@@ -164,7 +166,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         .order("created_at", { ascending: false }),
       supabase
         .from("emails")
-        .select("*")
+        .select("*, attachments:email_attachments(*)")
         .eq("job_id", jobId)
         .order("received_at", { ascending: false }),
     ]);
@@ -1173,9 +1175,23 @@ function EmailRow({
             <p><span className="font-medium text-foreground/80">To:</span> {toLine}</p>
             <p><span className="font-medium text-foreground/80">Date:</span> {format(new Date(email.received_at), "EEEE, MMM d, yyyy 'at' h:mm a")}</p>
           </div>
-          <div className="bg-muted/50 rounded-lg p-3 text-sm text-foreground/80 whitespace-pre-wrap leading-relaxed max-h-80 overflow-y-auto">
-            {email.body_text || email.snippet || "(No content)"}
+          <div className="bg-muted/50 rounded-lg p-3 text-sm text-foreground/80 leading-relaxed max-h-80 overflow-y-auto">
+            {email.body_html ? (
+              <EmailBodyFrame html={email.body_html} />
+            ) : (
+              <div className="whitespace-pre-wrap">
+                {email.body_text || email.snippet || "(No content)"}
+              </div>
+            )}
           </div>
+          {email.has_attachments && (
+            <div className="mt-3">
+              <EmailAttachments
+                attachments={email.attachments}
+                hasAttachments={email.has_attachments}
+              />
+            </div>
+          )}
           <button
             onClick={(e) => { e.stopPropagation(); onReply(); }}
             className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline"

--- a/src/lib/email/html-to-text.test.ts
+++ b/src/lib/email/html-to-text.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { htmlToText } from "./html-to-text";
+
+// Issue #212 — Job View's sent-email body was a wall of text because the
+// compose flow derived body_text via DOM `textContent`, which silently drops
+// every `<p>` and `<br>` boundary. The fix routes body_text through
+// htmlToText() instead; these tests pin the newline semantics that the
+// bug fix depends on so a future "simplification" can't quietly regress it.
+describe("htmlToText", () => {
+  it("turns a paragraph boundary into a blank line", () => {
+    expect(htmlToText("<p>first</p><p>second</p>")).toBe("first\n\nsecond");
+  });
+
+  it("turns a <br> into a single newline inside a paragraph", () => {
+    expect(htmlToText("<p>line one<br>line two</p>")).toBe("line one\nline two");
+  });
+
+  it("preserves multi-paragraph spacing in a realistic email body", () => {
+    const html = "<p>Hi Jane,</p><p>Please find the report attached.<br>Let me know if you have questions.</p><p>Thanks,<br>Eric</p>";
+    expect(htmlToText(html)).toBe(
+      "Hi Jane,\n\nPlease find the report attached.\nLet me know if you have questions.\n\nThanks,\nEric",
+    );
+  });
+
+  it("decodes the five HTML entities the encoder produces", () => {
+    expect(htmlToText("<p>5 &amp; 6 &lt; 7 &gt; 4 &quot;ok&quot; it&#39;s</p>"))
+      .toBe(`5 & 6 < 7 > 4 "ok" it's`);
+  });
+});


### PR DESCRIPTION
Closes #212.

## Summary

- Job View's sent-email row now renders `body_html` via the shared `EmailBodyFrame` (falling back to plain text), so paragraph spacing is preserved.
- Job View's emails fetch now joins `email_attachments`, and the expanded row renders the attachment list with download links via `/api/email/attachments/{id}`.
- `compose-email` derives `body_text` via `htmlToText(bodyHtml)` instead of DOM `textContent`, so the stored plain-text body and the SMTP `text` field retain paragraph + line-break structure for plain-text-only recipients.
- Extracted `EmailBodyFrame` and `EmailAttachments` into `src/components/email/` so the Inbox and Job View share one renderer and cannot drift again.
- New unit test `src/lib/email/html-to-text.test.ts` pins the paragraph / line-break / entity-decode semantics that the fix depends on.

Follow-up loose ends (CC/BCC visibility, Reply quoting, iOS verification) are scoped in PRD #213.

## Test plan

- [x] `vitest run src/lib/email src/components/email-inbox.test.tsx` — 32/32 passing locally
- [x] `tsc --noEmit` clean on all touched files
- [x] `eslint` clean on all new files; existing baseline errors in `job-detail.tsx` unrelated
- [ ] Manual: open a job with a sent email + PDF attachments in the web app; confirm paragraph spacing and attachment download both work
- [ ] Manual: open the same job on the iOS app and confirm the iframe body renders correctly (deferred — tracked in PRD #213)


---
_Generated by [Claude Code](https://claude.ai/code/session_01S9pxQK28wUVuhq9bXFmJoJ)_