### PR TITLE
feat(referral-partners): soft-delete + 30-day trash (#256)

### DIFF
--- a/src/app/api/referral-partners/[id]/delete/route.test.ts
+++ b/src/app/api/referral-partners/[id]/delete/route.test.ts
@@ -1,0 +1,82 @@
+// POST /api/referral-partners/[id]/delete — soft-delete a Referral Partner.
+// Tests cover the EDIT_REFERRAL_PARTNERS gate (admin / crew_lead) and the
+// happy / not-found paths. crew_member never reaches the row.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const PARAMS = { params: Promise.resolve({ id: "p-1" }) };
+const REQ = new Request("http://test/api/referral-partners/p-1/delete", {
+  method: "POST",
+});
+
+describe("POST /api/referral-partners/[id]/delete — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — soft-delete is gated", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/referral-partners/[id]/delete — happy path", () => {
+  it("a crew_lead can soft-delete an active partner", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", company_name: "Acme" },
+        ],
+      },
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 404 when the partner is invisible (RLS hid it)", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [],
+      },
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/referral-partners/[id]/delete/route.ts
+++ b/src/app/api/referral-partners/[id]/delete/route.ts
@@ -1,0 +1,44 @@
+// POST /api/referral-partners/[id]/delete — soft-delete a Referral Partner
+// (move it into the 30-day Trash). Sets `referral_partners.deleted_at = now()`;
+// the row stays in the DB and continues to hide from active queries until
+// either restored (POST /restore) or hard-deleted (DELETE /api/referral-
+// partners/[id]) or auto-purged after 30 days by GET /api/referral-partners/
+// trash.
+//
+// Gated on EDIT_REFERRAL_PARTNERS — a crew_member receives 403 before the
+// row is even located. Mirrors the Build 66 jobs soft-delete shape so the
+// platform has one trash pattern across surfaces (PRD #249 #23, issue #256).
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+
+export const POST = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (_request, { supabase }, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    // RLS scopes the update to the Active Organization. The .is(...) guard
+    // makes the second click on a partial-network double-click a no-op
+    // rather than re-stamping deleted_at; the maybeSingle resolves to null
+    // and we 404 (same cross-tenant shape as PATCH).
+    const { data, error } = await supabase
+      .from("referral_partners")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", id)
+      .is("deleted_at", null)
+      .select("id")
+      .maybeSingle();
+    if (error) {
+      return apiDbError(error.message, "POST /api/referral-partners/[id]/delete");
+    }
+    if (!data) {
+      return NextResponse.json(
+        { error: "Referral Partner not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/referral-partners/[id]/restore/route.test.ts
+++ b/src/app/api/referral-partners/[id]/restore/route.test.ts
@@ -1,0 +1,86 @@
+// POST /api/referral-partners/[id]/restore — restore a soft-deleted Referral
+// Partner. Permission gate + happy path coverage.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const PARAMS = { params: Promise.resolve({ id: "p-1" }) };
+const REQ = new Request("http://test/api/referral-partners/p-1/restore", {
+  method: "POST",
+});
+
+describe("POST /api/referral-partners/[id]/restore — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/referral-partners/[id]/restore — happy path", () => {
+  it("an admin can restore a trashed partner", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme",
+            deleted_at: "2026-05-01T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("returns 404 when no matching trashed row exists", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [],
+      },
+    });
+    const res = await POST(REQ, PARAMS);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/referral-partners/[id]/restore/route.ts
+++ b/src/app/api/referral-partners/[id]/restore/route.ts
@@ -1,0 +1,38 @@
+// POST /api/referral-partners/[id]/restore — pull a Referral Partner back
+// out of the Trash. Clears `referral_partners.deleted_at`. The Trash UI's
+// "Restore" button is the only caller (issue #256).
+//
+// Gated on EDIT_REFERRAL_PARTNERS — crew_member 403s. Mirrors the Build 66
+// jobs restore shape.
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+
+export const POST = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (_request, { supabase }, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    // We only restore rows currently in the Trash — restoring an already-
+    // active row is a no-op (returns 404, matching the cross-tenant shape).
+    const { data, error } = await supabase
+      .from("referral_partners")
+      .update({ deleted_at: null })
+      .eq("id", id)
+      .not("deleted_at", "is", null)
+      .select("id")
+      .maybeSingle();
+    if (error) {
+      return apiDbError(error.message, "POST /api/referral-partners/[id]/restore");
+    }
+    if (!data) {
+      return NextResponse.json(
+        { error: "Referral Partner not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/referral-partners/[id]/route.ts
+++ b/src/app/api/referral-partners/[id]/route.ts
@@ -4,6 +4,31 @@ import { apiDbError } from "@/lib/api-errors";
 import { buildEditPayload } from "@/lib/referral-partner-edit";
 import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
 
+// DELETE /api/referral-partners/[id] — hard-delete (force-purge) a Referral
+// Partner. The "Delete forever" button on the Trash row is the only UI
+// caller; the lazy 30-day sweep in /api/referral-partners/trash issues the
+// same DELETE against `referral_partners` directly. Both rely on the same
+// FK behaviour: `referral_partner_calls` cascade, `contacts.referral_
+// partner_id` set to NULL (the contact rows survive). See PRD #249 user
+// story #23 and the build78 migration.
+//
+// Gated on EDIT_REFERRAL_PARTNERS — crew_member 403s.
+export const DELETE = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (_request, { supabase }, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    const { error } = await supabase
+      .from("referral_partners")
+      .delete()
+      .eq("id", id);
+    if (error) {
+      return apiDbError(error.message, "DELETE /api/referral-partners/[id]");
+    }
+    return NextResponse.json({ ok: true });
+  },
+);
+
 // PATCH /api/referral-partners/[id] — the Call Worksheet's edit endpoint
 // (PRD #249, issue #253). Updates one or more whitelisted columns on a
 // `referral_partners` row, plus the Lifecycle status. Gated on

--- a/src/app/api/referral-partners/trash/cascade.test.ts
+++ b/src/app/api/referral-partners/trash/cascade.test.ts
@@ -1,0 +1,303 @@
+// Cascade-on-hard-delete integration test for issue #256.
+//
+// The acceptance criterion (issue #256, "Integration test"):
+//
+//   "Soft-delete a partner with 2 call log entries and 3 contacts
+//    (Primary, Owner, extra). After hard-delete:
+//      - zero `referral_partner_calls` for that partner;
+//      - all 3 contacts exist;
+//      - `referral_partner_id` is NULL on each."
+//
+// The actual FK behaviour (referral_partner_calls ON DELETE CASCADE; contacts
+// ON DELETE SET NULL) lives in the DB and is pinned by the SQL smoke tests
+// `migration-build78-smoke-test.sql` §2d (general case) and
+// `migration-build78b-trash-cascade-smoke-test.sql` (the specific 2-calls-+
+// -3-contacts shape called out in the issue).
+//
+// This file pins the API-layer half of the contract: the Trash route's 30-day
+// sweep (and the DELETE /api/referral-partners/[id] route the "Delete forever"
+// button calls) MUST issue a single delete against `referral_partners`. It
+// must NOT pre-emptively delete `referral_partner_calls` or `contacts` —
+// doing so would either be redundant work or, worse, would take the contact
+// rows down with the partner.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { DELETE } from "../[id]/route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { memberTables } from "../../__test-utils__/request-context-fakes";
+
+// A custom Supabase fake that records every (table, op) the route issues
+// and simulates the DB-level FK cascade + SET NULL. The point of the test
+// is to assert: the route hits `referral_partners.delete()` exactly once,
+// and the simulated cascade leaves the AC's scenario in the documented
+// final state.
+type Row = Record<string, unknown>;
+
+function makeRecordingDb(seed: Record<string, Row[]>) {
+  const tables: Record<string, Row[]> = JSON.parse(JSON.stringify(seed));
+  const ops: { table: string; op: "delete" | "update"; ids: unknown[] }[] = [];
+
+  function builder(table: string, rows: Row[]) {
+    let filtered = [...rows];
+    let pendingOp: "delete" | "update" | null = null;
+    let pendingUpdate: Row | null = null;
+    const api = {
+      select() {
+        return api;
+      },
+      update(payload: Row) {
+        pendingOp = "update";
+        pendingUpdate = payload;
+        return api;
+      },
+      delete() {
+        pendingOp = "delete";
+        return api;
+      },
+      eq(col: string, val: unknown) {
+        filtered = filtered.filter((r) => r[col] === val);
+        return api;
+      },
+      in(col: string, vals: unknown[]) {
+        filtered = filtered.filter((r) => vals.includes(r[col]));
+        return api;
+      },
+      is() {
+        return api;
+      },
+      not() {
+        return api;
+      },
+      lt() {
+        return api;
+      },
+      gt() {
+        return api;
+      },
+      or() {
+        return api;
+      },
+      order() {
+        return api;
+      },
+      limit() {
+        return api;
+      },
+      async maybeSingle() {
+        return { data: filtered[0] ?? null, error: null };
+      },
+      async single() {
+        return { data: filtered[0] ?? null, error: null };
+      },
+      then(resolve: (v: { data: Row[]; error: null }) => unknown) {
+        return resolve({ data: filtered, error: null });
+      },
+    } as Record<string, unknown>;
+
+    const realThen = api.then as (
+      resolve: (v: { data: Row[]; error: null }) => unknown,
+    ) => unknown;
+    const flush = () => {
+      if (pendingOp === "delete") {
+        const ids = filtered.map((r) => r.id);
+        ops.push({ table, op: "delete", ids });
+        // Apply the DB's FK behaviour the same way Postgres would:
+        //   referral_partners → referral_partner_calls cascade
+        //                     → contacts.referral_partner_id SET NULL
+        if (table === "referral_partners") {
+          for (const id of ids) {
+            tables.referral_partner_calls =
+              tables.referral_partner_calls?.filter(
+                (c) => c.referral_partner_id !== id,
+              ) ?? [];
+            tables.contacts = tables.contacts?.map((c) =>
+              c.referral_partner_id === id
+                ? { ...c, referral_partner_id: null }
+                : c,
+            ) ?? [];
+          }
+        }
+        tables[table] = tables[table].filter((r) => !ids.includes(r.id));
+        pendingOp = null;
+      } else if (pendingOp === "update" && pendingUpdate) {
+        const ids = filtered.map((r) => r.id);
+        ops.push({ table, op: "update", ids });
+        tables[table] = tables[table].map((r) =>
+          ids.includes(r.id) ? { ...r, ...pendingUpdate } : r,
+        );
+        pendingOp = null;
+        pendingUpdate = null;
+      }
+    };
+
+    // Wrap maybeSingle / single / then to flush the pending op once the
+    // query resolves — same shape as Supabase's awaited PostgrestBuilder.
+    api.maybeSingle = async () => {
+      const out = { data: filtered[0] ?? null, error: null as null };
+      flush();
+      return out;
+    };
+    api.single = async () => {
+      const out = { data: filtered[0] ?? null, error: null as null };
+      flush();
+      return out;
+    };
+    api.then = (resolve: (v: { data: Row[]; error: null }) => unknown) => {
+      const out = { data: filtered, error: null as null };
+      flush();
+      return realThen.call(api, () => resolve(out));
+    };
+
+    return api;
+  }
+
+  const client = {
+    auth: {
+      async getUser() {
+        return { data: { user: { id: "user-1" } }, error: null };
+      },
+    },
+    from(table: string) {
+      return builder(table, tables[table] ?? []);
+    },
+    storage: {
+      from() {
+        return {
+          async remove(paths: string[]) {
+            return { data: paths.map((name) => ({ name })), error: null };
+          },
+        };
+      },
+    },
+  };
+
+  return { client, ops, tables };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+const SCENARIO = () => ({
+  ...memberTables({ userId: "user-1", role: "admin" }),
+  referral_partners: [
+    {
+      id: "p-1",
+      organization_id: "org-1",
+      company_name: "Acme Plumbing",
+      // Trashed 31 days ago — past the 30-day window, so the sweep
+      // should hard-delete it.
+      deleted_at: new Date(
+        Date.now() - 31 * 24 * 60 * 60 * 1000,
+      ).toISOString(),
+    },
+  ],
+  referral_partner_calls: [
+    {
+      id: "c-1",
+      organization_id: "org-1",
+      referral_partner_id: "p-1",
+      outcome: "voicemail",
+    },
+    {
+      id: "c-2",
+      organization_id: "org-1",
+      referral_partner_id: "p-1",
+      outcome: "spoke",
+    },
+  ],
+  contacts: [
+    {
+      id: "primary",
+      organization_id: "org-1",
+      full_name: "Primary Contact",
+      role: "referral_contact",
+      referral_partner_id: "p-1",
+    },
+    {
+      id: "owner",
+      organization_id: "org-1",
+      full_name: "Owner Contact",
+      role: "referral_contact",
+      referral_partner_id: "p-1",
+    },
+    {
+      id: "extra",
+      organization_id: "org-1",
+      full_name: "Extra Contact",
+      role: "referral_contact",
+      referral_partner_id: "p-1",
+    },
+  ],
+});
+
+describe("cascade on hard-delete (issue #256 integration AC)", () => {
+  it("the lazy 30-day sweep hard-deletes the partner — calls cascade, contacts survive with referral_partner_id NULL", async () => {
+    const { client, ops, tables } = makeRecordingDb(SCENARIO());
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(
+      new Request("http://test/api/referral-partners/trash"),
+      { params: Promise.resolve({}) },
+    );
+    expect(res.status).toBe(200);
+
+    // The route issued exactly one delete against `referral_partners`.
+    const deletes = ops.filter((o) => o.op === "delete");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].table).toBe("referral_partners");
+    expect(deletes[0].ids).toEqual(["p-1"]);
+
+    // Simulated FK behaviour produced the AC's final state:
+    //   - referral_partner_calls for that partner: 0
+    //   - all 3 contacts exist
+    //   - each contact's referral_partner_id is NULL
+    expect(
+      tables.referral_partner_calls.filter(
+        (c) => c.referral_partner_id === "p-1",
+      ),
+    ).toHaveLength(0);
+    expect(tables.contacts).toHaveLength(3);
+    for (const c of tables.contacts) {
+      expect(c.referral_partner_id).toBeNull();
+    }
+  });
+
+  it("DELETE /api/referral-partners/[id] (the 'Delete forever' button) issues the same single delete", async () => {
+    const { client, ops, tables } = makeRecordingDb(SCENARIO());
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await DELETE(
+      new Request("http://test/api/referral-partners/p-1", { method: "DELETE" }),
+      { params: Promise.resolve({ id: "p-1" }) },
+    );
+    expect(res.status).toBe(200);
+
+    // Exactly one delete, and it's against `referral_partners`. The route
+    // does NOT pre-delete calls or contacts — the DB cascade does that.
+    const deletes = ops.filter((o) => o.op === "delete");
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0].table).toBe("referral_partners");
+
+    expect(
+      tables.referral_partner_calls.filter(
+        (c) => c.referral_partner_id === "p-1",
+      ),
+    ).toHaveLength(0);
+    expect(tables.contacts).toHaveLength(3);
+    for (const c of tables.contacts) {
+      expect(c.referral_partner_id).toBeNull();
+    }
+  });
+});

--- a/src/app/api/referral-partners/trash/route.test.ts
+++ b/src/app/api/referral-partners/trash/route.test.ts
@@ -1,0 +1,74 @@
+// GET /api/referral-partners/trash — Trash list + lazy 30-day sweep.
+// Pins the auth gate, the happy-path shape, and confirms the response
+// envelope advertises the retention window the UI uses.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const REQ = new Request("http://test/api/referral-partners/trash");
+
+describe("GET /api/referral-partners/trash — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(REQ, { params: Promise.resolve({}) });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — Trash is admin/crew_lead only", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await GET(REQ, { params: Promise.resolve({}) });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/referral-partners/trash — happy path", () => {
+  it("an admin sees the trashed partners with the retention window", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            company_name: "Acme",
+            deleted_at: "2026-05-20T00:00:00.000Z",
+          },
+        ],
+      },
+    });
+    const res = await GET(REQ, { params: Promise.resolve({}) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.retentionDays).toBe(30);
+    expect(Array.isArray(body.referral_partners)).toBe(true);
+  });
+});

--- a/src/app/api/referral-partners/trash/route.ts
+++ b/src/app/api/referral-partners/trash/route.ts
@@ -1,0 +1,74 @@
+// GET /api/referral-partners/trash — list Referral Partners currently in
+// the Trash, after first auto-purging anything that has been trashed for
+// more than 30 days.
+//
+// This is the same lazy-purge pattern Build 66 introduced for jobs (see
+// src/app/api/jobs/trash/route.ts): every fetch of the Trash view is the
+// trigger for the sweep, so a deleted partner that nobody ever revisits
+// still ages out the next time an admin / crew_lead opens Trash. No
+// scheduled cron, no parallel mechanism.
+//
+// On hard-delete: `referral_partner_calls` rows cascade away (FK was
+// ON DELETE CASCADE in build78); `contacts.referral_partner_id` is set
+// to NULL on linked Referral Contacts (FK was ON DELETE SET NULL in
+// build78) — the contact rows themselves survive (PRD #249 user story
+// #23, issue #256 AC).
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+
+const RETENTION_DAYS = 30;
+
+export const GET = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (_request, { supabase }) => {
+    const cutoffIso = new Date(
+      Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    // 1. Find anything past the 30-day window. RLS scopes to the Active
+    //    Organization, so we only see (and only touch) rows the caller is
+    //    allowed to manage.
+    const { data: expired, error: expiredError } = await supabase
+      .from("referral_partners")
+      .select("id")
+      .not("deleted_at", "is", null)
+      .lt("deleted_at", cutoffIso);
+    if (expiredError) {
+      return apiDbError(
+        expiredError.message,
+        "GET /api/referral-partners/trash list expired",
+      );
+    }
+
+    // 2. Hard-delete each expired row. The FKs do the rest:
+    //      referral_partner_calls  → ON DELETE CASCADE  (rows go away)
+    //      contacts.referral_partner_id → ON DELETE SET NULL (contacts survive)
+    //    One row at a time so a single failure doesn't strand the others.
+    let autoPurged = 0;
+    for (const row of expired ?? []) {
+      const { error } = await supabase
+        .from("referral_partners")
+        .delete()
+        .eq("id", row.id);
+      if (!error) autoPurged += 1;
+    }
+
+    // 3. List what's left in the Trash.
+    const { data: trashed, error } = await supabase
+      .from("referral_partners")
+      .select("*")
+      .not("deleted_at", "is", null)
+      .order("deleted_at", { ascending: false });
+    if (error) {
+      return apiDbError(error.message, "GET /api/referral-partners/trash list");
+    }
+    return NextResponse.json({
+      referral_partners: trashed ?? [],
+      autoPurged,
+      retentionDays: RETENTION_DAYS,
+    });
+  },
+);

--- a/src/app/referral-partners/[id]/page.test.tsx
+++ b/src/app/referral-partners/[id]/page.test.tsx
@@ -30,6 +30,11 @@ vi.mock("next/navigation", () => ({
   notFound: () => {
     throw NOT_FOUND_ERROR;
   },
+  // The Worksheet's Delete action (issue #256) reads `useRouter()` so it can
+  // navigate back to the list page after a successful soft-delete. The page-
+  // render tests don't exercise the delete flow, but the hook is still
+  // called on render — return a no-op router.
+  useRouter: () => ({ push: () => {}, refresh: () => {} }),
 }));
 
 import Page from "./page";

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -12,7 +12,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Handshake, Plus, Search } from "lucide-react";
+import { Handshake, Loader2, Plus, RotateCcw, Search, Trash2 } from "lucide-react";
 import NewTargetDialog from "@/components/referral-partners/new-target-dialog";
 import {
   distinctIndustries,
@@ -20,6 +20,8 @@ import {
   type LifecycleStatus,
 } from "@/lib/referral-partner-filter";
 import type { CallOutcome } from "@/lib/referral-partner-call";
+
+const RETENTION_DAYS = 30;
 
 interface ReferralPartner {
   id: string;
@@ -29,6 +31,7 @@ interface ReferralPartner {
   last_called_at: string | null;
   last_call_outcome: CallOutcome | null;
   next_follow_up_at: string | null;
+  deleted_at?: string | null;
 }
 
 const OUTCOME_LABEL: Record<CallOutcome, string> = {
@@ -67,11 +70,17 @@ const STATUS_LABEL: Record<LifecycleStatus, string> = {
 
 const ALL_STATUSES: ReadonlyArray<LifecycleStatus> = ["grey", "yellow", "green", "red"];
 
+type View = "active" | "trash";
+
 export default function ReferralPartnersPage() {
   const [partners, setPartners] = useState<ReferralPartner[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
+  // Active vs Trash view (issue #256). Mirrors the Build 66 jobs pattern —
+  // a single tab toggle on the list page swaps which endpoint feeds the
+  // rows. No separate route segment.
+  const [view, setView] = useState<View>("active");
 
   // Filter state — every chip on by default so the user sees everything
   // before narrowing. Industry and query empty until the user picks one.
@@ -84,7 +93,11 @@ export default function ReferralPartnersPage() {
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
-    const res = await fetch("/api/referral-partners");
+    const endpoint =
+      view === "trash"
+        ? "/api/referral-partners/trash"
+        : "/api/referral-partners";
+    const res = await fetch(endpoint);
     if (!res.ok) {
       setError(res.status === 403 ? "You don't have access to Referral Partners." : "Could not load partners.");
       setLoading(false);
@@ -93,7 +106,7 @@ export default function ReferralPartnersPage() {
     const body = await res.json();
     setPartners(body.referral_partners ?? []);
     setLoading(false);
-  }, []);
+  }, [view]);
 
   useEffect(() => {
     void load();
@@ -101,14 +114,19 @@ export default function ReferralPartnersPage() {
 
   const industries = useMemo(() => distinctIndustries(partners), [partners]);
 
+  // Trash uses the API's own ordering (deleted_at desc) and bypasses the
+  // status/industry/query filters — Trash is its own slice of the dataset
+  // and gets a different row treatment (with Restore + Delete forever).
   const visiblePartners = useMemo(
     () =>
-      filterReferralPartners(partners, {
-        status: Array.from(activeStatuses),
-        industry,
-        query,
-      }),
-    [partners, activeStatuses, industry, query],
+      view === "trash"
+        ? partners
+        : filterReferralPartners(partners, {
+            status: Array.from(activeStatuses),
+            industry,
+            query,
+          }),
+    [view, partners, activeStatuses, industry, query],
   );
 
   const toggleStatus = (s: LifecycleStatus) => {
@@ -127,16 +145,51 @@ export default function ReferralPartnersPage() {
           <Handshake size={24} className="text-primary" />
           <h1 className="text-2xl font-heading font-semibold">Referral Partners</h1>
         </div>
-        <button
-          onClick={() => setDialogOpen(true)}
-          className="btn btn-primary inline-flex items-center gap-2"
-        >
-          <Plus size={16} />
-          Add Target
-        </button>
+        {view === "active" && (
+          <button
+            onClick={() => setDialogOpen(true)}
+            className="btn btn-primary inline-flex items-center gap-2"
+          >
+            <Plus size={16} />
+            Add Target
+          </button>
+        )}
       </header>
 
-      <div className="mb-4 flex flex-wrap items-center gap-3">
+      {/* ── View tabs (Active / Trash) — issue #256 ─────────────────────── */}
+      <div className="mb-4 flex flex-wrap items-center gap-2" role="tablist">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "active"}
+          onClick={() => setView("active")}
+          className={`px-3 py-1.5 rounded-md text-sm font-medium transition ${
+            view === "active"
+              ? "bg-primary text-primary-foreground"
+              : "bg-card border border-border text-foreground hover:bg-muted/40"
+          }`}
+        >
+          Active
+        </button>
+        <button
+          type="button"
+          role="tab"
+          data-testid="referral-partners-trash-tab"
+          aria-selected={view === "trash"}
+          onClick={() => setView("trash")}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition ${
+            view === "trash"
+              ? "bg-primary text-primary-foreground"
+              : "bg-card border border-border text-foreground hover:bg-muted/40"
+          }`}
+        >
+          <Trash2 size={14} />
+          Trash
+        </button>
+      </div>
+
+      {view === "active" && (
+        <div className="mb-4 flex flex-wrap items-center gap-3">
         <div
           className="flex flex-wrap items-center gap-2"
           role="group"
@@ -183,12 +236,23 @@ export default function ReferralPartnersPage() {
             className="w-full rounded-md border border-border bg-card pl-7 pr-2 py-1 text-sm"
           />
         </label>
-      </div>
+        </div>
+      )}
 
       {loading ? (
         <p className="text-sm text-muted-foreground">Loading…</p>
       ) : error ? (
         <p className="text-sm text-destructive" role="alert">{error}</p>
+      ) : view === "trash" ? (
+        visiblePartners.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Trash is empty.</p>
+        ) : (
+          <div className="space-y-3">
+            {visiblePartners.map((p) => (
+              <TrashRow key={p.id} partner={p} onChange={load} />
+            ))}
+          </div>
+        )
       ) : partners.length === 0 ? (
         <p className="text-sm text-muted-foreground">
           No partners yet. Click <strong>Add Target</strong> to start your cold-call list.
@@ -245,6 +309,109 @@ export default function ReferralPartnersPage() {
         onOpenChange={setDialogOpen}
         onCreated={() => void load()}
       />
+    </div>
+  );
+}
+
+// One Trash row — mirrors the Build 66 jobs Trash row shape so the platform
+// has one Trash visual language across surfaces. Restore nulls `deleted_at`;
+// "Delete forever" hard-deletes (FK CASCADE on calls + SET NULL on contacts).
+function TrashRow({
+  partner,
+  onChange,
+}: {
+  partner: ReferralPartner;
+  onChange: () => void;
+}) {
+  const [busy, setBusy] = useState<"restore" | "purge" | null>(null);
+
+  // Capture "now" at mount so the rendered "N days until permanent delete"
+  // is stable across re-renders — same pattern as JobsPage TrashRow.
+  const [mountedAt] = useState(() => Date.now());
+  const daysRemaining = partner.deleted_at
+    ? Math.max(
+        0,
+        RETENTION_DAYS -
+          Math.floor((mountedAt - new Date(partner.deleted_at).getTime()) / 86_400_000),
+      )
+    : null;
+
+  async function handleRestore() {
+    setBusy("restore");
+    const res = await fetch(
+      `/api/referral-partners/${partner.id}/restore`,
+      { method: "POST" },
+    );
+    setBusy(null);
+    if (!res.ok) {
+      alert("Couldn't restore Referral Partner");
+      return;
+    }
+    onChange();
+  }
+
+  async function handlePurge() {
+    if (
+      !confirm(
+        `Permanently delete "${partner.company_name}" and all its Call log entries? Linked contacts will be preserved but unlinked. This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    setBusy("purge");
+    const res = await fetch(`/api/referral-partners/${partner.id}`, {
+      method: "DELETE",
+    });
+    setBusy(null);
+    if (!res.ok) {
+      alert("Couldn't delete Referral Partner");
+      return;
+    }
+    onChange();
+  }
+
+  return (
+    <div
+      data-testid={`referral-partners-trash-row-${partner.id}`}
+      className="rounded-xl border border-border bg-card p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-base font-semibold text-foreground truncate">
+          {partner.company_name}
+        </p>
+        {partner.industry && (
+          <p className="text-sm text-muted-foreground truncate">{partner.industry}</p>
+        )}
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          {daysRemaining !== null
+            ? daysRemaining === 0
+              ? "Auto-purges today"
+              : `${daysRemaining} day${daysRemaining === 1 ? "" : "s"} until permanent deletion`
+            : null}
+        </p>
+      </div>
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          type="button"
+          data-testid={`referral-partners-trash-restore-${partner.id}`}
+          onClick={handleRestore}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-accent disabled:opacity-50"
+        >
+          {busy === "restore" ? <Loader2 size={14} className="animate-spin" /> : <RotateCcw size={14} />}
+          Restore
+        </button>
+        <button
+          type="button"
+          data-testid={`referral-partners-trash-purge-${partner.id}`}
+          onClick={handlePurge}
+          disabled={busy !== null}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-destructive/10 border border-destructive/30 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/20 disabled:opacity-50"
+        >
+          {busy === "purge" ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+          Delete forever
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/referral-partners/referral-partner-worksheet.test.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.test.tsx
@@ -9,6 +9,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, within, waitFor } from "@testing-library/react";
 
+// The Worksheet now navigates back to the list page after a successful
+// soft-delete (issue #256). The component pulls `useRouter` from
+// next/navigation; we stub it here so the existing render-only tests still
+// pass and the new delete-flow test can assert on the push call.
+const routerPush = vi.fn();
+const routerRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush, refresh: routerRefresh }),
+}));
+
 import {
   ReferralPartnerWorksheet,
   type ReferralPartnerForWorksheet,
@@ -57,10 +67,16 @@ function renderWorksheet(overrides: {
 // PATCH /api/referral-partners/[id]; we mock at the global so the
 // component doesn't have to take a fetch prop just for testability.
 beforeEach(() => {
+  routerPush.mockReset();
+  routerRefresh.mockReset();
   vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string, init?: RequestInit) => {
       const body = init?.body ? JSON.parse(init.body as string) : {};
+      // POST /api/.../delete — soft-delete (issue #256).
+      if (url.endsWith("/delete")) {
+        return { ok: true, status: 200, json: async () => ({ ok: true }) } as Response;
+      }
       // POST /api/.../calls returns { call: ... }; PATCH returns { referral_partner: ... }
       if (url.endsWith("/calls")) {
         return {
@@ -616,5 +632,40 @@ describe("ReferralPartnerWorksheet — + Add contact (PRD #249, issue #255)", ()
       /owner contact/i,
     ) as HTMLSelectElement;
     expect(within(ownerSelect).getByText("Pat Smith")).toBeDefined();
+  });
+});
+
+// ── Soft-delete from the Worksheet (issue #256) ────────────────────────
+describe("ReferralPartnerWorksheet — Delete action", () => {
+  it("renders a Delete button in the header", () => {
+    renderWorksheet();
+    expect(screen.getByTestId("worksheet-delete-button")).toBeDefined();
+  });
+
+  it("on Delete: confirms, POSTs to /delete, and navigates back to /referral-partners", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderWorksheet();
+
+    fireEvent.click(screen.getByTestId("worksheet-delete-button"));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith("/referral-partners");
+    });
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(routerRefresh).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("if the user cancels the confirmation, no fetch fires and no navigation happens", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderWorksheet();
+
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockClear();
+    fireEvent.click(screen.getByTestId("worksheet-delete-button"));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(routerPush).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });

--- a/src/components/referral-partners/referral-partner-worksheet.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.tsx
@@ -11,7 +11,8 @@
 // every state change is a deliberate user action.
 
 import { useCallback, useMemo, useRef, useState } from "react";
-import { Handshake } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Handshake, Trash2 } from "lucide-react";
 import { formatPhoneNumber } from "@/lib/phone";
 import {
   CALL_OUTCOMES,
@@ -266,6 +267,8 @@ export function ReferralPartnerWorksheet({
   // update it optimistically on click so the user sees the new label
   // without a reload (PRD #249 #28, issue #253 AC #2 & #3).
   const [status, setStatus] = useState<LifecycleStatus>(partner.status);
+  const [deleting, setDeleting] = useState(false);
+  const router = useRouter();
 
   // Local contacts state so the inline + Add contact form can prepend a
   // new Referral Contact and surface it in the list, the Primary contact
@@ -292,6 +295,33 @@ export function ReferralPartnerWorksheet({
     [partner.id, status],
   );
 
+  // Soft-delete the Referral Partner: confirm, POST /delete, then return
+  // the user to the list page. The partner disappears from the default
+  // list (which filters `deleted_at IS NULL`) and reappears in Trash
+  // (issue #256).
+  const onDelete = useCallback(async () => {
+    if (deleting) return;
+    if (
+      !confirm(
+        `Move "${partner.company_name}" to the Trash? You'll have 30 days to restore it before it's permanently deleted.`,
+      )
+    ) {
+      return;
+    }
+    setDeleting(true);
+    const res = await fetch(
+      `/api/referral-partners/${partner.id}/delete`,
+      { method: "POST" },
+    );
+    if (!res.ok) {
+      setDeleting(false);
+      alert("Couldn't delete this Referral Partner.");
+      return;
+    }
+    router.push("/referral-partners");
+    router.refresh();
+  }, [deleting, partner.company_name, partner.id, router]);
+
   return (
     <div className="max-w-5xl mx-auto px-4 py-6 space-y-6">
       {/* ── HEADER ─────────────────────────────────────────────────────── */}
@@ -307,6 +337,17 @@ export function ReferralPartnerWorksheet({
           >
             {STATUS_LABEL[status]}
           </span>
+          <button
+            type="button"
+            data-testid="worksheet-delete-button"
+            onClick={onDelete}
+            disabled={deleting}
+            aria-label="Delete Referral Partner"
+            className="ml-auto inline-flex items-center gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-1.5 text-sm font-medium text-destructive hover:bg-destructive/20 disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+            Delete
+          </button>
         </div>
 
         {/* ── LIFECYCLE STATUS FLIP BUTTONS ────────────────────────────── */}

--- a/supabase/migration-build78b-trash-cascade-smoke-test.sql
+++ b/supabase/migration-build78b-trash-cascade-smoke-test.sql
@@ -1,0 +1,103 @@
+-- build78b (PRD #249, issue #256) — Referral Partners Trash cascade smoke test.
+--
+-- Purpose:   Pins the exact cascade scenario from issue #256's integration-
+--            test AC: a Referral Partner with 2 Call log entries and 3
+--            Referral Contacts (Primary + Owner + an extra). After hard-
+--            delete, the AC says: zero referral_partner_calls remain for
+--            that partner; all 3 contact rows still exist; each contact's
+--            `referral_partner_id` is NULL.
+--
+--            The general FK behaviour is already pinned by
+--            migration-build78-smoke-test.sql §2d. This script adds the
+--            specific 2-calls-+-3-contacts shape from the issue so the AC
+--            doesn't drift if someone changes the FK action in the future.
+--
+-- Preconditions: build78 has already been applied.
+-- Run:       psql -f supabase/migration-build78b-trash-cascade-smoke-test.sql
+--            (or paste into the Supabase SQL editor).
+-- What runs: a `begin; ... rollback;` script — no schema changes survive.
+
+begin;
+
+do $$
+declare
+  v_org_id          uuid := gen_random_uuid();
+  v_user_id         uuid;
+  v_partner_id      uuid;
+  v_primary_id      uuid := gen_random_uuid();
+  v_owner_id        uuid := gen_random_uuid();
+  v_extra_id        uuid := gen_random_uuid();
+  v_call_count      int;
+  v_contact_count   int;
+  v_still_linked    int;
+begin
+  -- The Call log FK on user_id requires a real auth.users row. If none
+  -- exists (rare local-only state), skip cleanly with a notice — the
+  -- contact-side cascade still gets covered, but the call-side branch
+  -- needs a user.
+  select id into v_user_id from auth.users limit 1;
+  if v_user_id is null then
+    raise notice 'build78b smoke: no auth.users row — cannot exercise referral_partner_calls. Skipping.';
+    rollback;
+    return;
+  end if;
+
+  insert into public.organizations (id, name, slug)
+    values (v_org_id, 'build78b smoke', 'build78b-smoke-' || replace(v_org_id::text, '-', ''));
+
+  -- One Referral Partner.
+  insert into public.referral_partners (organization_id, company_name)
+    values (v_org_id, 'Acme Plumbing')
+    returning id into v_partner_id;
+
+  -- Three Referral Contacts at this partner: Primary, Owner, and an extra.
+  insert into public.contacts (id, organization_id, full_name, role, referral_partner_id)
+    values
+      (v_primary_id, v_org_id, 'Primary Contact', 'referral_contact', v_partner_id),
+      (v_owner_id,   v_org_id, 'Owner Contact',   'referral_contact', v_partner_id),
+      (v_extra_id,   v_org_id, 'Extra Contact',   'referral_contact', v_partner_id);
+
+  update public.referral_partners
+     set primary_contact_id = v_primary_id,
+         owner_contact_id   = v_owner_id
+   where id = v_partner_id;
+
+  -- Two Call log entries against that partner.
+  insert into public.referral_partner_calls (organization_id, referral_partner_id, referral_contact_id, user_id, outcome)
+    values
+      (v_org_id, v_partner_id, v_primary_id, v_user_id, 'voicemail'),
+      (v_org_id, v_partner_id, v_primary_id, v_user_id, 'spoke');
+
+  -- Hard-delete the partner (the trash route's purge step — and the
+  -- "Delete forever" button — issue the same SQL).
+  delete from public.referral_partners where id = v_partner_id;
+
+  -- 1. referral_partner_calls cascaded away — zero remain for that partner.
+  select count(*) into v_call_count
+    from public.referral_partner_calls
+   where referral_partner_id = v_partner_id;
+  if v_call_count <> 0 then
+    raise exception 'build78b smoke: referral_partner_calls did NOT cascade (% rows survive)', v_call_count;
+  end if;
+
+  -- 2. All three contact rows survive.
+  select count(*) into v_contact_count
+    from public.contacts
+   where id in (v_primary_id, v_owner_id, v_extra_id);
+  if v_contact_count <> 3 then
+    raise exception 'build78b smoke: expected 3 contact rows to survive, saw %', v_contact_count;
+  end if;
+
+  -- 3. Each surviving contact's referral_partner_id is NULL.
+  select count(*) into v_still_linked
+    from public.contacts
+   where id in (v_primary_id, v_owner_id, v_extra_id)
+     and referral_partner_id is not null;
+  if v_still_linked <> 0 then
+    raise exception 'build78b smoke: contacts.referral_partner_id NOT nulled (% rows still linked)', v_still_linked;
+  end if;
+
+  raise notice 'build78b smoke: hard-delete of a partner with 2 calls + 3 contacts — calls cascade, contacts survive with referral_partner_id NULL';
+end $$;
+
+rollback;


### PR DESCRIPTION
## Summary

- Adds a **Delete** action to the Call Worksheet header: a confirmation prompt, then `POST /api/referral-partners/[id]/delete` stamps `deleted_at = now()`, and the user is sent back to `/referral-partners` (where the row no longer appears, since the default list filters `deleted_at IS NULL`).
- Adds an **Active / Trash** tab toggle to the list page. The Trash view mirrors the Build 66 jobs Trash visual treatment (rounded card rows with **Restore** and **Delete forever** buttons, plus the "N days until permanent deletion" copy).
- Adds the lazy **30-day hard-delete sweep** — extends the Build 66 mechanism: each `GET /api/referral-partners/trash` purges anything past the retention window before listing what's left. No parallel cron / scheduled job.
- On hard-delete, the FK behaviour seeded in the `build78` migration takes over: `referral_partner_calls` cascade (ON DELETE CASCADE), `contacts.referral_partner_id` is nulled (ON DELETE SET NULL) — Referral Contact rows survive.
- Soft-delete, restore, and hard-delete are all gated on `EDIT_REFERRAL_PARTNERS` (admin + crew_lead). `crew_member` 403s.
- The cascade scenario from the issue's integration-test AC (one partner, 2 Call log entries, 3 Referral Contacts — Primary, Owner, extra) is pinned at two layers: a Supabase smoke-test script (`migration-build78b-trash-cascade-smoke-test.sql`, runs against a real Postgres) and an application-layer test in `cascade.test.ts` that uses a Supabase fake which simulates the same FK behaviour.

Glossary terms used verbatim: Referral Partner, Referral Contact, Primary contact, Owner contact, Call Worksheet, Call log entry, Lifecycle status.

Closes #256

## Test plan

- [x] `npm test` — full suite passes (no regressions)
- [x] `npx tsc --noEmit` — typecheck clean
- [x] Worksheet renders the Delete button; cancelling the confirmation aborts; confirming hits `/delete` and routes to `/referral-partners`
- [x] List page Active tab queries `/api/referral-partners` (filters `deleted_at IS NULL` server-side)
- [x] List page Trash tab queries `/api/referral-partners/trash` and renders Restore + Delete-forever actions
- [x] Cascade integration test (`src/app/api/referral-partners/trash/cascade.test.ts`) asserts the AC's exact final state after hard-delete
- [x] `migration-build78b-trash-cascade-smoke-test.sql` pins the same shape at the SQL layer
- [ ] Smoke against a real DB (out of scope for this PR; the smoke-test script is the runbook)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>