### PR TITLE
feat(referral-partners): + Add contact inline + Contacts tab badge (#255)

### DIFF
--- a/src/app/api/referral-partners/[id]/contacts/route.test.ts
+++ b/src/app/api/referral-partners/[id]/contacts/route.test.ts
@@ -1,0 +1,115 @@
+// POST /api/referral-partners/[id]/contacts — inline + Add contact endpoint
+// (PRD #249, issue #255). Creates a `contacts` row with
+// role = 'referral_contact' and referral_partner_id set to the partner the
+// Worksheet is open on. Gated on EDIT_REFERRAL_PARTNERS — a crew_member
+// cannot add Referral Contacts.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const PARAMS = { params: Promise.resolve({ id: "p-1" }) };
+
+function postReq(body: unknown) {
+  return new Request("http://test/api/referral-partners/p-1/contacts", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/referral-partners/[id]/contacts — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(postReq({ full_name: "Pat" }), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — gated on EDIT_REFERRAL_PARTNERS", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+    const res = await POST(postReq({ full_name: "Pat" }), PARAMS);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/referral-partners/[id]/contacts — validation", () => {
+  it("rejects a body with no full_name with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "admin" }),
+    });
+    const res = await POST(postReq({ phone: "555-1234" }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a blank full_name with 400", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "admin" }),
+    });
+    const res = await POST(postReq({ full_name: "   " }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/referral-partners/[id]/contacts — happy path", () => {
+  it("a crew_lead can add a Referral Contact; the new row is returned with status 201", async () => {
+    const seededContact = {
+      id: "c-new",
+      organization_id: "org-1",
+      referral_partner_id: "p-1",
+      full_name: "Pat Smith",
+      phone: "5551234567",
+      email: "pat@acme.test",
+      role: "referral_contact",
+      notes: null,
+    };
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "crew_lead" }),
+        contacts: [seededContact],
+      },
+    });
+    const res = await POST(
+      postReq({
+        full_name: "Pat Smith",
+        phone: "5551234567",
+        email: "pat@acme.test",
+        notes: "",
+      }),
+      PARAMS,
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.contact.full_name).toBe("Pat Smith");
+    expect(body.contact.role).toBe("referral_contact");
+    expect(body.contact.referral_partner_id).toBe("p-1");
+  });
+});

--- a/src/app/api/referral-partners/[id]/contacts/route.ts
+++ b/src/app/api/referral-partners/[id]/contacts/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { EDIT_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+import {
+  buildNewReferralContactPayload,
+  isValidNewReferralContact,
+  type NewReferralContactInput,
+} from "@/lib/referral-contact-form";
+
+// POST /api/referral-partners/[id]/contacts — inline "+ Add contact" endpoint
+// (PRD #249, issue #255). Creates a `contacts` row with role =
+// 'referral_contact' and referral_partner_id pinned to the partner the Call
+// Worksheet is open on. Gated on EDIT_REFERRAL_PARTNERS so a crew_member
+// receives 403 before the body is parsed.
+//
+// Validation and payload shape live in the pure `referral-contact-form`
+// module so this route stays a thin adapter, matching the New Target POST
+// mirror from issue #250.
+export const POST = withRequestContext(
+  EDIT_REFERRAL_PARTNERS,
+  async (
+    request,
+    { supabase, orgId },
+    { params }: { params: Promise<{ id: string }> },
+  ) => {
+    const { id } = await params;
+    const raw = (await request.json()) as Partial<NewReferralContactInput>;
+    const input: NewReferralContactInput = {
+      full_name: raw.full_name ?? "",
+      phone: raw.phone ?? "",
+      email: raw.email ?? "",
+      notes: raw.notes ?? "",
+    };
+    if (!isValidNewReferralContact(input)) {
+      return NextResponse.json(
+        { error: "full_name is required" },
+        { status: 400 },
+      );
+    }
+    if (!orgId) {
+      // `roles` rule guarantees a non-null orgId on success, but the type
+      // exposes a nullable orgId; this is defensive.
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 400 },
+      );
+    }
+    const payload = buildNewReferralContactPayload(input, orgId, id);
+    const { data, error } = await supabase
+      .from("contacts")
+      .insert(payload)
+      .select("*")
+      .single();
+    if (error) {
+      return apiDbError(
+        error.message,
+        "POST /api/referral-partners/[id]/contacts insert",
+      );
+    }
+    return NextResponse.json({ contact: data }, { status: 201 });
+  },
+);

--- a/src/app/contacts/page.test.tsx
+++ b/src/app/contacts/page.test.tsx
@@ -1,0 +1,124 @@
+// Contacts tab — Referral Contact badge (PRD #249, issue #255 AC #4).
+//
+// Mounts the Contacts page and asserts that a contact whose `role` is
+// `referral_contact` renders a clear "Referral Contact" badge — visually
+// consistent with the existing role badges (homeowner, adjuster,
+// insurance, etc.). The list / search / phone-format infrastructure is
+// reused; no parallel code path.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(async () => "org-1"),
+}));
+
+import ContactsPage from "./page";
+import { createClient } from "@/lib/supabase";
+
+type Row = Record<string, unknown>;
+
+function fakeQueryBuilder(rows: Row[]) {
+  let filtered = [...rows];
+  const passthrough = () => builder;
+  const builder = {
+    select: passthrough,
+    eq(col: string, val: unknown) {
+      filtered = filtered.filter((r) => r[col] === val);
+      return builder;
+    },
+    order: passthrough,
+    then(resolve: (v: { data: Row[]; error: null }) => unknown) {
+      return resolve({ data: filtered, error: null });
+    },
+  };
+  return builder;
+}
+
+function useTables(tables: Record<string, Row[]>) {
+  vi.mocked(createClient).mockReturnValue({
+    from(table: string) {
+      return fakeQueryBuilder(tables[table] ?? []);
+    },
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("/contacts — Referral Contact badge (issue #255 AC #4)", () => {
+  it("renders a 'Referral Contact' badge on rows with role = 'referral_contact'", async () => {
+    useTables({
+      contacts: [
+        {
+          id: "c-1",
+          organization_id: "org-1",
+          full_name: "Pat Referral",
+          phone: null,
+          email: null,
+          role: "referral_contact",
+          company: null,
+          notes: null,
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+      jobs: [],
+    });
+
+    render(<ContactsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/pat referral/i)).toBeDefined();
+    });
+    // The badge text must call out "Referral Contact" so the user can
+    // distinguish a Referral Partner contact from a homeowner / adjuster
+    // / insurance rep at a glance.
+    expect(screen.getByText(/referral contact/i)).toBeDefined();
+  });
+
+  it("uses the same row layout for Referral Contacts as for other roles (no parallel code path)", async () => {
+    useTables({
+      contacts: [
+        {
+          id: "c-1",
+          organization_id: "org-1",
+          full_name: "Hannah Homeowner",
+          phone: "+15551110001",
+          email: null,
+          role: "homeowner",
+          company: null,
+          notes: null,
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+        },
+        {
+          id: "c-2",
+          organization_id: "org-1",
+          full_name: "Riley Referral",
+          phone: "+15551110002",
+          email: null,
+          role: "referral_contact",
+          company: null,
+          notes: null,
+          created_at: "2026-05-01T00:00:00Z",
+          updated_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+      jobs: [],
+    });
+
+    render(<ContactsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/riley referral/i)).toBeDefined();
+    });
+    // Phone-format infrastructure works on Referral Contacts identically.
+    expect(screen.getByText(/\(555\) 111-0002/)).toBeDefined();
+    expect(screen.getByText(/\(555\) 111-0001/)).toBeDefined();
+  });
+});

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -47,6 +47,10 @@ const roleColors: Record<string, string> = {
   property_manager: "bg-[#FAEEDA] text-[#633806]",
   adjuster: "bg-[#E1F5EE] text-[#085041]",
   insurance: "bg-[#FFF8E6] text-[#7A5E00]",
+  // PRD #249, issue #255: badge for `referral_contact` rows on the
+  // Contacts tab — visually consistent with the existing role badges so
+  // a user can pick out Referral Partner contacts at a glance.
+  referral_contact: "bg-[#FDECEF] text-[#7A1B2B]",
 };
 
 const roleLabels: Record<string, string> = {
@@ -55,6 +59,7 @@ const roleLabels: Record<string, string> = {
   property_manager: "Prop Manager",
   adjuster: "Adjuster",
   insurance: "Insurance",
+  referral_contact: "Referral Contact",
 };
 
 type ContactWithJobs = Contact & {

--- a/src/components/referral-partners/referral-partner-worksheet.test.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.test.tsx
@@ -77,6 +77,24 @@ beforeEach(() => {
           }),
         } as Response;
       }
+      if (url.endsWith("/contacts")) {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            contact: {
+              id: "c-new",
+              organization_id: "org-1",
+              referral_partner_id: "p-1",
+              full_name: body.full_name,
+              phone: body.phone || null,
+              email: body.email || null,
+              notes: body.notes || null,
+              role: "referral_contact",
+            },
+          }),
+        } as Response;
+      }
       return {
         ok: true,
         status: 200,
@@ -411,6 +429,14 @@ describe("ReferralPartnerWorksheet — Log a call (PRD #249, issue #254 AC #2 + 
     expect(body.follow_up_at).toBe("2026-06-15");
   });
 
+  // ── + Add contact integration tests (issue #255) ─────────────────────
+  //
+  // Mounts the Worksheet, clicks "+ Add contact", fills the inline 4-field
+  // form (name, number, email, note), submits, and asserts the new contact
+  // is visible in (a) the "Contacts at this company" list, (b) the Primary
+  // contact dropdown, AND (c) the Owner contact dropdown — all on the SAME
+  // render (no reload). This is the load-bearing contract for the slice.
+
   it("the referral_contact dropdown defaults to the Primary contact", () => {
     renderWorksheet({
       partner: { primary_contact_id: "c-primary" },
@@ -480,5 +506,115 @@ describe("ReferralPartnerWorksheet — Log a call (PRD #249, issue #254 AC #2 + 
     const section = screen.getByTestId("worksheet-call-log");
     expect(section.textContent).toMatch(/last call/i);
     expect(section.textContent).toMatch(/interested/i);
+  });
+});
+
+describe("ReferralPartnerWorksheet — + Add contact (PRD #249, issue #255)", () => {
+  it("renders a + Add contact button inside the Contacts at this company section", () => {
+    renderWorksheet();
+    const list = screen.getByTestId("worksheet-contacts-list");
+    expect(
+      within(list).getByRole("button", { name: /\+ add contact/i }),
+    ).toBeDefined();
+  });
+
+  it("clicking + Add contact reveals an inline 4-field form (name, number, email, note)", () => {
+    renderWorksheet();
+    const list = screen.getByTestId("worksheet-contacts-list");
+    fireEvent.click(
+      within(list).getByRole("button", { name: /\+ add contact/i }),
+    );
+    const form = screen.getByTestId("worksheet-add-contact-form");
+    expect(within(form).getByLabelText(/^name$/i)).toBeDefined();
+    expect(within(form).getByLabelText(/^number$/i)).toBeDefined();
+    expect(within(form).getByLabelText(/^email$/i)).toBeDefined();
+    expect(within(form).getByLabelText(/^note$/i)).toBeDefined();
+  });
+
+  it("renders a Primary contact dropdown and an Owner contact dropdown that include every Referral Contact", () => {
+    renderWorksheet({
+      contacts: [
+        { id: "c-1", full_name: "Pat Smith", phone: null, email: null },
+        { id: "c-2", full_name: "Jamie Other", phone: null, email: null },
+      ],
+    });
+    const primarySelect = screen.getByLabelText(
+      /primary contact/i,
+    ) as HTMLSelectElement;
+    const ownerSelect = screen.getByLabelText(
+      /owner contact/i,
+    ) as HTMLSelectElement;
+    expect(within(primarySelect).getByText("Pat Smith")).toBeDefined();
+    expect(within(primarySelect).getByText("Jamie Other")).toBeDefined();
+    expect(within(ownerSelect).getByText("Pat Smith")).toBeDefined();
+    expect(within(ownerSelect).getByText("Jamie Other")).toBeDefined();
+  });
+
+  // ── THE LOAD-BEARING CONTRACT TEST (issue #255 acceptance criteria) ─────
+  //
+  // After clicking + Add contact and submitting the inline form, the new
+  // Referral Contact MUST appear, on the same render, in:
+  //   (a) the "Contacts at this company" list
+  //   (b) the Primary contact dropdown
+  //   (c) the Owner contact dropdown
+  // — without any page reload. List-page filtering of Referral Contacts and
+  // the Worksheet's own primary/owner pickers depend on this contract.
+  it("submitting + Add contact POSTs the new contact and makes it visible in the list AND both dropdowns without reload", async () => {
+    renderWorksheet({ contacts: [] });
+
+    const list = screen.getByTestId("worksheet-contacts-list");
+    fireEvent.click(
+      within(list).getByRole("button", { name: /\+ add contact/i }),
+    );
+
+    const form = screen.getByTestId("worksheet-add-contact-form");
+    fireEvent.change(within(form).getByLabelText(/^name$/i), {
+      target: { value: "Pat Smith" },
+    });
+    fireEvent.change(within(form).getByLabelText(/^number$/i), {
+      target: { value: "5551234567" },
+    });
+    fireEvent.change(within(form).getByLabelText(/^email$/i), {
+      target: { value: "pat@acme.test" },
+    });
+    fireEvent.change(within(form).getByLabelText(/^note$/i), {
+      target: { value: "found via Yelp" },
+    });
+    fireEvent.click(
+      within(form).getByRole("button", { name: /^save contact$/i }),
+    );
+
+    // POST goes to the new endpoint with the 4-field payload.
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/referral-partners/p-1/contacts",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    const call = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c) => c[0] === "/api/referral-partners/p-1/contacts",
+    );
+    const body = JSON.parse((call![1] as RequestInit).body as string);
+    expect(body.full_name).toBe("Pat Smith");
+    expect(body.email).toBe("pat@acme.test");
+    expect(body.notes).toBe("found via Yelp");
+
+    // (a) Visible in the Contacts at this company list, without reload.
+    await waitFor(() => {
+      const refreshedList = screen.getByTestId("worksheet-contacts-list");
+      expect(within(refreshedList).getByText("Pat Smith")).toBeDefined();
+    });
+
+    // (b) Visible in the Primary contact dropdown.
+    const primarySelect = screen.getByLabelText(
+      /primary contact/i,
+    ) as HTMLSelectElement;
+    expect(within(primarySelect).getByText("Pat Smith")).toBeDefined();
+
+    // (c) Visible in the Owner contact dropdown.
+    const ownerSelect = screen.getByLabelText(
+      /owner contact/i,
+    ) as HTMLSelectElement;
+    expect(within(ownerSelect).getByText("Pat Smith")).toBeDefined();
   });
 });

--- a/src/components/referral-partners/referral-partner-worksheet.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.tsx
@@ -19,6 +19,8 @@ import {
   type CallLogEntry,
   type CallOutcome,
 } from "@/lib/referral-partner-call";
+import { shouldOfferCreate } from "@/lib/insurance-picker";
+import type { NewReferralContactInput } from "@/lib/referral-contact-form";
 
 export interface ReferralPartnerForWorksheet {
   id: string;
@@ -172,35 +174,78 @@ function EditableField({
   );
 }
 
-// One Primary or Owner contact slot. Display-only in this slice — wiring
-// the linked-contact picker lands in a later slice (#6).
+// One Primary or Owner contact slot. Renders the current contact's details
+// and a dropdown that lists every Referral Contact at this company — so the
+// user can promote a newly added contact to Primary/Owner without leaving
+// the Worksheet (issue #255 AC #3). Changing the selection PATCHes the FK
+// on the partner row. The full linked-contact picker (search, type-ahead,
+// etc.) is the concern of a later slice (#6).
 function ContactSlot({
   testId,
   heading,
+  column,
+  partnerId,
   contact,
+  contacts,
 }: {
   testId: string;
   heading: string;
+  column: "primary_contact_id" | "owner_contact_id";
+  partnerId: string;
   contact: ReferralContactForWorksheet | null;
+  contacts: ReferralContactForWorksheet[];
 }) {
+  const [selectedId, setSelectedId] = useState<string>(contact?.id ?? "");
+  const selectId = `worksheet-${column}`;
+
+  const onChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const next = e.target.value;
+    setSelectedId(next);
+    await fetch(`/api/referral-partners/${partnerId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ [column]: next || null }),
+    });
+  };
+
+  const selectedContact =
+    contacts.find((c) => c.id === selectedId) ?? contact ?? null;
+
   return (
     <div
       data-testid={testId}
       className="rounded-lg border border-border bg-card px-5 py-4"
     >
-      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2">
+      <label
+        htmlFor={selectId}
+        className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-2 block"
+      >
         {heading}
-      </p>
-      {contact ? (
+      </label>
+      <select
+        id={selectId}
+        aria-label={heading}
+        value={selectedId}
+        onChange={onChange}
+        className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground focus:border-[var(--brand-primary)] focus:outline-none mb-2"
+      >
+        <option value="">— Not set —</option>
+        {contacts.map((c) => (
+          <option key={c.id} value={c.id}>
+            {c.full_name}
+          </option>
+        ))}
+      </select>
+      {selectedContact ? (
         <div className="space-y-0.5">
-          <p className="font-medium text-foreground">{contact.full_name}</p>
-          {contact.phone && (
+          <p className="font-medium text-foreground">{selectedContact.full_name}</p>
+          {selectedContact.phone && (
             <p className="text-sm text-muted-foreground">
-              {formatPhoneNumber(contact.phone)}
+              {formatPhoneNumber(selectedContact.phone)}
             </p>
           )}
-          {contact.email && (
-            <p className="text-sm text-muted-foreground">{contact.email}</p>
+          {selectedContact.email && (
+            <p className="text-sm text-muted-foreground">{selectedContact.email}</p>
           )}
         </div>
       ) : (
@@ -214,13 +259,25 @@ export function ReferralPartnerWorksheet({
   partner,
   primaryContact,
   ownerContact,
-  contacts,
+  contacts: initialContacts,
   initialCalls,
 }: Props) {
   // Local Lifecycle status drives the chip + active-button ring; we
   // update it optimistically on click so the user sees the new label
   // without a reload (PRD #249 #28, issue #253 AC #2 & #3).
   const [status, setStatus] = useState<LifecycleStatus>(partner.status);
+
+  // Local contacts state so the inline + Add contact form can prepend a
+  // new Referral Contact and surface it in the list, the Primary contact
+  // dropdown, and the Owner contact dropdown on the SAME render — without
+  // any page reload (issue #255 AC #3).
+  const [contacts, setContacts] = useState<ReferralContactForWorksheet[]>(
+    initialContacts,
+  );
+
+  const addContact = useCallback((c: ReferralContactForWorksheet) => {
+    setContacts((prev) => [c, ...prev]);
+  }, []);
 
   const flipStatus = useCallback(
     async (next: LifecycleStatus) => {
@@ -366,12 +423,18 @@ export function ReferralPartnerWorksheet({
         <ContactSlot
           testId="worksheet-primary-contact"
           heading="Primary contact"
+          column="primary_contact_id"
+          partnerId={partner.id}
           contact={primaryContact}
+          contacts={contacts}
         />
         <ContactSlot
           testId="worksheet-owner-contact"
           heading="Owner contact"
+          column="owner_contact_id"
+          partnerId={partner.id}
           contact={ownerContact}
+          contacts={contacts}
         />
       </div>
 
@@ -380,9 +443,16 @@ export function ReferralPartnerWorksheet({
         data-testid="worksheet-contacts-list"
         className="rounded-lg border border-border bg-card px-5 py-4"
       >
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground mb-3">
-          Contacts at this company
-        </p>
+        <div className="flex items-center justify-between mb-3 gap-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Contacts at this company
+          </p>
+          <AddContactAffordance
+            partnerId={partner.id}
+            existingNames={contacts.map((c) => c.full_name)}
+            onAdded={addContact}
+          />
+        </div>
         {contacts.length === 0 ? (
           <p className="text-sm italic text-muted-foreground">
             No contacts yet.
@@ -410,6 +480,179 @@ export function ReferralPartnerWorksheet({
         primaryContactId={partner.primary_contact_id}
       />
     </div>
+  );
+}
+
+// Inline "+ Add contact" affordance on the Call Worksheet (PRD #249, issue
+// #255). A button reveals a 4-field form (name / number / email / note);
+// submitting POSTs to /api/referral-partners/[id]/contacts and hands the
+// new Referral Contact back up to the parent so it surfaces in the list
+// AND both Primary/Owner contact dropdowns on the SAME render (no reload).
+//
+// The "save is offered" guard reuses `shouldOfferCreate` from
+// `src/lib/insurance-picker.ts` (PRD #47) — typing a duplicate name (case-
+// insensitive, exact match against existing Referral Contacts at this
+// company) withholds the save button so loose duplicates aren't created.
+function AddContactAffordance({
+  partnerId,
+  existingNames,
+  onAdded,
+}: {
+  partnerId: string;
+  existingNames: string[];
+  onAdded: (c: ReferralContactForWorksheet) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<NewReferralContactInput>({
+    full_name: "",
+    phone: "",
+    email: "",
+    notes: "",
+  });
+  const [submitting, setSubmitting] = useState(false);
+
+  const setField = (k: keyof NewReferralContactInput, v: string) =>
+    setForm((prev) => ({ ...prev, [k]: v }));
+
+  // Same gate the insurance-picker uses — only offer save when the typed
+  // name is non-empty AND not an exact, case-insensitive match for an
+  // existing Referral Contact at this company.
+  const canSave = shouldOfferCreate(form.full_name, existingNames);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSave || submitting) return;
+    setSubmitting(true);
+    const res = await fetch(`/api/referral-partners/${partnerId}/contacts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        full_name: form.full_name,
+        phone: form.phone,
+        email: form.email,
+        notes: form.notes,
+      }),
+    });
+    if (res.ok) {
+      const body = (await res.json()) as {
+        contact: {
+          id: string;
+          full_name: string;
+          phone: string | null;
+          email: string | null;
+        };
+      };
+      onAdded({
+        id: body.contact.id,
+        full_name: body.contact.full_name,
+        phone: body.contact.phone,
+        email: body.contact.email,
+      });
+      setForm({ full_name: "", phone: "", email: "", notes: "" });
+      setOpen(false);
+    }
+    setSubmitting(false);
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-xs font-medium text-[var(--brand-primary)] hover:underline"
+      >
+        + Add contact
+      </button>
+    );
+  }
+
+  const inputClass =
+    "w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground focus:border-[var(--brand-primary)] focus:outline-none";
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      data-testid="worksheet-add-contact-form"
+      className="w-full rounded-md border border-border bg-background p-3 grid grid-cols-1 sm:grid-cols-2 gap-3"
+    >
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="add-contact-name"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Name
+        </label>
+        <input
+          id="add-contact-name"
+          aria-label="Name"
+          value={form.full_name}
+          onChange={(e) => setField("full_name", e.target.value)}
+          className={inputClass}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="add-contact-number"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Number
+        </label>
+        <input
+          id="add-contact-number"
+          aria-label="Number"
+          value={form.phone}
+          onChange={(e) => setField("phone", e.target.value)}
+          className={inputClass}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="add-contact-email"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Email
+        </label>
+        <input
+          id="add-contact-email"
+          aria-label="Email"
+          type="email"
+          value={form.email}
+          onChange={(e) => setField("email", e.target.value)}
+          className={inputClass}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor="add-contact-note"
+          className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+        >
+          Note
+        </label>
+        <input
+          id="add-contact-note"
+          aria-label="Note"
+          value={form.notes}
+          onChange={(e) => setField("notes", e.target.value)}
+          className={inputClass}
+        />
+      </div>
+      <div className="sm:col-span-2 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="rounded-md border border-border bg-card text-muted-foreground px-3 py-1.5 text-xs font-medium hover:bg-accent"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={!canSave || submitting}
+          className="rounded-md bg-[var(--brand-primary)] text-white px-3 py-1.5 text-xs font-medium disabled:opacity-50"
+        >
+          Save contact
+        </button>
+      </div>
+    </form>
   );
 }
 

--- a/src/lib/referral-contact-form.test.ts
+++ b/src/lib/referral-contact-form.test.ts
@@ -1,0 +1,81 @@
+// Pure-logic tests for the "+ Add contact" form on the Call Worksheet
+// (PRD #249, issue #255). Mirrors `referral-partner-form.test.ts` from
+// issue #250 — validity guard + insert-payload builder, both I/O-free.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNewReferralContactPayload,
+  isValidNewReferralContact,
+  type NewReferralContactInput,
+} from "./referral-contact-form";
+
+const ORG = "org-1";
+const PARTNER = "p-1";
+
+function input(
+  overrides: Partial<NewReferralContactInput> = {},
+): NewReferralContactInput {
+  return {
+    full_name: "Pat Smith",
+    phone: "",
+    email: "",
+    notes: "",
+    ...overrides,
+  };
+}
+
+describe("isValidNewReferralContact", () => {
+  it("rejects an empty full_name — the only required field", () => {
+    expect(isValidNewReferralContact(input({ full_name: "" }))).toBe(false);
+    expect(isValidNewReferralContact(input({ full_name: "   " }))).toBe(false);
+  });
+
+  it("accepts any input with a non-blank full_name — every other field is optional", () => {
+    expect(isValidNewReferralContact(input())).toBe(true);
+    expect(
+      isValidNewReferralContact(input({ full_name: "X", phone: "" })),
+    ).toBe(true);
+  });
+});
+
+describe("buildNewReferralContactPayload", () => {
+  it("pins role='referral_contact' and links the Referral Partner", () => {
+    const payload = buildNewReferralContactPayload(input(), ORG, PARTNER);
+    expect(payload.role).toBe("referral_contact");
+    expect(payload.referral_partner_id).toBe(PARTNER);
+    expect(payload.organization_id).toBe(ORG);
+    expect(payload.full_name).toBe("Pat Smith");
+  });
+
+  it("trims full_name so leading and trailing whitespace doesn't survive into storage", () => {
+    const payload = buildNewReferralContactPayload(
+      input({ full_name: "  Pat Smith  " }),
+      ORG,
+      PARTNER,
+    );
+    expect(payload.full_name).toBe("Pat Smith");
+  });
+
+  it("collapses every blank optional field to null — empty strings never reach the column", () => {
+    const payload = buildNewReferralContactPayload(input(), ORG, PARTNER);
+    expect(payload.phone).toBeNull();
+    expect(payload.email).toBeNull();
+    expect(payload.notes).toBeNull();
+  });
+
+  it("trims optional fields and keeps the non-blank ones", () => {
+    const payload = buildNewReferralContactPayload(
+      input({
+        phone: " 555-123-4567 ",
+        email: "pat@acme.test",
+        notes: "  loves email  ",
+      }),
+      ORG,
+      PARTNER,
+    );
+    expect(payload.phone).toBe("555-123-4567");
+    expect(payload.email).toBe("pat@acme.test");
+    expect(payload.notes).toBe("loves email");
+  });
+});

--- a/src/lib/referral-contact-form.ts
+++ b/src/lib/referral-contact-form.ts
@@ -1,0 +1,68 @@
+// Pure logic behind the inline "+ Add contact" affordance on the Call
+// Worksheet (PRD #249, issue #255). Modelled after `referral-partner-form.ts`
+// from issue #250 — one validity guard, one insert-payload builder, both
+// I/O-free so they can be exhaustively unit-tested without React or Supabase.
+//
+// The inline-create button's *visibility* reuses `shouldOfferCreate` from
+// `src/lib/insurance-picker.ts` (PRD #47) — no parallel helper. See the
+// Worksheet component for that wiring.
+
+/** Raw user input from the inline + Add contact form on the Worksheet —
+ *  every optional field is empty-string-or-content, never undefined, so the
+ *  React form can bind directly without controlled/uncontrolled gymnastics. */
+export interface NewReferralContactInput {
+  full_name: string;
+  phone: string;
+  email: string;
+  notes: string;
+}
+
+/** The insert-ready shape for a new `contacts` row representing a Referral
+ *  Contact. `role` is pinned to `'referral_contact'` and the row carries the
+ *  current Referral Partner's id; optional fields are null (not empty string)
+ *  to match how every other nullable text column behaves. */
+export interface NewReferralContactPayload {
+  organization_id: string;
+  referral_partner_id: string;
+  full_name: string;
+  phone: string | null;
+  email: string | null;
+  notes: string | null;
+  role: "referral_contact";
+}
+
+/**
+ * Whether the inline + Add contact form is saveable. Only `full_name` is
+ * required; phone, email, and notes are all optional.
+ */
+export function isValidNewReferralContact(
+  input: NewReferralContactInput,
+): boolean {
+  return input.full_name.trim().length > 0;
+}
+
+/**
+ * Build the row payload for inserting a Referral Contact. `role` is always
+ * `'referral_contact'` and `referral_partner_id` is set to the partner the
+ * Worksheet is open on. Trims `full_name`; trims every other text field and
+ * collapses to null when blank.
+ */
+export function buildNewReferralContactPayload(
+  input: NewReferralContactInput,
+  organizationId: string,
+  referralPartnerId: string,
+): NewReferralContactPayload {
+  const nullable = (s: string): string | null => {
+    const trimmed = s.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  };
+  return {
+    organization_id: organizationId,
+    referral_partner_id: referralPartnerId,
+    full_name: input.full_name.trim(),
+    phone: nullable(input.phone),
+    email: nullable(input.email),
+    notes: nullable(input.notes),
+    role: "referral_contact",
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -4,10 +4,24 @@ export interface Contact {
   full_name: string;
   phone: string | null;
   email: string | null;
-  role: "homeowner" | "tenant" | "property_manager" | "adjuster" | "insurance";
+  // `referral_contact` (PRD #249, issue #250 migration build78) identifies
+  // a contact that belongs to a Referral Partner company — surfaced on
+  // the Call Worksheet's "Contacts at this company" list and the
+  // Contacts tab's Referral Contact badge (issue #255).
+  role:
+    | "homeowner"
+    | "tenant"
+    | "property_manager"
+    | "adjuster"
+    | "insurance"
+    | "referral_contact";
   company: string | null;
   title: string | null;
   notes: string | null;
+  /** FK to a `referral_partners` row when role = 'referral_contact'. ON
+   *  DELETE SET NULL so a hard-deleted partner leaves its people behind
+   *  as orphans rather than dragging them out of /contacts. */
+  referral_partner_id?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Closes #255

## Summary

- Inline `+ Add contact` affordance on the Call Worksheet: button reveals a 4-field form (name, number, email, note) inside the "Contacts at this company" section. Submitting creates a `contacts` row with `role = 'referral_contact'` and `referral_partner_id` set to the partner. New contact appears in the list AND in the Primary contact + Owner contact dropdowns on the SAME render — no reload.
- New `POST /api/referral-partners/[id]/contacts` endpoint gated on `EDIT_REFERRAL_PARTNERS` (admin / crew_lead). Thin adapter over the new pure `referral-contact-form` module, matching the New Target POST shape from #250.
- The Worksheet's Primary / Owner contact slots become dropdowns sourced from the same `contacts` list, so a newly added contact is immediately promotable.
- `/contacts` tab renders a "Referral Contact" badge on every row with `role = 'referral_contact'`, reusing the existing `roleColors` / `roleLabels` maps — list / search / phone-format infrastructure is unchanged.
- Save-button visibility on the inline form reuses `shouldOfferCreate` from `src/lib/insurance-picker.ts` (PRD #47). No parallel helper.
- `Contact` type in `src/lib/types.ts` extended with `referral_contact` role and optional `referral_partner_id` (schema already in place from build78 / #250).

## Test plan

- [x] `npx vitest run src/lib/referral-contact-form.test.ts` — 6 pure-helper tests (validity + payload shape)
- [x] `npx vitest run src/app/api/referral-partners/[id]/contacts/route.test.ts` — 5 route tests (401 / 403 / 400 validation / 201 happy path)
- [x] `npx vitest run src/components/referral-partners/referral-partner-worksheet.test.tsx` — 29 Worksheet tests, including the load-bearing integration test that mounts the Worksheet, clicks `+ Add contact`, fills the inline form, submits, and asserts the new contact is visible in the list AND both dropdowns without reload
- [x] `npx vitest run src/app/contacts/page.test.tsx` — 2 Contacts-tab badge tests (badge text + phone-format parity with other roles)
- [x] Full suite: 1101 passed / 2 pre-existing failures in `src/app/api/email/accounts/route.test.ts` (unrelated to this slice)
- [x] `npx tsc --noEmit` clean on touched files (one pre-existing TS error in `src/lib/email/sync-folder-incremental.test.ts` unrelated)
- [x] `npx eslint` clean on new files; pre-existing warnings in `src/app/contacts/page.tsx` left untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)