### PR TITLE
feat: render CC and BCC in Job View email row (#216)

### DIFF
--- a/src/components/job-detail.test.tsx
+++ b/src/components/job-detail.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// #216 — the expanded EmailRow in Job View must mirror the Inbox's
+// recipient visibility rules: CC is shown whenever cc_addresses is
+// non-empty (both directions), and BCC is shown only on sender-side
+// folders (sent / drafts). Received emails never show BCC even if the
+// field happens to be populated. These DOM assertions pin the four
+// visibility cases so a future EmailRow refactor can't silently drop
+// CC/BCC or leak BCC into received-folder views.
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ user: null, profile: null }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/components/email/email-body-frame", () => ({
+  EmailBodyFrame: () => null,
+}));
+
+vi.mock("@/components/email/email-attachments", () => ({
+  EmailAttachments: () => null,
+}));
+
+import { EmailRow } from "./job-detail";
+import type { Email } from "@/lib/types";
+
+function makeEmail(overrides: Partial<Email> = {}): Email {
+  return {
+    id: "email-1",
+    account_id: "acc-1",
+    job_id: "job-1",
+    message_id: "<msg-1@example.com>",
+    thread_id: null,
+    folder: "inbox",
+    from_address: "alice@example.com",
+    from_name: "Alice",
+    to_addresses: [{ email: "bob@example.com", name: "Bob" }],
+    cc_addresses: [],
+    bcc_addresses: [],
+    subject: "Hello",
+    body_text: "body",
+    body_html: null,
+    snippet: "body",
+    is_read: true,
+    is_starred: false,
+    has_attachments: false,
+    matched_by: null,
+    category: null,
+    uid: 1,
+    received_at: "2026-05-22T12:00:00Z",
+    created_at: "2026-05-22T12:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderRow(email: Email) {
+  return render(
+    <EmailRow
+      email={email}
+      isExpanded={true}
+      onToggle={() => {}}
+      onReply={() => {}}
+    />,
+  );
+}
+
+describe("EmailRow CC/BCC visibility (#216)", () => {
+  it("shows CC line on a sent email with CC recipients", () => {
+    renderRow(
+      makeEmail({
+        folder: "sent",
+        cc_addresses: [{ email: "carol@example.com", name: "Carol" }],
+      }),
+    );
+    expect(screen.getByText(/^CC:/)).toBeDefined();
+    expect(screen.getByText(/Carol/)).toBeDefined();
+  });
+
+  it("shows CC line on a received email with CC recipients", () => {
+    renderRow(
+      makeEmail({
+        folder: "inbox",
+        cc_addresses: [{ email: "dave@example.com", name: "Dave" }],
+      }),
+    );
+    expect(screen.getByText(/^CC:/)).toBeDefined();
+    expect(screen.getByText(/Dave/)).toBeDefined();
+  });
+
+  it("shows BCC line on a sent email with BCC recipients", () => {
+    renderRow(
+      makeEmail({
+        folder: "sent",
+        bcc_addresses: [{ email: "eve@example.com", name: "Eve" }],
+      }),
+    );
+    expect(screen.getByText(/^BCC:/)).toBeDefined();
+    expect(screen.getByText(/Eve/)).toBeDefined();
+  });
+
+  it("hides BCC line on a received email even when bcc_addresses is populated", () => {
+    renderRow(
+      makeEmail({
+        folder: "inbox",
+        bcc_addresses: [{ email: "frank@example.com", name: "Frank" }],
+      }),
+    );
+    expect(screen.queryByText(/^BCC:/)).toBeNull();
+    expect(screen.queryByText(/Frank/)).toBeNull();
+  });
+
+  it("renders no CC label when cc_addresses is empty", () => {
+    renderRow(makeEmail({ folder: "sent", cc_addresses: [] }));
+    expect(screen.queryByText(/^CC:/)).toBeNull();
+  });
+
+  it("renders no BCC label when bcc_addresses is empty on a sent email", () => {
+    renderRow(makeEmail({ folder: "sent", bcc_addresses: [] }));
+    expect(screen.queryByText(/^BCC:/)).toBeNull();
+  });
+});

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -1104,7 +1104,7 @@ function AdjusterCard({
   );
 }
 
-function EmailRow({
+export function EmailRow({
   email,
   isExpanded,
   onToggle,
@@ -1117,6 +1117,10 @@ function EmailRow({
 }) {
   const isSent = email.folder === "sent" || email.folder === "drafts";
   const toLine = (email.to_addresses || []).map((a) => a.name || a.email).join(", ");
+  const ccLine = (email.cc_addresses || []).map((a) => a.name || a.email).join(", ");
+  const bccLine = (email.bcc_addresses || []).map((a) => a.name || a.email).join(", ");
+  const showCc = (email.cc_addresses || []).length > 0;
+  const showBcc = isSent && (email.bcc_addresses || []).length > 0;
 
   const directionIcon = isSent
     ? <Send size={14} className="text-primary" />
@@ -1173,6 +1177,12 @@ function EmailRow({
           <div className="mt-3 text-xs text-muted-foreground space-y-1 mb-3">
             <p><span className="font-medium text-foreground/80">From:</span> {fullFrom}</p>
             <p><span className="font-medium text-foreground/80">To:</span> {toLine}</p>
+            {showCc && (
+              <p><span className="font-medium text-foreground/80">CC:</span> {ccLine}</p>
+            )}
+            {showBcc && (
+              <p><span className="font-medium text-foreground/80">BCC:</span> {bccLine}</p>
+            )}
             <p><span className="font-medium text-foreground/80">Date:</span> {format(new Date(email.received_at), "EEEE, MMM d, yyyy 'at' h:mm a")}</p>
           </div>
           <div className="bg-muted/50 rounded-lg p-3 text-sm text-foreground/80 leading-relaxed max-h-80 overflow-y-auto">


### PR DESCRIPTION
## Summary
- Adds `CC:` / `BCC:` lines to the expanded `EmailRow` in Job View. `CC` shows whenever `cc_addresses` is non-empty (both directions). `BCC` shows only on sender-side folders (`sent` / `drafts`), so received emails never leak BCC even if the field is populated.
- Exports `EmailRow` from `job-detail.tsx` so it can be tested directly. No other refactor.
- New `src/components/job-detail.test.tsx` with 6 RTL cases pinning the four visibility states from #216's acceptance criteria, plus the two empty-cases.

Closes #216. First slice of PRD #213.

## Test plan
- [x] `vitest run src/components/job-detail.test.tsx` — 6/6 pass (watched 3 fail RED first)
- [x] `vitest run src/components src/lib/email` — 88/88 pass, no regressions
- [x] `tsc --noEmit` clean on touched files (only the pre-existing `sync-folder-incremental.test.ts` error called out in the build 212 handoff remains)
- [x] `eslint src/components/job-detail.{tsx,test.tsx}` — only the 6 pre-existing `react-hooks/set-state-in-effect` errors at unrelated `useEffect` sites; none in `EmailRow` or the new test
- [ ] Manual browser verify on a job with a sent email containing CC + BCC, and a received email with CC, that the labels render where expected
- [ ] iOS Capacitor verify — same scenarios (tracked as a separate slice in PRD #213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)