### PR TITLE
feat(referral-partners): Call Worksheet read-only shell (#252)

### DIFF
--- a/src/app/referral-partners/[id]/page.test.tsx
+++ b/src/app/referral-partners/[id]/page.test.tsx
@@ -1,0 +1,215 @@
+// /referral-partners/[id] — Call Worksheet page tests (PRD #249, issue #252).
+//
+// Two load-bearing rules this slice has to pin against future drift:
+//
+//   1. crew_member is denied at the route — fee/lifecycle data is gated to
+//      admin + crew_lead (PRD #249 user story #24, mirrors slice #250).
+//   2. The page never reaches outside the Active Organization. Even if a
+//      crew_lead in Org A direct-navigates to a partner id that exists in
+//      Org B, RLS returns no row and the page responds 404 (notFound) —
+//      the same pattern jobs/estimates use for cross-tenant access.
+//
+// Sections-rendering is exhaustively pinned in
+// `src/components/referral-partners/referral-partner-worksheet.test.tsx`;
+// this file only verifies the page wires that component up correctly.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+// notFound() throws a Next.js redirect-like error in real life. The test
+// just needs to detect the call so we mock it to throw a tagged error.
+const NOT_FOUND_ERROR = new Error("__NOT_FOUND__");
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw NOT_FOUND_ERROR;
+  },
+}));
+
+import Page from "./page";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+async function renderPage(id = "p-1") {
+  const tree = await Page({ params: Promise.resolve({ id }) });
+  return render(tree);
+}
+
+describe("/referral-partners/[id] Call Worksheet page", () => {
+  it("renders an access-restricted UI for a crew_member", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+
+    await renderPage();
+
+    // The shared ErrorPage pattern other gated pages use (estimates/[id])
+    // surfaces an "Access restricted" heading.
+    expect(screen.getByText(/access restricted/i)).toBeDefined();
+    // No Worksheet content should have rendered.
+    expect(screen.queryByTestId("worksheet-company-info")).toBeNull();
+  });
+
+  it("calls notFound() for a partner id that doesn't resolve in the Active Organization", async () => {
+    // The fake's `eq('id', ...)` filters by id; a non-matching id returns no
+    // rows from .maybeSingle() — same observable behavior as RLS denying a
+    // cross-org read. The page is expected to call notFound().
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-other-org", organization_id: "org-2", company_name: "Other Org Partner", status: "grey" },
+        ],
+      },
+    });
+
+    await expect(renderPage("p-1")).rejects.toThrow(NOT_FOUND_ERROR);
+  });
+
+  it("renders the Call Worksheet for an admin viewing a partner in their Active Organization", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme Plumbing",
+            status: "grey",
+            industry: "Plumbing",
+            lead_source: null,
+            operation_size: null,
+            office_phone: null,
+            office_email: null,
+            website: null,
+            address: null,
+            referral_fee_terms: null,
+            notes: null,
+            primary_contact_id: null,
+            owner_contact_id: null,
+            deleted_at: null,
+          },
+        ],
+        contacts: [],
+      },
+    });
+
+    await renderPage("p-1");
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /acme plumbing/i }),
+    ).toBeDefined();
+    expect(screen.getByTestId("worksheet-company-info")).toBeDefined();
+    expect(screen.getByTestId("worksheet-primary-contact")).toBeDefined();
+    expect(screen.getByTestId("worksheet-owner-contact")).toBeDefined();
+    expect(screen.getByTestId("worksheet-contacts-list")).toBeDefined();
+    expect(screen.getByTestId("worksheet-call-log")).toBeDefined();
+  });
+
+  it("renders the Worksheet for a crew_lead — the second permitted role", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme Plumbing",
+            status: "grey",
+          },
+        ],
+        contacts: [],
+      },
+    });
+
+    await renderPage("p-1");
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: /acme plumbing/i }),
+    ).toBeDefined();
+  });
+
+  it("passes the partner's linked Primary contact + the contacts at this company through to the Worksheet", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+            primary_contact_id: "c-1",
+            owner_contact_id: null,
+          },
+        ],
+        contacts: [
+          {
+            id: "c-1",
+            full_name: "Pat Smith",
+            phone: "+15555550100",
+            email: "pat@acme.test",
+            referral_partner_id: "p-1",
+            role: "referral_contact",
+          },
+          {
+            id: "c-2",
+            full_name: "Jamie Doe",
+            phone: null,
+            email: null,
+            referral_partner_id: "p-1",
+            role: "referral_contact",
+          },
+          {
+            id: "c-orphan",
+            full_name: "Unrelated Person",
+            phone: null,
+            email: null,
+            referral_partner_id: "p-other-partner",
+            role: "referral_contact",
+          },
+        ],
+      },
+    });
+
+    await renderPage("p-1");
+
+    const primary = screen.getByTestId("worksheet-primary-contact");
+    expect(primary.textContent).toContain("Pat Smith");
+
+    const owner = screen.getByTestId("worksheet-owner-contact");
+    expect(owner.textContent).toMatch(/not set/i);
+
+    const contactsList = screen.getByTestId("worksheet-contacts-list");
+    expect(contactsList.textContent).toContain("Pat Smith");
+    expect(contactsList.textContent).toContain("Jamie Doe");
+    // The contact whose referral_partner_id points elsewhere must NOT appear.
+    expect(contactsList.textContent).not.toContain("Unrelated Person");
+  });
+});

--- a/src/app/referral-partners/[id]/page.tsx
+++ b/src/app/referral-partners/[id]/page.tsx
@@ -1,0 +1,131 @@
+// /referral-partners/[id] — read-only Call Worksheet (PRD #249, issue #252).
+//
+// The page is a Server Component. It performs three steps and hands off:
+//
+//   1. Permission gate via `requirePagePermission` with VIEW_REFERRAL_PARTNERS
+//      (admin + crew_lead). crew_member is denied here, not by the database.
+//   2. Fetch the partner via the User client — RLS scopes the read to the
+//      Active Organization, so a partner id from another Org returns no row
+//      and the page calls notFound() (matching the platform's cross-tenant
+//      pattern in jobs/estimates).
+//   3. Fetch the linked Primary / Owner contacts and the full "Contacts at
+//      this company" list, then render the read-only Worksheet.
+//
+// Editing, Lifecycle-status flip buttons, the "Log a call" form, and the
+// "+ Add contact" affordance all land in later slices (#4, #5, #6).
+
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { AlertCircle, ArrowLeft } from "lucide-react";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requirePagePermission } from "@/lib/request-context/require-page-permission";
+import { VIEW_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+import {
+  ReferralPartnerWorksheet,
+  type ReferralPartnerForWorksheet,
+  type ReferralContactForWorksheet,
+} from "@/components/referral-partners/referral-partner-worksheet";
+
+interface ErrorPageProps {
+  title: string;
+  message: string;
+}
+
+function ErrorPage({ title, message }: ErrorPageProps) {
+  return (
+    <div className="flex items-center justify-center min-h-[40vh] px-4">
+      <div className="rounded-xl border border-border bg-card p-8 text-center max-w-md w-full">
+        <AlertCircle size={28} className="mx-auto text-destructive mb-3" />
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="text-sm text-muted-foreground mt-1">{message}</p>
+        <Link
+          href="/referral-partners"
+          className="inline-flex items-center gap-1 mt-4 text-sm font-medium text-[var(--brand-primary)] hover:underline"
+        >
+          <ArrowLeft size={14} />
+          Back to Referral Partners
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+export default async function ReferralPartnerWorksheetPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const supabase = await createServerSupabaseClient();
+
+  // 1. Permission gate — admin / crew_lead only. crew_member sees the
+  //    same ErrorPage an unauthenticated caller does (PRD #249 #24).
+  const auth = await requirePagePermission(supabase, VIEW_REFERRAL_PARTNERS);
+  if (!auth.ok) {
+    return (
+      <ErrorPage
+        title="Access restricted"
+        message="You don't have permission to view Referral Partners."
+      />
+    );
+  }
+
+  // 2. Fetch the partner. RLS scopes to the Active Organization — a cross-
+  //    org id (or a soft-deleted partner) resolves to no row and we 404.
+  const { data: partner } = await supabase
+    .from("referral_partners")
+    .select("*")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle<ReferralPartnerForWorksheet>();
+
+  if (!partner) notFound();
+
+  // 3. Fetch the contacts surface — the linked Primary + Owner slots and
+  //    every Referral Contact at this company. Three parallel reads keep
+  //    the page-render path short.
+  const [primary, owner, contactsList] = await Promise.all([
+    partner.primary_contact_id
+      ? supabase
+          .from("contacts")
+          .select("id, full_name, phone, email")
+          .eq("id", partner.primary_contact_id)
+          .maybeSingle<ReferralContactForWorksheet>()
+          .then((r) => r.data)
+      : Promise.resolve(null),
+    partner.owner_contact_id
+      ? supabase
+          .from("contacts")
+          .select("id, full_name, phone, email")
+          .eq("id", partner.owner_contact_id)
+          .maybeSingle<ReferralContactForWorksheet>()
+          .then((r) => r.data)
+      : Promise.resolve(null),
+    supabase
+      .from("contacts")
+      .select("id, full_name, phone, email")
+      .eq("referral_partner_id", id)
+      .order("full_name", { ascending: true })
+      .then((r) => (r.data ?? []) as ReferralContactForWorksheet[]),
+  ]);
+
+  return (
+    <>
+      <div className="max-w-5xl mx-auto px-4 pt-6">
+        <Link
+          href="/referral-partners"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft size={14} />
+          Back to Referral Partners
+        </Link>
+      </div>
+      <ReferralPartnerWorksheet
+        partner={partner}
+        primaryContact={primary}
+        ownerContact={owner}
+        contacts={contactsList}
+      />
+    </>
+  );
+}

--- a/src/app/referral-partners/page.test.tsx
+++ b/src/app/referral-partners/page.test.tsx
@@ -1,0 +1,53 @@
+// /referral-partners list-page tests.
+//
+// The list page already covered its own happy path (#250); this file adds
+// the issue-#252 acceptance criterion that "the list page's rows link to
+// the Worksheet for that partner". Wired via Next.js <Link>, so the test
+// just looks for an anchor whose `href` is `/referral-partners/<id>`.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+import ReferralPartnersPage from "./page";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockList(partners: unknown[]) {
+  fetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({ referral_partners: partners }),
+  } as Response);
+}
+
+describe("/referral-partners list page", () => {
+  it("renders each partner row as a link to its Call Worksheet", async () => {
+    mockList([
+      { id: "p-1", company_name: "Acme Plumbing", status: "grey", industry: "Plumbing" },
+      { id: "p-2", company_name: "Beta Restoration", status: "green", industry: null },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Plumbing")).toBeDefined();
+      expect(screen.getByText("Beta Restoration")).toBeDefined();
+    });
+
+    const acmeLink = screen.getByText("Acme Plumbing").closest("a");
+    expect(acmeLink).not.toBeNull();
+    expect(acmeLink?.getAttribute("href")).toBe("/referral-partners/p-1");
+
+    const betaLink = screen.getByText("Beta Restoration").closest("a");
+    expect(betaLink?.getAttribute("href")).toBe("/referral-partners/p-2");
+  });
+});

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -8,6 +8,7 @@
 // slices (#251, #254).
 
 import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
 import { Handshake, Plus } from "lucide-react";
 import NewTargetDialog from "@/components/referral-partners/new-target-dialog";
 
@@ -83,18 +84,23 @@ export default function ReferralPartnersPage() {
       ) : (
         <ul className="divide-y rounded-lg border border-border bg-card">
           {partners.map((p) => (
-            <li key={p.id} className="flex items-center gap-4 px-4 py-3">
-              <span
-                className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[p.status]}`}
+            <li key={p.id}>
+              <Link
+                href={`/referral-partners/${p.id}`}
+                className="flex items-center gap-4 px-4 py-3 hover:bg-muted/40 transition-colors"
               >
-                {STATUS_LABEL[p.status]}
-              </span>
-              <div className="flex-1 min-w-0">
-                <p className="font-medium truncate">{p.company_name}</p>
-                {p.industry && (
-                  <p className="text-xs text-muted-foreground truncate">{p.industry}</p>
-                )}
-              </div>
+                <span
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[p.status]}`}
+                >
+                  {STATUS_LABEL[p.status]}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <p className="font-medium truncate">{p.company_name}</p>
+                  {p.industry && (
+                    <p className="text-xs text-muted-foreground truncate">{p.industry}</p>
+                  )}
+                </div>
+              </Link>
             </li>
           ))}
         </ul>

--- a/src/components/referral-partners/referral-partner-worksheet.test.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.test.tsx
@@ -1,0 +1,180 @@
+// Read-only Call Worksheet presentational tests (PRD #249, issue #252).
+//
+// This slice ships a read-only Call Worksheet — header + company info, Primary
+// contact / Owner contact slots, "Contacts at this company" list, and a Call
+// log placeholder. Edit affordances, Lifecycle flip buttons, "Log a call", and
+// "+ Add contact" all explicitly land in later slices (#4, #5, #6); the tests
+// below pin that none of those appear here.
+
+import { describe, it, expect } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+
+import {
+  ReferralPartnerWorksheet,
+  type ReferralPartnerForWorksheet,
+  type ReferralContactForWorksheet,
+} from "./referral-partner-worksheet";
+
+const BASE_PARTNER: ReferralPartnerForWorksheet = {
+  id: "p-1",
+  organization_id: "org-1",
+  company_name: "Acme Plumbing",
+  status: "grey",
+  industry: "Plumbing",
+  lead_source: "Google",
+  operation_size: null,
+  office_phone: "+15551230001",
+  office_email: "ops@acme.test",
+  website: "acme.test",
+  address: "100 Main St",
+  referral_fee_terms: null,
+  notes: null,
+  primary_contact_id: null,
+  owner_contact_id: null,
+};
+
+function renderWorksheet(overrides: {
+  partner?: Partial<ReferralPartnerForWorksheet>;
+  primaryContact?: ReferralContactForWorksheet | null;
+  ownerContact?: ReferralContactForWorksheet | null;
+  contacts?: ReferralContactForWorksheet[];
+} = {}) {
+  const partner = { ...BASE_PARTNER, ...overrides.partner };
+  return render(
+    <ReferralPartnerWorksheet
+      partner={partner}
+      primaryContact={overrides.primaryContact ?? null}
+      ownerContact={overrides.ownerContact ?? null}
+      contacts={overrides.contacts ?? []}
+    />,
+  );
+}
+
+describe("ReferralPartnerWorksheet (read-only)", () => {
+  it("renders the partner's company name in the header", () => {
+    renderWorksheet();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /acme plumbing/i }),
+    ).toBeDefined();
+  });
+
+  it("renders the Lifecycle status chip alongside the header", () => {
+    renderWorksheet({ partner: { status: "green" } });
+    const chip = screen.getByTestId("worksheet-lifecycle-status-chip");
+    // The chip surfaces a readable label for each Lifecycle status. "Active"
+    // is the label for `green` in the existing list page; we re-use it here.
+    expect(chip.textContent).toMatch(/active/i);
+  });
+
+  it("does NOT render Lifecycle-status flip buttons (deferred to #5)", () => {
+    renderWorksheet();
+    // The flip buttons are accessible buttons keyed by Lifecycle status
+    // label. No button should announce itself as "set status to grey" etc.
+    expect(
+      screen.queryByRole("button", { name: /set status to/i }),
+    ).toBeNull();
+  });
+
+  it("does NOT render any edit / log-a-call / add-contact affordances (deferred)", () => {
+    renderWorksheet({
+      primaryContact: {
+        id: "c-1",
+        full_name: "Pat Smith",
+        phone: null,
+        email: null,
+      },
+      contacts: [
+        { id: "c-1", full_name: "Pat Smith", phone: null, email: null },
+      ],
+    });
+    expect(screen.queryByRole("button", { name: /edit/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /log a call/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /add contact/i })).toBeNull();
+    // No form controls at all in this read-only slice.
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("renders a company-info section listing the partner's columns", () => {
+    renderWorksheet();
+    const section = screen.getByTestId("worksheet-company-info");
+    // Spot-check the columns: industry, office phone (formatted), office
+    // email, website, address. The presentational rule is "show every
+    // partner column read-only" — the test pins the visible ones.
+    expect(section.textContent).toContain("Plumbing");
+    expect(section.textContent).toContain("(555) 123-0001");
+    expect(section.textContent).toContain("ops@acme.test");
+    expect(section.textContent).toContain("acme.test");
+    expect(section.textContent).toContain("100 Main St");
+  });
+
+  it("renders the Primary contact slot as 'Not set' when no primary is linked", () => {
+    renderWorksheet({ primaryContact: null });
+    const slot = screen.getByTestId("worksheet-primary-contact");
+    expect(slot.textContent).toMatch(/primary contact/i);
+    expect(slot.textContent).toMatch(/not set/i);
+  });
+
+  it("renders the Primary contact's name, formatted phone, and email when set", () => {
+    renderWorksheet({
+      primaryContact: {
+        id: "c-1",
+        full_name: "Pat Smith",
+        phone: "+15555550100",
+        email: "pat@acme.test",
+      },
+    });
+    const slot = screen.getByTestId("worksheet-primary-contact");
+    expect(slot.textContent).toContain("Pat Smith");
+    // Phone is formatted via the platform's `formatPhoneNumber`.
+    expect(slot.textContent).toContain("(555) 555-0100");
+    expect(slot.textContent).toContain("pat@acme.test");
+  });
+
+  it("renders the Owner contact slot as 'Not set' when no owner is linked", () => {
+    renderWorksheet({ ownerContact: null });
+    const slot = screen.getByTestId("worksheet-owner-contact");
+    expect(slot.textContent).toMatch(/owner contact/i);
+    expect(slot.textContent).toMatch(/not set/i);
+  });
+
+  it("renders the Owner contact's name, formatted phone, and email when set", () => {
+    renderWorksheet({
+      ownerContact: {
+        id: "c-2",
+        full_name: "Jamie Owner",
+        phone: "+15555550200",
+        email: "jamie@acme.test",
+      },
+    });
+    const slot = screen.getByTestId("worksheet-owner-contact");
+    expect(slot.textContent).toContain("Jamie Owner");
+    expect(slot.textContent).toContain("(555) 555-0200");
+    expect(slot.textContent).toContain("jamie@acme.test");
+  });
+
+  it("lists every Referral Contact in the 'Contacts at this company' section", () => {
+    renderWorksheet({
+      contacts: [
+        { id: "c-1", full_name: "Pat Smith", phone: null, email: null },
+        { id: "c-2", full_name: "Jamie Owner", phone: null, email: null },
+        { id: "c-3", full_name: "Riley Newhire", phone: null, email: null },
+      ],
+    });
+    const list = screen.getByTestId("worksheet-contacts-list");
+    expect(within(list).getByText("Pat Smith")).toBeDefined();
+    expect(within(list).getByText("Jamie Owner")).toBeDefined();
+    expect(within(list).getByText("Riley Newhire")).toBeDefined();
+  });
+
+  it("renders an empty-state in 'Contacts at this company' when none are linked", () => {
+    renderWorksheet({ contacts: [] });
+    const list = screen.getByTestId("worksheet-contacts-list");
+    expect(list.textContent).toMatch(/no contacts/i);
+  });
+
+  it("renders a Call log placeholder section (write lands in #5)", () => {
+    renderWorksheet();
+    const section = screen.getByTestId("worksheet-call-log");
+    expect(section.textContent).toMatch(/call log/i);
+  });
+});

--- a/src/components/referral-partners/referral-partner-worksheet.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.tsx
@@ -1,0 +1,238 @@
+// Read-only Call Worksheet (PRD #249, issue #252).
+//
+// The page-level Server Component fetches a Referral Partner, its Primary
+// contact, its Owner contact, and every Referral Contact at the company, then
+// hands them to this presentational component. This slice ships *read-only*:
+// no editing, no Lifecycle-status flip buttons, no "Log a call" form, no
+// "+ Add contact" affordance. Those land in slices #4, #5, and #6.
+
+import { Handshake } from "lucide-react";
+import { formatPhoneNumber } from "@/lib/phone";
+
+// The columns from `referral_partners` this surface needs. The page fetches
+// the row with `select('*')` so the shape it hands in carries everything;
+// we name just the columns the Worksheet actually reads so the prop type
+// stays a contract rather than a free-for-all.
+export interface ReferralPartnerForWorksheet {
+  id: string;
+  organization_id: string;
+  company_name: string;
+  status: "grey" | "yellow" | "green" | "red";
+  industry: string | null;
+  lead_source: string | null;
+  operation_size: string | null;
+  office_phone: string | null;
+  office_email: string | null;
+  website: string | null;
+  address: string | null;
+  referral_fee_terms: string | null;
+  notes: string | null;
+  primary_contact_id: string | null;
+  owner_contact_id: string | null;
+}
+
+// The minimum fields the Worksheet needs from a linked Referral Contact —
+// name + phone + email — to render the Primary / Owner contact slots and
+// the "Contacts at this company" list. The underlying `contacts` row has
+// more columns; this is the read-only slice's view.
+export interface ReferralContactForWorksheet {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  email: string | null;
+}
+
+interface Props {
+  partner: ReferralPartnerForWorksheet;
+  primaryContact: ReferralContactForWorksheet | null;
+  ownerContact: ReferralContactForWorksheet | null;
+  contacts: ReferralContactForWorksheet[];
+}
+
+// Lifecycle-status display values. Mirrors the labels used on the list page
+// (`src/app/referral-partners/page.tsx`) so the chip reads the same string
+// the user already learned there.
+const STATUS_CHIP_CLASS: Record<ReferralPartnerForWorksheet["status"], string> = {
+  grey: "bg-gray-200 text-gray-700",
+  yellow: "bg-yellow-200 text-yellow-900",
+  green: "bg-green-200 text-green-900",
+  red: "bg-red-200 text-red-900",
+};
+
+const STATUS_LABEL: Record<ReferralPartnerForWorksheet["status"], string> = {
+  grey: "Uncontacted",
+  yellow: "In progress",
+  green: "Active",
+  red: "Declined",
+};
+
+// One read-only label/value row used by both the company-info grid and the
+// contact-slot detail lines. Empty `value` is rendered as an em-dash so
+// missing columns are visually distinct from "Not set" (which is reserved
+// for the contact-slot empty state in PRD #249).
+function InfoRow({ label, value }: { label: string; value: string | null }) {
+  const display = value && value.trim().length > 0 ? value : "—";
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-sm text-foreground">{display}</span>
+    </div>
+  );
+}
+
+// One Primary or Owner contact slot. Shows the linked Referral Contact's
+// name + formatted phone + email when set; "Not set" otherwise (PRD #249
+// #19, #29; issue #252 acceptance criteria).
+function ContactSlot({
+  testId,
+  heading,
+  contact,
+}: {
+  testId: string;
+  heading: string;
+  contact: ReferralContactForWorksheet | null;
+}) {
+  return (
+    <div
+      data-testid={testId}
+      className="rounded-lg border border-border bg-card px-5 py-4"
+    >
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+        {heading}
+      </p>
+      {contact ? (
+        <div className="space-y-0.5">
+          <p className="font-medium text-foreground">{contact.full_name}</p>
+          {contact.phone && (
+            <p className="text-sm text-muted-foreground">
+              {formatPhoneNumber(contact.phone)}
+            </p>
+          )}
+          {contact.email && (
+            <p className="text-sm text-muted-foreground">{contact.email}</p>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm italic text-muted-foreground">Not set</p>
+      )}
+    </div>
+  );
+}
+
+export function ReferralPartnerWorksheet({
+  partner,
+  primaryContact,
+  ownerContact,
+  contacts,
+}: Props) {
+  const formattedOfficePhone = partner.office_phone
+    ? formatPhoneNumber(partner.office_phone)
+    : null;
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
+      {/* ── HEADER ─────────────────────────────────────────────────────── */}
+      <header className="flex items-center gap-3">
+        <Handshake size={22} className="text-primary shrink-0" />
+        <h1 className="text-2xl font-heading font-semibold text-foreground">
+          {partner.company_name}
+        </h1>
+        <span
+          data-testid="worksheet-lifecycle-status-chip"
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[partner.status]}`}
+        >
+          {STATUS_LABEL[partner.status]}
+        </span>
+      </header>
+
+      {/* ── COMPANY INFO ──────────────────────────────────────────────── */}
+      <section
+        data-testid="worksheet-company-info"
+        className="rounded-lg border border-border bg-card px-5 py-4"
+      >
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">
+          Company info
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+          <InfoRow label="Industry" value={partner.industry} />
+          <InfoRow label="Lead source" value={partner.lead_source} />
+          <InfoRow label="Operation size" value={partner.operation_size} />
+          <InfoRow label="Office phone" value={formattedOfficePhone} />
+          <InfoRow label="Office email" value={partner.office_email} />
+          <InfoRow label="Website" value={partner.website} />
+          <InfoRow label="Address" value={partner.address} />
+          <InfoRow
+            label="Referral-fee terms"
+            value={partner.referral_fee_terms}
+          />
+        </div>
+        {partner.notes && partner.notes.trim().length > 0 && (
+          <div className="mt-4 flex flex-col gap-0.5">
+            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Notes
+            </span>
+            <p className="text-sm text-foreground whitespace-pre-wrap">
+              {partner.notes}
+            </p>
+          </div>
+        )}
+      </section>
+
+      {/* ── PRIMARY + OWNER CONTACT SLOTS ─────────────────────────────── */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <ContactSlot
+          testId="worksheet-primary-contact"
+          heading="Primary contact"
+          contact={primaryContact}
+        />
+        <ContactSlot
+          testId="worksheet-owner-contact"
+          heading="Owner contact"
+          contact={ownerContact}
+        />
+      </div>
+
+      {/* ── CONTACTS AT THIS COMPANY ──────────────────────────────────── */}
+      <section
+        data-testid="worksheet-contacts-list"
+        className="rounded-lg border border-border bg-card px-5 py-4"
+      >
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">
+          Contacts at this company
+        </p>
+        {contacts.length === 0 ? (
+          <p className="text-sm italic text-muted-foreground">
+            No contacts yet.
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {contacts.map((c) => (
+              <li key={c.id} className="py-2 first:pt-0 last:pb-0">
+                <p className="font-medium text-foreground">{c.full_name}</p>
+                <div className="flex flex-wrap gap-x-4 text-sm text-muted-foreground">
+                  {c.phone && <span>{formatPhoneNumber(c.phone)}</span>}
+                  {c.email && <span>{c.email}</span>}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* ── CALL LOG (placeholder until slice #5) ─────────────────────── */}
+      <section
+        data-testid="worksheet-call-log"
+        className="rounded-lg border border-border bg-card px-5 py-4"
+      >
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">
+          Call log
+        </p>
+        <p className="text-sm italic text-muted-foreground">
+          The Call log lands with the Log-a-call form in the next slice.
+        </p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Lands `/referral-partners/[id]` as a read-only Call Worksheet: header (company name + Lifecycle status chip), company-info section, Primary contact / Owner contact slots ("Not set" when null), "Contacts at this company" list, and a Call log placeholder.
- Wires the list page rows to link to the Worksheet.
- Routes through `requirePagePermission(VIEW_REFERRAL_PARTNERS)`; `crew_member` sees the Access-restricted UI, cross-Organization ids return no row under RLS and `notFound()` 404s — matching the cross-tenant pattern in jobs/estimates.

Closes #252. Out of scope (deferred per PRD #249): editing, Lifecycle flip buttons, "Log a call" form, "+ Add contact" inline-create — slices #4, #5, #6.

## Test plan

- [x] `npx vitest run` — 1026 passing including 18 new tests for this slice. The 2 pre-existing `src/app/api/email/accounts/route.test.ts` failures are on `main`, unrelated.
- [x] `npx tsc --noEmit` — no new TS errors in the referral-partners surface.
- [x] `npx eslint src/app/referral-partners src/components/referral-partners` — the only error is the pre-existing `void load()` effect from #250; no new lint issues from this slice.
- [ ] Manual browser pass: an admin opens `/referral-partners`, clicks a row, lands on the Worksheet; a `crew_member` direct-navigating sees the Access-restricted UI.
- [ ] Manual cross-org pass: an admin in Org A direct-navigating to a Worksheet id from Org B 404s.

## Notes for the reviewer

- `src/app/referral-partners/page.tsx` will likely conflict with #251 (filter chips + search modify the same list-page JSX). Happy to rebase whichever lands second.
- Glossary terms used verbatim in commit, comments, and UI copy: **Call Worksheet**, **Primary contact**, **Owner contact**, **Referral Partner**, **Referral Contact**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)