### PR TITLE
chore: Referral Partner glossary terms + ADR 0002 (picker eligibility)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -73,6 +73,32 @@ not active. The dashboard's "Jobs to advance" and "People to respond to"
 sections both filter to Active jobs only.
 _Avoid_: open job, current job, running job, in-progress job (that one is a specific status, not the whole alive set)
 
+**Target**:
+A row on the Referral Partners call list whose Lifecycle status is still
+Uncontacted (grey) or In progress (yellow) — i.e. someone we want to call
+but who hasn't agreed to send us work yet. Same database row as a Referral
+Partner; the name shifts based on Lifecycle status. The "Add Target" button
+on the Referral Partners page creates one of these (always at status grey).
+_Avoid_: lead, prospect, cold contact
+
+**Referral Partner**:
+A row on the Referral Partners call list whose Lifecycle status is Active
+(green) — i.e. a company that has agreed to send us work, whether or not
+they have actually sent a job yet. Same database row as a Target; the name
+shifts the moment the row is flipped to Active. A row at Declined (red) is
+an ex-Partner; the page title "Referral Partners" is used loosely to cover
+all four statuses because the whole list is in service of producing
+Referral Partners.
+_Avoid_: referrer (in code — fine in UI copy), affiliate, source
+
+**Lifecycle status**:
+The four-state status that decides whether a row on the Referral Partners
+call list is a Target or a Referral Partner: Uncontacted (grey), In
+progress (yellow), Active (green), Declined (red). Every transition is a
+deliberate user click — no automated promotions. Active is the only
+status that makes the row a Referral Partner in the strict sense.
+_Avoid_: stage, pipeline status, partner status
+
 ## Relationships
 
 - A **User** belongs to one or more **Organizations**; each membership carries a role.
@@ -80,6 +106,8 @@ _Avoid_: open job, current job, running job, in-progress job (that one is a spec
 - A **Request Context** always carries a **User client**; it carries a **Service client** only when the route opts in.
 - An **Email account** belongs to one **Organization**; a **Personal email account** is additionally owned by one **User**, a **Shared email account** by none.
 - An **Outgoing email** belongs to one **Organization** and names exactly one **Email account** (the mailbox the document is sent from). There is one Outgoing email per document kind per Organization.
+- A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
+- A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 
 ## Example dialogue
 

--- a/docs/adr/0002-only-active-partners-attach-to-jobs.md
+++ b/docs/adr/0002-only-active-partners-attach-to-jobs.md
@@ -1,0 +1,51 @@
+# 0002 — Only Active Referral Partners can be attached to a Job
+
+**Status:** Accepted
+**Date:** 2026-05-26
+
+## Context
+
+Issue #296 adds a Job ↔ Referral Partner relationship so the team can
+track who sent us which project. Under the glossary's Model A, a single
+database row is called a **Target** while its Lifecycle status is
+Uncontacted (grey) or In progress (yellow), and becomes a **Referral
+Partner** the moment it flips to Active (green).
+
+When the user logs a job, the picker for "who referred this job" could
+plausibly:
+
+- (A) show every non-Declined row regardless of status,
+- (B) show only Active rows, or
+- (C) show every non-Declined row and auto-flip a chosen Target to
+  Active on attach.
+
+## Decision
+
+The Job referrer picker shows **only Lifecycle = Active rows**. To
+attach a yellow Target, the user must first flip the row to Active on
+the Referral Partner Worksheet. The picker may include a "+ Promote
+and attach" affordance for yellow rows so the explicit promotion is
+one click away, but the status change is still a deliberate user
+action.
+
+## Consequences
+
+- The wording on the picker ("Add Referral Partner") stays literally
+  accurate — only Referral Partners (Active rows) appear there.
+- The Referral Partner Worksheet's rule of *no automated Lifecycle
+  transitions* (PRD #249) is preserved. Every grey→yellow→green→red
+  flip remains a deliberate click.
+- A small ergonomics cost: logging a job from a brand-new lead is a
+  two-step flow (promote, then attach) rather than one.
+- The referral tracker count (item 4 of #296) only ever credits
+  Active rows, which matches the natural meaning of "how many jobs
+  has this Partner sent us."
+
+## Alternatives considered
+
+- **(A) Allow any non-Declined row.** Rejected: makes the word
+  "Referral Partner" on the picker mean "Target or Partner", which
+  fights the glossary.
+- **(C) Auto-promote yellow → green on attach.** Rejected: violates
+  the Worksheet's no-automated-transitions rule and hides a meaningful
+  business event behind a side effect.


### PR DESCRIPTION
## Summary

- Adds **Target**, **Referral Partner**, and **Lifecycle status** to `CONTEXT.md`, plus two relationship lines (call-list row ownership; Job → Referral Partner attribution).
- Adds `docs/adr/0002-only-active-partners-attach-to-jobs.md` recording the picker-eligibility rule (only Active partners are pickable for Jobs; yellow Targets get a one-click `+ Promote and attach` affordance).

Documentation only — no code changes. Grounded in the `/grill-with-docs` session for #296 and the parent PRD #297. Slice #298 (the implementation spine) relies on the rule recorded in ADR 0002, so landing the docs first keeps the glossary ahead of the code that references it.

## Test plan

- [ ] `CONTEXT.md` diff renders correctly on GitHub
- [ ] ADR file renders correctly on GitHub
- [ ] No code changes; CI should be clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)