### PR TITLE
feat(referral-partners): schema foundation + create-and-list (#250)

### DIFF
--- a/src/app/api/referral-partners/route.test.ts
+++ b/src/app/api/referral-partners/route.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postBody(body: unknown) {
+  return new Request("http://test/api/referral-partners", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("GET /api/referral-partners", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(new Request("http://test/api/referral-partners"), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — fee/lifecycle data is gated", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await GET(new Request("http://test/api/referral-partners"), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the list of partners for an admin", async () => {
+    const partner = {
+      id: "p-1",
+      organization_id: "org-1",
+      company_name: "Acme Plumbing",
+      status: "grey",
+    };
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [partner],
+      },
+    });
+    const res = await GET(new Request("http://test/api/referral-partners"), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.referral_partners).toEqual([partner]);
+  });
+
+  it("returns the list of partners for a crew_lead", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        referral_partners: [],
+      },
+    });
+    const res = await GET(new Request("http://test/api/referral-partners"), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/referral-partners", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(postBody({ company_name: "X" }), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await POST(postBody({ company_name: "X" }), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a body with no company_name with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "admin" }),
+    });
+    const res = await POST(postBody({ company_name: "  " }), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("a crew_lead can create a Target — the row is returned with status grey", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        // Seed the inserted-and-read-back row; the fake's insert() is a
+        // passthrough so single() returns whatever is on the table fixture.
+        referral_partners: [
+          {
+            id: "p-new",
+            organization_id: "org-1",
+            company_name: "Acme Plumbing",
+            status: "grey",
+            office_phone: null,
+            lead_source: null,
+            industry: null,
+            notes: null,
+          },
+        ],
+      },
+    });
+    const res = await POST(
+      postBody({
+        company_name: "Acme Plumbing",
+        office_phone: "",
+        lead_source: "",
+        industry: "",
+        notes: "",
+      }),
+      { params: Promise.resolve({}) },
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.referral_partner.status).toBe("grey");
+    expect(body.referral_partner.company_name).toBe("Acme Plumbing");
+  });
+});

--- a/src/app/api/referral-partners/route.ts
+++ b/src/app/api/referral-partners/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import {
+  buildNewTargetPayload,
+  isValidNewTarget,
+  type NewTargetInput,
+} from "@/lib/referral-partner-form";
+import {
+  EDIT_REFERRAL_PARTNERS,
+  VIEW_REFERRAL_PARTNERS,
+} from "@/lib/referral-partners/permission";
+
+// GET /api/referral-partners — list every Referral Partner in the Active
+// Organization that isn't in the soft-delete bin. Gated to admin / crew_lead;
+// crew_member receives 403.
+export const GET = withRequestContext(
+  VIEW_REFERRAL_PARTNERS,
+  async (_request, { supabase }) => {
+    const { data, error } = await supabase
+      .from("referral_partners")
+      .select("*")
+      .is("deleted_at", null)
+      .order("company_name", { ascending: true });
+    if (error) return apiDbError(error.message, "GET /api/referral-partners list");
+    return NextResponse.json({ referral_partners: data ?? [] });
+  },
+);
+
+// POST /api/referral-partners — create a new Target. Body matches the
+// NewTargetInput shape (5 fields). Validation + payload shape live in the
+// pure `referral-partner-form` module so this route stays a thin adapter.
+export const POST = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (request, { supabase, orgId }) => {
+    const raw = (await request.json()) as Partial<NewTargetInput>;
+    const input: NewTargetInput = {
+      company_name: raw.company_name ?? "",
+      office_phone: raw.office_phone ?? "",
+      lead_source: raw.lead_source ?? "",
+      industry: raw.industry ?? "",
+      notes: raw.notes ?? "",
+    };
+    if (!isValidNewTarget(input)) {
+      return NextResponse.json(
+        { error: "company_name is required" },
+        { status: 400 },
+      );
+    }
+    if (!orgId) {
+      // `roles` rule guarantees a non-null orgId on success, but the type
+      // exposes a nullable orgId; this is defensive.
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 400 },
+      );
+    }
+    const payload = buildNewTargetPayload(input, orgId);
+    const { data, error } = await supabase
+      .from("referral_partners")
+      .insert(payload)
+      .select("*")
+      .single();
+    if (error) {
+      return apiDbError(error.message, "POST /api/referral-partners insert");
+    }
+    return NextResponse.json({ referral_partner: data }, { status: 201 });
+  },
+);

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+// Referral Partners list page (PRD #249, issue #250).
+// Renders every non-deleted partner in the Active Organization with the
+// Lifecycle-status color chip, company name, and industry. The "+ Add
+// Target" button opens the New Target dialog. Filtering, sorting, and
+// per-row denormalized columns (last_called_at etc.) arrive in later
+// slices (#251, #254).
+
+import { useCallback, useEffect, useState } from "react";
+import { Handshake, Plus } from "lucide-react";
+import NewTargetDialog from "@/components/referral-partners/new-target-dialog";
+
+interface ReferralPartner {
+  id: string;
+  company_name: string;
+  status: "grey" | "yellow" | "green" | "red";
+  industry: string | null;
+}
+
+const STATUS_CHIP_CLASS: Record<ReferralPartner["status"], string> = {
+  grey:   "bg-gray-200 text-gray-700",
+  yellow: "bg-yellow-200 text-yellow-900",
+  green:  "bg-green-200 text-green-900",
+  red:    "bg-red-200 text-red-900",
+};
+
+const STATUS_LABEL: Record<ReferralPartner["status"], string> = {
+  grey:   "Uncontacted",
+  yellow: "In progress",
+  green:  "Active",
+  red:    "Declined",
+};
+
+export default function ReferralPartnersPage() {
+  const [partners, setPartners] = useState<ReferralPartner[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const res = await fetch("/api/referral-partners");
+    if (!res.ok) {
+      setError(res.status === 403 ? "You don't have access to Referral Partners." : "Could not load partners.");
+      setLoading(false);
+      return;
+    }
+    const body = await res.json();
+    setPartners(body.referral_partners ?? []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <header className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <Handshake size={24} className="text-primary" />
+          <h1 className="text-2xl font-heading font-semibold">Referral Partners</h1>
+        </div>
+        <button
+          onClick={() => setDialogOpen(true)}
+          className="btn btn-primary inline-flex items-center gap-2"
+        >
+          <Plus size={16} />
+          Add Target
+        </button>
+      </header>
+
+      {loading ? (
+        <p className="text-sm text-muted-foreground">Loading…</p>
+      ) : error ? (
+        <p className="text-sm text-destructive" role="alert">{error}</p>
+      ) : partners.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No partners yet. Click <strong>Add Target</strong> to start your cold-call list.
+        </p>
+      ) : (
+        <ul className="divide-y rounded-lg border border-border bg-card">
+          {partners.map((p) => (
+            <li key={p.id} className="flex items-center gap-4 px-4 py-3">
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[p.status]}`}
+              >
+                {STATUS_LABEL[p.status]}
+              </span>
+              <div className="flex-1 min-w-0">
+                <p className="font-medium truncate">{p.company_name}</p>
+                {p.industry && (
+                  <p className="text-xs text-muted-foreground truncate">{p.industry}</p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <NewTargetDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        onCreated={() => void load()}
+      />
+    </div>
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -21,9 +21,15 @@ export default function Sidebar() {
   const { order } = useNavOrder();
   const { collapsed, toggle } = useSidebarCollapse();
 
-  // Sort the canonical nav items by DB sort_order.
+  // Filter by membership role first, then sort by DB sort_order.
   // Items missing from the DB fall to the bottom in code-defined order.
-  const sortedNavItems = [...navItems].sort((a, b) => {
+  // An item with `requiredRoles` is hidden from any caller whose role
+  // isn't in the list (e.g. crew_member never sees Referral Partners).
+  const visibleNavItems = navItems.filter((item) => {
+    if (!item.requiredRoles) return true;
+    return profile?.role ? item.requiredRoles.includes(profile.role) : false;
+  });
+  const sortedNavItems = [...visibleNavItems].sort((a, b) => {
     const aOrder = order.get(a.href) ?? Infinity;
     const bOrder = order.get(b.href) ?? Infinity;
     if (aOrder !== bOrder) return aOrder - bOrder;

--- a/src/components/referral-partners/new-target-dialog.test.tsx
+++ b/src/components/referral-partners/new-target-dialog.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import NewTargetDialog from "./new-target-dialog";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockOkResponse(body: unknown = {}) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 201,
+    json: async () => body,
+  } as Response);
+}
+
+describe("NewTargetDialog", () => {
+  it("renders the five New Target fields when open", () => {
+    render(
+      <NewTargetDialog open onOpenChange={() => {}} onCreated={() => {}} />,
+    );
+    expect(screen.getByLabelText(/company name/i)).toBeDefined();
+    expect(screen.getByLabelText(/office phone/i)).toBeDefined();
+    expect(screen.getByLabelText(/lead source/i)).toBeDefined();
+    expect(screen.getByLabelText(/industry/i)).toBeDefined();
+    expect(screen.getByLabelText(/notes/i)).toBeDefined();
+  });
+
+  it("submit is disabled until company_name has a non-blank value", () => {
+    render(
+      <NewTargetDialog open onOpenChange={() => {}} onCreated={() => {}} />,
+    );
+    const submit = screen.getByRole("button", { name: /add target/i });
+    expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Acme Plumbing" },
+    });
+    expect((submit as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("posts the five fields to /api/referral-partners on submit", async () => {
+    mockOkResponse({
+      referral_partner: { id: "p-1", status: "grey", company_name: "Acme" },
+    });
+    render(
+      <NewTargetDialog open onOpenChange={() => {}} onCreated={() => {}} />,
+    );
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Acme Plumbing" },
+    });
+    fireEvent.change(screen.getByLabelText(/office phone/i), {
+      target: { value: "555-123-4567" },
+    });
+    fireEvent.change(screen.getByLabelText(/lead source/i), {
+      target: { value: "Google" },
+    });
+    fireEvent.change(screen.getByLabelText(/industry/i), {
+      target: { value: "Plumbing" },
+    });
+    fireEvent.change(screen.getByLabelText(/notes/i), {
+      target: { value: "found on yelp" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add target/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/referral-partners");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({
+      company_name: "Acme Plumbing",
+      office_phone: "555-123-4567",
+      lead_source: "Google",
+      industry: "Plumbing",
+      notes: "found on yelp",
+    });
+  });
+
+  it("closes the dialog and notifies the parent on a successful create", async () => {
+    mockOkResponse({
+      referral_partner: { id: "p-1", status: "grey", company_name: "Acme" },
+    });
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    render(
+      <NewTargetDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Acme Plumbing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add target/i }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalled());
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does NOT close the dialog when the server rejects the create", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "company_name is required" }),
+    } as Response);
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    render(
+      <NewTargetDialog
+        open
+        onOpenChange={onOpenChange}
+        onCreated={onCreated}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/company name/i), {
+      target: { value: "Acme Plumbing" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add target/i }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(onCreated).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/referral-partners/new-target-dialog.tsx
+++ b/src/components/referral-partners/new-target-dialog.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+// New Target dialog (PRD #249, issue #250). A minimal 5-field create form
+// for batch-adding cold-call targets off Google, Yelp, BBB. Every Target
+// lands in `grey` Lifecycle status — the API pins that, the dialog does
+// not negotiate. The Worksheet is where lifecycle progresses.
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { isValidNewTarget } from "@/lib/referral-partner-form";
+
+interface NewTargetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Invoked after a successful create — parent re-fetches the list. */
+  onCreated?: () => void;
+}
+
+export default function NewTargetDialog({
+  open,
+  onOpenChange,
+  onCreated,
+}: NewTargetDialogProps) {
+  const [companyName, setCompanyName] = useState("");
+  const [officePhone, setOfficePhone] = useState("");
+  const [leadSource, setLeadSource] = useState("");
+  const [industry, setIndustry] = useState("");
+  const [notes, setNotes] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function reset() {
+    setCompanyName("");
+    setOfficePhone("");
+    setLeadSource("");
+    setIndustry("");
+    setNotes("");
+    setError(null);
+  }
+
+  const input = {
+    company_name: companyName,
+    office_phone: officePhone,
+    lead_source: leadSource,
+    industry,
+    notes,
+  };
+  const canSubmit = !submitting && isValidNewTarget(input);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/referral-partners", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError(body.error ?? "Could not save target");
+        return;
+      }
+      reset();
+      onCreated?.();
+      onOpenChange(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) reset();
+        onOpenChange(o);
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a new Target</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Company name *</span>
+            <input
+              type="text"
+              required
+              value={companyName}
+              onChange={(e) => setCompanyName(e.target.value)}
+              className="rounded-md border border-input bg-background px-3 py-2"
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Office phone</span>
+            <input
+              type="text"
+              value={officePhone}
+              onChange={(e) => setOfficePhone(e.target.value)}
+              className="rounded-md border border-input bg-background px-3 py-2"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Lead source</span>
+            <input
+              type="text"
+              value={leadSource}
+              onChange={(e) => setLeadSource(e.target.value)}
+              placeholder="Google, Yelp, Thumbtack, website…"
+              className="rounded-md border border-input bg-background px-3 py-2"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Industry</span>
+            <input
+              type="text"
+              value={industry}
+              onChange={(e) => setIndustry(e.target.value)}
+              className="rounded-md border border-input bg-background px-3 py-2"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm">
+            <span>Notes</span>
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={3}
+              className="rounded-md border border-input bg-background px-3 py-2"
+            />
+          </label>
+          {error && (
+            <p className="text-sm text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => onOpenChange(false)}
+              className="btn"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className="btn btn-primary"
+            >
+              {submitting ? "Adding…" : "Add Target"}
+            </button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -10,6 +10,7 @@ import {
   Sparkles,
   Megaphone,
   Calculator,
+  Handshake,
 } from "lucide-react";
 import type { ComponentType } from "react";
 
@@ -17,6 +18,9 @@ export interface NavItem {
   href: string;
   label: string;
   icon: ComponentType<{ size?: number }>;
+  /** Membership roles allowed to see this item. Undefined = visible to every
+   *  authenticated member (the default for legacy items). */
+  requiredRoles?: readonly string[];
 }
 
 /**
@@ -33,6 +37,11 @@ export const navItems: NavItem[] = [
   { href: "/",          label: "Dashboard",  icon: LayoutDashboard },
   { href: "/jarvis",    label: "Jarvis",     icon: Sparkles },
   { href: "/marketing", label: "Marketing",  icon: Megaphone },
+  // Referral Partners sits directly below Marketing — gated to admin and
+  // crew_lead since referral-fee terms and decline reasons aren't
+  // crew_member-visible (PRD #249).
+  { href: "/referral-partners", label: "Referral Partners", icon: Handshake,
+    requiredRoles: ["admin", "crew_lead"] },
   { href: "/intake",    label: "New Intake", icon: ClipboardPlus },
   { href: "/jobs",      label: "Jobs",       icon: Briefcase },
   { href: "/photos",    label: "Photos",     icon: Camera },

--- a/src/lib/referral-partner-form.test.ts
+++ b/src/lib/referral-partner-form.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNewTargetPayload,
+  isValidNewTarget,
+  type NewTargetInput,
+} from "./referral-partner-form";
+
+const ORG = "org-1";
+
+function input(overrides: Partial<NewTargetInput> = {}): NewTargetInput {
+  return {
+    company_name: "Acme Plumbing",
+    office_phone: "",
+    lead_source: "",
+    industry: "",
+    notes: "",
+    ...overrides,
+  };
+}
+
+describe("isValidNewTarget", () => {
+  it("rejects an empty company_name — the only required field", () => {
+    expect(isValidNewTarget(input({ company_name: "" }))).toBe(false);
+    expect(isValidNewTarget(input({ company_name: "   " }))).toBe(false);
+  });
+
+  it("accepts any input with a non-blank company_name — every other field is optional", () => {
+    expect(isValidNewTarget(input())).toBe(true);
+    expect(
+      isValidNewTarget(input({ company_name: "X", office_phone: "" })),
+    ).toBe(true);
+  });
+});
+
+describe("buildNewTargetPayload", () => {
+  it("produces an insert payload pinned to grey status and scoped to the organization", () => {
+    const payload = buildNewTargetPayload(input(), ORG);
+    expect(payload.status).toBe("grey");
+    expect(payload.organization_id).toBe(ORG);
+    expect(payload.company_name).toBe("Acme Plumbing");
+  });
+
+  it("trims company_name so leading and trailing whitespace doesn't survive into storage", () => {
+    const payload = buildNewTargetPayload(
+      input({ company_name: "  Acme Plumbing  " }),
+      ORG,
+    );
+    expect(payload.company_name).toBe("Acme Plumbing");
+  });
+
+  it("collapses every blank optional field to null — empty strings never reach the column", () => {
+    const payload = buildNewTargetPayload(input(), ORG);
+    expect(payload.office_phone).toBeNull();
+    expect(payload.lead_source).toBeNull();
+    expect(payload.industry).toBeNull();
+    expect(payload.notes).toBeNull();
+  });
+
+  it("trims optional fields and keeps the non-blank ones", () => {
+    const payload = buildNewTargetPayload(
+      input({
+        office_phone: " 555-123-4567 ",
+        lead_source: "Google",
+        industry: "Plumbing",
+        notes: "  found on yelp  ",
+      }),
+      ORG,
+    );
+    expect(payload.office_phone).toBe("555-123-4567");
+    expect(payload.lead_source).toBe("Google");
+    expect(payload.industry).toBe("Plumbing");
+    expect(payload.notes).toBe("found on yelp");
+  });
+});

--- a/src/lib/referral-partner-form.ts
+++ b/src/lib/referral-partner-form.ts
@@ -1,0 +1,69 @@
+// Pure logic behind the New Target form (PRD #249, issue #250).
+//
+// Two I/O-free helpers, unit-tested in isolation: a validity guard for the
+// minimal 5-field cold-call create form, and a payload builder that
+// produces the row shape ready to insert into `referral_partners`. The
+// `status` field is always `'grey'` — every Target lands uncontacted; the
+// Worksheet is where the lifecycle progresses. Modelled after
+// `src/lib/insurance-picker.ts`.
+
+/** Raw user input from the New Target dialog — every optional field is
+ *  empty-string-or-content, never undefined, so the React form can bind
+ *  directly without controlled/uncontrolled gymnastics. */
+export interface NewTargetInput {
+  company_name: string;
+  office_phone: string;
+  lead_source: string;
+  industry: string;
+  notes: string;
+}
+
+/** The insert-ready shape for a new row in `referral_partners`. Optional
+ *  fields are null (not empty string) so the column reflects "not yet
+ *  known," matching how every other nullable text column in the schema
+ *  behaves. */
+export interface NewTargetPayload {
+  organization_id: string;
+  company_name: string;
+  office_phone: string | null;
+  lead_source: string | null;
+  industry: string | null;
+  notes: string | null;
+  status: "grey";
+}
+
+/**
+ * Whether the New Target form's contents are saveable.
+ *
+ * The only requirement is a non-blank `company_name`. Every other field is
+ * optional; the user may legitimately add a target with just a name they
+ * intend to enrich on the call.
+ */
+export function isValidNewTarget(input: NewTargetInput): boolean {
+  return input.company_name.trim().length > 0;
+}
+
+/**
+ * Build the row payload for inserting a Target. Always pinned to `grey`
+ * Lifecycle status (the cold-call list is by definition uncontacted).
+ * `company_name` is trimmed; every other text field is trimmed and
+ * collapsed to `null` when empty.
+ */
+export function buildNewTargetPayload(
+  input: NewTargetInput,
+  organizationId: string,
+): NewTargetPayload {
+  const nullable = (s: string): string | null => {
+    const trimmed = s.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+  return {
+    organization_id: organizationId,
+    company_name: input.company_name.trim(),
+    office_phone: nullable(input.office_phone),
+    lead_source: nullable(input.lead_source),
+    industry: nullable(input.industry),
+    notes: nullable(input.notes),
+    status: "grey",
+  };
+}

--- a/src/lib/referral-partners/permission.test.ts
+++ b/src/lib/referral-partners/permission.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluatePermissionRule } from "@/lib/request-context/evaluate-permission-rule";
+import {
+  EDIT_REFERRAL_PARTNERS,
+  VIEW_REFERRAL_PARTNERS,
+} from "./permission";
+
+function facts(role: string | null) {
+  return { role, grantedPermissions: [] };
+}
+
+describe("VIEW_REFERRAL_PARTNERS / EDIT_REFERRAL_PARTNERS", () => {
+  it("admin passes both rules — admins can do anything anyone else can on this surface", () => {
+    expect(evaluatePermissionRule(VIEW_REFERRAL_PARTNERS, facts("admin"))).toBe(true);
+    expect(evaluatePermissionRule(EDIT_REFERRAL_PARTNERS, facts("admin"))).toBe(true);
+  });
+
+  it("crew_lead passes both rules — leads run the cold-call program", () => {
+    expect(evaluatePermissionRule(VIEW_REFERRAL_PARTNERS, facts("crew_lead"))).toBe(true);
+    expect(evaluatePermissionRule(EDIT_REFERRAL_PARTNERS, facts("crew_lead"))).toBe(true);
+  });
+
+  it("crew_member is denied — fee terms and decline reasons aren't theirs to see", () => {
+    expect(evaluatePermissionRule(VIEW_REFERRAL_PARTNERS, facts("crew_member"))).toBe(false);
+    expect(evaluatePermissionRule(EDIT_REFERRAL_PARTNERS, facts("crew_member"))).toBe(false);
+  });
+
+  it("a caller with no membership in the active organization is denied", () => {
+    expect(evaluatePermissionRule(VIEW_REFERRAL_PARTNERS, facts(null))).toBe(false);
+    expect(evaluatePermissionRule(EDIT_REFERRAL_PARTNERS, facts(null))).toBe(false);
+  });
+});

--- a/src/lib/referral-partners/permission.ts
+++ b/src/lib/referral-partners/permission.ts
@@ -1,0 +1,21 @@
+// Permission rules for the Referral Partners surface (PRD #249, issue #250).
+//
+// `admin` and `crew_lead` memberships can view AND edit Referral Partners.
+// `crew_member` cannot see the surface at all. Splitting view and edit into
+// two named rules keeps room to diverge later (e.g. a future read-only role
+// for an outside-sales contractor) without rewriting every call site.
+
+import type { RequestContextRule } from "@/lib/request-context/with-request-context";
+
+const REFERRAL_PARTNER_ROLES = ["admin", "crew_lead"] as const;
+
+/** Used by the nav-visibility check, the list route, and the Worksheet route. */
+export const VIEW_REFERRAL_PARTNERS: RequestContextRule = {
+  roles: [...REFERRAL_PARTNER_ROLES],
+};
+
+/** Used by every mutation endpoint that creates, updates, or deletes
+ *  Referral Partners or Call log entries. */
+export const EDIT_REFERRAL_PARTNERS: RequestContextRule = {
+  roles: [...REFERRAL_PARTNER_ROLES],
+};

--- a/supabase/migration-build78-referral-partners-foundation.sql
+++ b/supabase/migration-build78-referral-partners-foundation.sql
@@ -1,0 +1,219 @@
+-- build78 (PRD #249, issue #250): Referral Partners foundation.
+--
+-- Schema for the first vertical slice of the Referral Partners surface:
+-- two new tables, an extension of contacts.role with `'referral_contact'`,
+-- and a nullable `contacts.referral_partner_id` FK that lets unlimited
+-- Referral Contacts point at one Referral Partner without a join table.
+--
+-- The call table (`referral_partner_calls`) is created here even though
+-- the UI doesn't exercise it yet (call-log read/write lands in issue
+-- #254). One migration round-trip is cheaper than two; the smoke test
+-- covers both tables in the same `begin; ... rollback;` script.
+--
+-- RLS pattern: tenant_isolation_* (mirrors build49) AND a role check
+-- restricting all CRUD to `admin` and `crew_lead`. `crew_member` cannot
+-- see Referral Partners at all (PRD #249 user story #24).
+--
+-- Revert: see -- ROLLBACK --- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. referral_partners — the canonical home for each Referral Partner company.
+-- ---------------------------------------------------------------------------
+create table if not exists public.referral_partners (
+  id                  uuid primary key default gen_random_uuid(),
+  organization_id     uuid not null references public.organizations(id) on delete restrict,
+  company_name        text not null,
+  status              text not null default 'grey'
+                        check (status in ('grey', 'yellow', 'green', 'red')),
+  industry            text,
+  lead_source         text,
+  operation_size      text,
+  office_phone        text,
+  office_email        text,
+  website             text,
+  address             text,
+  referral_fee_terms  text,
+  notes               text,
+  primary_contact_id  uuid references public.contacts(id) on delete set null,
+  owner_contact_id    uuid references public.contacts(id) on delete set null,
+  last_called_at      timestamptz,
+  last_call_outcome   text,
+  next_follow_up_at   timestamptz,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  deleted_at          timestamptz
+);
+
+create index if not exists idx_referral_partners_org
+  on public.referral_partners (organization_id, deleted_at);
+
+create trigger trg_referral_partners_updated_at
+  before update on public.referral_partners
+  for each row execute function update_updated_at();
+
+alter table public.referral_partners enable row level security;
+
+-- Tenant isolation + admin / crew_lead gate. crew_member sees nothing.
+create policy tenant_isolation_referral_partners
+  on public.referral_partners for all to authenticated
+  using (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = referral_partners.organization_id
+         and uo.role in ('admin', 'crew_lead')
+    )
+  )
+  with check (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = referral_partners.organization_id
+         and uo.role in ('admin', 'crew_lead')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 2. referral_partner_calls — one row per cold-call attempt. Cascades on the
+--    partner so a hard-delete cleans the history with the row.
+-- ---------------------------------------------------------------------------
+create table if not exists public.referral_partner_calls (
+  id                    uuid primary key default gen_random_uuid(),
+  organization_id       uuid not null references public.organizations(id) on delete restrict,
+  referral_partner_id   uuid not null references public.referral_partners(id) on delete cascade,
+  referral_contact_id   uuid references public.contacts(id) on delete set null,
+  user_id               uuid not null references auth.users(id) on delete restrict,
+  called_at             timestamptz not null default now(),
+  outcome               text not null
+                          check (outcome in (
+                            'no_answer',
+                            'voicemail',
+                            'spoke',
+                            'not_interested',
+                            'interested',
+                            'scheduled_followup'
+                          )),
+  notes                 text,
+  follow_up_at          timestamptz,
+  created_at            timestamptz not null default now()
+);
+
+create index if not exists idx_referral_partner_calls_partner
+  on public.referral_partner_calls (referral_partner_id, called_at desc);
+
+create index if not exists idx_referral_partner_calls_org
+  on public.referral_partner_calls (organization_id);
+
+alter table public.referral_partner_calls enable row level security;
+
+create policy tenant_isolation_referral_partner_calls
+  on public.referral_partner_calls for all to authenticated
+  using (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = referral_partner_calls.organization_id
+         and uo.role in ('admin', 'crew_lead')
+    )
+  )
+  with check (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = referral_partner_calls.organization_id
+         and uo.role in ('admin', 'crew_lead')
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. Extend contacts.role with 'referral_contact'.
+--    The original constraint was inline-on-column from supabase/schema.sql,
+--    so its name is the Postgres default `contacts_role_check`. Drop and
+--    re-add with the extended value set. Existing roles are preserved.
+-- ---------------------------------------------------------------------------
+alter table public.contacts drop constraint if exists contacts_role_check;
+alter table public.contacts add constraint contacts_role_check
+  check (role in (
+    'homeowner',
+    'tenant',
+    'property_manager',
+    'adjuster',
+    'insurance',
+    'referral_contact'
+  ));
+
+-- ---------------------------------------------------------------------------
+-- 4. contacts.referral_partner_id — nullable FK to referral_partners.
+--    ON DELETE SET NULL so a hard-deleted partner doesn't take its people
+--    with it (PRD #249 user story #23) — the contacts survive as orphans.
+-- ---------------------------------------------------------------------------
+alter table public.contacts
+  add column if not exists referral_partner_id uuid
+    references public.referral_partners(id) on delete set null;
+
+create index if not exists idx_contacts_referral_partner_id
+  on public.contacts (referral_partner_id)
+  where referral_partner_id is not null;
+
+-- ---------------------------------------------------------------------------
+-- 5. Sidebar position — put "Referral Partners" directly below Marketing.
+--    Look up Marketing's CURRENT sort_order at apply-time (it may have been
+--    reordered by an admin since the build29 seed — at the time this
+--    migration first shipped, AAA prod had Marketing at 9, not 3). Shift
+--    everything below Marketing by +1 and insert at Marketing+1. If
+--    Marketing isn't present at all (a fresh DB without the seed),
+--    append to the end. Idempotent against re-runs.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_marketing_pos int;
+  v_target_pos    int;
+begin
+  if not exists (select 1 from public.nav_items where href = '/referral-partners') then
+    select sort_order into v_marketing_pos
+      from public.nav_items where href = '/marketing';
+
+    if v_marketing_pos is null then
+      select coalesce(max(sort_order), 0) + 1
+        into v_target_pos from public.nav_items;
+    else
+      v_target_pos := v_marketing_pos + 1;
+      update public.nav_items
+         set sort_order = sort_order + 1
+       where sort_order >= v_target_pos;
+    end if;
+
+    insert into public.nav_items (href, sort_order)
+      values ('/referral-partners', v_target_pos);
+  end if;
+end $$;
+
+-- ROLLBACK ---
+-- -- Capture the slot the new item occupied, then peel everything back.
+-- do $$
+-- declare v_pos int;
+-- begin
+--   select sort_order into v_pos from public.nav_items where href = '/referral-partners';
+--   delete from public.nav_items where href = '/referral-partners';
+--   if v_pos is not null then
+--     update public.nav_items set sort_order = sort_order - 1 where sort_order > v_pos;
+--   end if;
+-- end $$;
+-- drop index if exists public.idx_contacts_referral_partner_id;
+-- alter table public.contacts drop column if exists referral_partner_id;
+-- alter table public.contacts drop constraint if exists contacts_role_check;
+-- alter table public.contacts add constraint contacts_role_check
+--   check (role in ('homeowner', 'tenant', 'property_manager', 'adjuster', 'insurance'));
+-- drop policy if exists tenant_isolation_referral_partner_calls on public.referral_partner_calls;
+-- drop table if exists public.referral_partner_calls;
+-- drop policy if exists tenant_isolation_referral_partners on public.referral_partners;
+-- drop trigger if exists trg_referral_partners_updated_at on public.referral_partners;
+-- drop table if exists public.referral_partners;

--- a/supabase/migration-build78-smoke-test.sql
+++ b/supabase/migration-build78-smoke-test.sql
@@ -1,0 +1,251 @@
+-- build78 (PRD #249, issue #250) — Referral Partners foundation smoke test.
+--
+-- Purpose:   Self-checking script that verifies the migration's schema
+--            invariants. NOT part of the migration. Wrapped in
+--            begin; ... rollback; so the database is unchanged on a clean
+--            run. Every assertion raises an exception on failure; a clean
+--            run prints only NOTICE lines.
+--
+-- Preconditions: build78 has already been applied. The script exercises
+--            invariants assuming the tables, constraints, FKs, and RLS
+--            policies are in place.
+--
+-- Run:       psql -f supabase/migration-build78-smoke-test.sql
+--            (or paste into the Supabase SQL editor).
+--
+-- What it pins:
+--   1. Both new tables exist with expected columns.
+--   2. referral_partners.status check accepts every value in the
+--      Lifecycle-status enum (grey/yellow/green/red) and rejects others;
+--      `grey` is the default.
+--   3. referral_partner_calls.outcome check accepts every value in the
+--      call-outcome enum and rejects others.
+--   4. contacts.role check accepts 'referral_contact' AND every existing
+--      role value — the extension is non-breaking.
+--   5. Hard-delete of a referral_partner cascades referral_partner_calls
+--      and nulls contacts.referral_partner_id (people survive as orphans).
+--   6. RLS policies with the admin/crew_lead role gate exist on both new
+--      tables. (Live RLS visibility is exercised by integration tests at
+--      the application layer where auth.uid() is real.)
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Tables and key columns exist.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_missing text;
+begin
+  select string_agg(missing_col, ', ')
+    into v_missing
+  from (
+    select 'referral_partners.' || col as missing_col
+      from unnest(array[
+        'id', 'organization_id', 'company_name', 'status', 'industry',
+        'lead_source', 'operation_size', 'office_phone', 'office_email',
+        'website', 'address', 'referral_fee_terms', 'notes',
+        'primary_contact_id', 'owner_contact_id',
+        'last_called_at', 'last_call_outcome', 'next_follow_up_at',
+        'created_at', 'updated_at', 'deleted_at'
+      ]) as col
+     where not exists (
+       select 1 from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'referral_partners'
+          and column_name = col
+     )
+    union all
+    select 'referral_partner_calls.' || col
+      from unnest(array[
+        'id', 'organization_id', 'referral_partner_id', 'referral_contact_id',
+        'user_id', 'called_at', 'outcome', 'notes', 'follow_up_at', 'created_at'
+      ]) as col
+     where not exists (
+       select 1 from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'referral_partner_calls'
+          and column_name = col
+     )
+    union all
+    select 'contacts.referral_partner_id'
+     where not exists (
+       select 1 from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'contacts'
+          and column_name = 'referral_partner_id'
+     )
+  ) m;
+
+  if v_missing is not null then
+    raise exception 'build78 smoke: missing column(s): %', v_missing;
+  end if;
+  raise notice 'build78 smoke: tables + columns present';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Constraint + behavior tests. Wrapped in one do-block so every locally
+--    declared id is in scope. All inserts roll back at the end.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_org_id        uuid := gen_random_uuid();
+  v_user_id       uuid;
+  v_have_real_user boolean;
+  v_partner_id    uuid;
+  v_partner_status text;
+  v_contact_a     uuid := gen_random_uuid();
+  v_contact_b     uuid := gen_random_uuid();
+  v_call_count    int;
+  v_contact_link_count int;
+begin
+  -- Pick any existing auth.users row so the FK on referral_partner_calls.user_id
+  -- is satisfiable. If the smoke test runs on a DB with no users (rare), the
+  -- call-attempt branches below skip themselves.
+  select id into v_user_id from auth.users limit 1;
+  v_have_real_user := v_user_id is not null;
+
+  insert into public.organizations (id, name, slug)
+    values (
+      v_org_id,
+      'build78 smoke',
+      'build78-smoke-' || replace(v_org_id::text, '-', '')
+    );
+
+  -- ----- 2a. Lifecycle-status check constraint -----
+  begin
+    insert into public.referral_partners (organization_id, company_name, status)
+      values (v_org_id, 'Bad Status Co', 'purple');
+    raise exception 'build78 smoke: referral_partners.status accepted invalid value "purple"';
+  exception when check_violation then
+    null; -- expected
+  end;
+
+  insert into public.referral_partners (organization_id, company_name)
+    values (v_org_id, 'Default Grey Co')
+    returning id, status into v_partner_id, v_partner_status;
+  if v_partner_status is distinct from 'grey' then
+    raise exception 'build78 smoke: referral_partners.status default is not "grey" (got %)', v_partner_status;
+  end if;
+
+  update public.referral_partners set status = 'yellow' where id = v_partner_id;
+  update public.referral_partners set status = 'green'  where id = v_partner_id;
+  update public.referral_partners set status = 'red'    where id = v_partner_id;
+  update public.referral_partners set status = 'grey'   where id = v_partner_id;
+  raise notice 'build78 smoke: referral_partners.status — default grey, accepts all 4 values, rejects "purple"';
+
+  -- ----- 2b. Call-outcome check constraint -----
+  if v_have_real_user then
+    begin
+      insert into public.referral_partner_calls (organization_id, referral_partner_id, user_id, outcome)
+        values (v_org_id, v_partner_id, v_user_id, 'maybe_later');
+      raise exception 'build78 smoke: referral_partner_calls.outcome accepted invalid value "maybe_later"';
+    exception when check_violation then
+      null;
+    end;
+
+    -- Every valid outcome must accept (no exception expected on the inserts).
+    insert into public.referral_partner_calls (organization_id, referral_partner_id, user_id, outcome)
+      values
+        (v_org_id, v_partner_id, v_user_id, 'no_answer'),
+        (v_org_id, v_partner_id, v_user_id, 'voicemail'),
+        (v_org_id, v_partner_id, v_user_id, 'spoke'),
+        (v_org_id, v_partner_id, v_user_id, 'not_interested'),
+        (v_org_id, v_partner_id, v_user_id, 'interested'),
+        (v_org_id, v_partner_id, v_user_id, 'scheduled_followup');
+    raise notice 'build78 smoke: referral_partner_calls.outcome — accepts all 6 values, rejects "maybe_later"';
+  else
+    raise notice 'build78 smoke: outcome check skipped — no auth.users row available';
+  end if;
+
+  -- ----- 2c. contacts.role extension -----
+  insert into public.contacts (id, organization_id, full_name, role)
+    values
+      (gen_random_uuid(), v_org_id, 'Homeowner A',        'homeowner'),
+      (gen_random_uuid(), v_org_id, 'Tenant A',           'tenant'),
+      (gen_random_uuid(), v_org_id, 'PM A',               'property_manager'),
+      (gen_random_uuid(), v_org_id, 'Adjuster A',         'adjuster'),
+      (gen_random_uuid(), v_org_id, 'Insurance A',        'insurance'),
+      (gen_random_uuid(), v_org_id, 'Referral Contact A', 'referral_contact');
+  raise notice 'build78 smoke: contacts.role — accepts referral_contact + all 5 pre-existing roles';
+
+  begin
+    insert into public.contacts (id, organization_id, full_name, role)
+      values (gen_random_uuid(), v_org_id, 'Bad Role', 'crew_member');
+    raise exception 'build78 smoke: contacts.role accepted invalid value "crew_member"';
+  exception when check_violation then
+    null;
+  end;
+
+  -- ----- 2d. Hard-delete cascade + SET NULL behavior -----
+  insert into public.contacts (id, organization_id, full_name, role, referral_partner_id)
+    values
+      (v_contact_a, v_org_id, 'Primary @ Partner', 'referral_contact', v_partner_id),
+      (v_contact_b, v_org_id, 'Owner @ Partner',   'referral_contact', v_partner_id);
+
+  update public.referral_partners
+     set primary_contact_id = v_contact_a,
+         owner_contact_id   = v_contact_b
+   where id = v_partner_id;
+
+  delete from public.referral_partners where id = v_partner_id;
+
+  select count(*) into v_call_count
+    from public.referral_partner_calls
+   where referral_partner_id = v_partner_id;
+  if v_call_count <> 0 then
+    raise exception 'build78 smoke: referral_partner_calls did NOT cascade (% rows survive)', v_call_count;
+  end if;
+
+  select count(*) into v_contact_link_count
+    from public.contacts
+   where id in (v_contact_a, v_contact_b)
+     and referral_partner_id is not null;
+  if v_contact_link_count <> 0 then
+    raise exception 'build78 smoke: contacts.referral_partner_id NOT nulled on partner delete (% rows still linked)', v_contact_link_count;
+  end if;
+
+  if not exists (select 1 from public.contacts where id = v_contact_a)
+     or not exists (select 1 from public.contacts where id = v_contact_b) then
+    raise exception 'build78 smoke: contact rows vanished on partner delete — they should orphan, not cascade';
+  end if;
+
+  raise notice 'build78 smoke: hard-delete — calls cascade, contacts.referral_partner_id nulled, contact rows survive';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS policies with admin/crew_lead role gate exist on both tables.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_partners_policy text;
+  v_calls_policy    text;
+begin
+  select string_agg(polname, ', ')
+    into v_partners_policy
+  from pg_policy p
+  join pg_class c on c.oid = p.polrelid
+  where c.relname = 'referral_partners'
+    and pg_get_expr(p.polqual, p.polrelid) ilike '%admin%'
+    and pg_get_expr(p.polqual, p.polrelid) ilike '%crew_lead%';
+
+  if v_partners_policy is null then
+    raise exception 'build78 smoke: referral_partners has no RLS policy gating on admin/crew_lead';
+  end if;
+
+  select string_agg(polname, ', ')
+    into v_calls_policy
+  from pg_policy p
+  join pg_class c on c.oid = p.polrelid
+  where c.relname = 'referral_partner_calls'
+    and pg_get_expr(p.polqual, p.polrelid) ilike '%admin%'
+    and pg_get_expr(p.polqual, p.polrelid) ilike '%crew_lead%';
+
+  if v_calls_policy is null then
+    raise exception 'build78 smoke: referral_partner_calls has no RLS policy gating on admin/crew_lead';
+  end if;
+
+  raise notice 'build78 smoke: RLS — referral_partners (%) and referral_partner_calls (%) gate on admin/crew_lead', v_partners_policy, v_calls_policy;
+end $$;
+
+rollback;


### PR DESCRIPTION
## Summary
- build78 migration adds `referral_partners` + `referral_partner_calls` tables, extends `contacts.role` with `'referral_contact'`, adds nullable `contacts.referral_partner_id` FK. RLS on both new tables gates to `admin` / `crew_lead`; `crew_member` cannot see the surface at all.
- New role-gated nav item **Referral Partners** sits directly below Marketing. List page renders status chip + company name + industry; "+ Add Target" opens the 5-field New Target dialog that creates the row in `grey` Lifecycle status via `POST /api/referral-partners`.
- Two pure-logic deep modules: `referral-partner-form` (validation + insert-payload shape) and `referral-partners/permission` (`VIEW_REFERRAL_PARTNERS` / `EDIT_REFERRAL_PARTNERS` rules reused by the route + nav + future call sites).

## TDD breakdown
| Module / surface | Tests | Prior art |
|---|---|---|
| `referral-partner-form` | 6 Vitest unit | `src/lib/insurance-picker.test.ts` |
| `referral-partners/permission` | 4 Vitest unit | `src/lib/email/email-account-access.test.ts` |
| `POST /api/referral-partners` + `GET` | 8 route tests (401 / 403 crew_member / 200 admin + crew_lead / 400 missing name / 201 with status=grey) | `src/app/api/estimates/route.test.ts` |
| New Target dialog | 5 RTL integration | `src/components/intake-form.test.tsx` |
| `supabase/migration-build78-smoke-test.sql` | self-checking `begin; ... rollback;` | `supabase/migration-186-smoke-test.sql` |

**23 new tests, all green.** Pre-existing failures unchanged: 2 in `src/app/api/email/accounts/route.test.ts` and 1 TS error in `src/lib/email/sync-folder-incremental.test.ts:246` — both verified on `main` via `git stash`.

## Migration
Applied to AAA prod (`rzzprgidqbnqcdupmpfe`). Post-apply nav reordering corrected: the initial migration's hardcoded "shift everything ≥ sort_order 4" assumed Marketing was still at the build29-seed position of 3, but it had since been reordered to 9. Corrected in prod with a 2-statement `UPDATE` (Intake..Marketing shifted down by 1; Referral Partners set to 9), and the migration SQL now looks up Marketing's actual `sort_order` at apply-time. Final prod nav order:

```
1 Jarvis · 2 Dashboard · 3 Email · 4 Intake · 5 Jobs · 6 Photos
7 Reports · 8 Marketing · 9 Referral Partners · 10 Accounting
11 Contacts · 12 Settings
```

Schema invariants verified in prod via `information_schema` reads (21 cols on `referral_partners`, 10 on `referral_partner_calls`, `contacts.referral_partner_id` present).

## Test plan
- [ ] Browser: sign in as `admin` → confirm **Referral Partners** appears below Marketing in the sidebar
- [ ] Browser: click it → `/referral-partners` renders the empty-state copy
- [ ] Browser: click **+ Add Target** → dialog opens with 5 fields, submit disabled until company name is non-blank
- [ ] Browser: submit → row appears in the list with the grey "Uncontacted" chip
- [ ] Browser: switch to a `crew_member` membership → nav item is hidden and `/referral-partners` returns 403
- [ ] Re-run `supabase/migration-build78-smoke-test.sql` in the SQL editor (the live execution was blocked by the auto-mode classifier this session; the script is unchanged from what was written)

**Not browser-verified yet** — no Chrome MCP reachable from this session. Closes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)