### PR TITLE
feat: pull email account create rule into access-decision module (#221)

### DIFF
--- a/src/app/api/email/accounts/route.ts
+++ b/src/app/api/email/accounts/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { encrypt } from "@/lib/encryption";
 import { assignAccountColor } from "@/lib/email/assign-account-color";
+import { canCreateEmailAccount } from "@/lib/email/email-account-access";
 
 // GET /api/email/accounts — list accounts for the active org (passwords excluded).
 //
@@ -56,10 +57,23 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
     );
   }
 
-  // ADR 0001 ownership rule. Admin may set any owner (or null for Shared);
-  // non-admin may only own the account themselves — any other `user_id`,
-  // including null, is denied.
-  if (ctx.role !== "admin" && user_id !== ctx.userId) {
+  // ADR 0001 ownership rule lives in the access-decision module. The matrix
+  // is captured once; this route delegates rather than re-implementing it.
+  const proposedUserId = user_id ?? null;
+  const allowed = canCreateEmailAccount(
+    {
+      userId: ctx.userId,
+      organizationId: ctx.orgId ?? "",
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    },
+    {
+      kind: proposedUserId === null ? "shared" : "personal",
+      organizationId: ctx.orgId ?? "",
+      userId: proposedUserId,
+    },
+  );
+  if (!allowed) {
     return NextResponse.json({ error: "Permission denied" }, { status: 403 });
   }
 

--- a/src/lib/email/email-account-access.test.ts
+++ b/src/lib/email/email-account-access.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import {
+  canCreateEmailAccount,
   evaluateEmailAccountAccess,
   type EmailAccount,
   type EmailAccountCaller,
@@ -157,6 +158,142 @@ describe("evaluateEmailAccountAccess", () => {
       };
       expect(() =>
         evaluateEmailAccountAccess(caller({ role: "admin" }), bogus),
+      ).toThrow(/unknown email account kind "service"/);
+    });
+  });
+});
+
+describe("canCreateEmailAccount", () => {
+  describe("shared account", () => {
+    it("same-org admin with send_email: allowed", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: ["send_email"] }),
+          shared(),
+        ),
+      ).toBe(true);
+    });
+
+    it("same-org non-admin with send_email: denied (admin-only kind)", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "crew_lead", grantedPermissions: ["send_email"] }),
+          shared(),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("personal account", () => {
+    it("same-org admin with send_email creates Personal owned by self: allowed", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: ["send_email"] }),
+          personal(ALICE),
+        ),
+      ).toBe(true);
+    });
+
+    it("same-org admin with send_email creates Personal owned by another user: allowed", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: ["send_email"] }),
+          personal(BOB),
+        ),
+      ).toBe(true);
+    });
+
+    it("same-org non-admin with send_email creates Personal owned by self: allowed", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "crew_lead", grantedPermissions: ["send_email"] }),
+          personal(ALICE),
+        ),
+      ).toBe(true);
+    });
+
+    it("same-org non-admin with send_email creates Personal owned by another user: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "crew_lead", grantedPermissions: ["send_email"] }),
+          personal(BOB),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("belt-and-suspenders send_email re-check", () => {
+    // The route wrapper already gates send_email. The function re-checks
+    // defensively — if a future caller wires the function in without the
+    // wrapper, the answer must still be no.
+    it("admin without send_email creating Shared: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: [] }),
+          shared(),
+        ),
+      ).toBe(false);
+    });
+
+    it("admin without send_email creating Personal-as-self: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: [] }),
+          personal(ALICE),
+        ),
+      ).toBe(false);
+    });
+
+    it("non-admin without send_email creating Personal-as-self: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "crew_lead", grantedPermissions: [] }),
+          personal(ALICE),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("cross-Organization caller", () => {
+    it("admin in another org with send_email creating Shared in the target org: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({
+            organizationId: OTHER_ORG,
+            role: "admin",
+            grantedPermissions: ["send_email"],
+          }),
+          shared(),
+        ),
+      ).toBe(false);
+    });
+
+    it("admin in another org with send_email creating Personal-as-self in the target org: denied", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({
+            organizationId: OTHER_ORG,
+            role: "admin",
+            grantedPermissions: ["send_email"],
+          }),
+          personal(ALICE),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("guard rails", () => {
+    it("throws for an unknown account kind (never quietly returns false)", () => {
+      const bogus = {
+        kind: "service" as unknown as EmailAccount["kind"],
+        organizationId: ORG,
+        userId: null,
+      };
+      expect(() =>
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: ["send_email"] }),
+          bogus,
+        ),
       ).toThrow(/unknown email account kind "service"/);
     });
   });

--- a/src/lib/email/email-account-access.ts
+++ b/src/lib/email/email-account-access.ts
@@ -1,24 +1,25 @@
-// `evaluateEmailAccountAccess` — the access-decision module for Email
-// accounts. A pure function: no I/O, no Supabase, no HTTP. Given a caller
-// and an Email account, it answers the three questions every email-area
-// route needs:
+// The access-decision module for Email accounts. Pure functions: no I/O,
+// no Supabase, no HTTP. Given a caller and an Email account (existing or
+// proposed), they answer the four questions every email-area route needs:
 //
 //   canSee    — does the account appear in the caller's UI?
 //   canRead   — can the caller open its mail?
 //   canManage — can the caller edit its settings or disconnect it?
+//   canCreate — may the caller create an account of this kind / owner?
 //
-// The decision matrix is fixed by ADR 0001 (Shared and Personal email
-// accounts). The matrix varies by account kind and the caller's role and
-// permissions within the account's Organization; cross-Organization
-// callers get all-false on every account, regardless of permissions —
-// the same 404-equivalent convention as #98/#101/#119.
+// The first three are returned together by `evaluateEmailAccountAccess`;
+// the fourth is returned by `canCreateEmailAccount`. The matrix is fixed
+// by ADR 0001 (Shared and Personal email accounts) and varies by account
+// kind and the caller's role and permissions within the account's
+// Organization; cross-Organization callers get denied on every account,
+// regardless of permissions — the same 404-equivalent convention as
+// #98/#101/#119.
 //
 // This module is the single source of truth for the matrix. Routes
-// delegate to it rather than re-implementing the rule; the next slice
-// wires it into the email-area Service-client routes.
+// delegate to it rather than re-implementing the rule.
 //
-// An unknown account kind throws, never quietly returns all-false —
-// same posture as the #97 resolver registry: an unregistered case is a
+// An unknown account kind throws, never quietly returns false — same
+// posture as the #97 resolver registry: an unregistered case is a
 // programming error, not a silent deny.
 
 export type EmailAccountKind = "shared" | "personal";
@@ -116,4 +117,54 @@ export function evaluateEmailAccountAccess(
     );
   }
   return evaluator(caller, account);
+}
+
+// One create-evaluator per account kind. Mirrors EVALUATORS above: each
+// evaluator only deals with the in-org branches of the create matrix, and
+// canCreateEmailAccount handles the cross-Organization short-circuit at the
+// top.
+type CreateEvaluator = (
+  caller: EmailAccountCaller,
+  proposed: EmailAccount,
+) => boolean;
+
+const canCreateShared: CreateEvaluator = (caller) => caller.role === "admin";
+
+const canCreatePersonal: CreateEvaluator = (caller, proposed) => {
+  if (caller.role === "admin") return true;
+  return proposed.userId === caller.userId;
+};
+
+const CREATE_EVALUATORS: Record<EmailAccountKind, CreateEvaluator> = {
+  shared: canCreateShared,
+  personal: canCreatePersonal,
+};
+
+/**
+ * Decides whether a caller may create an Email account of a given kind for a
+ * proposed owner. See ADR 0001: the access matrix is captured once, in this
+ * module; every route delegates. This function is the create branch of that
+ * matrix.
+ */
+export function canCreateEmailAccount(
+  caller: EmailAccountCaller,
+  proposed: EmailAccount,
+): boolean {
+  if (caller.organizationId !== proposed.organizationId) {
+    return false;
+  }
+  // Belt-and-suspenders: the email-area route wrapper gates send_email at
+  // the door, but a future caller (CLI, server action, script) might wire
+  // this function in without that wrapper. Re-check here so the answer is
+  // safe regardless of how we're called.
+  if (!caller.grantedPermissions.includes("send_email")) {
+    return false;
+  }
+  const evaluator = CREATE_EVALUATORS[proposed.kind];
+  if (!evaluator) {
+    throw new Error(
+      `canCreateEmailAccount: unknown email account kind "${proposed.kind}"`,
+    );
+  }
+  return evaluator(caller, proposed);
 }


### PR DESCRIPTION
## Summary

- Adds `canCreateEmailAccount` to `email-account-access` so all four cells of ADR-0001's matrix (see/read/manage/create) live in one Module
- POST `/api/email/accounts` delegates to it instead of hand-rolling the rule at lines 59-64
- 9-case unit-test matrix added (23 tests in the file total, all passing)

## Test plan

- [x] `npm test -- src/lib/email/email-account-access.test.ts` — 23/23 green
- [x] No TS errors in touched files (pre-existing unrelated TS error in `sync-folder-incremental.test.ts`, untouched)
- [ ] Manual: admin creates a Shared account from Settings → Email → still works
- [ ] Manual: Crew Lead creates a Personal account from Settings → Email → still works
- [ ] Manual: crafted POST `/api/email/accounts` with `user_id: null` from a non-admin → 403

Closes #221. Parent #220. DB-layer half is #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)