### PR TITLE
feat(jobs): default to Comfortable view (#171)

### DIFF
--- a/src/lib/jobs/use-jobs-view-mode.ts
+++ b/src/lib/jobs/use-jobs-view-mode.ts
@@ -38,7 +38,7 @@ function getSnapshot(): JobsViewMode {
 // The server has no localStorage; render the default so the server markup
 // matches the first client paint and React hydrates without a mismatch.
 function getServerSnapshot(): JobsViewMode {
-  return "grid";
+  return "comfortable";
 }
 
 /**

--- a/src/lib/jobs/view-mode.test.ts
+++ b/src/lib/jobs/view-mode.test.ts
@@ -13,14 +13,14 @@ describe("parseJobsViewMode", () => {
     expect(parseJobsViewMode("list")).toBe("list");
   });
 
-  it("falls back to grid when nothing is stored", () => {
-    expect(parseJobsViewMode(null)).toBe("grid");
-    expect(parseJobsViewMode(undefined)).toBe("grid");
+  it("falls back to comfortable when nothing is stored", () => {
+    expect(parseJobsViewMode(null)).toBe("comfortable");
+    expect(parseJobsViewMode(undefined)).toBe("comfortable");
   });
 
-  it("falls back to grid for an unrecognized stored value", () => {
-    expect(parseJobsViewMode("banana")).toBe("grid");
-    expect(parseJobsViewMode("")).toBe("grid");
-    expect(parseJobsViewMode("GRID")).toBe("grid");
+  it("falls back to comfortable for an unrecognized stored value", () => {
+    expect(parseJobsViewMode("banana")).toBe("comfortable");
+    expect(parseJobsViewMode("")).toBe("comfortable");
+    expect(parseJobsViewMode("GRID")).toBe("comfortable");
   });
 });

--- a/src/lib/jobs/view-mode.ts
+++ b/src/lib/jobs/view-mode.ts
@@ -15,5 +15,5 @@ export function parseJobsViewMode(
   if (raw && (JOBS_VIEW_MODES as readonly string[]).includes(raw)) {
     return raw as JobsViewMode;
   }
-  return "grid";
+  return "comfortable";
 }


### PR DESCRIPTION
## Summary

- Switches the Jobs page default view from Cards to **Comfortable** for new visitors and anyone without a stored preference. Users who've already used the toggle keep whatever they picked.
- Touches the two spots that pin the default: `parseJobsViewMode` fallback in `src/lib/jobs/view-mode.ts:18` and `getServerSnapshot` in `src/lib/jobs/use-jobs-view-mode.ts:41`. Moving both together keeps SSR markup and the first client paint in sync (otherwise unstored users would flicker Comfortable → Grid on hydration via `useSyncExternalStore`).
- Updates the two fallback assertions in `src/lib/jobs/view-mode.test.ts`.

Closes #171.

## Test plan

- [x] `npx vitest run src/lib/jobs src/components/job-comfortable-row.test.tsx` — 26/26 pass.
- [ ] Manual smoke on `/jobs` in a fresh profile / cleared `jobs-view-mode` localStorage entry: Comfortable rows render on first load.
- [ ] Manual smoke on `/jobs` with `localStorage.jobs-view-mode = "grid"` set: Cards still render (stored preference still wins).
- [ ] Toggle to List and back, refresh — chosen mode persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)