### PR TITLE
feat(dashboard): per-user welcome greeting (#292)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,10 +6,15 @@ import { Briefcase, FileText, CalendarDays, Camera } from "lucide-react";
 import Link from "next/link";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
+import { useAuth } from "@/lib/auth-context";
+import { getFirstName } from "@/lib/first-name";
 
 export default function DashboardPage() {
+  const { profile } = useAuth();
   const [stats, setStats] = useState({ active: 0, pendingInvoice: 0, thisMonth: 0, reports: 0 });
   const [recentJobs, setRecentJobs] = useState<Job[]>([]);
+
+  const firstName = getFirstName(profile?.full_name);
 
   useEffect(() => {
     async function load() {
@@ -63,7 +68,7 @@ export default function DashboardPage() {
           <span className="gradient-text">Dashboard</span>
         </h1>
         <p className="text-muted-foreground mt-1">
-          Welcome back, Eric. Here&apos;s your overview.
+          {firstName ? `Welcome back, ${firstName}.` : "Welcome back."} Here&apos;s your overview.
         </p>
       </div>
 

--- a/src/lib/first-name.test.ts
+++ b/src/lib/first-name.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { getFirstName } from "./first-name";
+
+describe("getFirstName", () => {
+  it("returns the first segment of a two-token name", () => {
+    expect(getFirstName("Eric Daniels")).toBe("Eric");
+  });
+
+  it("returns only the first token for three-or-more-token names (known limitation)", () => {
+    expect(getFirstName("Ana Maria Garcia")).toBe("Ana");
+  });
+
+  it("returns a single-token name unchanged", () => {
+    expect(getFirstName("Eric")).toBe("Eric");
+  });
+
+  it("returns an empty string for an empty input", () => {
+    expect(getFirstName("")).toBe("");
+  });
+
+  it("returns an empty string for null", () => {
+    expect(getFirstName(null)).toBe("");
+  });
+
+  it("returns an empty string for undefined", () => {
+    expect(getFirstName(undefined)).toBe("");
+  });
+
+  it("trims surrounding whitespace before splitting", () => {
+    expect(getFirstName("  Eric  ")).toBe("Eric");
+  });
+});

--- a/src/lib/first-name.ts
+++ b/src/lib/first-name.ts
@@ -1,0 +1,12 @@
+/**
+ * Returns the first whitespace-delimited token of a full name. Used by the
+ * dashboard greeting; `'Ana Maria Garcia' → 'Ana'` is a known limitation
+ * (issue #292).
+ */
+export function getFirstName(fullName: string | null | undefined): string {
+  if (fullName == null) return "";
+  const trimmed = fullName.trim();
+  if (trimmed === "") return "";
+  const firstSpace = trimmed.indexOf(" ");
+  return firstSpace === -1 ? trimmed : trimmed.slice(0, firstSpace);
+}


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `Welcome back, Eric.` greeting on `/` with a per-user `Welcome back, <first name>.` derived from `profile.full_name`.
- Adds `src/lib/first-name.ts` — pure `getFirstName(string | null | undefined)` helper that trims and returns the first whitespace-delimited token.
- Falls back to `Welcome back.` (no trailing comma) when `profile.full_name` is null/empty/whitespace-only, so nobody sees `Welcome back, .` or `Welcome back, undefined.`.

Closes #292.

## Test plan
- [x] `getFirstName` unit tests: `'Eric Daniels' → 'Eric'`, `'Ana Maria Garcia' → 'Ana'` (pinned known limitation), `'Eric' → 'Eric'`, `'' → ''`, `null → ''`, `undefined → ''`, `'  Eric  ' → 'Eric'` — 7/7 green.
- [x] No grep hits for `Welcome back, Eric` remain in `src/`.
- [x] Stat cards + recent-jobs grid preserved verbatim (Slice 2 will replace them).
- [ ] Manual: sign in as a non-Eric user and confirm the dashboard shows their own first name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)