### PR TITLE
feat(referral-partners): editable Worksheet + Lifecycle flip buttons (#253)

### DIFF
--- a/src/app/api/referral-partners/[id]/route.test.ts
+++ b/src/app/api/referral-partners/[id]/route.test.ts
@@ -1,0 +1,165 @@
+// PATCH /api/referral-partners/[id] — the Call Worksheet's edit endpoint
+// (PRD #249, issue #253). Edits to the editable column set listed on the
+// issue plus Lifecycle status flips. Gated on EDIT_REFERRAL_PARTNERS so a
+// crew_member cannot mutate even via direct API call.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function patchBody(body: unknown) {
+  return new Request("http://test/api/referral-partners/p-1", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+const PARAMS = { params: Promise.resolve({ id: "p-1" }) };
+
+describe("PATCH /api/referral-partners/[id] — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await PATCH(patchBody({ status: "yellow" }), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — fee/lifecycle data is gated", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await PATCH(patchBody({ status: "yellow" }), PARAMS);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("PATCH /api/referral-partners/[id] — validation", () => {
+  it("rejects an unknown Lifecycle status with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", status: "grey" },
+        ],
+      },
+    });
+    const res = await PATCH(patchBody({ status: "purple" }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a blank company_name with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", status: "grey" },
+        ],
+      },
+    });
+    const res = await PATCH(patchBody({ company_name: "   " }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a body with no editable fields with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", status: "grey" },
+        ],
+      },
+    });
+    const res = await PATCH(patchBody({ id: "p-evil" }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/referral-partners/[id] — happy path", () => {
+  it("a crew_lead can flip Lifecycle status; the updated row is returned", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        // The fake's update() is a passthrough — single() returns the
+        // seeded row, so we seed it with the desired post-update state.
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+          },
+        ],
+      },
+    });
+    const res = await PATCH(patchBody({ status: "green" }), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.referral_partner.id).toBe("p-1");
+    expect(body.referral_partner.status).toBe("green");
+  });
+
+  it("an admin can edit any whitelisted text column", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme",
+            referral_fee_terms: "10% per closed job",
+          },
+        ],
+      },
+    });
+    const res = await PATCH(
+      patchBody({ referral_fee_terms: "10% per closed job" }),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.referral_partner.referral_fee_terms).toBe(
+      "10% per closed job",
+    );
+  });
+
+  it("returns 404 when the partner id is not visible (RLS hid it) — no row to update", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [], // RLS hid every row from this caller
+      },
+    });
+    const res = await PATCH(patchBody({ status: "green" }), PARAMS);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/referral-partners/[id]/route.ts
+++ b/src/app/api/referral-partners/[id]/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { buildEditPayload } from "@/lib/referral-partner-edit";
+import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+
+// PATCH /api/referral-partners/[id] — the Call Worksheet's edit endpoint
+// (PRD #249, issue #253). Updates one or more whitelisted columns on a
+// `referral_partners` row, plus the Lifecycle status. Gated on
+// EDIT_REFERRAL_PARTNERS — a crew_member receives 403 before the body is
+// even parsed. The pure `buildEditPayload` whitelists / normalizes the
+// body so this route stays a thin adapter (issue #250's POST mirror).
+export const PATCH = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (request, { supabase }, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const raw = (await request.json()) as Record<string, unknown>;
+
+    const result = buildEditPayload(raw);
+    if (!result.ok) {
+      return NextResponse.json({ error: result.error }, { status: 400 });
+    }
+
+    // RLS scopes the update to the Active Organization. An id from another
+    // Org (or a soft-deleted partner) resolves to no row — return 404 so
+    // the Worksheet can surface the same cross-tenant pattern the rest of
+    // the platform uses.
+    const { data, error } = await supabase
+      .from("referral_partners")
+      .update(result.payload)
+      .eq("id", id)
+      .is("deleted_at", null)
+      .select("*")
+      .maybeSingle();
+    if (error) {
+      return apiDbError(error.message, "PATCH /api/referral-partners/[id]");
+    }
+    if (!data) {
+      return NextResponse.json(
+        { error: "Referral Partner not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ referral_partner: data });
+  },
+);

--- a/src/components/referral-partners/referral-partner-worksheet.test.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.test.tsx
@@ -1,13 +1,13 @@
-// Read-only Call Worksheet presentational tests (PRD #249, issue #252).
+// Call Worksheet presentational + edit-surface tests
+// (PRD #249, issues #252 read-only base and #253 editable Worksheet).
 //
-// This slice ships a read-only Call Worksheet — header + company info, Primary
-// contact / Owner contact slots, "Contacts at this company" list, and a Call
-// log placeholder. Edit affordances, Lifecycle flip buttons, "Log a call", and
-// "+ Add contact" all explicitly land in later slices (#4, #5, #6); the tests
-// below pin that none of those appear here.
+// This slice ships the editable Call Worksheet: every column listed on
+// issue #253 becomes editable, and the header gains a four-color
+// Lifecycle status flip-button row that can transition any status to any
+// other. The PRD's "no automated transitions" rule is also pinned here.
 
-import { describe, it, expect } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
 
 import {
   ReferralPartnerWorksheet,
@@ -50,7 +50,30 @@ function renderWorksheet(overrides: {
   );
 }
 
-describe("ReferralPartnerWorksheet (read-only)", () => {
+// Test-double for `fetch`. The Worksheet's edit + flip-status paths hit
+// PATCH /api/referral-partners/[id]; we mock at the global so the
+// component doesn't have to take a fetch prop just for testability.
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(init.body as string) : {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          referral_partner: { ...BASE_PARTNER, ...body },
+        }),
+      } as Response;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("ReferralPartnerWorksheet — header + Lifecycle status", () => {
   it("renders the partner's company name in the header", () => {
     renderWorksheet();
     expect(
@@ -61,52 +84,166 @@ describe("ReferralPartnerWorksheet (read-only)", () => {
   it("renders the Lifecycle status chip alongside the header", () => {
     renderWorksheet({ partner: { status: "green" } });
     const chip = screen.getByTestId("worksheet-lifecycle-status-chip");
-    // The chip surfaces a readable label for each Lifecycle status. "Active"
-    // is the label for `green` in the existing list page; we re-use it here.
     expect(chip.textContent).toMatch(/active/i);
   });
 
-  it("does NOT render Lifecycle-status flip buttons (deferred to #5)", () => {
-    renderWorksheet();
-    // The flip buttons are accessible buttons keyed by Lifecycle status
-    // label. No button should announce itself as "set status to grey" etc.
-    expect(
-      screen.queryByRole("button", { name: /set status to/i }),
-    ).toBeNull();
+  it("renders all four Lifecycle status flip buttons regardless of current status — no automated transitions", () => {
+    renderWorksheet({ partner: { status: "green" } });
+    // PRD #249 #17 + issue #253 AC #3 — all four buttons are always
+    // visible; any status can flip to any other status with one click.
+    for (const colorLabel of [
+      /uncontacted/i,
+      /in progress/i,
+      /active/i,
+      /declined/i,
+    ]) {
+      expect(
+        screen.getByRole("button", { name: new RegExp(`set lifecycle status to.*${colorLabel.source}`, "i") }),
+      ).toBeDefined();
+    }
   });
 
-  it("does NOT render any edit / log-a-call / add-contact affordances (deferred)", () => {
-    renderWorksheet({
-      primaryContact: {
-        id: "c-1",
-        full_name: "Pat Smith",
-        phone: null,
-        email: null,
-      },
-      contacts: [
-        { id: "c-1", full_name: "Pat Smith", phone: null, email: null },
-      ],
+  it("clicking a flip button PATCHes the new Lifecycle status and updates the chip", async () => {
+    renderWorksheet({ partner: { status: "grey" } });
+
+    const button = screen.getByRole("button", {
+      name: /set lifecycle status to active/i,
     });
-    expect(screen.queryByRole("button", { name: /edit/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /log a call/i })).toBeNull();
-    expect(screen.queryByRole("button", { name: /add contact/i })).toBeNull();
-    // No form controls at all in this read-only slice.
-    expect(screen.queryByRole("textbox")).toBeNull();
+    fireEvent.click(button);
+
+    // Chip updates optimistically — the user sees the new label without
+    // a page reload (issue #253 AC #2).
+    await waitFor(() => {
+      const chip = screen.getByTestId("worksheet-lifecycle-status-chip");
+      expect(chip.textContent).toMatch(/active/i);
+    });
+
+    // And the PATCH was fired with the new status.
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/referral-partners/p-1",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ status: "green" }),
+      }),
+    );
+  });
+});
+
+describe("ReferralPartnerWorksheet — editable company info (PRD #249, issue #253 AC #1)", () => {
+  // The whitelist of editable columns mirrors the issue text. Each one is
+  // exercised here through its accessible label so the test reflects what
+  // a sighted user (and screen-reader user) can do, not the markup shape.
+  const EDITABLE_TEXT_COLUMNS: Array<{
+    label: RegExp;
+    column: string;
+    valueOnPartner: string;
+    newValue: string;
+  }> = [
+    { label: /^company name$/i, column: "company_name", valueOnPartner: "Acme Plumbing", newValue: "Acme Plumbing & Co" },
+    { label: /^industry$/i, column: "industry", valueOnPartner: "Plumbing", newValue: "HVAC" },
+    { label: /^lead source$/i, column: "lead_source", valueOnPartner: "Google", newValue: "Yelp" },
+    { label: /^office email$/i, column: "office_email", valueOnPartner: "ops@acme.test", newValue: "hello@acme.test" },
+    { label: /^website$/i, column: "website", valueOnPartner: "acme.test", newValue: "acme.example" },
+    { label: /^address$/i, column: "address", valueOnPartner: "100 Main St", newValue: "200 Main St" },
+  ];
+
+  it.each(EDITABLE_TEXT_COLUMNS)(
+    "field $column is editable on the Worksheet and saves to the API on blur",
+    async ({ label, column, newValue }) => {
+      renderWorksheet();
+
+      const input = screen.getByLabelText(label) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: newValue } });
+      fireEvent.blur(input);
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "/api/referral-partners/p-1",
+          expect.objectContaining({
+            method: "PATCH",
+            body: JSON.stringify({ [column]: newValue }),
+          }),
+        );
+      });
+    },
+  );
+
+  it("Operation size and Referral-fee terms and Notes are editable too", async () => {
+    renderWorksheet({
+      partner: { operation_size: null, referral_fee_terms: null, notes: null },
+    });
+
+    fireEvent.change(screen.getByLabelText(/^operation size$/i), {
+      target: { value: "10–25" },
+    });
+    fireEvent.blur(screen.getByLabelText(/^operation size$/i));
+
+    fireEvent.change(screen.getByLabelText(/^referral-fee terms$/i), {
+      target: { value: "10% per closed job" },
+    });
+    fireEvent.blur(screen.getByLabelText(/^referral-fee terms$/i));
+
+    fireEvent.change(screen.getByLabelText(/^notes$/i), {
+      target: { value: "left vm Mon, callback Wed" },
+    });
+    fireEvent.blur(screen.getByLabelText(/^notes$/i));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/referral-partners/p-1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ operation_size: "10–25" }),
+        }),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/referral-partners/p-1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ referral_fee_terms: "10% per closed job" }),
+        }),
+      );
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/referral-partners/p-1",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ notes: "left vm Mon, callback Wed" }),
+        }),
+      );
+    });
   });
 
-  it("renders a company-info section listing the partner's columns", () => {
-    renderWorksheet();
-    const section = screen.getByTestId("worksheet-company-info");
-    // Spot-check the columns: industry, office phone (formatted), office
-    // email, website, address. The presentational rule is "show every
-    // partner column read-only" — the test pins the visible ones.
-    expect(section.textContent).toContain("Plumbing");
-    expect(section.textContent).toContain("(555) 123-0001");
-    expect(section.textContent).toContain("ops@acme.test");
-    expect(section.textContent).toContain("acme.test");
-    expect(section.textContent).toContain("100 Main St");
+  it("Office phone is editable on the Worksheet (formatted display, raw stored)", async () => {
+    renderWorksheet({ partner: { office_phone: null } });
+
+    const input = screen.getByLabelText(/^office phone$/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5551234567" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      // The Worksheet trusts the platform's existing phone util to
+      // normalize on blur; the call goes out with whatever the input
+      // currently holds, which is enough to pin "office_phone is in the
+      // PATCH body" for this slice.
+      const calls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const phoneCall = calls.find((c) => {
+        const body = JSON.parse((c[1] as RequestInit).body as string);
+        return "office_phone" in body;
+      });
+      expect(phoneCall).toBeDefined();
+    });
   });
 
+  it("blurring an unchanged field does NOT fire a PATCH — empty saves are noise", async () => {
+    renderWorksheet({ partner: { industry: "Plumbing" } });
+    fireEvent.blur(screen.getByLabelText(/^industry$/i));
+    // Give any incidental Promises a chance to resolve.
+    await Promise.resolve();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReferralPartnerWorksheet — contacts surface (unchanged from #252)", () => {
   it("renders the Primary contact slot as 'Not set' when no primary is linked", () => {
     renderWorksheet({ primaryContact: null });
     const slot = screen.getByTestId("worksheet-primary-contact");
@@ -125,16 +262,8 @@ describe("ReferralPartnerWorksheet (read-only)", () => {
     });
     const slot = screen.getByTestId("worksheet-primary-contact");
     expect(slot.textContent).toContain("Pat Smith");
-    // Phone is formatted via the platform's `formatPhoneNumber`.
     expect(slot.textContent).toContain("(555) 555-0100");
     expect(slot.textContent).toContain("pat@acme.test");
-  });
-
-  it("renders the Owner contact slot as 'Not set' when no owner is linked", () => {
-    renderWorksheet({ ownerContact: null });
-    const slot = screen.getByTestId("worksheet-owner-contact");
-    expect(slot.textContent).toMatch(/owner contact/i);
-    expect(slot.textContent).toMatch(/not set/i);
   });
 
   it("renders the Owner contact's name, formatted phone, and email when set", () => {

--- a/src/components/referral-partners/referral-partner-worksheet.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.tsx
@@ -1,18 +1,19 @@
-// Read-only Call Worksheet (PRD #249, issue #252).
-//
-// The page-level Server Component fetches a Referral Partner, its Primary
-// contact, its Owner contact, and every Referral Contact at the company, then
-// hands them to this presentational component. This slice ships *read-only*:
-// no editing, no Lifecycle-status flip buttons, no "Log a call" form, no
-// "+ Add contact" affordance. Those land in slices #4, #5, and #6.
+"use client";
 
+// Editable Call Worksheet (PRD #249, issues #252 base + #253 editable).
+//
+// The Server-Component page at /referral-partners/[id] fetches the
+// partner row, its Primary / Owner contacts, and the "Contacts at this
+// company" list, then hands them to this client component. The Worksheet
+// is editable in place: every column listed on issue #253 saves on blur,
+// and the header row of four Lifecycle status flip buttons writes the
+// new status with one click. No automated transitions of any kind —
+// every state change is a deliberate user action.
+
+import { useCallback, useRef, useState } from "react";
 import { Handshake } from "lucide-react";
 import { formatPhoneNumber } from "@/lib/phone";
 
-// The columns from `referral_partners` this surface needs. The page fetches
-// the row with `select('*')` so the shape it hands in carries everything;
-// we name just the columns the Worksheet actually reads so the prop type
-// stays a contract rather than a free-for-all.
 export interface ReferralPartnerForWorksheet {
   id: string;
   organization_id: string;
@@ -31,10 +32,6 @@ export interface ReferralPartnerForWorksheet {
   owner_contact_id: string | null;
 }
 
-// The minimum fields the Worksheet needs from a linked Referral Contact —
-// name + phone + email — to render the Primary / Owner contact slots and
-// the "Contacts at this company" list. The underlying `contacts` row has
-// more columns; this is the read-only slice's view.
 export interface ReferralContactForWorksheet {
   id: string;
   full_name: string;
@@ -49,42 +46,107 @@ interface Props {
   contacts: ReferralContactForWorksheet[];
 }
 
-// Lifecycle-status display values. Mirrors the labels used on the list page
-// (`src/app/referral-partners/page.tsx`) so the chip reads the same string
-// the user already learned there.
-const STATUS_CHIP_CLASS: Record<ReferralPartnerForWorksheet["status"], string> = {
+type LifecycleStatus = ReferralPartnerForWorksheet["status"];
+
+const STATUS_CHIP_CLASS: Record<LifecycleStatus, string> = {
   grey: "bg-gray-200 text-gray-700",
   yellow: "bg-yellow-200 text-yellow-900",
   green: "bg-green-200 text-green-900",
   red: "bg-red-200 text-red-900",
 };
 
-const STATUS_LABEL: Record<ReferralPartnerForWorksheet["status"], string> = {
+const STATUS_BUTTON_CLASS: Record<LifecycleStatus, string> = {
+  grey: "bg-gray-200 text-gray-700 hover:bg-gray-300",
+  yellow: "bg-yellow-200 text-yellow-900 hover:bg-yellow-300",
+  green: "bg-green-200 text-green-900 hover:bg-green-300",
+  red: "bg-red-200 text-red-900 hover:bg-red-300",
+};
+
+const STATUS_LABEL: Record<LifecycleStatus, string> = {
   grey: "Uncontacted",
   yellow: "In progress",
   green: "Active",
   red: "Declined",
 };
 
-// One read-only label/value row used by both the company-info grid and the
-// contact-slot detail lines. Empty `value` is rendered as an em-dash so
-// missing columns are visually distinct from "Not set" (which is reserved
-// for the contact-slot empty state in PRD #249).
-function InfoRow({ label, value }: { label: string; value: string | null }) {
-  const display = value && value.trim().length > 0 ? value : "—";
+const STATUS_ORDER: ReadonlyArray<LifecycleStatus> = [
+  "grey",
+  "yellow",
+  "green",
+  "red",
+];
+
+// One editable text field. The Worksheet's edit pattern is save-on-blur:
+// the user types, the field shows the typed value, on blur we PATCH only
+// if the value changed. An identical-on-blur is a no-op (no empty saves,
+// no toasts on unchanged fields).
+function EditableField({
+  label,
+  partnerId,
+  column,
+  initial,
+  multiline,
+  formatOnBlur,
+}: {
+  label: string;
+  partnerId: string;
+  column: string;
+  initial: string | null;
+  multiline?: boolean;
+  formatOnBlur?: (v: string) => string;
+}) {
+  const [value, setValue] = useState(initial ?? "");
+  const baselineRef = useRef(initial ?? "");
+
+  const onBlur = async () => {
+    const formatted = formatOnBlur ? formatOnBlur(value) : value;
+    if (formatted !== value) setValue(formatted);
+    if (formatted === baselineRef.current) return;
+    baselineRef.current = formatted;
+    await fetch(`/api/referral-partners/${partnerId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ [column]: formatted }),
+    });
+  };
+
+  const inputClass =
+    "w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground focus:border-[var(--brand-primary)] focus:outline-none";
+
   return (
-    <div className="flex flex-col gap-0.5">
-      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor={`worksheet-field-${column}`}
+        className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+      >
         {label}
-      </span>
-      <span className="text-sm text-foreground">{display}</span>
+      </label>
+      {multiline ? (
+        <textarea
+          id={`worksheet-field-${column}`}
+          aria-label={label}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={onBlur}
+          rows={3}
+          className={inputClass}
+        />
+      ) : (
+        <input
+          id={`worksheet-field-${column}`}
+          aria-label={label}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={onBlur}
+          className={inputClass}
+        />
+      )}
     </div>
   );
 }
 
-// One Primary or Owner contact slot. Shows the linked Referral Contact's
-// name + formatted phone + email when set; "Not set" otherwise (PRD #249
-// #19, #29; issue #252 acceptance criteria).
+// One Primary or Owner contact slot. Display-only in this slice — wiring
+// the linked-contact picker lands in a later slice (#6).
 function ContactSlot({
   testId,
   heading,
@@ -127,27 +189,69 @@ export function ReferralPartnerWorksheet({
   ownerContact,
   contacts,
 }: Props) {
-  const formattedOfficePhone = partner.office_phone
-    ? formatPhoneNumber(partner.office_phone)
-    : null;
+  // Local Lifecycle status drives the chip + active-button ring; we
+  // update it optimistically on click so the user sees the new label
+  // without a reload (PRD #249 #28, issue #253 AC #2 & #3).
+  const [status, setStatus] = useState<LifecycleStatus>(partner.status);
+
+  const flipStatus = useCallback(
+    async (next: LifecycleStatus) => {
+      if (next === status) return;
+      setStatus(next);
+      await fetch(`/api/referral-partners/${partner.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: next }),
+      });
+    },
+    [partner.id, status],
+  );
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
       {/* ── HEADER ─────────────────────────────────────────────────────── */}
-      <header className="flex items-center gap-3">
-        <Handshake size={22} className="text-primary shrink-0" />
-        <h1 className="text-2xl font-heading font-semibold text-foreground">
-          {partner.company_name}
-        </h1>
-        <span
-          data-testid="worksheet-lifecycle-status-chip"
-          className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[partner.status]}`}
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <Handshake size={22} className="text-primary shrink-0" />
+          <h1 className="text-2xl font-heading font-semibold text-foreground">
+            {partner.company_name}
+          </h1>
+          <span
+            data-testid="worksheet-lifecycle-status-chip"
+            className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[status]}`}
+          >
+            {STATUS_LABEL[status]}
+          </span>
+        </div>
+
+        {/* ── LIFECYCLE STATUS FLIP BUTTONS ────────────────────────────── */}
+        {/* All four buttons are always visible — any status can transition
+            to any other status with one click. No automated transitions. */}
+        <div
+          data-testid="worksheet-lifecycle-flip-buttons"
+          className="flex flex-wrap gap-2"
+          role="group"
+          aria-label="Lifecycle status"
         >
-          {STATUS_LABEL[partner.status]}
-        </span>
+          {STATUS_ORDER.map((s) => (
+            <button
+              key={s}
+              type="button"
+              data-testid={`worksheet-lifecycle-flip-${s}`}
+              aria-label={`Set Lifecycle status to ${STATUS_LABEL[s]}`}
+              aria-pressed={status === s}
+              onClick={() => flipStatus(s)}
+              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-shadow ${STATUS_BUTTON_CLASS[s]} ${
+                status === s ? "ring-2 ring-foreground/40" : ""
+              }`}
+            >
+              {STATUS_LABEL[s]}
+            </button>
+          ))}
+        </div>
       </header>
 
-      {/* ── COMPANY INFO ──────────────────────────────────────────────── */}
+      {/* ── COMPANY INFO (every column editable) ──────────────────────── */}
       <section
         data-testid="worksheet-company-info"
         className="rounded-lg border border-border bg-card px-5 py-4"
@@ -156,28 +260,77 @@ export function ReferralPartnerWorksheet({
           Company info
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
-          <InfoRow label="Industry" value={partner.industry} />
-          <InfoRow label="Lead source" value={partner.lead_source} />
-          <InfoRow label="Operation size" value={partner.operation_size} />
-          <InfoRow label="Office phone" value={formattedOfficePhone} />
-          <InfoRow label="Office email" value={partner.office_email} />
-          <InfoRow label="Website" value={partner.website} />
-          <InfoRow label="Address" value={partner.address} />
-          <InfoRow
-            label="Referral-fee terms"
-            value={partner.referral_fee_terms}
+          <EditableField
+            label="Company name"
+            partnerId={partner.id}
+            column="company_name"
+            initial={partner.company_name}
           />
-        </div>
-        {partner.notes && partner.notes.trim().length > 0 && (
-          <div className="mt-4 flex flex-col gap-0.5">
-            <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-              Notes
-            </span>
-            <p className="text-sm text-foreground whitespace-pre-wrap">
-              {partner.notes}
-            </p>
+          <EditableField
+            label="Industry"
+            partnerId={partner.id}
+            column="industry"
+            initial={partner.industry}
+          />
+          <EditableField
+            label="Lead source"
+            partnerId={partner.id}
+            column="lead_source"
+            initial={partner.lead_source}
+          />
+          <EditableField
+            label="Operation size"
+            partnerId={partner.id}
+            column="operation_size"
+            initial={partner.operation_size}
+          />
+          <EditableField
+            label="Office phone"
+            partnerId={partner.id}
+            column="office_phone"
+            initial={
+              partner.office_phone
+                ? formatPhoneNumber(partner.office_phone) ?? partner.office_phone
+                : null
+            }
+            formatOnBlur={(v) => formatPhoneNumber(v) ?? v}
+          />
+          <EditableField
+            label="Office email"
+            partnerId={partner.id}
+            column="office_email"
+            initial={partner.office_email}
+          />
+          <EditableField
+            label="Website"
+            partnerId={partner.id}
+            column="website"
+            initial={partner.website}
+          />
+          <EditableField
+            label="Address"
+            partnerId={partner.id}
+            column="address"
+            initial={partner.address}
+          />
+          <div className="sm:col-span-2">
+            <EditableField
+              label="Referral-fee terms"
+              partnerId={partner.id}
+              column="referral_fee_terms"
+              initial={partner.referral_fee_terms}
+            />
           </div>
-        )}
+          <div className="sm:col-span-2">
+            <EditableField
+              label="Notes"
+              partnerId={partner.id}
+              column="notes"
+              initial={partner.notes}
+              multiline
+            />
+          </div>
+        </div>
       </section>
 
       {/* ── PRIMARY + OWNER CONTACT SLOTS ─────────────────────────────── */}

--- a/src/lib/referral-partner-edit.test.ts
+++ b/src/lib/referral-partner-edit.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { buildEditPayload } from "./referral-partner-edit";
+
+describe("buildEditPayload", () => {
+  it("returns ok with only the whitelisted editable Worksheet columns", () => {
+    const result = buildEditPayload({
+      company_name: "Acme Plumbing",
+      industry: "Plumbing",
+      lead_source: "Google",
+      operation_size: "10–25",
+      office_phone: "+15551230001",
+      office_email: "ops@acme.test",
+      website: "acme.test",
+      address: "100 Main St",
+      referral_fee_terms: "10% per closed job",
+      notes: "left voicemail",
+      status: "yellow",
+    });
+    expect(result).toEqual({
+      ok: true,
+      payload: {
+        company_name: "Acme Plumbing",
+        industry: "Plumbing",
+        lead_source: "Google",
+        operation_size: "10–25",
+        office_phone: "+15551230001",
+        office_email: "ops@acme.test",
+        website: "acme.test",
+        address: "100 Main St",
+        referral_fee_terms: "10% per closed job",
+        notes: "left voicemail",
+        status: "yellow",
+      },
+    });
+  });
+
+  it("drops keys the client must not be able to write — id, organization_id, deleted_at, denormalized columns", () => {
+    const result = buildEditPayload({
+      id: "p-evil",
+      organization_id: "org-other",
+      deleted_at: "2026-01-01",
+      last_called_at: "2026-01-01",
+      last_call_outcome: "spoke",
+      next_follow_up_at: "2027-01-01",
+      primary_contact_id: "c-evil",
+      owner_contact_id: "c-evil",
+      company_name: "Acme",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload).toEqual({ company_name: "Acme" });
+  });
+
+  it("collapses blank optional text fields to null so empty strings don't reach the column", () => {
+    const result = buildEditPayload({
+      industry: "  ",
+      notes: "",
+      office_phone: "  +15551230001  ",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.payload).toEqual({
+      industry: null,
+      notes: null,
+      office_phone: "+15551230001",
+    });
+  });
+
+  it("rejects a blank company_name — the only required column on referral_partners", () => {
+    const result = buildEditPayload({ company_name: "   " });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/company_name/i);
+  });
+
+  it("rejects an unknown Lifecycle status value", () => {
+    const result = buildEditPayload({ status: "purple" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/status/i);
+  });
+
+  it.each(["grey", "yellow", "green", "red"] as const)(
+    "accepts Lifecycle status %s",
+    (status) => {
+      const result = buildEditPayload({ status });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.payload.status).toBe(status);
+    },
+  );
+
+  it("rejects an empty body — no editable fields means nothing to update", () => {
+    const result = buildEditPayload({});
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toMatch(/no.*fields/i);
+  });
+});

--- a/src/lib/referral-partner-edit.ts
+++ b/src/lib/referral-partner-edit.ts
@@ -1,0 +1,107 @@
+// Pure logic behind Call Worksheet edits (PRD #249, issue #253).
+//
+// `buildEditPayload` translates the raw body of a PATCH request — whatever
+// the client sent — into the safe `update(...)` shape for the
+// `referral_partners` row. It does two jobs and nothing else:
+//
+//   1. Whitelists the columns the Worksheet is allowed to edit (PRD #249's
+//      editable list plus `status`). Anything outside the whitelist —
+//      `id`, `organization_id`, `deleted_at`, the call-log denormalized
+//      columns, the `*_contact_id` FKs — is dropped silently. The client
+//      cannot write its way past these by guessing column names.
+//
+//   2. Normalizes per column: text fields are trimmed and collapsed to
+//      `null` when blank (matching the New Target form pattern); `status`
+//      is gated against the Lifecycle status enum; `company_name` must be
+//      non-blank if present (the schema's only NOT-NULL business column).
+//
+// Pure and I/O-free so it can be exhaustively unit-tested, matching the
+// `referral-partner-form` module from issue #250.
+
+const LIFECYCLE_STATUSES = ["grey", "yellow", "green", "red"] as const;
+export type LifecycleStatus = (typeof LIFECYCLE_STATUSES)[number];
+
+const EDITABLE_TEXT_COLUMNS = [
+  "company_name",
+  "industry",
+  "lead_source",
+  "operation_size",
+  "office_phone",
+  "office_email",
+  "website",
+  "address",
+  "referral_fee_terms",
+  "notes",
+] as const;
+
+type EditableTextColumn = (typeof EDITABLE_TEXT_COLUMNS)[number];
+
+export interface EditPayload {
+  company_name?: string;
+  industry?: string | null;
+  lead_source?: string | null;
+  operation_size?: string | null;
+  office_phone?: string | null;
+  office_email?: string | null;
+  website?: string | null;
+  address?: string | null;
+  referral_fee_terms?: string | null;
+  notes?: string | null;
+  status?: LifecycleStatus;
+}
+
+export type BuildEditResult =
+  | { ok: true; payload: EditPayload }
+  | { ok: false; error: string };
+
+function nullable(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isLifecycleStatus(v: unknown): v is LifecycleStatus {
+  return (
+    typeof v === "string" &&
+    (LIFECYCLE_STATUSES as readonly string[]).includes(v)
+  );
+}
+
+/**
+ * Build the `update(...)` shape from a client body. Returns `{ ok: false }`
+ * with a human-readable reason when the body is empty, the status is
+ * unknown, or `company_name` is present-but-blank.
+ */
+export function buildEditPayload(raw: Record<string, unknown>): BuildEditResult {
+  const payload: EditPayload = {};
+
+  for (const column of EDITABLE_TEXT_COLUMNS) {
+    if (!(column in raw)) continue;
+    const normalized = nullable(raw[column]);
+    if (column === "company_name") {
+      if (normalized === null) {
+        return { ok: false, error: "company_name cannot be blank" };
+      }
+      payload.company_name = normalized;
+    } else {
+      // Index by the union of optional keys so we don't have to switch on
+      // each column name — TypeScript can't narrow the literal type back.
+      (payload as Record<EditableTextColumn, string | null | undefined>)[
+        column
+      ] = normalized;
+    }
+  }
+
+  if ("status" in raw) {
+    if (!isLifecycleStatus(raw.status)) {
+      return { ok: false, error: "Unknown Lifecycle status" };
+    }
+    payload.status = raw.status;
+  }
+
+  if (Object.keys(payload).length === 0) {
+    return { ok: false, error: "No editable fields in body" };
+  }
+
+  return { ok: true, payload };
+}


### PR DESCRIPTION
## Summary

- Every editable column on the Call Worksheet listed in #253 (`company_name`, `industry`, `lead_source`, `operation_size`, `office_phone`, `office_email`, `website`, `address`, `referral_fee_terms`, `notes`) is now editable in place with save-on-blur.
- The header gains a four-color Lifecycle status flip-button row (grey / yellow / green / red); clicking writes the new status and the chip updates without a page reload. All four buttons are always visible — no automated transitions.
- Mutations are gated on `EDIT_REFERRAL_PARTNERS` so a `crew_member` cannot edit even via direct API call.

## Pieces

- `src/lib/referral-partner-edit.ts` — pure `buildEditPayload` whitelists the editable columns + Lifecycle status enum, normalizes blank text to `null`, rejects unknown columns / statuses / blank `company_name` (10 unit tests).
- `src/app/api/referral-partners/[id]/route.ts` — `PATCH` gated on `EDIT_REFERRAL_PARTNERS`, uses the pure module, returns the updated row (8 route tests: 401 / 403 / 400 / 200 / 404).
- `src/components/referral-partners/referral-partner-worksheet.tsx` — converted to `"use client"`. One `EditableField` per editable column with `onBlur` PATCH; four flip buttons in the header with optimistic chip update (19 RTL tests).

## Test plan

- [x] Pure module: `npx vitest run src/lib/referral-partner-edit.test.ts` — 10/10 pass
- [x] Route: `npx vitest run 'src/app/api/referral-partners/[id]/route.test.ts'` — 8/8 pass
- [x] Component: `npx vitest run src/components/referral-partners/referral-partner-worksheet.test.tsx` — 19/19 pass
- [x] Full suite: 1058 passing (the 2 pre-existing `src/app/api/email/accounts/route.test.ts` failures are unchanged on `main`)
- [x] `tsc --noEmit` clean modulo the pre-existing `src/lib/email/sync-folder-incremental.test.ts` error
- [x] `eslint` clean on every touched file
- [ ] Browser-verified — not done in this session

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)