### PR TITLE
fix(jobs): disambiguate jobs→contacts PostgREST embeds (#282)

### DIFF
--- a/src/app/api/estimates/trash/route.ts
+++ b/src/app/api/estimates/trash/route.ts
@@ -54,7 +54,7 @@ export const GET = withRequestContext(
     // 3. List remaining trashed rows.
     let listQuery = supabase
       .from("estimates")
-      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts(*))")
+      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))")
       .not("deleted_at", "is", null)
       .order("deleted_at", { ascending: false });
     if (jobId) listQuery = listQuery.eq("job_id", jobId);

--- a/src/app/api/invoices/trash/route.ts
+++ b/src/app/api/invoices/trash/route.ts
@@ -43,7 +43,7 @@ export const GET = withRequestContext(
 
     let listQuery = supabase
       .from("invoices")
-      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts(*))")
+      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))")
       .not("deleted_at", "is", null)
       .order("deleted_at", { ascending: false });
     if (jobId) listQuery = listQuery.eq("job_id", jobId);

--- a/src/app/api/jarvis/field-ops/route.ts
+++ b/src/app/api/jarvis/field-ops/route.ts
@@ -106,7 +106,7 @@ async function executeFieldOpsTool(
         // Get job with contact info
         const { data: job, error: jobError } = await supabase
           .from("jobs")
-          .select("*, contact:contacts(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
+          .select("*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
           .eq("id", jobId)
           .single();
 

--- a/src/app/estimates/[id]/edit/page.tsx
+++ b/src/app/estimates/[id]/edit/page.tsx
@@ -79,7 +79,7 @@ export default async function EstimateEditPage({
   //    Destructure error separately (Task 19 lesson: don't swallow lookup errors).
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts(*)")
+    .select("*, contact:contacts!contact_id(*)")
     .eq("id", estimate.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -125,7 +125,7 @@ export default async function EstimateViewPage({
   //    Destructure error separately (Task 19 lesson).
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts(*)")
+    .select("*, contact:contacts!contact_id(*)")
     .eq("id", estimate.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 

--- a/src/app/invoices/[id]/edit/page.tsx
+++ b/src/app/invoices/[id]/edit/page.tsx
@@ -78,7 +78,7 @@ export default async function InvoiceEditPage({
   // 3. Fetch the parent job + contact for the customer block.
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts(*)")
+    .select("*, contact:contacts!contact_id(*)")
     .eq("id", inv.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 


### PR DESCRIPTION
## Summary
Closes #282. Migration 193 added `jobs.insurance_contact_id` alongside `jobs.contact_id`, making every implicit `contact:contacts(*)` embed off `jobs` ambiguous (PGRST201). Pin each one to the homeowner FK by replacing `contact:contacts(*)` with `contact:contacts!contact_id(*)`.

Six surfaces:
- `src/app/estimates/[id]/edit/page.tsx` — parent-job customer block
- `src/app/estimates/[id]/page.tsx` — parent job (read-only view)
- `src/app/invoices/[id]/edit/page.tsx` — parent-job customer block
- `src/app/api/estimates/trash/route.ts` — nested embed via parent job
- `src/app/api/invoices/trash/route.ts` — nested embed via parent job
- `src/app/api/jarvis/field-ops/route.ts` — `get_job_context` (job + contact + adjusters)

Grep confirms no remaining ambiguous `jobs` → `contacts(*)` embeds outside the six listed surfaces.

No schema changes, no helper extraction, no type changes — `contact: Contact | null` is unchanged.

## Test plan
- [ ] On a job with both a homeowner and an insurance contact: **Create Estimate** lands on the estimate editor with the homeowner in the customer block.
- [ ] Same flow for **Create Invoice** lands on the invoice editor with the homeowner in the customer block.
- [ ] Opening an existing estimate's read-only view loads with the homeowner contact.
- [ ] Estimates trash and invoices trash both load without error and each row shows the correct homeowner.
- [ ] A Jarvis prompt that triggers `get_job_context` returns a non-error response.

Automated regression coverage is the follow-up slice (per #282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)