### PR TITLE
feat: tighten email_accounts INSERT RLS to admin-only Shared (#222)

### DIFF
--- a/supabase/migration-222-smoke-test.sql
+++ b/supabase/migration-222-smoke-test.sql
@@ -1,0 +1,263 @@
+-- issue #222 (PRD #220, ADR 0001) — admin-only Shared INSERT RLS — migration smoke test.
+--
+-- Purpose:   Verify that the tightened `email_accounts_shared_or_personal`
+--            INSERT policy enforces every cell of ADR-0001's create matrix at
+--            the database. The migration adds an admin-EXISTS clause to the
+--            existing WITH CHECK; this smoke test exercises the 5 cases
+--            enumerated in issue #222 against authenticated-role sessions.
+--
+-- Shape:     One transaction, rolled back at the end. The script:
+--              1. Re-applies the tightened policy inside the transaction
+--                 (idempotent — DROP IF EXISTS, then CREATE). This lets the
+--                 smoke test run against either the pre-migration policy or
+--                 the post-migration policy without conflict; the rollback
+--                 restores whatever was in place before.
+--              2. Seeds 2 orgs and 3 users (admin of org1, crew_lead of
+--                 org1, admin of org2) under service-role bypass.
+--              3. Runs 5 assertion blocks under `role authenticated`, each
+--                 attempting an INSERT and asserting allow vs. deny. RLS
+--                 violations surface as `insufficient_privilege` exceptions
+--                 (SQLSTATE 42501); each block catches that and treats it
+--                 as the expected outcome.
+--
+-- Run:       Via Supabase MCP `execute_sql` with the project_id of the
+--            target project. Once the migration has been applied to prod,
+--            this script remains in the repo as the documented test of the
+--            policy. It is NOT run by CI.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Apply the tightened policy inside the transaction. Idempotent via
+--    DROP IF EXISTS; the rollback at the end restores whatever was there
+--    (the old policy if run pre-migration, the new policy if run post-
+--    migration with the same shape).
+-- ---------------------------------------------------------------------------
+drop policy if exists email_accounts_shared_or_personal on public.email_accounts;
+
+create policy email_accounts_shared_or_personal on public.email_accounts
+  for all to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (user_id is null and nookleus.is_member_of(organization_id))
+      or user_id = auth.uid()
+    )
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (
+        user_id is null
+        and nookleus.is_member_of(organization_id)
+        and exists (
+          select 1
+            from public.user_organizations uo
+           where uo.user_id = auth.uid()
+             and uo.organization_id = email_accounts.organization_id
+             and uo.role = 'admin'
+        )
+      )
+      or user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 1. Seed. Service-role bypass for orgs / users / memberships. Fixed UUIDs
+--    so assertions can name them.
+--      Org 1: smoke-org-1
+--        User A — admin
+--        User B — crew_lead (non-admin, send_email-equivalent at app layer)
+--      Org 2: smoke-org-2
+--        User C — admin
+--    Used by the 5 cases below.
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('41000000-0000-0000-0000-000000000001', 'smoke-222-org-1', 'smoke-222-org-1'),
+  ('41000000-0000-0000-0000-000000000002', 'smoke-222-org-2', 'smoke-222-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('41000000-0000-0000-0000-000000000010', 'smoke-222-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('41000000-0000-0000-0000-000000000011', 'smoke-222-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('41000000-0000-0000-0000-000000000012', 'smoke-222-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('41000000-0000-0000-0000-000000000010', '41000000-0000-0000-0000-000000000001', 'admin'),
+  ('41000000-0000-0000-0000-000000000011', '41000000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('41000000-0000-0000-0000-000000000012', '41000000-0000-0000-0000-000000000002', 'admin');
+
+-- ---------------------------------------------------------------------------
+-- 2. Cases 1–5. Each block sets request.jwt.claims, switches to the
+--    authenticated role, attempts an INSERT, catches RLS denial as
+--    insufficient_privilege (SQLSTATE 42501), then resets role and
+--    asserts the expected outcome. Each block uses a unique row id so
+--    the inserts from earlier cases (allowed ones) don't collide with
+--    later assertion attempts. The transaction is rolled back at the
+--    end, so allowed inserts leave no residue.
+-- ---------------------------------------------------------------------------
+
+-- Case 1: Admin (User A in org1) inserts a Shared row (user_id IS NULL) in
+-- their own organization → allowed. This is the canonical "admin creates
+-- team@ mailbox" path the policy must continue to support.
+do $$
+declare
+  v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"41000000-0000-0000-0000-000000000010","active_organization_id":"41000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  begin
+    insert into public.email_accounts
+      (id, label, email_address, username, encrypted_password, organization_id, user_id)
+    values
+      ('41000000-0000-0000-0000-000000000101', 'admin-shared', 'team-1@smoke-222.invalid',
+       'team-1@smoke-222.invalid', 'x',
+       '41000000-0000-0000-0000-000000000001', null);
+  exception
+    when insufficient_privilege then v_blocked := true;
+  end;
+
+  reset role;
+
+  if v_blocked then
+    raise exception 'migration-222 smoke (case 1): admin INSERT of Shared row should be allowed, but RLS blocked it';
+  end if;
+  raise notice 'migration-222 smoke (case 1): admin Shared INSERT correctly allowed';
+end $$;
+
+-- Case 2 — TRACER BULLET. Non-admin (crew_lead, User B in org1) attempts to
+-- insert a Shared row (user_id IS NULL) in their own organization → denied
+-- by the new admin-EXISTS branch. The old migration-140 policy allowed this;
+-- this is the gap closed by #222.
+do $$
+declare
+  v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"41000000-0000-0000-0000-000000000011","active_organization_id":"41000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  begin
+    insert into public.email_accounts
+      (id, label, email_address, username, encrypted_password, organization_id, user_id)
+    values
+      ('41000000-0000-0000-0000-000000000102', 'crew_lead-shared-attempt', 'team-2@smoke-222.invalid',
+       'team-2@smoke-222.invalid', 'x',
+       '41000000-0000-0000-0000-000000000001', null);
+  exception
+    when insufficient_privilege then v_blocked := true;
+  end;
+
+  reset role;
+
+  if not v_blocked then
+    raise exception 'migration-222 smoke (case 2): non-admin INSERT of Shared row should have been blocked by RLS, but it succeeded';
+  end if;
+  raise notice 'migration-222 smoke (case 2): non-admin Shared INSERT correctly denied';
+end $$;
+
+-- Case 3: Non-admin (crew_lead, User B in org1) inserts a Personal row
+-- owned by themselves (user_id = auth.uid()) → allowed. The
+-- "user_id = auth.uid()" branch of WITH CHECK is unchanged from migration-140.
+do $$
+declare
+  v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"41000000-0000-0000-0000-000000000011","active_organization_id":"41000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  begin
+    insert into public.email_accounts
+      (id, label, email_address, username, encrypted_password, organization_id, user_id)
+    values
+      ('41000000-0000-0000-0000-000000000103', 'crew_lead-personal-self', 'b-self@smoke-222.invalid',
+       'b-self@smoke-222.invalid', 'x',
+       '41000000-0000-0000-0000-000000000001',
+       '41000000-0000-0000-0000-000000000011');
+  exception
+    when insufficient_privilege then v_blocked := true;
+  end;
+
+  reset role;
+
+  if v_blocked then
+    raise exception 'migration-222 smoke (case 3): non-admin INSERT of Personal-owned-by-self should be allowed, but RLS blocked it';
+  end if;
+  raise notice 'migration-222 smoke (case 3): non-admin Personal-self INSERT correctly allowed';
+end $$;
+
+-- Case 4: Non-admin (crew_lead, User B in org1) attempts to insert a
+-- Personal row owned by ANOTHER user (user_id = User A, the org admin) →
+-- denied. Neither branch of WITH CHECK passes: User B isn't an admin
+-- (Shared branch fails) and user_id != auth.uid() (Personal branch fails).
+do $$
+declare
+  v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"41000000-0000-0000-0000-000000000011","active_organization_id":"41000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  begin
+    insert into public.email_accounts
+      (id, label, email_address, username, encrypted_password, organization_id, user_id)
+    values
+      ('41000000-0000-0000-0000-000000000104', 'crew_lead-personal-other', 'a-by-b@smoke-222.invalid',
+       'a-by-b@smoke-222.invalid', 'x',
+       '41000000-0000-0000-0000-000000000001',
+       '41000000-0000-0000-0000-000000000010');
+  exception
+    when insufficient_privilege then v_blocked := true;
+  end;
+
+  reset role;
+
+  if not v_blocked then
+    raise exception 'migration-222 smoke (case 4): non-admin INSERT of Personal-owned-by-other should have been blocked by RLS, but it succeeded';
+  end if;
+  raise notice 'migration-222 smoke (case 4): non-admin Personal-other INSERT correctly denied';
+end $$;
+
+-- Case 5: Cross-Organization caller. User C is admin of org2; the JWT
+-- claims active_organization_id = org2; but the proposed row has
+-- organization_id = org1. WITH CHECK requires organization_id =
+-- nookleus.active_organization_id(), so the mismatch causes denial
+-- regardless of role. This case is unchanged from migration-140 — we
+-- include it for completeness of the create matrix.
+do $$
+declare
+  v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"41000000-0000-0000-0000-000000000012","active_organization_id":"41000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  begin
+    insert into public.email_accounts
+      (id, label, email_address, username, encrypted_password, organization_id, user_id)
+    values
+      ('41000000-0000-0000-0000-000000000105', 'cross-org-attempt', 'cross@smoke-222.invalid',
+       'cross@smoke-222.invalid', 'x',
+       '41000000-0000-0000-0000-000000000001', null);
+  exception
+    when insufficient_privilege then v_blocked := true;
+  end;
+
+  reset role;
+
+  if not v_blocked then
+    raise exception 'migration-222 smoke (case 5): cross-Organization INSERT should have been blocked by RLS, but it succeeded';
+  end if;
+  raise notice 'migration-222 smoke (case 5): cross-Organization INSERT correctly denied';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Done. A clean run prints no NOTICE lines after this ROLLBACK; a failed
+--    run aborted earlier with a clearly-labeled exception.
+-- ---------------------------------------------------------------------------
+rollback;

--- a/supabase/migration-222-tighten-email-accounts-shared-insert-rls.sql
+++ b/supabase/migration-222-tighten-email-accounts-shared-insert-rls.sql
@@ -1,0 +1,89 @@
+-- issue #222 (PRD #220, ADR 0001) — Tighten email_accounts INSERT RLS to
+-- enforce admin-only Shared creation.
+--
+-- Purpose:   Close the last open cell of ADR-0001's create matrix at the
+--            database. The migration-140 policy already enforces cross-Org
+--            isolation and "Personal owned by yourself only" in WITH CHECK;
+--            it does NOT enforce "Shared creation is admin-only." This
+--            migration adds that final cell — an inline admin EXISTS on
+--            user_organizations — to the Shared branch of WITH CHECK so
+--            every cell of the matrix is enforced at both layers (the
+--            email-account-access TypeScript module + the RLS policy).
+--
+-- Shape:     DROP + CREATE the policy. Only the WITH CHECK clause's
+--            "user_id IS NULL" branch changes; the USING clause is
+--            untouched (reads of existing rows are governed by the
+--            existing ADR-0001 matrix and do not need to know about
+--            admin-ness for visibility purposes). No helper function is
+--            introduced — the admin check is inlined. If a second policy
+--            ever needs the same check, a `nookleus.is_admin_of(org_id)`
+--            helper can be extracted in a follow-up.
+--
+-- Depends on: migration-140-email-accounts-shared-and-personal.sql (the
+--            policy this migration rewrites; if 140 has not run, this
+--            migration's DROP becomes a no-op and the CREATE establishes
+--            the policy from scratch in its post-#222 shape).
+--
+-- Smoke test: supabase/migration-222-smoke-test.sql exercises every cell
+--            of the create matrix (5 cases) via authenticated-role
+--            sessions. Run via Supabase MCP `execute_sql` once before
+--            this migration is applied to prod; it remains in the repo
+--            as the documented test of the policy.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom. Reverts the WITH
+--            CHECK clause to the migration-140 shape.
+
+-- ---------------------------------------------------------------------------
+-- 1. Drop + recreate the policy with the tightened WITH CHECK. The USING
+--    clause is byte-identical to migration-140. The WITH CHECK clause's
+--    "user_id IS NULL" branch now additionally requires the caller to be
+--    an admin of the proposed organization_id, inlined as an EXISTS
+--    against user_organizations.
+-- ---------------------------------------------------------------------------
+drop policy if exists email_accounts_shared_or_personal on public.email_accounts;
+
+create policy email_accounts_shared_or_personal on public.email_accounts
+  for all to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (user_id is null and nookleus.is_member_of(organization_id))
+      or user_id = auth.uid()
+    )
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (
+        user_id is null
+        and nookleus.is_member_of(organization_id)
+        and exists (
+          select 1
+            from public.user_organizations uo
+           where uo.user_id = auth.uid()
+             and uo.organization_id = email_accounts.organization_id
+             and uo.role = 'admin'
+        )
+      )
+      or user_id = auth.uid()
+    )
+  );
+
+-- ROLLBACK ---
+-- drop policy if exists email_accounts_shared_or_personal on public.email_accounts;
+-- create policy email_accounts_shared_or_personal on public.email_accounts
+--   for all to authenticated
+--   using (
+--     organization_id = nookleus.active_organization_id()
+--     and (
+--       (user_id is null and nookleus.is_member_of(organization_id))
+--       or user_id = auth.uid()
+--     )
+--   )
+--   with check (
+--     organization_id = nookleus.active_organization_id()
+--     and (
+--       (user_id is null and nookleus.is_member_of(organization_id))
+--       or user_id = auth.uid()
+--     )
+--   );


### PR DESCRIPTION
## Summary

- New `supabase/migration-222-tighten-email-accounts-shared-insert-rls.sql` drops + recreates the `email_accounts_shared_or_personal` policy with an inline admin EXISTS on `user_organizations` added to the WITH CHECK's `user_id IS NULL` branch. USING clause unchanged from migration-140.
- New `supabase/migration-222-smoke-test.sql` exercises all 5 create-matrix cases via `set local role authenticated` + JWT-claim seeding, catching RLS denial as `insufficient_privilege` (SQLSTATE 42501). Pattern follows migration-186-smoke-test (BEGIN/ROLLBACK) and migration-140-smoke-test (authenticated-role + JWT claims).
- Migration includes `-- ROLLBACK --` block restoring the migration-140 WITH CHECK shape.

## TDD evidence

1. **RED.** Ran case 2 (non-admin attempts Shared INSERT) against the *current* migration-140 policy via `execute_sql` — the assertion fired (`non-admin INSERT of Shared row should have been blocked by RLS, but it succeeded`), proving the test detects the gap.
2. **GREEN — tracer bullet.** Ran case 2 against the tightened policy applied in-transaction — pass.
3. **GREEN — full matrix.** Added cases 1, 3, 4, 5; ran the full 5-case smoke test against the tightened policy — all pass, empty result, transaction rolled back.
4. **Applied to prod.** `apply_migration` invoked after explicit "yes apply" approval. Migration recorded as version `20260523160721`. Live policy verified via `pg_policy` — the admin-EXISTS clause is in place.
5. **Post-apply re-verification.** Re-ran the 5-case smoke test against the now-live policy (skipping the embedded DROP+CREATE since the policy is already in the new shape) — all pass.

## Relationship to PRD #220

This is the **RLS slice** (issue #222). The **TypeScript slice** (issue #221 — `canCreateEmailAccount` + route delegation + unit tests) is being implemented in a parallel session and will land separately. ADR-0001's two-layer pattern is satisfied once both PRs merge: the TS module is the readable form, this RLS policy is the database floor.

## Out of scope

- No `nookleus.is_admin_of(org_id)` helper — admin check is inlined. If a second policy ever needs the same check, extract a helper in a follow-up.
- No UI changes. No new permission key. No domain-language change.

## Test plan

- [x] RED demonstrated against current policy (smoke case 2 catches the gap)
- [x] GREEN demonstrated against tightened policy applied in-transaction (5/5 cases)
- [x] Migration applied to prod via `apply_migration` after explicit approval
- [x] Live policy verified to contain the admin-EXISTS clause
- [x] Post-apply smoke test passes against the live policy (5/5 cases)
- [ ] Settings → Email flow manually verified unchanged (admin creates Shared; Crew Lead creates Personal-as-self)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)