### PR TITLE
chore: Active job glossary + /to-prd parent label

### DIFF
--- a/.claude/skills/to-prd/SKILL.md
+++ b/.claude/skills/to-prd/SKILL.md
@@ -17,7 +17,9 @@ A deep module (as opposed to a shallow module) is one which encapsulates a lot o
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply two labels:
+   - `parent` — marks the issue as a PRD that may be decomposed into slice issues (via `/to-issues`). This distinguishes parent PRDs from the slices that descend from them.
+   - `ready-for-agent` — standard triage signal; no additional triage needed.
 
 <prd-template>
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,13 @@ of thing. The settings UI groups these together because they share a shape
 being sent.
 _Avoid_: send config, mail rule, payment email / invoice email / contract email (use "Outgoing email for X")
 
+**Active job**:
+A job that is still alive — its status is neither `completed` nor `cancelled`,
+and it has not been trashed (`deleted_at IS NULL`). A cancelled job is dead,
+not active. The dashboard's "Jobs to advance" and "People to respond to"
+sections both filter to Active jobs only.
+_Avoid_: open job, current job, running job, in-progress job (that one is a specific status, not the whole alive set)
+
 ## Relationships
 
 - A **User** belongs to one or more **Organizations**; each membership carries a role.
@@ -82,3 +89,4 @@ _Avoid_: send config, mail rule, payment email / invoice email / contract email 
 ## Flagged ambiguities
 
 - "auth gate" was used for four near-identical route helpers (`requirePermission`, `requireAdmin`, `requireViewAccounting`, and an inline `requireLogExpenses`) — resolved: these collapse into the one **Request Context** wrapper.
+- "active" was being used for two unrelated concepts in `src/lib/accounting/margins.ts`: (a) a job with financial activity in a reporting period, and (b) a non-completed job (the user-facing filter pill on the Job Profitability page, which also folds cancelled jobs in with active ones). Neither matches the canonical **Active job** definition above. The dashboard rebuild adopts the canonical meaning; the accounting page is left as-is for now but is a cleanup candidate.


### PR DESCRIPTION
## Summary
- Adds canonical **Active job** entry to `CONTEXT.md` — resolves the "active" drift surfaced while grilling the #246 dashboard rebuild
- Flags `src/lib/accounting/margins.ts` overloaded "active" usage as a cleanup candidate (not in scope here)
- Updates `/to-prd` skill to apply both `parent` and `ready-for-agent` labels, so parent PRDs are distinguishable from slice issues produced by `/to-issues` (#246 backfilled with `parent` already)

## Test plan
- [ ] `CONTEXT.md` renders correctly on GitHub
- [ ] Future `/to-prd` invocations apply the `parent` label alongside `ready-for-agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)