### PR TITLE
feat(templates): inline Active checkbox replaces Deactivate/Reactivate (#285)

### DIFF
--- a/src/components/templates/template-list-client.test.tsx
+++ b/src/components/templates/template-list-client.test.tsx
@@ -102,8 +102,6 @@ function calledWith(
 beforeEach(() => {
   vi.clearAllMocks();
   navState.pushCalls = [];
-  // Disable confirm() so handleDeactivate runs through.
-  vi.stubGlobal("confirm", () => true);
 });
 
 describe("TemplateListClient — styling fix (#284)", () => {
@@ -136,9 +134,6 @@ describe("TemplateListClient — styling fix (#284)", () => {
 
     const duplicate = screen.getByRole("button", { name: /duplicate/i });
     expect(duplicate.getAttribute("data-slot")).toBe("button");
-
-    const deactivate = screen.getByRole("button", { name: /deactivate/i });
-    expect(deactivate.getAttribute("data-slot")).toBe("button");
   });
 
   it("renders \"+ New Template\" as the default solid <Button> (primary)", async () => {
@@ -192,27 +187,81 @@ describe("TemplateListClient — styling fix (#284)", () => {
   });
 });
 
-describe("TemplateListClient — behavior unchanged (#284 regression guards)", () => {
-  it("Deactivate fires DELETE /api/estimate-templates/:id on an active template", async () => {
-    const fetchSpy = stubFetch([makeTemplate({ id: "tmpl-1" })]);
+describe("TemplateListClient — inline Active checkbox (#285)", () => {
+  it("renders an inline 'Active' checkbox per card, checked when is_active", async () => {
+    stubFetch([makeTemplate({ id: "tmpl-1", name: "Roof Replacement", is_active: true })]);
 
     render(<TemplateListClient />);
 
-    fireEvent.click(await screen.findByRole("button", { name: /deactivate/i }));
+    const checkbox = (await screen.findByRole("checkbox", {
+      name: /active/i,
+    })) as HTMLInputElement;
+    expect(checkbox.type).toBe("checkbox");
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("renders the checkbox unchecked when is_active is false", async () => {
+    stubFetch([makeTemplate({ id: "tmpl-2", name: "Hail", is_active: false })]);
+
+    render(<TemplateListClient />);
+
+    const checkbox = (await screen.findByRole("checkbox", {
+      name: /active/i,
+    })) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+  });
+
+  it("no longer renders Deactivate or Reactivate buttons", async () => {
+    stubFetch([
+      makeTemplate({ id: "tmpl-1" }),
+      makeTemplate({ id: "tmpl-2", name: "Hail", is_active: false }),
+    ]);
+
+    render(<TemplateListClient />);
+
+    await screen.findByText("Roof Replacement");
+
+    expect(screen.queryByRole("button", { name: /deactivate/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /reactivate/i })).toBeNull();
+  });
+
+  it("toggling an active card's checkbox PUTs { is_active: false }", async () => {
+    const fetchSpy = stubFetch([makeTemplate({ id: "tmpl-1", is_active: true })]);
+
+    render(<TemplateListClient />);
+
+    const checkbox = (await screen.findByRole("checkbox", {
+      name: /active/i,
+    })) as HTMLInputElement;
+
+    fireEvent.click(checkbox);
 
     await waitFor(() => {
-      expect(calledWith(fetchSpy, "/api/estimate-templates/tmpl-1", "DELETE")).toBe(true);
+      const putCall = fetchSpy.mock.calls.find(
+        (c) =>
+          c[0] === "/api/estimate-templates/tmpl-1" &&
+          (c[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(putCall).toBeDefined();
+      const body = JSON.parse(
+        (putCall![1] as RequestInit).body as string,
+      ) as { is_active: boolean };
+      expect(body.is_active).toBe(false);
     });
   });
 
-  it("Reactivate fires PUT /api/estimate-templates/:id with { is_active: true }", async () => {
+  it("toggling an inactive card's checkbox PUTs { is_active: true }", async () => {
     const fetchSpy = stubFetch([
       makeTemplate({ id: "tmpl-2", name: "Hail", is_active: false }),
     ]);
 
     render(<TemplateListClient />);
 
-    fireEvent.click(await screen.findByRole("button", { name: /reactivate/i }));
+    const checkbox = (await screen.findByRole("checkbox", {
+      name: /active/i,
+    })) as HTMLInputElement;
+
+    fireEvent.click(checkbox);
 
     await waitFor(() => {
       const putCall = fetchSpy.mock.calls.find(
@@ -228,6 +277,26 @@ describe("TemplateListClient — behavior unchanged (#284 regression guards)", (
     });
   });
 
+  it("after toggling an active card off, the card gains the opacity-60 fade without a reload", async () => {
+    stubFetch([makeTemplate({ id: "tmpl-1", is_active: true })]);
+
+    const { container } = render(<TemplateListClient />);
+
+    const checkbox = (await screen.findByRole("checkbox", {
+      name: /active/i,
+    })) as HTMLInputElement;
+
+    expect(container.querySelector(".opacity-60")).toBeNull();
+
+    fireEvent.click(checkbox);
+
+    await waitFor(() => {
+      expect(container.querySelector(".opacity-60")).not.toBeNull();
+    });
+  });
+});
+
+describe("TemplateListClient — behavior unchanged (regression guards)", () => {
   it("+ New Template POSTs and pushes the edit route for the new template", async () => {
     const fetchSpy = stubFetch([]);
 

--- a/src/components/templates/template-list-client.tsx
+++ b/src/components/templates/template-list-client.tsx
@@ -36,11 +36,19 @@ export default function TemplateListClient() {
     router.push(`/settings/estimate-templates/${tmpl.id}/edit`);
   }
 
-  async function handleDeactivate(id: string) {
-    if (!confirm("Deactivate this template?")) return;
-    const res = await fetch(`/api/estimate-templates/${id}`, { method: "DELETE" });
-    if (res.ok) { toast.success("Deactivated"); void load(); }
-    else toast.error("Failed");
+  async function handleToggleActive(t: EstimateTemplate, next: boolean) {
+    setRows((prev) =>
+      prev.map((row) => (row.id === t.id ? { ...row, is_active: next } : row)),
+    );
+    const res = await fetch(`/api/estimate-templates/${t.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ is_active: next }),
+    });
+    if (!res.ok) {
+      toast.error("Failed to update");
+      void load();
+    }
   }
 
   return (
@@ -52,6 +60,15 @@ export default function TemplateListClient() {
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
         {rows.map((t) => (
           <div key={t.id} className={`rounded-lg border border-border p-4 ${t.is_active ? "" : "opacity-60"}`}>
+            <label className="inline-flex items-center gap-2 cursor-pointer mb-2">
+              <input
+                type="checkbox"
+                checked={t.is_active}
+                onChange={(e) => handleToggleActive(t, e.target.checked)}
+                className="h-4 w-4 rounded border-border accent-[var(--brand-primary)]"
+              />
+              <span className="text-xs text-muted-foreground">Active</span>
+            </label>
             <h3 className="font-semibold">{t.name}</h3>
             <div className="text-xs text-muted-foreground mt-1">
               {t.damage_type_tags.map((dt) => <span key={dt} className="mr-1 inline-block px-2 py-0.5 rounded bg-blue-100">{dt}</span>)}
@@ -71,13 +88,6 @@ export default function TemplateListClient() {
                 Edit
               </Link>
               <Button variant="ghost" size="sm" disabled title="Coming soon">Duplicate</Button>
-              {t.is_active
-                ? <Button variant="ghost" size="sm" onClick={() => handleDeactivate(t.id)}>Deactivate</Button>
-                : <Button variant="ghost" size="sm" onClick={async () => {
-                    await fetch(`/api/estimate-templates/${t.id}`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ is_active: true }) });
-                    void load();
-                  }}>Reactivate</Button>
-              }
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary

- Replaces the Deactivate/Reactivate buttons on each Estimate Templates card with an inline "Active" checkbox in the top-left, matching the pattern the sibling Contract Templates tab uses.
- Toggling the checkbox `PUT`s `/api/estimate-templates/[id]` with `{ is_active: <new value> }` (no backend changes — route already accepts this body).
- Card state updates optimistically; `opacity-60` fade on inactive cards still tracks the toggle.

Backend cleanup (hard-delete + removing `deactivateTemplate` / `reactivateTemplate` helpers) intentionally stays with the trash-icon slice (#286).

## Test plan

- [x] `npx vitest run src/components/templates/template-list-client.test.tsx` — 14/14 green
- [x] New `#285` describe pins: checkbox renders, checked-when-active, no Deactivate/Reactivate buttons, toggle-off PUTs `{is_active: false}`, toggle-on PUTs `{is_active: true}`, card fade reflects new state without reload
- [ ] Manual: dev server, toggle a template active/inactive, verify the row fades/un-fades and no full reload occurs

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)