### PR TITLE
test(camera): fall-back-to-stacked + orientation-flip coverage (#271)

### DIFF
--- a/src/lib/mobile/compute-camera-layout.test.ts
+++ b/src/lib/mobile/compute-camera-layout.test.ts
@@ -89,4 +89,18 @@ describe("computeCameraLayout", () => {
 
     expect(layout.mode).toBe("split");
   });
+
+  it("landscape with residual width less than controlsMinSize falls back to stacked", () => {
+    // Pathological landscape where the controls cluster cannot fit:
+    // viewportWidth (250) is less than controlsMinSize (300), so we
+    // cannot carve out the controls strip without producing a degenerate
+    // preview. Per spec: fall back to stacked.
+    const layout = computeCameraLayout({
+      viewportWidth: 250,
+      viewportHeight: 200,
+      controlsMinSize: 300,
+    });
+
+    expect(layout.mode).toBe("stacked");
+  });
 });

--- a/src/lib/mobile/compute-camera-layout.ts
+++ b/src/lib/mobile/compute-camera-layout.ts
@@ -28,21 +28,25 @@ export function computeCameraLayout(
     const naturalWidth = (viewportHeight * 4) / 3;
     const maxWidth = viewportWidth - controlsMinSize;
 
-    if (naturalWidth <= maxWidth) {
-      const width = Math.round(naturalWidth);
+    if (maxWidth > 0) {
+      if (naturalWidth <= maxWidth) {
+        const width = Math.round(naturalWidth);
+        return {
+          mode: "split",
+          previewRect: { x: 0, y: 0, width, height: viewportHeight },
+        };
+      }
+
+      const width = Math.round(maxWidth);
+      const height = Math.round((width * 3) / 4);
+      const y = Math.round((viewportHeight - height) / 2);
       return {
         mode: "split",
-        previewRect: { x: 0, y: 0, width, height: viewportHeight },
+        previewRect: { x: 0, y, width, height },
       };
     }
-
-    const width = Math.round(maxWidth);
-    const height = Math.round((width * 3) / 4);
-    const y = Math.round((viewportHeight - height) / 2);
-    return {
-      mode: "split",
-      previewRect: { x: 0, y, width, height },
-    };
+    // Fall through to stacked when the controls cluster cannot fit
+    // alongside the preview — pathological narrow landscape windows.
   }
 
   // Stacked: 3:4 portrait preview, controls strip below.

--- a/src/lib/mobile/use-camera-lifecycle.test.ts
+++ b/src/lib/mobile/use-camera-lifecycle.test.ts
@@ -119,6 +119,38 @@ describe("useCameraLifecycle", () => {
     if (r) r();
   });
 
+  it("an orientation flip triggers exactly one restart with the new rect", async () => {
+    // Landscape rect at iPad 1024x768 split layout.
+    const landscape = { x: 0, y: 113, width: 724, height: 543 };
+    const { rerender } = renderHook(
+      ({ rect }) =>
+        useCameraLifecycle({ rect, position: "rear", safeAreaTop: 0 }),
+      { initialProps: { rect: landscape } },
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(startMock).toHaveBeenCalledTimes(1);
+    startMock.mockClear();
+    stopMock.mockClear();
+
+    // Rotate to portrait — the layout module would produce a tall rect.
+    const portrait = { x: 0, y: 0, width: 543, height: 724 };
+    await act(async () => {
+      rerender({ rect: portrait });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Exactly one stop + one start, with the new rect.
+    expect(stopMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledTimes(1);
+    expect(startMock).toHaveBeenCalledWith(
+      expect.objectContaining({ width: 543, height: 724 }),
+    );
+  });
+
   it("does not restart when the rect change is within tolerance", async () => {
     const initial = { x: 0, y: 0, width: 390, height: 520 };
     const { rerender } = renderHook(


### PR DESCRIPTION
Closes #271. Follow-up to PR #276 which shipped PRD #269 (issues #270 + #271) in one PR.

## Summary

- `compute-camera-layout` now falls back to `stacked` when a landscape viewport cannot reserve `controlsMinSize` for the controls cluster (previously it shrank the preview and stayed in `split`). Covers the iPad split-screen-below-controls-reserve case called out in #271's spec.
- `use-camera-lifecycle` gains a dedicated test asserting an orientation flip produces exactly one `stop()` + one `start()` with the new rect. Existing rect-change-beyond-tolerance logic already debounces this correctly — the test locks in the behavior.

## Test plan

- [x] `npx vitest run src/lib/mobile/compute-camera-layout.test.ts` — 8 passed (1 new)
- [x] `npx vitest run src/lib/mobile/use-camera-lifecycle.test.ts` — 6 passed (1 new)
- [x] Wider camera suite: `npx vitest run src/lib/mobile/ src/components/mobile/camera-view.test.tsx` — 62 passed across 10 files
- [ ] Real-device verification on physical iPad — gating per PRD #269, deferred per PR #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)