### PR TITLE
feat(camera): reposition in-camera sheets for iPad landscape split (#272)

### DIFF
--- a/src/components/mobile/camera-view.test.tsx
+++ b/src/components/mobile/camera-view.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
 
 // Mock the native camera plugin entirely.
 vi.mock("@capacitor-community/camera-preview", () => ({
@@ -108,5 +108,167 @@ describe("CameraView adaptive layout", () => {
     const shutter = screen.getByLabelText(/Capture photo/i);
     const panel = screen.getByTestId("camera-controls-panel");
     expect(panel.contains(shutter)).toBe(true);
+  });
+});
+
+describe("CameraView in-camera surfaces (issue #272)", () => {
+  beforeEach(() => {
+    viewportMock.mockReset();
+  });
+
+  describe("split mode (iPad landscape)", () => {
+    beforeEach(() => {
+      viewportMock.mockReturnValue({
+        width: 1024,
+        height: 768,
+        orientation: "landscape",
+      });
+    });
+
+    it("settings sheet anchors to the right and is dismissible", () => {
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Camera settings/i));
+
+      const sheet = screen.getByTestId("settings-sheet");
+      expect(sheet.getAttribute("data-mode")).toBe("split");
+      expect(sheet.className).toMatch(/right-0/);
+      expect(sheet.className).not.toMatch(/bottom-0/);
+
+      fireEvent.click(within(sheet).getByText(/Close/i));
+      expect(screen.queryByTestId("settings-sheet")).toBeNull();
+    });
+
+    it("tag-after sheet anchors to the right and is dismissible", async () => {
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Capture photo/i));
+
+      const sheet = await screen.findByTestId("tag-sheet");
+      expect(sheet.getAttribute("data-mode")).toBe("split");
+      expect(sheet.className).toMatch(/right-0/);
+      expect(sheet.className).not.toMatch(/bottom-0/);
+
+      fireEvent.click(within(sheet).getByText(/Continue/i));
+      await waitFor(() => {
+        expect(screen.queryByTestId("tag-sheet")).toBeNull();
+      });
+    });
+
+    it("leave-confirm dialog anchors to the right and Stay dismisses it", async () => {
+      const onAbort = vi.fn();
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={onAbort}
+        />,
+      );
+
+      // Capture one photo so the leave guard triggers.
+      fireEvent.click(screen.getByLabelText(/Capture photo/i));
+      const tagSheet = await screen.findByTestId("tag-sheet");
+      fireEvent.click(within(tagSheet).getByText(/Continue/i));
+      await waitFor(() => {
+        expect(screen.queryByTestId("tag-sheet")).toBeNull();
+      });
+
+      fireEvent.click(screen.getByLabelText(/Cancel capture/i));
+
+      const dialog = screen.getByTestId("leave-confirm");
+      expect(dialog.getAttribute("data-mode")).toBe("split");
+      expect(dialog.className).toMatch(/right-0/);
+      expect(dialog.className).not.toMatch(/inset-0/);
+
+      fireEvent.click(within(dialog).getByText(/^Stay$/));
+      expect(screen.queryByTestId("leave-confirm")).toBeNull();
+      expect(onAbort).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stacked mode (iPhone + iPad portrait) — visual regression", () => {
+    beforeEach(() => {
+      viewportMock.mockReturnValue({
+        width: 390,
+        height: 844,
+        orientation: "portrait",
+      });
+    });
+
+    it("settings sheet slides up from the bottom", () => {
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Camera settings/i));
+
+      const sheet = screen.getByTestId("settings-sheet");
+      expect(sheet.getAttribute("data-mode")).toBe("stacked");
+      expect(sheet.className).toMatch(/bottom-0/);
+      expect(sheet.className).not.toMatch(/right-0/);
+    });
+
+    it("tag-after sheet slides up from the bottom", async () => {
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Capture photo/i));
+
+      const sheet = await screen.findByTestId("tag-sheet");
+      expect(sheet.getAttribute("data-mode")).toBe("stacked");
+      expect(sheet.className).toMatch(/bottom-0/);
+      expect(sheet.className).not.toMatch(/right-0/);
+    });
+
+    it("leave-confirm dialog covers the full screen", async () => {
+      render(
+        <CameraView
+          jobId="job-1"
+          sessionId="sess-1"
+          onDone={() => undefined}
+          onAbort={() => undefined}
+        />,
+      );
+
+      fireEvent.click(screen.getByLabelText(/Capture photo/i));
+      const tagSheet = await screen.findByTestId("tag-sheet");
+      fireEvent.click(within(tagSheet).getByText(/Continue/i));
+      await waitFor(() => {
+        expect(screen.queryByTestId("tag-sheet")).toBeNull();
+      });
+
+      fireEvent.click(screen.getByLabelText(/Cancel capture/i));
+
+      const dialog = screen.getByTestId("leave-confirm");
+      expect(dialog.getAttribute("data-mode")).toBe("stacked");
+      expect(dialog.className).toMatch(/inset-0/);
+      expect(dialog.className).not.toMatch(/right-0/);
+    });
   });
 });

--- a/src/components/mobile/camera-view.tsx
+++ b/src/components/mobile/camera-view.tsx
@@ -444,7 +444,16 @@ export default function CameraView({
       )}
 
       {showLeaveConfirm && (
-        <div className="absolute inset-0 z-[1030] flex items-center justify-center bg-black/70 px-6">
+        <div
+          data-testid="leave-confirm"
+          data-mode={layout.mode}
+          className={cn(
+            "absolute z-[1030] flex items-center justify-center bg-black/70",
+            stacked
+              ? "inset-0 px-6"
+              : "inset-y-0 right-0 w-80 max-w-[60%] px-4",
+          )}
+        >
           <div className="w-full max-w-sm rounded-2xl bg-black p-6 text-white">
             <h3 className="mb-3 text-lg font-semibold">Leave camera?</h3>
             <p className="mb-6 text-sm text-white/85">
@@ -472,6 +481,8 @@ export default function CameraView({
 
       {settingsOpen && (
         <div
+          data-testid="settings-sheet"
+          data-mode={layout.mode}
           className={cn(
             "absolute z-[1020] bg-black/95 px-5 backdrop-blur",
             stacked
@@ -497,6 +508,8 @@ export default function CameraView({
 
       {pendingTag && (
         <div
+          data-testid="tag-sheet"
+          data-mode={layout.mode}
           className={cn(
             "absolute z-[1010] bg-black/95 px-5 backdrop-blur",
             stacked


### PR DESCRIPTION
## Summary
- Third and final tracer-bullet slice of PRD #269 — polishes the in-camera overlay UI for iPad landscape split mode.
- The "Leave camera?" confirm dialog now anchors to the right edge over the controls panel region in split mode (matching the settings and tag-after sheets, which already had a split variant).
- All three surfaces' positioning is driven by the same `layout.mode` from `compute-camera-layout` — no separate `isIpad` flag.
- Stacked mode (iPhone + iPad portrait + iPad split-screen-narrow) is byte-identical to before.

## Test plan
- [x] `vitest run src/components/mobile/camera-view.test.tsx` — 8/8 pass (2 prior + 6 new integration tests covering each of the three surfaces in both modes)
- [x] Full vitest suite — only failures are pre-existing in `src/app/api/email/accounts/route.test.ts` (confirmed on `main`)
- [x] `tsc --noEmit` — only pre-existing errors in `estimate-builder/template-drag-end.test.tsx` and `sync-folder-incremental.test.ts`
- [x] ESLint — clean on changed files (one pre-existing `useEffect` unused-import warning is on `main`)
- [ ] Real-device verification on a physical iPad in landscape (per AC) — walking through tag-after sheet, settings sheet, and Leave confirm
- [ ] iPhone visual regression check — no change expected

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)