### PR TITLE
feat(templates): trash icon hard-deletes a template (#286)

### DIFF
--- a/src/app/api/estimate-templates/[id]/route.ts
+++ b/src/app/api/estimate-templates/[id]/route.ts
@@ -4,7 +4,7 @@ import { apiDbError } from "@/lib/api-errors";
 import {
   getTemplateWithContents,
   updateTemplate,
-  deactivateTemplate,
+  hardDeleteTemplate,
   serializeStructureFromBuilder,
 } from "@/lib/estimate-templates";
 import type { TemplateStructure, TemplateWithContents } from "@/lib/types";
@@ -78,7 +78,7 @@ export const DELETE = withRequestContext(
   async (_request, ctx, context: { params: Promise<{ id: string }> }) => {
     const { id } = await context.params;
     try {
-      await deactivateTemplate(ctx.supabase, id);
+      await hardDeleteTemplate(ctx.supabase, id);
       return NextResponse.json({ ok: true });
     } catch (e: unknown) {
       return apiDbError(e instanceof Error ? e.message : String(e), "DELETE /api/estimate-templates/[id]");

--- a/src/components/templates/delete-template-confirm-dialog.test.tsx
+++ b/src/components/templates/delete-template-confirm-dialog.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// #286 — DeleteTemplateConfirmDialog is the hard-delete confirm prompt that
+// the Estimate Templates list opens when the user clicks the trash icon on
+// a template card. Patterned on TrashConfirmDialog but simpler: no reason
+// input, no 30-day soft-trash language, no document-kind switch.
+
+import { DeleteTemplateConfirmDialog } from "./delete-template-confirm-dialog";
+
+describe("DeleteTemplateConfirmDialog", () => {
+  it("renders the template name inside the dialog", async () => {
+    render(
+      <DeleteTemplateConfirmDialog
+        open
+        onOpenChange={() => {}}
+        templateName="Roof Replacement"
+        onConfirm={async () => {}}
+        isDeleting={false}
+      />,
+    );
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toMatch(/Roof Replacement/);
+  });
+
+  it("cancel button calls onOpenChange(false) and not onConfirm", async () => {
+    const onOpenChange = vi.fn();
+    const onConfirm = vi.fn(async () => {});
+
+    render(
+      <DeleteTemplateConfirmDialog
+        open
+        onOpenChange={onOpenChange}
+        templateName="Roof Replacement"
+        onConfirm={onConfirm}
+        isDeleting={false}
+      />,
+    );
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("delete button calls onConfirm", async () => {
+    const onConfirm = vi.fn(async () => {});
+
+    render(
+      <DeleteTemplateConfirmDialog
+        open
+        onOpenChange={() => {}}
+        templateName="Roof Replacement"
+        onConfirm={onConfirm}
+        isDeleting={false}
+      />,
+    );
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("delete button is the destructive variant", async () => {
+    render(
+      <DeleteTemplateConfirmDialog
+        open
+        onOpenChange={() => {}}
+        templateName="Roof Replacement"
+        onConfirm={async () => {}}
+        isDeleting={false}
+      />,
+    );
+
+    await screen.findByRole("dialog");
+    const del = screen.getByRole("button", { name: /^delete$/i });
+    // bg-destructive is the Tailwind hook the destructive Button variant uses.
+    expect(del.className).toMatch(/bg-destructive/);
+  });
+
+  it("disables both buttons while isDeleting is true", async () => {
+    render(
+      <DeleteTemplateConfirmDialog
+        open
+        onOpenChange={() => {}}
+        templateName="Roof Replacement"
+        onConfirm={async () => {}}
+        isDeleting
+      />,
+    );
+
+    await screen.findByRole("dialog");
+    expect(
+      (screen.getByRole("button", { name: /cancel/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    // While deleting, label flips to "Deleting…"; assert by data-slot to find it.
+    const slotButtons = screen.getAllByRole("button");
+    const destructive = slotButtons.find((b) =>
+      b.className.includes("bg-destructive"),
+    );
+    expect(destructive).toBeDefined();
+    expect((destructive as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/src/components/templates/delete-template-confirm-dialog.tsx
+++ b/src/components/templates/delete-template-confirm-dialog.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+
+interface DeleteTemplateConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  templateName: string;
+  onConfirm: () => Promise<void>;
+  isDeleting: boolean;
+}
+
+export function DeleteTemplateConfirmDialog({
+  open,
+  onOpenChange,
+  templateName,
+  onConfirm,
+  isDeleting,
+}: DeleteTemplateConfirmDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={isDeleting ? undefined : onOpenChange}>
+      <DialogContent showCloseButton={!isDeleting}>
+        <DialogHeader>
+          <DialogTitle>Delete template &ldquo;{templateName}&rdquo;?</DialogTitle>
+          <DialogDescription>
+            This permanently deletes the template. Estimates already created
+            from it are unaffected.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => void onConfirm()}
+            disabled={isDeleting}
+          >
+            {isDeleting ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/templates/template-list-client.test.tsx
+++ b/src/components/templates/template-list-client.test.tsx
@@ -296,6 +296,85 @@ describe("TemplateListClient — inline Active checkbox (#285)", () => {
   });
 });
 
+describe("TemplateListClient — trash icon hard-delete (#286)", () => {
+  it("renders a trash icon button per card with destructive hover styling", async () => {
+    stubFetch([
+      makeTemplate({ id: "tmpl-1", name: "Roof Replacement" }),
+      makeTemplate({ id: "tmpl-2", name: "Hail" }),
+    ]);
+
+    render(<TemplateListClient />);
+
+    const trashButtons = await screen.findAllByRole("button", {
+      name: /delete template/i,
+    });
+    expect(trashButtons).toHaveLength(2);
+    for (const btn of trashButtons) {
+      expect(btn.className).toMatch(/hover:text-destructive/);
+    }
+  });
+
+  it("clicking the trash icon opens a confirm dialog displaying the template name", async () => {
+    stubFetch([makeTemplate({ id: "tmpl-1", name: "Roof Replacement" })]);
+
+    render(<TemplateListClient />);
+
+    const trash = await screen.findByRole("button", { name: /delete template/i });
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    fireEvent.click(trash);
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog.textContent).toMatch(/Roof Replacement/);
+  });
+
+  it("cancelling the dialog closes it without firing any request", async () => {
+    const fetchSpy = stubFetch([makeTemplate({ id: "tmpl-1", name: "Roof Replacement" })]);
+
+    render(<TemplateListClient />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /delete template/i }));
+    await screen.findByRole("dialog");
+
+    const callCountBefore = fetchSpy.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    // No new fetch calls fired between opening the dialog and cancelling.
+    expect(fetchSpy.mock.calls.length).toBe(callCountBefore);
+  });
+
+  it("confirming fires DELETE /api/estimate-templates/<id> and removes the row", async () => {
+    const fetchSpy = stubFetch([
+      makeTemplate({ id: "tmpl-1", name: "Roof Replacement" }),
+      makeTemplate({ id: "tmpl-2", name: "Hail" }),
+    ]);
+
+    render(<TemplateListClient />);
+
+    const trashButtons = await screen.findAllByRole("button", {
+      name: /delete template/i,
+    });
+    fireEvent.click(trashButtons[0]);
+
+    await screen.findByRole("dialog");
+    fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(
+        calledWith(fetchSpy, "/api/estimate-templates/tmpl-1", "DELETE"),
+      ).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Roof Replacement")).toBeNull();
+    });
+    expect(screen.getByText("Hail")).toBeDefined();
+  });
+});
+
 describe("TemplateListClient — behavior unchanged (regression guards)", () => {
   it("+ New Template POSTs and pushes the edit route for the new template", async () => {
     const fetchSpy = stubFetch([]);

--- a/src/components/templates/template-list-client.tsx
+++ b/src/components/templates/template-list-client.tsx
@@ -4,12 +4,16 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
 import { Button, buttonVariants } from "@/components/ui/button";
+import { DeleteTemplateConfirmDialog } from "./delete-template-confirm-dialog";
 import type { EstimateTemplate } from "@/lib/types";
 
 export default function TemplateListClient() {
   const router = useRouter();
   const [rows, setRows] = useState<EstimateTemplate[]>([]);
+  const [deleteTarget, setDeleteTarget] = useState<EstimateTemplate | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   async function load() {
     const res = await fetch(`/api/estimate-templates?_`);
@@ -51,6 +55,25 @@ export default function TemplateListClient() {
     }
   }
 
+  async function handleConfirmDelete() {
+    if (!deleteTarget) return;
+    const id = deleteTarget.id;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/estimate-templates/${id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        toast.error("Failed to delete template");
+        return;
+      }
+      setRows((prev) => prev.filter((row) => row.id !== id));
+      setDeleteTarget(null);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
   return (
     <div className="p-6 max-w-6xl mx-auto">
       <div className="flex items-center justify-between mb-4">
@@ -79,15 +102,27 @@ export default function TemplateListClient() {
             <div className="text-xs text-muted-foreground mt-1">
               Edited {new Date(t.updated_at).toLocaleDateString()}
             </div>
-            <div className="mt-3 flex gap-2 text-sm">
-              <Link
-                href={`/settings/estimate-templates/${t.id}/edit`}
-                data-slot="button"
-                className={buttonVariants({ variant: "ghost", size: "sm" })}
+            <div className="mt-3 flex items-center justify-between text-sm">
+              <div className="flex gap-2">
+                <Link
+                  href={`/settings/estimate-templates/${t.id}/edit`}
+                  data-slot="button"
+                  className={buttonVariants({ variant: "ghost", size: "sm" })}
+                >
+                  Edit
+                </Link>
+                <Button variant="ghost" size="sm" disabled title="Coming soon">Duplicate</Button>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Delete template"
+                title="Delete template"
+                className="hover:text-destructive"
+                onClick={() => setDeleteTarget(t)}
               >
-                Edit
-              </Link>
-              <Button variant="ghost" size="sm" disabled title="Coming soon">Duplicate</Button>
+                <Trash2 />
+              </Button>
             </div>
           </div>
         ))}
@@ -97,6 +132,13 @@ export default function TemplateListClient() {
           No templates yet. Click &quot;+ New Template&quot; to create one.
         </div>
       )}
+      <DeleteTemplateConfirmDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}
+        templateName={deleteTarget?.name ?? ""}
+        onConfirm={handleConfirmDelete}
+        isDeleting={isDeleting}
+      />
     </div>
   );
 }

--- a/src/lib/estimate-templates.ts
+++ b/src/lib/estimate-templates.ts
@@ -188,18 +188,10 @@ export async function updateTemplate(
   return data;
 }
 
-export async function deactivateTemplate(supabase: SupabaseClient, id: string): Promise<void> {
+export async function hardDeleteTemplate(supabase: SupabaseClient, id: string): Promise<void> {
   const { error } = await supabase
     .from("estimate_templates")
-    .update({ is_active: false, updated_at: new Date().toISOString() })
-    .eq("id", id);
-  if (error) throw error;
-}
-
-export async function reactivateTemplate(supabase: SupabaseClient, id: string): Promise<void> {
-  const { error } = await supabase
-    .from("estimate_templates")
-    .update({ is_active: true, updated_at: new Date().toISOString() })
+    .delete()
     .eq("id", id);
   if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- Adds `Trash2` icon button at the bottom-right of each Estimate Templates card.
- Clicking it opens a new `DeleteTemplateConfirmDialog` (patterned on `TrashConfirmDialog`, simpler — no reason input, no 30-day soft-trash language). Confirm fires `DELETE /api/estimate-templates/[id]`; the row is removed from the list on success.
- The `DELETE` route now calls a new `hardDeleteTemplate` helper that issues `DELETE FROM estimate_templates WHERE id = ?` instead of `is_active = false`. Permission gate (`manage_templates`) unchanged.
- Removes `deactivateTemplate` and `reactivateTemplate` (no callers after #285).

Safe because `apply_template_to_estimate` copies template contents into `estimate_sections` at apply time — estimates carry no FK back to templates. Deleting a template cannot orphan an estimate.

Closes #286. Builds on #285 (the prerequisite active-checkbox slice — already merged in `fd3dc9e`).

## Test plan
- [x] Failing tests written first (RED): 4 new in `template-list-client.test.tsx` for the trash flow + 5 new in `delete-template-confirm-dialog.test.tsx` for the dialog.
- [x] Implementation lands tests green (GREEN): 23/23 in the two touched test files.
- [x] Full vitest suite: 1198/1200 passing — the 2 failing tests in `src/app/api/email/accounts/route.test.ts` are pre-existing on `main` (`fd3dc9e`) and unrelated to this slice.
- [x] Lint clean on all touched files.
- [x] Typecheck: pre-existing errors in `template-drag-end.test.tsx` and `sync-folder-incremental.test.ts` reproduce on `main`; no new errors introduced.
- [ ] Manual dev-server smoke-test deferred — change is visually identical to the established Trash icon + dialog pattern used elsewhere (e.g. invoices list), and unit + integration tests cover render / open / close / delete / row removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)