### PR TITLE
fix(invoice-line-items): read body.items instead of body.reorder (#265)

### DIFF
--- a/src/app/api/invoices/[id]/line-items/route.test.ts
+++ b/src/app/api/invoices/[id]/line-items/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PUT } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { fakeUserClient, memberTables } from "../../../__test-utils__/request-context-fakes";
+
+const routeCtx = { params: Promise.resolve({ id: "inv-1" }) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function putRequest(body: unknown) {
+  return new Request("http://test/api/invoices/inv-1/line-items", {
+    method: "PUT",
+    body: JSON.stringify(body),
+  });
+}
+
+// #265 — the route is being aligned with the client (use-auto-save.ts's
+// `saveLineItemsReorder`), which sends `{ items: [...] }`, and with the
+// sibling estimate route, which already reads `body.items`.
+describe("PUT /api/invoices/[id]/line-items (#265 reorder field rename)", () => {
+  it("accepts { items: [...] } and returns 200 OK", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_invoices"],
+        extraTables: {
+          invoices: [{ id: "inv-1", deleted_at: null, updated_at: "2026-05-01T00:00:00Z" }],
+        },
+      }),
+    });
+
+    const res = await PUT(putRequest({ items: [] }), routeCtx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, updated_at: "2026-05-01T00:00:00Z" });
+  });
+
+  it("returns 400 when body has no items array (e.g. legacy `reorder` field only)", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_invoices"],
+        extraTables: {
+          invoices: [{ id: "inv-1", deleted_at: null, updated_at: "2026-05-01T00:00:00Z" }],
+        },
+      }),
+    });
+
+    const res = await PUT(putRequest({ reorder: [] }), routeCtx);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "items array required" });
+  });
+});

--- a/src/app/api/invoices/[id]/line-items/route.ts
+++ b/src/app/api/invoices/[id]/line-items/route.ts
@@ -133,7 +133,7 @@ export const POST = withRequestContext(
 );
 
 interface PutBody {
-  reorder: Array<{
+  items: Array<{
     id: string;
     section_id: string;
     sort_order: number;
@@ -155,8 +155,8 @@ export const PUT = withRequestContext(
     if (trashedPut) return trashedPut;
 
     const body = (await request.json().catch(() => null)) as PutBody | null;
-    if (!body || !Array.isArray(body.reorder)) {
-      return NextResponse.json({ error: "reorder array required" }, { status: 400 });
+    if (!body || !Array.isArray(body.items)) {
+      return NextResponse.json({ error: "items array required" }, { status: 400 });
     }
 
     try {
@@ -169,17 +169,17 @@ export const PUT = withRequestContext(
       }
 
       // Pre-validate every section_id belongs to this invoice (defense-in-depth — RLS catches cross-org)
-      const sectionIds = Array.from(new Set(body.reorder.map((r) => r.section_id)));
+      const sectionIds = Array.from(new Set(body.items.map((r) => r.section_id)));
       const { data: sections } = await supabase
         .from("invoice_sections").select("id").in("id", sectionIds).eq("invoice_id", id);
       const validIds = new Set((sections ?? []).map((s) => s.id));
-      for (const r of body.reorder) {
+      for (const r of body.items) {
         if (!validIds.has(r.section_id)) {
           return NextResponse.json({ error: "section_not_in_invoice", section_id: r.section_id }, { status: 400 });
         }
       }
 
-      for (const r of body.reorder) {
+      for (const r of body.items) {
         const { error } = await supabase
           .from("invoice_line_items")
           .update({ section_id: r.section_id, sort_order: r.sort_order })


### PR DESCRIPTION
## Summary

Closes #265.

The invoice line-items PUT reorder route validated and iterated over `body.reorder`, but the only caller (`use-auto-save.ts`'s `saveLineItemsReorder`) sends `body.items`. Every invoice line-item reorder silently 400'd — including pure within-container reorders. The sibling estimate route already reads `body.items`, so this brings the invoice route in line with both the client and its sibling endpoint.

- Rename `body.reorder` → `body.items` (5 sites in `src/app/api/invoices/[id]/line-items/route.ts`)
- Update the validator error to `"items array required"`
- Add focused route tests covering the new shape and the legacy-field 400

Pre-existing bug; ships independently of the broader cross-container drag work in #247.

## Test plan

- [x] `npx vitest run src/app/api/invoices/\[id\]/line-items/route.test.ts` — 2/2 pass
- [ ] Reorder a line item within a section in the invoice editor — persists, no rollback toast
- [ ] 409 snapshot conflict and `section_not_in_invoice` 400 paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)