### PR TITLE
test(integration): regression harness for jobs→contacts PostgREST embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.86.1",

--- a/src/app/api/estimates/trash/route.ts
+++ b/src/app/api/estimates/trash/route.ts
@@ -8,6 +8,7 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { purgeEstimateStorage } from "@/lib/documents/purge";
+import { ESTIMATE_TRASH_WITH_JOB_HOMEOWNER_EMBED } from "@/lib/embeds/jobs-contacts";
 
 const RETENTION_DAYS = 30;
 
@@ -54,7 +55,7 @@ export const GET = withRequestContext(
     // 3. List remaining trashed rows.
     let listQuery = supabase
       .from("estimates")
-      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))")
+      .select(ESTIMATE_TRASH_WITH_JOB_HOMEOWNER_EMBED)
       .not("deleted_at", "is", null)
       .order("deleted_at", { ascending: false });
     if (jobId) listQuery = listQuery.eq("job_id", jobId);

--- a/src/app/api/invoices/trash/route.ts
+++ b/src/app/api/invoices/trash/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { purgeInvoiceStorage } from "@/lib/documents/purge";
+import { INVOICE_TRASH_WITH_JOB_HOMEOWNER_EMBED } from "@/lib/embeds/jobs-contacts";
 
 const RETENTION_DAYS = 30;
 
@@ -43,7 +44,7 @@ export const GET = withRequestContext(
 
     let listQuery = supabase
       .from("invoices")
-      .select("*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))")
+      .select(INVOICE_TRASH_WITH_JOB_HOMEOWNER_EMBED)
       .not("deleted_at", "is", null)
       .order("deleted_at", { ascending: false });
     if (jobId) listQuery = listQuery.eq("job_id", jobId);

--- a/src/app/api/jarvis/field-ops/route.ts
+++ b/src/app/api/jarvis/field-ops/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/jarvis/attachments/storage";
 import { ANTHROPIC_FILES_BETA } from "@/lib/jarvis/attachments/anthropic-files";
 import { withPromptCache } from "@/lib/jarvis/prompt-cache";
+import { JARVIS_JOB_CONTEXT_EMBED } from "@/lib/embeds/jobs-contacts";
 import type { JarvisAttachment } from "@/lib/types";
 
 export const maxDuration = 60;
@@ -106,7 +107,7 @@ async function executeFieldOpsTool(
         // Get job with contact info
         const { data: job, error: jobError } = await supabase
           .from("jobs")
-          .select("*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))")
+          .select(JARVIS_JOB_CONTEXT_EMBED)
           .eq("id", jobId)
           .single();
 

--- a/src/app/estimates/[id]/edit/page.tsx
+++ b/src/app/estimates/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
 import { getEstimateWithContents } from "@/lib/estimates";
 import { EstimateBuilder } from "@/components/estimate-builder/estimate-builder";
+import { JOB_WITH_HOMEOWNER_EMBED } from "@/lib/embeds/jobs-contacts";
 import type { Contact, Job } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -79,7 +80,7 @@ export default async function EstimateEditPage({
   //    Destructure error separately (Task 19 lesson: don't swallow lookup errors).
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts!contact_id(*)")
+    .select(JOB_WITH_HOMEOWNER_EMBED)
     .eq("id", estimate.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -10,6 +10,7 @@ import { STATUS_BADGE_CLASSES, formatStatusLabel } from "@/lib/estimate-status";
 import { ExportPdfButton } from "@/components/export-pdf-modal/button";
 import { SendButton } from "@/components/send-modal/button";
 import { TrashedBanner } from "@/components/trash/trashed-banner";
+import { JOB_WITH_HOMEOWNER_EMBED } from "@/lib/embeds/jobs-contacts";
 import type {
   Contact,
   EstimateLineItem,
@@ -125,7 +126,7 @@ export default async function EstimateViewPage({
   //    Destructure error separately (Task 19 lesson).
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts!contact_id(*)")
+    .select(JOB_WITH_HOMEOWNER_EMBED)
     .eq("id", estimate.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 

--- a/src/app/invoices/[id]/edit/page.tsx
+++ b/src/app/invoices/[id]/edit/page.tsx
@@ -5,6 +5,7 @@ import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
 import { getInvoiceWithContents } from "@/lib/invoices";
 import { EstimateBuilder } from "@/components/estimate-builder/estimate-builder";
+import { JOB_WITH_HOMEOWNER_EMBED } from "@/lib/embeds/jobs-contacts";
 import type { Contact, Job } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -78,7 +79,7 @@ export default async function InvoiceEditPage({
   // 3. Fetch the parent job + contact for the customer block.
   const { data: job, error: jobErr } = await supabase
     .from("jobs")
-    .select("*, contact:contacts!contact_id(*)")
+    .select(JOB_WITH_HOMEOWNER_EMBED)
     .eq("id", inv.job_id)
     .maybeSingle<Job & { contact: Contact | null }>();
 

--- a/src/lib/embeds/jobs-contacts.ts
+++ b/src/lib/embeds/jobs-contacts.ts
@@ -1,0 +1,47 @@
+// PostgREST embed strings for `jobs` → `contacts` reads.
+//
+// Background. Migration 193 added `jobs.insurance_contact_id` alongside the
+// existing `jobs.contact_id`. PostgREST then sees two foreign keys from
+// `jobs` to `contacts` and refuses an implicit `contacts(*)` embed with
+// `PGRST201` ("more than one relationship was found"). Every embed must
+// pick its FK explicitly, e.g. `contacts!contact_id(*)`.
+//
+// Centralising the embed strings here gives the integration harness (#283)
+// a single point of attachment: tests import the same constant the routes
+// use, so reverting one is the same as reverting the other.
+//
+// If a third FK from `jobs` to `contacts` is ever added, every embed
+// targeting `contacts` from a `jobs` row needs to re-pick its FK — start
+// here.
+
+/** Job + the homeowner contact. Surfaces:
+ *  - src/app/estimates/[id]/edit/page.tsx
+ *  - src/app/estimates/[id]/page.tsx
+ *  - src/app/invoices/[id]/edit/page.tsx
+ */
+export const JOB_WITH_HOMEOWNER_EMBED =
+  "*, contact:contacts!contact_id(*)" as const;
+
+/** Estimates-trash listing with nested job → homeowner. Surface:
+ *  - src/app/api/estimates/trash/route.ts
+ */
+export const ESTIMATE_TRASH_WITH_JOB_HOMEOWNER_EMBED =
+  "*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))" as const;
+
+/** Invoices-trash listing with nested job → homeowner. Surface:
+ *  - src/app/api/invoices/trash/route.ts
+ *
+ *  String matches the estimates form — kept as a distinct constant so
+ *  each surface can evolve independently. (If they diverge, that is
+ *  fine; the integration tests assert each surface against its own
+ *  constant.) */
+export const INVOICE_TRASH_WITH_JOB_HOMEOWNER_EMBED =
+  "*, job:jobs!job_id(job_number, contact_id, contact:contacts!contact_id(*))" as const;
+
+/** Jarvis `get_job_context`: job + homeowner + adjusters (with their
+ *  contact rows). Surface:
+ *  - src/app/api/jarvis/field-ops/route.ts
+ *
+ *  Two embeds against `contacts` — both pin via `!contact_id`. */
+export const JARVIS_JOB_CONTEXT_EMBED =
+  "*, contact:contacts!contact_id(*), job_adjusters(*, adjuster:contacts!contact_id(*))" as const;

--- a/supabase/README-integration-tests.md
+++ b/supabase/README-integration-tests.md
@@ -1,0 +1,44 @@
+# Integration test harness
+
+`npm run test:integration` boots a local Supabase stack via `supabase start`,
+applies a minimal FK-ambiguity schema (`tests/integration/schema.sql`), seeds
+a single job linked to both a homeowner and an insurance contact, and runs
+the regression suite at `tests/integration/jobs-contacts-embed.test.ts` —
+one test per surface from #282. The harness exists so the PostgREST
+embed-disambiguation bug class (`PGRST201`) can't silently come back the
+next time a new FK lands.
+
+## Prerequisites
+
+- Supabase CLI installed (`brew install supabase/tap/supabase`,
+  `scoop install supabase`, or follow
+  [the CLI install guide](https://supabase.com/docs/guides/cli/getting-started)).
+- Docker Desktop running — the CLI's `start` command provisions Postgres
+  and PostgREST in containers.
+- `psql` on `PATH` (used to apply the schema file).
+
+## Running
+
+```sh
+npm run test:integration
+```
+
+The first run downloads container images (one-time cost). Subsequent runs
+boot in a few seconds. The harness stops the stack on teardown; pass
+`supabase stop` is idempotent, so a stuck previous run won't break the
+next attempt.
+
+## Why a minimal schema?
+
+The schema file under `tests/integration/schema.sql` is intentionally
+small — it ships only the tables and FKs the six embed queries touch,
+not a full clone of production. The bug class lives entirely in
+PostgREST's embed parsing against the FK shape, so reproducing prod
+faithfully would be churn without payoff. See the header comment in
+that file for the full rationale.
+
+## CI
+
+This repo currently has no GitHub Actions workflow; CI integration for
+`test:integration` is tracked as a follow-up. Run it locally before
+opening PRs that touch the embed queries.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,50 @@
+# Supabase local-stack config for the integration harness (#283).
+#
+# Production config is managed in the Supabase dashboard; this file
+# only exists so `supabase start` can boot a local stack for
+# `npm run test:integration`. Most services are disabled because the
+# harness only needs Postgres + PostgREST (the embed disambiguation
+# bug class lives in PostgREST). Studio / Storage / Realtime / Edge
+# Functions add boot time without changing what's under test.
+
+project_id = "nookleus"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 15
+
+[db.pooler]
+enabled = false
+
+[realtime]
+enabled = false
+
+[studio]
+enabled = false
+
+[storage]
+enabled = false
+
+[auth]
+# Kept enabled so the service-role key the CLI prints is a valid JWT
+# signed by the local jwt secret. The test client uses
+# `persistSession: false`, so we never actually exercise the auth flows.
+enabled = true
+site_url = "http://localhost:3000"
+
+[edge_runtime]
+enabled = false
+
+[functions]
+enabled = false
+
+[analytics]
+enabled = false

--- a/tests/integration/global-setup.ts
+++ b/tests/integration/global-setup.ts
@@ -1,0 +1,92 @@
+// Vitest `globalSetup` for the jobs→contacts embed harness (#283).
+//
+// Responsibilities, in order:
+//   1. Boot the local Supabase stack (`supabase start`).
+//   2. Read its URL + service-role key out of `supabase status -o env`.
+//   3. Apply `tests/integration/schema.sql` via `psql` — this is the
+//      minimal FK-ambiguity skeleton, not a prod clone (see schema.sql
+//      header for the rationale).
+//   4. Expose `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` / `SUPABASE_DB_URL`
+//      to the test process via `process.env`.
+//   5. On teardown, stop the stack.
+//
+// Why globalSetup and not beforeAll? Booting the stack takes seconds, and
+// we want it once for the whole run, not per-file. Fixture seeding still
+// happens in `beforeAll` inside the test file so a single fresh fixture
+// is visible across the six tests.
+//
+// Stack management. We assume `supabase` CLI + Docker are available.
+// If a stack is already running on this machine we reuse it (the CLI's
+// `start` is a no-op when the project is already up). We always `stop`
+// in teardown — devs who want to keep the stack between runs should run
+// `supabase start` manually before invoking the harness.
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const INTEGRATION_DIR = join(process.cwd(), "tests", "integration");
+
+function run(cmd: string, args: string[]): string {
+  return execFileSync(cmd, args, {
+    stdio: ["ignore", "pipe", "inherit"],
+    encoding: "utf8",
+  });
+}
+
+function parseSupabaseEnv(envOutput: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of envOutput.split(/\r?\n/)) {
+    const match = line.match(/^([A-Z0-9_]+)="?(.*?)"?$/);
+    if (match) out[match[1]] = match[2];
+  }
+  return out;
+}
+
+export async function setup(): Promise<void> {
+  console.log("[integration] starting supabase stack...");
+  // `start` is idempotent: when the project is already up it prints status
+  // and exits 0. When it's down it boots and exits 0 after readiness.
+  run("supabase", ["start"]);
+
+  console.log("[integration] reading supabase status...");
+  const statusOutput = run("supabase", ["status", "-o", "env"]);
+  const status = parseSupabaseEnv(statusOutput);
+
+  const apiUrl = status.API_URL;
+  const dbUrl = status.DB_URL;
+  const serviceRoleKey = status.SERVICE_ROLE_KEY;
+  if (!apiUrl || !dbUrl || !serviceRoleKey) {
+    throw new Error(
+      `[integration] could not parse supabase status output; got keys: ${Object.keys(status).join(", ")}`,
+    );
+  }
+
+  console.log("[integration] applying test schema via psql...");
+  run("psql", [dbUrl, "-v", "ON_ERROR_STOP=1", "-f", join(INTEGRATION_DIR, "schema.sql")]);
+
+  process.env.SUPABASE_URL = apiUrl;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = serviceRoleKey;
+  process.env.SUPABASE_DB_URL = dbUrl;
+
+  // Smaller bit of resilience: PostgREST caches the schema. Even with the
+  // NOTIFY pgrst at the end of schema.sql, on a freshly booted container
+  // the listener may not be attached yet. Give it a moment and ping again.
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  try {
+    run("psql", [dbUrl, "-c", "NOTIFY pgrst, 'reload schema';"]);
+  } catch {
+    // Non-fatal; the first request will eventually trigger the reload.
+  }
+
+  console.log("[integration] ready.");
+}
+
+export async function teardown(): Promise<void> {
+  console.log("[integration] stopping supabase stack...");
+  try {
+    run("supabase", ["stop"]);
+  } catch (err) {
+    console.warn("[integration] supabase stop failed (continuing):", err);
+  }
+}

--- a/tests/integration/jobs-contacts-embed.test.ts
+++ b/tests/integration/jobs-contacts-embed.test.ts
@@ -1,0 +1,235 @@
+// Integration regression coverage for #282 — the six PostgREST embed
+// surfaces that hit `jobs` → `contacts` after migration 193 introduced a
+// second FK (`jobs.insurance_contact_id`) alongside the existing
+// `jobs.contact_id`.
+//
+// Strategy. Each test imports the production embed string from
+// `@/lib/embeds/jobs-contacts`, the same module the routes/pages use,
+// and executes it against a local Supabase stack provisioned by
+// `tests/integration/global-setup.ts`. The fixture is a single job
+// linked to BOTH a homeowner and an insurance contact. The
+// load-bearing assertion is that the embed returns the homeowner —
+// not just that the query didn't error — because that's what proves
+// the `!contact_id` disambiguation actually points where #282 intended.
+//
+// Smoke check. If you revert any of the constants in
+// `src/lib/embeds/jobs-contacts.ts` to the bare `contact:contacts(*)`
+// form, the corresponding test below fails with PGRST201. That's the
+// harness sanity check called out in the issue.
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import {
+  ESTIMATE_TRASH_WITH_JOB_HOMEOWNER_EMBED,
+  INVOICE_TRASH_WITH_JOB_HOMEOWNER_EMBED,
+  JARVIS_JOB_CONTEXT_EMBED,
+  JOB_WITH_HOMEOWNER_EMBED,
+} from "@/lib/embeds/jobs-contacts";
+
+let supabase: SupabaseClient;
+
+let homeownerId: string;
+let insurerId: string;
+let adjusterId: string;
+let jobId: string;
+let estimateId: string;
+let invoiceId: string;
+
+beforeAll(async () => {
+  const url = process.env.SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      "[integration] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing — global-setup did not run",
+    );
+  }
+
+  supabase = createClient(url, serviceRoleKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  // ── Contacts: one homeowner, one insurer, one adjuster ──────────────────
+  const { data: contacts, error: contactsErr } = await supabase
+    .from("contacts")
+    .insert([
+      { full_name: "Homeowner Helen", role: "homeowner" },
+      { full_name: "Insurer Inc.", role: "insurance" },
+      { full_name: "Adjuster Adam", role: "adjuster" },
+    ])
+    .select();
+  if (contactsErr || !contacts || contacts.length !== 3) {
+    throw new Error(
+      `[integration] contact fixture insert failed: ${contactsErr?.message ?? "no rows"}`,
+    );
+  }
+  homeownerId = contacts.find((c) => c.role === "homeowner")!.id;
+  insurerId = contacts.find((c) => c.role === "insurance")!.id;
+  adjusterId = contacts.find((c) => c.role === "adjuster")!.id;
+
+  // ── Job: linked to BOTH the homeowner and the insurer. This is what
+  //    triggers PGRST201 against any un-disambiguated `contacts(*)` embed.
+  const { data: job, error: jobErr } = await supabase
+    .from("jobs")
+    .insert({
+      job_number: "TEST-EMBED-001",
+      contact_id: homeownerId,
+      insurance_contact_id: insurerId,
+    })
+    .select()
+    .single();
+  if (jobErr || !job) {
+    throw new Error(`[integration] job fixture insert failed: ${jobErr?.message ?? "no row"}`);
+  }
+  jobId = job.id;
+
+  // ── Adjuster link: surface 6 (Jarvis) reads job_adjusters with an
+  //    embed back to contacts; both arms of the embed disambiguate.
+  const { error: adjErr } = await supabase
+    .from("job_adjusters")
+    .insert({ job_id: jobId, contact_id: adjusterId });
+  if (adjErr) {
+    throw new Error(`[integration] job_adjuster fixture insert failed: ${adjErr.message}`);
+  }
+
+  // ── Estimate + invoice rows, both soft-deleted so the trash listings
+  //    pick them up.
+  const trashedAt = new Date().toISOString();
+  const { data: est, error: estErr } = await supabase
+    .from("estimates")
+    .insert({
+      job_id: jobId,
+      estimate_number: "EST-TEST-001",
+      deleted_at: trashedAt,
+    })
+    .select()
+    .single();
+  if (estErr || !est) {
+    throw new Error(`[integration] estimate fixture insert failed: ${estErr?.message ?? "no row"}`);
+  }
+  estimateId = est.id;
+
+  const { data: inv, error: invErr } = await supabase
+    .from("invoices")
+    .insert({
+      job_id: jobId,
+      invoice_number: "INV-TEST-001",
+      deleted_at: trashedAt,
+    })
+    .select()
+    .single();
+  if (invErr || !inv) {
+    throw new Error(`[integration] invoice fixture insert failed: ${invErr?.message ?? "no row"}`);
+  }
+  invoiceId = inv.id;
+});
+
+afterAll(async () => {
+  // Best-effort cleanup so a re-used local stack doesn't accumulate
+  // fixtures. globalSetup wipes-and-recreates anyway, so failures are fine.
+  if (!supabase) return;
+  await supabase.from("job_adjusters").delete().eq("job_id", jobId);
+  await supabase.from("estimates").delete().eq("id", estimateId);
+  await supabase.from("invoices").delete().eq("id", invoiceId);
+  await supabase.from("jobs").delete().eq("id", jobId);
+  await supabase.from("contacts").delete().in("id", [homeownerId, insurerId, adjusterId]);
+});
+
+describe("jobs→contacts embed disambiguation", () => {
+  // ── Surface 1: src/app/estimates/[id]/edit/page.tsx ────────────────────
+  it("estimate-edit page: jobs→contact picks the homeowner", async () => {
+    const { data, error } = await supabase
+      .from("jobs")
+      .select(JOB_WITH_HOMEOWNER_EMBED)
+      .eq("id", jobId)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    // The load-bearing assertion: the embed picked the homeowner FK,
+    // not the insurance one.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((data as any).contact.id).toBe(homeownerId);
+  });
+
+  // ── Surface 2: src/app/estimates/[id]/page.tsx ─────────────────────────
+  it("estimate read-only view: jobs→contact picks the homeowner", async () => {
+    const { data, error } = await supabase
+      .from("jobs")
+      .select(JOB_WITH_HOMEOWNER_EMBED)
+      .eq("id", jobId)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((data as any).contact.id).toBe(homeownerId);
+  });
+
+  // ── Surface 3: src/app/invoices/[id]/edit/page.tsx ─────────────────────
+  it("invoice-edit page: jobs→contact picks the homeowner", async () => {
+    const { data, error } = await supabase
+      .from("jobs")
+      .select(JOB_WITH_HOMEOWNER_EMBED)
+      .eq("id", jobId)
+      .maybeSingle();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((data as any).contact.id).toBe(homeownerId);
+  });
+
+  // ── Surface 4: src/app/api/estimates/trash/route.ts ────────────────────
+  it("estimates trash: nested job→contact picks the homeowner", async () => {
+    const { data, error } = await supabase
+      .from("estimates")
+      .select(ESTIMATE_TRASH_WITH_JOB_HOMEOWNER_EMBED)
+      .not("deleted_at", "is", null)
+      .order("deleted_at", { ascending: false });
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    expect(data!.length).toBeGreaterThan(0);
+    const row = data!.find((r) => (r as { id: string }).id === estimateId)!;
+    expect(row).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((row as any).job.contact.id).toBe(homeownerId);
+  });
+
+  // ── Surface 5: src/app/api/invoices/trash/route.ts ─────────────────────
+  it("invoices trash: nested job→contact picks the homeowner", async () => {
+    const { data, error } = await supabase
+      .from("invoices")
+      .select(INVOICE_TRASH_WITH_JOB_HOMEOWNER_EMBED)
+      .not("deleted_at", "is", null)
+      .order("deleted_at", { ascending: false });
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    expect(data!.length).toBeGreaterThan(0);
+    const row = data!.find((r) => (r as { id: string }).id === invoiceId)!;
+    expect(row).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((row as any).job.contact.id).toBe(homeownerId);
+  });
+
+  // ── Surface 6: src/app/api/jarvis/field-ops/route.ts (get_job_context) ─
+  it("Jarvis get_job_context: jobs→contact + job_adjusters→adjuster both resolve", async () => {
+    const { data, error } = await supabase
+      .from("jobs")
+      .select(JARVIS_JOB_CONTEXT_EMBED)
+      .eq("id", jobId)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const job = data as any;
+    expect(job.contact.id).toBe(homeownerId);
+    // job_adjusters comes back as an array; the embedded `adjuster` row
+    // must resolve to the adjuster contact we seeded above.
+    expect(Array.isArray(job.job_adjusters)).toBe(true);
+    expect(job.job_adjusters.length).toBe(1);
+    expect(job.job_adjusters[0].adjuster.id).toBe(adjusterId);
+  });
+});

--- a/tests/integration/schema.sql
+++ b/tests/integration/schema.sql
@@ -1,0 +1,87 @@
+-- Minimal schema for the jobs→contacts embed integration tests (#283).
+--
+-- This is NOT a clone of production. It is the smallest schema that
+-- reproduces the PostgREST `PGRST201` ambiguity that #282 fixed: two
+-- foreign keys from `jobs` to `contacts` (`contact_id`, `insurance_contact_id`).
+-- The six surface queries from #282 read against this skeleton.
+--
+-- Why not the prod schema dump? `supabase/schema.sql` is historical and
+-- pre-dates most of the columns/RLS the prod stack carries, and the flat
+-- `supabase/migration-*.sql` files don't sort into a clean replay order.
+-- Reproducing prod faithfully would mean rebuilding the migration history
+-- — a project larger than this slice. The ambiguity itself doesn't depend
+-- on any of that; it depends only on the FK shape, which is what we set up
+-- here.
+--
+-- RLS is intentionally NOT enabled: PostgREST embed disambiguation runs
+-- before policy evaluation, so RLS-off makes the test surface smaller
+-- without changing what's under test. Fixture inserts use the service-role
+-- key per the issue.
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Wipe-and-recreate so re-runs against the same stack are idempotent.
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+GRANT USAGE ON SCHEMA public TO postgres, anon, authenticated, service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO postgres, anon, authenticated, service_role;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO postgres, anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON TABLES TO postgres, anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO postgres, anon, authenticated, service_role;
+
+-- Contacts: homeowner + insurance + adjuster rows live here.
+CREATE TABLE public.contacts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  full_name text NOT NULL,
+  role text NOT NULL DEFAULT 'homeowner'
+    CHECK (role IN ('homeowner', 'tenant', 'property_manager', 'adjuster', 'insurance')),
+  email text,
+  phone text,
+  company text,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Jobs: TWO FKs to contacts is the whole point of the harness.
+--   contact_id           — homeowner link (the one #282 pinned in every embed)
+--   insurance_contact_id — added by migration 193; created the ambiguity
+CREATE TABLE public.jobs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_number text NOT NULL,
+  contact_id uuid NOT NULL REFERENCES public.contacts(id),
+  insurance_contact_id uuid REFERENCES public.contacts(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Estimates: needs job_id + deleted_at to satisfy the trash listing query.
+CREATE TABLE public.estimates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  estimate_number text,
+  deleted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Invoices: same shape requirement as estimates.
+CREATE TABLE public.invoices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  invoice_number text,
+  deleted_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Job adjusters: needed by the Jarvis `get_job_context` embed, which pulls
+-- `job_adjusters(*, adjuster:contacts!contact_id(*))`.
+CREATE TABLE public.job_adjusters (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL REFERENCES public.jobs(id) ON DELETE CASCADE,
+  contact_id uuid NOT NULL REFERENCES public.contacts(id),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- PostgREST listens to NOTIFY pgrst on a schema-cache reload. Force one
+-- here so the just-created tables and FKs are visible to embed parsing
+-- on the very first request from the test process.
+NOTIFY pgrst, 'reload schema';

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,33 @@
+// Vitest config for the integration harness (#283). Separate from the
+// default `vitest.config.ts` because:
+//   - We boot a real Supabase stack in globalSetup (node env, longer
+//     timeouts).
+//   - We want `test:integration` opt-in, not coupled to `npm test`'s
+//     fast mocked suite.
+//
+// The default suite remains the source of truth for fast feedback;
+// this config exists so the integration runs only when explicitly
+// invoked via `npm run test:integration`.
+
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["tests/integration/**/*.test.ts"],
+    exclude: ["node_modules", ".next", "out", "ios"],
+    globalSetup: ["tests/integration/global-setup.ts"],
+    // Booting supabase + applying schema + seeding fixture can run long
+    // on a cold Docker boot; give the suite room without holding the
+    // unit tests hostage.
+    testTimeout: 30_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary

- Stands up `npm run test:integration` against a local Supabase stack — boots via `supabase start`, applies a minimal FK-ambiguity schema, seeds the standard fixture (org-less for now: one homeowner + one insurer + one job linked to both), and runs six regression tests — one per surface from #282.
- Extracts each surface's embed string into `src/lib/embeds/jobs-contacts.ts` so routes and tests reference the same constant. Reverting any constant to the bare `contact:contacts(*)` form fails the corresponding test with PGRST201 — the harness smoke check.
- Keeps the existing mocked `npm test` suite untouched / fast: integration is gated behind a separate `vitest.integration.config.ts`.

Closes #283.

## Notes / scope calls

- **Schema strategy.** `tests/integration/schema.sql` is a minimal skeleton that reproduces the FK ambiguity (two FKs from `jobs` to `contacts`), not a prod clone. The bug class lives entirely in PostgREST's embed parsing against the FK shape, so reproducing prod faithfully would be churn — `supabase/schema.sql` is historical and pre-dates most of the columns prod carries, and the flat `supabase/migration-*.sql` files don't sort into a clean replay order. Rationale documented inline in `tests/integration/schema.sql`.
- **Single-fixture interpretation.** The issue called for a single shared fixture across the six tests; the suite seeds one in `beforeAll` and reads it from all six. Trash listings get pre-trashed estimate/invoice rows.
- **End-to-end run wasn't validated on this machine** — the dev box has neither the `supabase` CLI nor Docker installed. Each test is structurally identical (same fixture, same embed-constant-from-the-prod-module shape), and TypeScript + the existing mocked suite are green, but a clean-checkout `npm run test:integration` on a machine with the CLI + Docker is the next confidence step. Calling this out so reviewers know to verify before merging.

## Follow-ups (not blocking this slice)

- **CI wiring.** This repo currently has no `.github/workflows/` — the integration suite needs to be added once CI exists. The issue's acceptance criterion explicitly allowed deferring this: "If a CI setup change is non-trivial, file a follow-up and call it out in the PR — do not block this slice on CI plumbing." Filing as a follow-up.

## Test plan

- [ ] `npm test` — existing mocked suite stays green (one pre-existing email-accounts failure on \`main\` is unchanged by this PR).
- [ ] `npm run test:integration` from a clean checkout with \`supabase\` CLI + Docker — all six tests pass.
- [ ] Smoke check: revert \`JOB_WITH_HOMEOWNER_EMBED\` in \`src/lib/embeds/jobs-contacts.ts\` to \`"*, contact:contacts(*)"\`, re-run \`test:integration\`, observe failures on surfaces 1/2/3 with \`PGRST201\`. Restore the constant after verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)