### PR TITLE
feat(template-editor): cross-container Line item drag + DnD foundations (#264)

### DIFF
--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -35,6 +35,10 @@ import {
   sortableKeyboardCoordinates,
   arrayMove,
 } from "@dnd-kit/sortable";
+import {
+  moveLineItemAcrossContainers,
+  resolveLineItemDropTarget,
+} from "./move-line-item";
 import { HeaderBar } from "./header-bar";
 import { TotalsPanel } from "./totals-panel";
 import { MetadataBar } from "./metadata-bar";
@@ -1311,32 +1315,27 @@ export function EstimateBuilder({
       }
 
       if (activeType === "line-item") {
-        const activeParentSectionId = active.data.current?.parentSectionId as string | undefined;
-        const overParentSectionId = over.data.current?.parentSectionId as string | undefined;
-        if (activeParentSectionId !== overParentSectionId) return;
-        const reorderedSections = state.entity.data.sections.map((s) => {
-          if (s.id === activeParentSectionId) {
-            const oldIdx = s.items.findIndex((i) => i.id === active.id);
-            const newIdx = s.items.findIndex((i) => i.id === over.id);
-            if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return s;
-            return { ...s, items: arrayMove(s.items, oldIdx, newIdx) };
-          }
-          return {
-            ...s,
-            subsections: s.subsections.map((sub) => {
-              if (sub.id !== activeParentSectionId) return sub;
-              const oldIdx = sub.items.findIndex((i) => i.id === active.id);
-              const newIdx = sub.items.findIndex((i) => i.id === over.id);
-              if (oldIdx === -1 || newIdx === -1 || oldIdx === newIdx) return sub;
-              return { ...sub, items: arrayMove(sub.items, oldIdx, newIdx) };
-            }),
-          };
-        });
+        // Cross-container Line item drag (#264). Helpers handle same-container
+        // reorder, the four cross-container shapes, drop-on-self, and invalid
+        // input. The existing debounced rootPut of builder_state persists the
+        // resulting tree — no per-item HTTP path.
+        const dest = resolveLineItemDropTarget(over);
+        if (!dest) return;
+        const result = moveLineItemAcrossContainers(
+          state.entity.data.sections,
+          String(active.id),
+          dest.destinationContainerId,
+          dest.overItemId ?? null,
+        );
+        if (!result) return;
         setState((prev) => {
           if (prev.entity.kind !== "template") return prev;
           return {
             ...prev,
-            entity: { ...prev.entity, data: { ...prev.entity.data, sections: reorderedSections } } as BuilderEntity,
+            entity: {
+              ...prev.entity,
+              data: { ...prev.entity.data, sections: result.sections },
+            } as BuilderEntity,
           };
         });
       }

--- a/src/components/estimate-builder/move-line-item.test.ts
+++ b/src/components/estimate-builder/move-line-item.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect } from "vitest";
+import {
+  moveLineItemAcrossContainers,
+  resolveLineItemDropTarget,
+} from "./move-line-item";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers — terse builders for Section / Subsection / Line item trees.
+// Items default to a `section_id` field so we exercise the estimate/invoice
+// shape; template-shape items (no `section_id`) get their own test.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TestItem {
+  id: string;
+  sort_order: number;
+  section_id?: string;
+  description?: string;
+}
+
+interface TestSub {
+  id: string;
+  sort_order: number;
+  items: TestItem[];
+}
+
+interface TestSec {
+  id: string;
+  sort_order: number;
+  items: TestItem[];
+  subsections: TestSub[];
+}
+
+function item(id: string, sectionId: string, sort_order: number, description = id): TestItem {
+  return { id, section_id: sectionId, sort_order, description };
+}
+
+function sub(id: string, sort_order: number, items: TestItem[]): TestSub {
+  return { id, sort_order, items };
+}
+
+function sec(
+  id: string,
+  sort_order: number,
+  items: TestItem[],
+  subsections: TestSub[] = [],
+): TestSec {
+  return { id, sort_order, items, subsections };
+}
+
+function ids(items: TestItem[]): string[] {
+  return items.map((i) => i.id);
+}
+
+function orders(items: TestItem[]): number[] {
+  return items.map((i) => i.sort_order);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// moveLineItemAcrossContainers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("moveLineItemAcrossContainers", () => {
+  // Scenario 1 — same-container reorder (top of list → middle).
+  it("reorders a Line item within its own Section", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1), item("C", "S1", 2)]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "S1", "C");
+
+    expect(result).not.toBeNull();
+    expect(ids(result!.sections[0].items)).toEqual(["B", "C", "A"]);
+    expect(orders(result!.sections[0].items)).toEqual([0, 1, 2]);
+  });
+
+  // Scenario 2 — Subsection → its parent Section's direct Line items.
+  it("promotes a Line item from a Subsection to its parent Section", () => {
+    const tree: TestSec[] = [
+      sec(
+        "S1",
+        0,
+        [item("A", "S1", 0)],
+        [sub("Sub1", 0, [item("X", "Sub1", 0), item("Y", "Sub1", 1)])],
+      ),
+    ];
+
+    // Drop X onto Section S1 chrome (no overItemId) → append to S1 items.
+    const result = moveLineItemAcrossContainers(tree, "X", "S1", null);
+
+    expect(result).not.toBeNull();
+    const s1 = result!.sections[0];
+    expect(ids(s1.items)).toEqual(["A", "X"]);
+    expect(orders(s1.items)).toEqual([0, 1]);
+    expect(s1.items[1].section_id).toBe("S1");
+    expect(ids(s1.subsections[0].items)).toEqual(["Y"]);
+    expect(orders(s1.subsections[0].items)).toEqual([0]);
+  });
+
+  // Scenario 3 — Subsection → sibling Subsection under same parent.
+  it("moves a Line item between two sibling Subsections", () => {
+    const tree: TestSec[] = [
+      sec(
+        "S1",
+        0,
+        [],
+        [
+          sub("Sub1", 0, [item("X", "Sub1", 0), item("Y", "Sub1", 1)]),
+          sub("Sub2", 1, [item("Z", "Sub2", 0)]),
+        ],
+      ),
+    ];
+
+    // Drop X onto Z → insert at Z's index in Sub2.
+    const result = moveLineItemAcrossContainers(tree, "X", "Sub2", "Z");
+
+    expect(result).not.toBeNull();
+    const [sub1, sub2] = result!.sections[0].subsections;
+    expect(ids(sub1.items)).toEqual(["Y"]);
+    expect(orders(sub1.items)).toEqual([0]);
+    expect(ids(sub2.items)).toEqual(["X", "Z"]);
+    expect(orders(sub2.items)).toEqual([0, 1]);
+    expect(sub2.items[0].section_id).toBe("Sub2");
+  });
+
+  // Scenario 4 — Subsection → Subsection under a different parent Section.
+  it("moves a Line item between Subsections under different parent Sections", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [], [sub("Sub1", 0, [item("X", "Sub1", 0)])]),
+      sec("S2", 1, [], [sub("Sub2", 0, [item("Y", "Sub2", 0)])]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "X", "Sub2", null);
+
+    expect(result).not.toBeNull();
+    expect(result!.sections[0].subsections[0].items).toEqual([]);
+    const sub2 = result!.sections[1].subsections[0];
+    expect(ids(sub2.items)).toEqual(["Y", "X"]);
+    expect(orders(sub2.items)).toEqual([0, 1]);
+    expect(sub2.items[1].section_id).toBe("Sub2");
+  });
+
+  // Scenario 5 — Section direct items → different Section's direct items.
+  it("moves a Line item between two Sections' direct items lists", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1)]),
+      sec("S2", 1, [item("C", "S2", 0)]),
+    ];
+
+    // Drop A onto C → insert at C's index in S2.
+    const result = moveLineItemAcrossContainers(tree, "A", "S2", "C");
+
+    expect(result).not.toBeNull();
+    expect(ids(result!.sections[0].items)).toEqual(["B"]);
+    expect(orders(result!.sections[0].items)).toEqual([0]);
+    expect(ids(result!.sections[1].items)).toEqual(["A", "C"]);
+    expect(orders(result!.sections[1].items)).toEqual([0, 1]);
+    expect(result!.sections[1].items[0].section_id).toBe("S2");
+  });
+
+  // Scenario 6 — Section direct items → a Subsection.
+  it("moves a Line item from a Section into a Subsection", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1)], [sub("Sub1", 0, [])]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "Sub1", null);
+
+    expect(result).not.toBeNull();
+    const s1 = result!.sections[0];
+    expect(ids(s1.items)).toEqual(["B"]);
+    expect(orders(s1.items)).toEqual([0]);
+    expect(ids(s1.subsections[0].items)).toEqual(["A"]);
+    expect(orders(s1.subsections[0].items)).toEqual([0]);
+    expect(s1.subsections[0].items[0].section_id).toBe("Sub1");
+  });
+
+  // Scenario 7 — drop on an otherwise-empty destination.
+  it("accepts a drop on an empty destination", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0)], [sub("Sub1", 0, [])]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "Sub1", null);
+
+    expect(result).not.toBeNull();
+    expect(result!.sections[0].items).toEqual([]);
+    expect(ids(result!.sections[0].subsections[0].items)).toEqual(["A"]);
+    expect(orders(result!.sections[0].subsections[0].items)).toEqual([0]);
+  });
+
+  // Scenario 8 — drop on self (over-item id equals active id in same container).
+  it("returns null when an item is dropped on itself", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1)]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "S1", "A");
+
+    expect(result).toBeNull();
+  });
+
+  // Scenario 9 — source container renumbered to contiguous 0..N-1.
+  it("recompacts the source container's sort_order to 0..N-1", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [
+        item("A", "S1", 0),
+        item("B", "S1", 1),
+        item("C", "S1", 2),
+        item("D", "S1", 3),
+      ]),
+      sec("S2", 1, []),
+    ];
+
+    // Move B (middle) out of S1 into S2.
+    const result = moveLineItemAcrossContainers(tree, "B", "S2", null);
+
+    expect(result).not.toBeNull();
+    expect(ids(result!.sections[0].items)).toEqual(["A", "C", "D"]);
+    expect(orders(result!.sections[0].items)).toEqual([0, 1, 2]);
+  });
+
+  // Scenario 10 — destination container renumbered to contiguous 0..N including inserted item.
+  it("recompacts the destination container's sort_order to include the inserted item", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0)]),
+      sec("S2", 1, [item("X", "S2", 0), item("Y", "S2", 1)]),
+    ];
+
+    // Insert A in front of Y (at Y's index = 1).
+    const result = moveLineItemAcrossContainers(tree, "A", "S2", "Y");
+
+    expect(result).not.toBeNull();
+    expect(ids(result!.sections[1].items)).toEqual(["X", "A", "Y"]);
+    expect(orders(result!.sections[1].items)).toEqual([0, 1, 2]);
+  });
+
+  // Scenario 11 — moved item's section_id equals destination container id.
+  it("reassigns the moved Line item's section_id to the destination container id", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0)], [sub("Sub1", 0, [])]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "Sub1", null);
+
+    expect(result).not.toBeNull();
+    const moved = result!.sections[0].subsections[0].items[0];
+    expect(moved.id).toBe("A");
+    expect(moved.section_id).toBe("Sub1");
+  });
+
+  // Scenario 12 — invalid input.
+  it("returns null when the active item id is not found", () => {
+    const tree: TestSec[] = [sec("S1", 0, [item("A", "S1", 0)])];
+    expect(moveLineItemAcrossContainers(tree, "missing", "S1", null)).toBeNull();
+  });
+
+  it("returns null when the destination container id is not found", () => {
+    const tree: TestSec[] = [sec("S1", 0, [item("A", "S1", 0)])];
+    expect(moveLineItemAcrossContainers(tree, "A", "S-missing", null)).toBeNull();
+  });
+
+  // Bonus — append-to-end on chrome drop within same container is a real move.
+  it("moves an item to the end of its container when dropped on chrome", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1), item("C", "S1", 2)]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "A", "S1", null);
+
+    expect(result).not.toBeNull();
+    expect(ids(result!.sections[0].items)).toEqual(["B", "C", "A"]);
+    expect(orders(result!.sections[0].items)).toEqual([0, 1, 2]);
+  });
+
+  // affectedItems contract — includes source + destination items with new sort_order.
+  it("returns affectedItems covering both source and destination", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1)]),
+      sec("S2", 1, [item("C", "S2", 0)]),
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "B", "S2", null);
+
+    expect(result).not.toBeNull();
+    const byId = new Map(result!.affectedItems.map((a) => [a.id, a]));
+    // Source S1 now has [A@0]
+    expect(byId.get("A")).toEqual({ id: "A", section_id: "S1", sort_order: 0 });
+    // Destination S2 now has [C@0, B@1]
+    expect(byId.get("C")).toEqual({ id: "C", section_id: "S2", sort_order: 0 });
+    expect(byId.get("B")).toEqual({ id: "B", section_id: "S2", sort_order: 1 });
+  });
+
+  // Template items lack `section_id` on their wire shape — the helper must not
+  // crash and must still reorder by tree position.
+  it("handles template-shape items that lack a section_id field", () => {
+    const tree = [
+      {
+        id: "S1",
+        sort_order: 0,
+        items: [
+          { id: "A", sort_order: 0 },
+          { id: "B", sort_order: 1 },
+        ],
+        subsections: [
+          {
+            id: "Sub1",
+            sort_order: 0,
+            items: [{ id: "X", sort_order: 0 }],
+          },
+        ],
+      },
+    ];
+
+    const result = moveLineItemAcrossContainers(tree, "X", "S1", null);
+
+    expect(result).not.toBeNull();
+    expect(result!.sections[0].items.map((i) => i.id)).toEqual(["A", "B", "X"]);
+    expect(result!.sections[0].subsections[0].items).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveLineItemDropTarget
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("resolveLineItemDropTarget", () => {
+  it("resolves over a Line item to {destinationContainerId, overItemId}", () => {
+    const over = {
+      id: "ITEM_X",
+      data: { current: { type: "line-item", parentSectionId: "Sub1" } },
+    };
+    expect(resolveLineItemDropTarget(over)).toEqual({
+      destinationContainerId: "Sub1",
+      overItemId: "ITEM_X",
+    });
+  });
+
+  it("resolves over a Section to {destinationContainerId}", () => {
+    const over = { id: "S1", data: { current: { type: "section" } } };
+    expect(resolveLineItemDropTarget(over)).toEqual({
+      destinationContainerId: "S1",
+    });
+  });
+
+  it("resolves over a Subsection to {destinationContainerId}", () => {
+    const over = {
+      id: "Sub1",
+      data: { current: { type: "subsection", parentSectionId: "S1" } },
+    };
+    expect(resolveLineItemDropTarget(over)).toEqual({
+      destinationContainerId: "Sub1",
+    });
+  });
+
+  it("returns null when over has no recognizable type", () => {
+    expect(resolveLineItemDropTarget(null)).toBeNull();
+    expect(resolveLineItemDropTarget({ id: "Z", data: { current: null } })).toBeNull();
+    expect(
+      resolveLineItemDropTarget({ id: "Z", data: { current: { type: "other" } } }),
+    ).toBeNull();
+  });
+});

--- a/src/components/estimate-builder/move-line-item.ts
+++ b/src/components/estimate-builder/move-line-item.ts
@@ -1,0 +1,264 @@
+// Pure helpers for cross-container Line item drag-and-drop.
+//
+// Isolated from React and from dnd-kit's React bindings so they can be unit
+// tested in plain Node and reused across the template, estimate, and invoice
+// builder modes.
+//
+// Domain language (CONTEXT.md):
+//   - Section: a top-level container in the estimate / invoice / template tree.
+//   - Subsection: a one-level-deep container nested under a Section.
+//   - Line item: a row inside a Section's direct items list OR a Subsection's
+//     items list. Its parent container's id is the line item's "container id".
+//
+// Both helpers are generic over the line-item shape so they work for both
+// estimate/invoice items (which carry `section_id`) and template items (which
+// do not — their parentage is implied by tree position).
+
+export interface LineItemLike {
+  id: string;
+  sort_order: number;
+  section_id?: string | null;
+}
+
+export interface SubsectionLike<I extends LineItemLike = LineItemLike> {
+  id: string;
+  sort_order: number;
+  items: I[];
+}
+
+export interface SectionLike<
+  I extends LineItemLike = LineItemLike,
+  Sub extends SubsectionLike<I> = SubsectionLike<I>,
+> {
+  id: string;
+  sort_order: number;
+  items: I[];
+  subsections: Sub[];
+}
+
+export interface AffectedItem {
+  id: string;
+  section_id: string;
+  sort_order: number;
+}
+
+export interface MoveLineItemResult<Sec> {
+  sections: Sec[];
+  affectedItems: AffectedItem[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// moveLineItemAcrossContainers
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function moveLineItemAcrossContainers<
+  I extends LineItemLike,
+  Sub extends SubsectionLike<I>,
+  Sec extends SectionLike<I, Sub>,
+>(
+  sections: Sec[],
+  activeItemId: string,
+  destinationContainerId: string,
+  overItemId: string | null,
+): MoveLineItemResult<Sec> | null {
+  // Locate the source container + the active item.
+  const located = locateItem(sections, activeItemId);
+  if (!located) return null;
+  const { sourceContainerId, item: activeItem } = located;
+
+  // Drop-on-self: same container + over-item id equals active id.
+  if (overItemId === activeItemId && sourceContainerId === destinationContainerId) {
+    return null;
+  }
+
+  // Confirm the destination container exists somewhere in the tree.
+  if (!containerExists(sections, destinationContainerId)) return null;
+
+  // Build the moved item with its new section_id (only when the field already
+  // exists — template-shape items don't carry one).
+  const movedItem: I = "section_id" in activeItem
+    ? ({ ...activeItem, section_id: destinationContainerId } as I)
+    : ({ ...activeItem } as I);
+
+  // Walk the tree once. For every container, drop the active item if present
+  // (source), then insert it if this is the destination, then recompact sort_order.
+  const nextSections = sections.map((section) =>
+    rewriteContainer(section, activeItemId, destinationContainerId, overItemId, movedItem),
+  );
+
+  // Collect affected items — every item in the source and destination containers.
+  const affectedIds = new Set<string>([sourceContainerId, destinationContainerId]);
+  const affectedItems: AffectedItem[] = [];
+  for (const section of nextSections) {
+    if (affectedIds.has(section.id)) {
+      for (const it of section.items) {
+        affectedItems.push({ id: it.id, section_id: section.id, sort_order: it.sort_order });
+      }
+    }
+    for (const sub of section.subsections) {
+      if (affectedIds.has(sub.id)) {
+        for (const it of sub.items) {
+          affectedItems.push({ id: it.id, section_id: sub.id, sort_order: it.sort_order });
+        }
+      }
+    }
+  }
+
+  return { sections: nextSections, affectedItems };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveLineItemDropTarget
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface DndOverObject {
+  id: string | number;
+  data?: { current?: Record<string, unknown> | null } | null;
+}
+
+export interface ResolvedDropTarget {
+  destinationContainerId: string;
+  overItemId?: string;
+}
+
+export function resolveLineItemDropTarget(
+  over: DndOverObject | null | undefined,
+): ResolvedDropTarget | null {
+  if (!over) return null;
+  const data = over.data?.current ?? null;
+  if (!data) return null;
+  const type = data.type;
+
+  if (type === "line-item") {
+    const parentSectionId = data.parentSectionId;
+    if (typeof parentSectionId !== "string") return null;
+    return { destinationContainerId: parentSectionId, overItemId: String(over.id) };
+  }
+
+  if (type === "section" || type === "subsection") {
+    return { destinationContainerId: String(over.id) };
+  }
+
+  return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internals
+// ─────────────────────────────────────────────────────────────────────────────
+
+function locateItem<I extends LineItemLike, Sub extends SubsectionLike<I>, Sec extends SectionLike<I, Sub>>(
+  sections: Sec[],
+  itemId: string,
+): { sourceContainerId: string; item: I } | null {
+  for (const section of sections) {
+    const direct = section.items.find((i) => i.id === itemId);
+    if (direct) return { sourceContainerId: section.id, item: direct };
+    for (const sub of section.subsections) {
+      const nested = sub.items.find((i) => i.id === itemId);
+      if (nested) return { sourceContainerId: sub.id, item: nested };
+    }
+  }
+  return null;
+}
+
+function containerExists<I extends LineItemLike, Sub extends SubsectionLike<I>, Sec extends SectionLike<I, Sub>>(
+  sections: Sec[],
+  containerId: string,
+): boolean {
+  for (const section of sections) {
+    if (section.id === containerId) return true;
+    for (const sub of section.subsections) {
+      if (sub.id === containerId) return true;
+    }
+  }
+  return false;
+}
+
+function rewriteContainer<
+  I extends LineItemLike,
+  Sub extends SubsectionLike<I>,
+  Sec extends SectionLike<I, Sub>,
+>(
+  section: Sec,
+  activeItemId: string,
+  destinationContainerId: string,
+  overItemId: string | null,
+  movedItem: I,
+): Sec {
+  const nextSubsections = section.subsections.map((sub) =>
+    rewriteSubsection(sub, activeItemId, destinationContainerId, overItemId, movedItem),
+  );
+
+  const nextDirectItems = applyContainerMutation(
+    section.id,
+    section.items,
+    activeItemId,
+    destinationContainerId,
+    overItemId,
+    movedItem,
+  );
+
+  return { ...section, items: nextDirectItems, subsections: nextSubsections };
+}
+
+function rewriteSubsection<I extends LineItemLike, Sub extends SubsectionLike<I>>(
+  sub: Sub,
+  activeItemId: string,
+  destinationContainerId: string,
+  overItemId: string | null,
+  movedItem: I,
+): Sub {
+  const nextItems = applyContainerMutation(
+    sub.id,
+    sub.items,
+    activeItemId,
+    destinationContainerId,
+    overItemId,
+    movedItem,
+  );
+  return { ...sub, items: nextItems };
+}
+
+function applyContainerMutation<I extends LineItemLike>(
+  containerId: string,
+  items: I[],
+  activeItemId: string,
+  destinationContainerId: string,
+  overItemId: string | null,
+  movedItem: I,
+): I[] {
+  const oldIdx = items.findIndex((i) => i.id === activeItemId);
+  const isSource = oldIdx !== -1;
+  const isDestination = containerId === destinationContainerId;
+
+  if (!isSource && !isDestination) return items;
+
+  // 1. Remove the active item if it lives here.
+  const withoutActive = isSource ? items.filter((i) => i.id !== activeItemId) : items.slice();
+
+  // 2. Insert the moved item if this container is the destination.
+  let nextItems = withoutActive;
+  if (isDestination) {
+    let insertIdx = withoutActive.length; // chrome-drop → append
+    if (overItemId !== null && overItemId !== activeItemId) {
+      const overIdxInWithout = withoutActive.findIndex((i) => i.id === overItemId);
+      if (overIdxInWithout !== -1) {
+        // Same-container drop-on-item: mirror dnd-kit's arrayMove. When the
+        // drag is downward in the same list (oldIdx < newIdx), the item lands
+        // *after* the over item — splice-after semantics. Upward drags and
+        // all cross-container drops land *at* the over item's index.
+        if (isSource) {
+          const newIdxInOriginal = items.findIndex((i) => i.id === overItemId);
+          insertIdx = oldIdx < newIdxInOriginal ? overIdxInWithout + 1 : overIdxInWithout;
+        } else {
+          insertIdx = overIdxInWithout;
+        }
+      }
+    }
+    nextItems = [...withoutActive.slice(0, insertIdx), movedItem, ...withoutActive.slice(insertIdx)];
+  }
+
+  if (!isSource && !isDestination) return items;
+
+  return nextItems.map((it, idx) => ({ ...it, sort_order: idx }));
+}

--- a/src/components/estimate-builder/section-card.tsx
+++ b/src/components/estimate-builder/section-card.tsx
@@ -24,6 +24,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useDndMonitor } from "@dnd-kit/core";
+import { resolveLineItemDropTarget } from "./move-line-item";
 import {
   GripVertical,
   MoreVertical,
@@ -249,6 +251,20 @@ export function SectionCard({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [addSubOpen, setAddSubOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Auto-expand on drop: if a Line item is dropped onto this Section
+  // (either onto its chrome or onto one of its direct items) while it is
+  // collapsed, expand so the user can see where the item landed.
+  useDndMonitor({
+    onDragEnd(event) {
+      const activeType = event.active.data.current?.type as string | undefined;
+      if (activeType !== "line-item") return;
+      const dest = resolveLineItemDropTarget(event.over ?? null);
+      if (dest && dest.destinationContainerId === section.id) {
+        setIsCollapsed(false);
+      }
+    },
+  });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/components/estimate-builder/subsection-card.tsx
+++ b/src/components/estimate-builder/subsection-card.tsx
@@ -13,6 +13,8 @@
 import { useState } from "react";
 import { useSortable, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useDndMonitor } from "@dnd-kit/core";
+import { resolveLineItemDropTarget } from "./move-line-item";
 import {
   GripVertical,
   MoreVertical,
@@ -152,6 +154,20 @@ export function SubsectionCard({
   const [draftTitle, setDraftTitle] = useState(subsection.title);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Auto-expand on drop: if a Line item is dropped onto this Subsection
+  // (either onto its chrome or onto one of its items) while it is collapsed,
+  // expand so the user can see where the item landed.
+  useDndMonitor({
+    onDragEnd(event) {
+      const activeType = event.active.data.current?.type as string | undefined;
+      if (activeType !== "line-item") return;
+      const dest = resolveLineItemDropTarget(event.over ?? null);
+      if (dest && dest.destinationContainerId === subsection.id) {
+        setIsCollapsed(false);
+      }
+    },
+  });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/components/estimate-builder/template-drag-end.test.tsx
+++ b/src/components/estimate-builder/template-drag-end.test.tsx
@@ -1,0 +1,285 @@
+// Integration test for the template branch of handleDragEnd. Mounts the
+// EstimateBuilder with a minimal seeded template, simulates a programmatic
+// cross-container DragEndEvent via a mocked @dnd-kit/core DndContext, and
+// asserts on the on-screen tree + auto-expand behaviour. Establishes the
+// dnd-kit RTL test pattern for this repo.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, within, act } from "@testing-library/react";
+
+import type {
+  BuilderEntity,
+  TemplateWithContents,
+} from "@/lib/types";
+
+// ── Mock @dnd-kit/core to capture the onDragEnd callback ─────────────────────
+// Real SortableContext / useSortable from @dnd-kit/sortable are left intact so
+// the cards still render; we only need a way to dispatch synthetic drag-end
+// events at the test layer.
+
+type Listener = {
+  onDragEnd?: (e: unknown) => void;
+};
+
+let capturedRootOnDragEnd: ((e: unknown) => void) | null = null;
+let listeners: Listener[] = [];
+
+vi.mock("@dnd-kit/core", async () => {
+  const actual = await vi.importActual<typeof import("@dnd-kit/core")>(
+    "@dnd-kit/core",
+  );
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragEnd?: (e: unknown) => void;
+    }) => {
+      capturedRootOnDragEnd = onDragEnd ?? null;
+      return <>{children}</>;
+    },
+    useDndMonitor: (l: Listener) => {
+      listeners.push(l);
+    },
+  };
+});
+
+// Stub the auto-save hook so no fetch is fired during the test.
+vi.mock("./use-auto-save", () => ({
+  useAutoSave: () => ({
+    saveStatus: "idle",
+    lastSavedAt: null,
+    saveSectionsReorder: vi.fn(async () => true),
+    saveLineItemsReorder: vi.fn(async () => true),
+  }),
+}));
+
+// next/navigation router stub.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+// ── Helpers to dispatch synthetic drag-end events ────────────────────────────
+
+import { EstimateBuilder } from "./estimate-builder";
+import React from "react";
+
+function dispatchDragEnd(event: unknown) {
+  act(() => {
+    capturedRootOnDragEnd?.(event);
+    for (const l of listeners) l.onDragEnd?.(event);
+  });
+}
+
+function makeDragEndEvent(opts: {
+  activeId: string;
+  overId: string;
+  activeParentSectionId: string;
+  overType: "line-item" | "section" | "subsection";
+  overParentSectionId?: string;
+}): unknown {
+  return {
+    active: {
+      id: opts.activeId,
+      data: {
+        current: {
+          type: "line-item",
+          parentSectionId: opts.activeParentSectionId,
+        },
+      },
+    },
+    over: {
+      id: opts.overId,
+      data: {
+        current:
+          opts.overType === "line-item"
+            ? {
+                type: "line-item",
+                parentSectionId: opts.overParentSectionId ?? "",
+              }
+            : opts.overType === "subsection"
+            ? {
+                type: "subsection",
+                parentSectionId: opts.overParentSectionId ?? "",
+              }
+            : { type: "section" },
+      },
+    },
+  };
+}
+
+// ── Minimal seeded template entity ───────────────────────────────────────────
+
+function makeTemplateEntity(): BuilderEntity {
+  const template: TemplateWithContents = {
+    id: "tmpl-1",
+    organization_id: "org-1",
+    name: "Drag-end test template",
+    description: null,
+    damage_type_tags: [],
+    opening_statement: null,
+    closing_statement: null,
+    structure: { sections: [] },
+    is_active: true,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    sections: [
+      {
+        id: "S1",
+        title: "Roof",
+        sort_order: 0,
+        parent_section_id: null,
+        items: [
+          {
+            id: "A",
+            library_item_id: null,
+            name: "Tear-off",
+            description: "Remove existing shingles",
+            code: null,
+            quantity: 1,
+            unit: null,
+            unit_price: 100,
+            sort_order: 0,
+          },
+        ],
+        subsections: [
+          {
+            id: "Sub1",
+            title: "Flashing",
+            sort_order: 0,
+            items: [
+              {
+                id: "X",
+                library_item_id: null,
+                name: "Step flashing",
+                description: "Install step flashing",
+                code: null,
+                quantity: 10,
+                unit: null,
+                unit_price: 5,
+                sort_order: 0,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        id: "S2",
+        title: "Gutters",
+        sort_order: 1,
+        parent_section_id: null,
+        items: [],
+        subsections: [],
+      },
+    ],
+  };
+  return { kind: "template", data: template };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  capturedRootOnDragEnd = null;
+  listeners = [];
+});
+
+describe("EstimateBuilder template drag-end", () => {
+  it("moves a Line item from a Subsection into its parent Section's direct items", () => {
+    render(<EstimateBuilder entity={makeTemplateEntity()} />);
+
+    // Sanity: X is rendered initially (Subsection is expanded by default).
+    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+
+    dispatchDragEnd(
+      makeDragEndEvent({
+        activeId: "X",
+        activeParentSectionId: "Sub1",
+        overId: "S1",
+        overType: "section",
+      }),
+    );
+
+    // After the drop, X still exists on screen — semantics are that the same
+    // row moved containers. Source Subsection should now be empty.
+    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    // Empty subsection placeholder appears.
+    expect(screen.getByText("No items yet.")).toBeDefined();
+  });
+
+  it("auto-expands a collapsed destination Section on drop", () => {
+    render(<EstimateBuilder entity={makeTemplateEntity()} />);
+
+    // Collapse S2 by clicking its collapse button.
+    const s2Heading = screen.getByText("Gutters");
+    const s2Card = s2Heading.closest("li");
+    expect(s2Card).not.toBeNull();
+    const collapseBtn = within(s2Card as HTMLElement).getByRole("button", {
+      name: /collapse section/i,
+    });
+    act(() => {
+      collapseBtn.click();
+    });
+    // Verify the body is hidden — the "No subsections or items yet." copy is
+    // inside the body, which is now removed.
+    expect(within(s2Card as HTMLElement).queryByText(/No subsections or items yet\./i)).toBeNull();
+    // The toggle should now read "Expand section".
+    expect(
+      within(s2Card as HTMLElement).getByRole("button", { name: /expand section/i }),
+    ).toBeDefined();
+
+    // Drop A from S1 onto S2's chrome.
+    dispatchDragEnd(
+      makeDragEndEvent({
+        activeId: "A",
+        activeParentSectionId: "S1",
+        overId: "S2",
+        overType: "section",
+      }),
+    );
+
+    // S2 should re-expand — the collapse-toggle's accessible name flips back
+    // to "Collapse section".
+    expect(
+      within(s2Card as HTMLElement).getByRole("button", { name: /collapse section/i }),
+    ).toBeDefined();
+  });
+
+  it("reorders a Line item within its own container (regression for existing reorder)", () => {
+    // Use an entity with two items in the same container so we can swap them.
+    const entity = makeTemplateEntity();
+    const s1 = entity.data.kind === undefined ? null : null;
+    void s1;
+    const template = (entity as { data: TemplateWithContents }).data;
+    template.sections[0].items.push({
+      id: "B",
+      library_item_id: null,
+      name: "Underlayment",
+      description: "Install underlayment",
+      code: null,
+      quantity: 30,
+      unit: null,
+      unit_price: 2,
+      sort_order: 1,
+    });
+
+    render(<EstimateBuilder entity={entity} />);
+
+    // Drop A onto B — within-container reorder.
+    dispatchDragEnd(
+      makeDragEndEvent({
+        activeId: "A",
+        activeParentSectionId: "S1",
+        overId: "B",
+        overType: "line-item",
+        overParentSectionId: "S1",
+      }),
+    );
+
+    // Both items still rendered.
+    expect(screen.getByDisplayValue("Tear-off")).toBeDefined();
+    expect(screen.getByDisplayValue("Underlayment")).toBeDefined();
+  });
+});


### PR DESCRIPTION
Closes #264.

## Summary
- Two pure helpers — `moveLineItemAcrossContainers` and `resolveLineItemDropTarget` — isolated from React and from dnd-kit's React bindings, generic over the line-item shape so the estimate and invoice slices can ride on them later.
- Template branch of `handleDragEnd` rewritten to call the helpers. Section / Subsection drag-to-reorder, voided/read-only gating, and the existing debounced `rootPut` of `builder_state` are untouched.
- `SectionCard` and `SubsectionCard` auto-expand on drop via `useDndMonitor` — mode-agnostic, so the estimate/invoice slices inherit the behaviour for free.

## Test plan
- [x] Unit: 20 tests across the 12 PRD scenarios for the move helper + 4 branches for the drop-target resolver + affected-items payload contract — `src/components/estimate-builder/move-line-item.test.ts`.
- [x] Integration: RTL test mounts the template editor, dispatches a synthetic `DragEndEvent`, and asserts on-screen tree + auto-expand — `src/components/estimate-builder/template-drag-end.test.tsx`. Establishes the dnd-kit RTL test pattern for this repo.
- [x] `npx vitest run src/components/estimate-builder/` → 23/23 pass.
- [x] `npx tsc --noEmit` clean for changed files.
- [x] `npx eslint src/components/estimate-builder/` clean for changed files (pre-existing errors in `header-bar.tsx` and `line-item-row.tsx` are unrelated).

Manual smoke (not yet done in browser):
- [ ] Drag a Line item out of a Subsection into its parent Section.
- [ ] Drag a Line item between two sibling Subsections.
- [ ] Drag a Line item between Sections' direct items lists.
- [ ] Drop on a collapsed Section / Subsection → auto-expand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)