### PR TITLE
feat(referral-partners): Lifecycle status / industry / company-name filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ yarn-error.log*
 !.claude/commands/
 !.claude/agents/
 
+# git worktrees
+.worktrees/
+
 # vercel
 .vercel
 

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -1,42 +1,60 @@
 "use client";
 
-// Referral Partners list page (PRD #249, issue #250).
+// Referral Partners list page (PRD #249, issues #250, #251).
 // Renders every non-deleted partner in the Active Organization with the
 // Lifecycle-status color chip, company name, and industry. The "+ Add
-// Target" button opens the New Target dialog. Filtering, sorting, and
-// per-row denormalized columns (last_called_at etc.) arrive in later
-// slices (#251, #254).
+// Target" button opens the New Target dialog.
+//
+// Filtering (#251) — Lifecycle-status chips, an industry dropdown, and a
+// search-by-company-name box — composes via the pure
+// `referral-partner-filter` module. The page does not encode the filter
+// rule; it just owns the form state and delegates.
 
-import { useCallback, useEffect, useState } from "react";
-import { Handshake, Plus } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Handshake, Plus, Search } from "lucide-react";
 import NewTargetDialog from "@/components/referral-partners/new-target-dialog";
+import {
+  distinctIndustries,
+  filterReferralPartners,
+  type LifecycleStatus,
+} from "@/lib/referral-partner-filter";
 
 interface ReferralPartner {
   id: string;
   company_name: string;
-  status: "grey" | "yellow" | "green" | "red";
+  status: LifecycleStatus;
   industry: string | null;
 }
 
-const STATUS_CHIP_CLASS: Record<ReferralPartner["status"], string> = {
+const STATUS_CHIP_CLASS: Record<LifecycleStatus, string> = {
   grey:   "bg-gray-200 text-gray-700",
   yellow: "bg-yellow-200 text-yellow-900",
   green:  "bg-green-200 text-green-900",
   red:    "bg-red-200 text-red-900",
 };
 
-const STATUS_LABEL: Record<ReferralPartner["status"], string> = {
+const STATUS_LABEL: Record<LifecycleStatus, string> = {
   grey:   "Uncontacted",
   yellow: "In progress",
   green:  "Active",
   red:    "Declined",
 };
 
+const ALL_STATUSES: ReadonlyArray<LifecycleStatus> = ["grey", "yellow", "green", "red"];
+
 export default function ReferralPartnersPage() {
   const [partners, setPartners] = useState<ReferralPartner[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Filter state — every chip on by default so the user sees everything
+  // before narrowing. Industry and query empty until the user picks one.
+  const [activeStatuses, setActiveStatuses] = useState<Set<LifecycleStatus>>(
+    () => new Set(ALL_STATUSES),
+  );
+  const [industry, setIndustry] = useState<string>("");
+  const [query, setQuery] = useState<string>("");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -56,6 +74,27 @@ export default function ReferralPartnersPage() {
     void load();
   }, [load]);
 
+  const industries = useMemo(() => distinctIndustries(partners), [partners]);
+
+  const visiblePartners = useMemo(
+    () =>
+      filterReferralPartners(partners, {
+        status: Array.from(activeStatuses),
+        industry,
+        query,
+      }),
+    [partners, activeStatuses, industry, query],
+  );
+
+  const toggleStatus = (s: LifecycleStatus) => {
+    setActiveStatuses((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  };
+
   return (
     <div className="p-6 max-w-5xl mx-auto">
       <header className="flex items-center justify-between mb-6">
@@ -72,6 +111,55 @@ export default function ReferralPartnersPage() {
         </button>
       </header>
 
+      <div className="mb-4 flex flex-wrap items-center gap-3">
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label="Filter by Lifecycle status"
+        >
+          {ALL_STATUSES.map((s) => {
+            const active = activeStatuses.has(s);
+            return (
+              <button
+                key={s}
+                type="button"
+                onClick={() => toggleStatus(s)}
+                aria-pressed={active}
+                className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium transition ${
+                  STATUS_CHIP_CLASS[s]
+                } ${active ? "ring-2 ring-primary" : "opacity-40"}`}
+              >
+                {STATUS_LABEL[s]}
+              </button>
+            );
+          })}
+        </div>
+
+        <select
+          aria-label="Filter by industry"
+          value={industry}
+          onChange={(e) => setIndustry(e.target.value)}
+          className="rounded-md border border-border bg-card px-2 py-1 text-sm"
+        >
+          <option value="">All industries</option>
+          {industries.map((i) => (
+            <option key={i} value={i}>{i}</option>
+          ))}
+        </select>
+
+        <label className="relative flex items-center flex-1 min-w-[12rem] max-w-sm">
+          <Search size={14} className="absolute left-2 text-muted-foreground" aria-hidden />
+          <input
+            type="search"
+            placeholder="Search company name"
+            aria-label="Search by company name"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="w-full rounded-md border border-border bg-card pl-7 pr-2 py-1 text-sm"
+          />
+        </label>
+      </div>
+
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : error ? (
@@ -80,9 +168,13 @@ export default function ReferralPartnersPage() {
         <p className="text-sm text-muted-foreground">
           No partners yet. Click <strong>Add Target</strong> to start your cold-call list.
         </p>
+      ) : visiblePartners.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No partners match the current filters.
+        </p>
       ) : (
         <ul className="divide-y rounded-lg border border-border bg-card">
-          {partners.map((p) => (
+          {visiblePartners.map((p) => (
             <li key={p.id} className="flex items-center gap-4 px-4 py-3">
               <span
                 className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[p.status]}`}

--- a/src/lib/referral-partner-filter.test.ts
+++ b/src/lib/referral-partner-filter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  distinctIndustries,
+  filterReferralPartners,
+  type FilterableReferralPartner,
+} from "./referral-partner-filter";
+
+const partner = (
+  overrides: Partial<FilterableReferralPartner> = {},
+): FilterableReferralPartner => ({
+  id: "p",
+  company_name: "Acme Plumbing",
+  status: "grey",
+  industry: "Plumbing",
+  ...overrides,
+});
+
+describe("filterReferralPartners", () => {
+  it("returns every partner when no filters are supplied", () => {
+    const partners = [
+      partner({ id: "a" }),
+      partner({ id: "b", status: "green" }),
+      partner({ id: "c", status: "red", industry: null }),
+    ];
+    expect(filterReferralPartners(partners, {})).toEqual(partners);
+  });
+
+  it("narrows to a single industry when the dropdown selects one", () => {
+    const partners = [
+      partner({ id: "a", industry: "Plumbing" }),
+      partner({ id: "b", industry: "Restoration" }),
+      partner({ id: "c", industry: "Plumbing" }),
+      partner({ id: "d", industry: null }),
+    ];
+    const result = filterReferralPartners(partners, { industry: "Plumbing" });
+    expect(result.map((p) => p.id)).toEqual(["a", "c"]);
+  });
+
+  it("matches the search query as a case-insensitive substring of company_name", () => {
+    const partners = [
+      partner({ id: "a", company_name: "Acme Plumbing" }),
+      partner({ id: "b", company_name: "Beachside Restoration" }),
+      partner({ id: "c", company_name: "ACE Plumbing & Heating" }),
+    ];
+    const result = filterReferralPartners(partners, { query: "plumb" });
+    expect(result.map((p) => p.id)).toEqual(["a", "c"]);
+  });
+
+  it("treats an empty or whitespace-only query as a no-op", () => {
+    const partners = [
+      partner({ id: "a" }),
+      partner({ id: "b", status: "green" }),
+    ];
+    expect(filterReferralPartners(partners, { query: "" })).toEqual(partners);
+    expect(filterReferralPartners(partners, { query: "   " })).toEqual(partners);
+  });
+
+  it("keeps only the Lifecycle statuses the chip filter has enabled", () => {
+    const partners = [
+      partner({ id: "g", status: "grey" }),
+      partner({ id: "y", status: "yellow" }),
+      partner({ id: "gr", status: "green" }),
+      partner({ id: "r", status: "red" }),
+    ];
+    const result = filterReferralPartners(partners, { status: ["yellow", "green"] });
+    expect(result.map((p) => p.id)).toEqual(["y", "gr"]);
+  });
+
+  it("composes status, industry, and query with AND semantics", () => {
+    const partners = [
+      partner({ id: "a", status: "grey",   industry: "Plumbing",    company_name: "Acme Plumbing" }),
+      partner({ id: "b", status: "green",  industry: "Plumbing",    company_name: "Acme Plumbing East" }),
+      partner({ id: "c", status: "grey",   industry: "Restoration", company_name: "Acme Restoration" }),
+      partner({ id: "d", status: "grey",   industry: "Plumbing",    company_name: "Beta Plumbing" }),
+    ];
+    const result = filterReferralPartners(partners, {
+      status: ["grey"],
+      industry: "Plumbing",
+      query: "acme",
+    });
+    expect(result.map((p) => p.id)).toEqual(["a"]);
+  });
+});
+
+describe("distinctIndustries", () => {
+  it("returns the unique, non-null industries sorted alphabetically", () => {
+    const partners = [
+      partner({ id: "a", industry: "Plumbing" }),
+      partner({ id: "b", industry: "Restoration" }),
+      partner({ id: "c", industry: "Plumbing" }),
+      partner({ id: "d", industry: null }),
+      partner({ id: "e", industry: "Adjusting" }),
+    ];
+    expect(distinctIndustries(partners)).toEqual(["Adjusting", "Plumbing", "Restoration"]);
+  });
+});

--- a/src/lib/referral-partner-filter.ts
+++ b/src/lib/referral-partner-filter.ts
@@ -1,0 +1,60 @@
+// Pure filter logic for the Referral Partners list page (PRD #249, issue #251).
+//
+// The list page asks three questions of every partner — does its Lifecycle
+// status pass the chip filter? does its industry match the dropdown? does
+// its company name contain the search query? — and this module owns the
+// rule. No I/O, no React; testable in isolation. Modelled after
+// `src/lib/insurance-picker.ts`.
+
+export type LifecycleStatus = "grey" | "yellow" | "green" | "red";
+
+/** The subset of a Referral Partner row this module reads. Callers may pass
+ *  richer objects; the filter ignores everything else. */
+export interface FilterableReferralPartner {
+  id: string;
+  company_name: string;
+  status: LifecycleStatus;
+  industry: string | null;
+}
+
+export interface ReferralPartnerFilter {
+  /** Lifecycle statuses to include. Omitted (or undefined) means every
+   *  status passes — matches the list page's default of all chips on. */
+  status?: ReadonlyArray<LifecycleStatus>;
+  /** A single industry to narrow to. Omitted or empty string means every
+   *  industry passes. */
+  industry?: string;
+  /** Case-insensitive substring match against `company_name`. Omitted,
+   *  empty, or whitespace-only means every name passes. */
+  query?: string;
+}
+
+/**
+ * The set of industry values that appear on at least one partner, with
+ * nulls dropped and duplicates collapsed. Sorted alphabetically so the
+ * dropdown is stable across renders regardless of insert order.
+ */
+export function distinctIndustries(
+  partners: ReadonlyArray<FilterableReferralPartner>,
+): string[] {
+  const seen = new Set<string>();
+  for (const p of partners) {
+    if (p.industry) seen.add(p.industry);
+  }
+  return Array.from(seen).sort((a, b) => a.localeCompare(b));
+}
+
+export function filterReferralPartners<T extends FilterableReferralPartner>(
+  partners: ReadonlyArray<T>,
+  filter: ReferralPartnerFilter,
+): T[] {
+  const statusSet = filter.status ? new Set(filter.status) : null;
+  const industry = filter.industry?.trim() ?? "";
+  const query = filter.query?.trim().toLowerCase() ?? "";
+  return partners.filter((p) => {
+    if (statusSet && !statusSet.has(p.status)) return false;
+    if (industry && p.industry !== industry) return false;
+    if (query && !p.company_name.toLowerCase().includes(query)) return false;
+    return true;
+  });
+}


### PR DESCRIPTION
## Summary

- Adds the pure-logic `referral-partner-filter` module (modelled after `src/lib/insurance-picker.ts`) — owns the filter rule, returns the narrowed list given `{ status?, industry?, query? }`. Includes a `distinctIndustries` helper for populating the dropdown from the partner list.
- Wires the Lifecycle status chip row, industry dropdown, and case-insensitive company-name search box into `/referral-partners`. All three filters compose with AND semantics; chips default to all four on.
- The list page is a thin wrapper around the module — it owns form state and delegates the rule.

Closes #251. Parent PRD: #249.

## Test plan

- [x] Vitest unit tests pin: no filters → all partners; each axis (Lifecycle status, industry, query) in isolation; all three composed; empty/whitespace query is a no-op; case-insensitive substring match on `company_name`; distinct industries collapse and sort.
- [ ] Manual: open `/referral-partners`, toggle chips, pick an industry, type a partial company name — list narrows immediately.
- [ ] Manual: clear all chips → empty state copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)