### PR TITLE
feat(dashboard): action-hub layout with New jobs queue (#293)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Mock the hook at the import boundary so the page test doesn't touch
+// Supabase. Per #293's plan, the hook owns the fetch + 30s polling.
+const useDashboardDataMock = vi.fn();
+vi.mock("@/lib/dashboard/use-dashboard-data", () => ({
+  useDashboardData: () => useDashboardDataMock(),
+}));
+
+// Stub auth context so the greeting comes from a fixed profile.
+const useAuthMock = vi.fn();
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+import DashboardPage from "./page";
+
+describe("DashboardPage — action hub", () => {
+  beforeEach(() => {
+    useDashboardDataMock.mockReset();
+    useAuthMock.mockReset();
+  });
+
+  it("renders the greeting derived from profile.full_name", () => {
+    useAuthMock.mockReturnValue({
+      profile: { full_name: "Eric Daniels" },
+    });
+    useDashboardDataMock.mockReturnValue({
+      newJobs: [],
+      newJobsCount: 0,
+      loading: false,
+      error: null,
+      canViewJobs: true,
+    });
+
+    render(<DashboardPage />);
+    expect(screen.getByText(/welcome back, eric\./i)).toBeTruthy();
+  });
+
+  it("renders the StatStrip ahead of the NewJobsSection in DOM order, with no legacy stat cards or Recent Jobs grid", () => {
+    useAuthMock.mockReturnValue({
+      profile: { full_name: "Eric Daniels" },
+    });
+    useDashboardDataMock.mockReturnValue({
+      newJobs: [],
+      newJobsCount: 2,
+      loading: false,
+      error: null,
+      canViewJobs: true,
+    });
+
+    const { container } = render(<DashboardPage />);
+
+    const stripEl = container.querySelector("[data-testid='stat-strip-new-jobs']");
+    const sectionCount = container.querySelector("[data-testid='new-jobs-count']");
+    expect(stripEl).not.toBeNull();
+    expect(sectionCount).not.toBeNull();
+
+    // Order: strip appears before the section.
+    const position = stripEl!.compareDocumentPosition(sectionCount!);
+    // Node.DOCUMENT_POSITION_FOLLOWING === 4
+    expect(position & 4).toBe(4);
+
+    // Legacy four stat cards are gone — none of their labels appear.
+    expect(screen.queryByText("Active Jobs")).toBeNull();
+    expect(screen.queryByText("Pending Invoice")).toBeNull();
+    expect(screen.queryByText("This Month")).toBeNull();
+    expect(screen.queryByText("Reports")).toBeNull();
+
+    // Legacy "Recent Jobs" grid is gone too.
+    expect(screen.queryByText(/recent jobs/i)).toBeNull();
+  });
+
+  it("hides the New jobs section AND its stat strip column when the viewer lacks view_jobs", () => {
+    useAuthMock.mockReturnValue({
+      profile: { full_name: "Crew Member" },
+    });
+    useDashboardDataMock.mockReturnValue({
+      newJobs: [],
+      newJobsCount: 0,
+      loading: false,
+      error: null,
+      canViewJobs: false,
+    });
+
+    render(<DashboardPage />);
+
+    // No section header, no count pill, no empty-state copy.
+    expect(screen.queryByText(/no new jobs/i)).toBeNull();
+    expect(screen.queryByText(/^new jobs$/i)).toBeNull();
+    expect(screen.queryByTestId("new-jobs-count")).toBeNull();
+    expect(screen.queryByTestId("stat-strip-new-jobs")).toBeNull();
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,162 +1,33 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabase";
-import { Briefcase, FileText, CalendarDays, Camera } from "lucide-react";
-import Link from "next/link";
-import { Job } from "@/lib/types";
-import JobCard from "@/components/job-card";
 import { useAuth } from "@/lib/auth-context";
+import { useDashboardData } from "@/lib/dashboard/use-dashboard-data";
 import { getFirstName } from "@/lib/first-name";
+import { StatStrip } from "@/components/dashboard/stat-strip";
+import { NewJobsSection } from "@/components/dashboard/new-jobs-section";
 
 export default function DashboardPage() {
   const { profile } = useAuth();
-  const [stats, setStats] = useState({ active: 0, pendingInvoice: 0, thisMonth: 0, reports: 0 });
-  const [recentJobs, setRecentJobs] = useState<Job[]>([]);
+  const { newJobs, newJobsCount, canViewJobs } = useDashboardData();
 
   const firstName = getFirstName(profile?.full_name);
 
-  useEffect(() => {
-    async function load() {
-      const supabase = createClient();
-
-      // Fetch all active jobs + report count for stats. Trashed jobs
-      // (deleted_at IS NOT NULL) are excluded from the dashboard.
-      const [{ data: allJobs }, { count: reportCount }] = await Promise.all([
-        supabase
-          .from("jobs")
-          .select("status, urgency, created_at")
-          .is("deleted_at", null),
-        supabase.from("photo_reports").select("*", { count: "exact", head: true }),
-      ]);
-
-      if (allJobs) {
-        const now = new Date();
-        const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-        setStats({
-          active: allJobs.filter(
-            (j) => j.status !== "completed" && j.status !== "cancelled"
-          ).length,
-          pendingInvoice: allJobs.filter(
-            (j) => j.status === "pending_invoice"
-          ).length,
-          thisMonth: allJobs.filter(
-            (j) => new Date(j.created_at) >= monthStart
-          ).length,
-          reports: reportCount ?? 0,
-        });
-      }
-
-      // Fetch 4 most recent active jobs (trashed jobs are hidden).
-      const { data: recent } = await supabase
-        .from("jobs")
-        .select("*, contact:contacts!contact_id(*)")
-        .is("deleted_at", null)
-        .order("created_at", { ascending: false })
-        .limit(4);
-
-      if (recent) setRecentJobs(recent as Job[]);
-    }
-    load();
-  }, []);
-
   return (
     <div className="max-w-6xl animate-fade-slide-up">
-      {/* Header */}
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold text-foreground">
           <span className="gradient-text">Dashboard</span>
         </h1>
         <p className="text-muted-foreground mt-1">
-          {firstName ? `Welcome back, ${firstName}.` : "Welcome back."} Here&apos;s your overview.
+          {firstName ? `Welcome back, ${firstName}.` : "Welcome back."}
         </p>
       </div>
 
-      {/* Stat cards — gradient hero style */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8">
-        <StatCard
-          label="Active Jobs"
-          value={stats.active}
-          icon={Briefcase}
-          gradient="gradient-primary"
-        />
-        <StatCard
-          label="Pending Invoice"
-          value={stats.pendingInvoice}
-          icon={FileText}
-          gradient="bg-gradient-to-br from-violet-500 to-purple-600"
-        />
-        <StatCard
-          label="This Month"
-          value={stats.thisMonth}
-          icon={CalendarDays}
-          gradient="gradient-secondary"
-        />
-        <StatCard
-          label="Reports"
-          value={stats.reports}
-          icon={Camera}
-          gradient="gradient-accent"
-        />
-      </div>
+      <StatStrip newJobsCount={newJobsCount} canViewJobs={canViewJobs} />
 
-      {/* Recent jobs */}
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-foreground">Recent Jobs</h2>
-        <Link
-          href="/jobs"
-          className="text-sm text-primary hover:underline font-medium"
-        >
-          View all
-        </Link>
-      </div>
-      {recentJobs.length === 0 ? (
-        <div className="text-center py-12 bg-card rounded-xl border border-border shadow-[var(--shadow-card)]">
-          <p className="text-muted-foreground">No jobs yet.</p>
-          <Link
-            href="/intake"
-            className="text-sm text-primary hover:underline font-medium mt-1 inline-block"
-          >
-            Create your first intake
-          </Link>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {recentJobs.map((job) => (
-            <JobCard key={job.id} job={job} />
-          ))}
-        </div>
+      {canViewJobs && (
+        <NewJobsSection jobs={newJobs} total={newJobsCount} />
       )}
-    </div>
-  );
-}
-
-function StatCard({
-  label,
-  value,
-  icon: Icon,
-  gradient,
-}: {
-  label: string;
-  value: number;
-  icon: React.ComponentType<{ size?: number; className?: string }>;
-  gradient: string;
-}) {
-  return (
-    <div
-      className={`rounded-xl p-5 text-white shadow-lg ${gradient}`}
-    >
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-xs font-medium text-white/70 uppercase tracking-wider">
-            {label}
-          </p>
-          <p className="text-3xl font-extrabold mt-1">{value}</p>
-        </div>
-        <div className="w-10 h-10 rounded-lg bg-white/20 flex items-center justify-center">
-          <Icon size={22} className="text-white" />
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/components/dashboard/new-jobs-section.test.tsx
+++ b/src/components/dashboard/new-jobs-section.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { Job } from "@/lib/types";
+import { NewJobsSection } from "./new-jobs-section";
+
+function makeJob(over: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "J-0001",
+    contact_id: "c-1",
+    status: "new",
+    urgency: "scheduled",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "1 Test St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    insurance_contact_id: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    created_at: "2026-05-27T10:00:00Z",
+    ...over,
+  } as Job;
+}
+
+describe("<NewJobsSection>", () => {
+  it("renders the stable empty-state copy when total is 0", () => {
+    render(<NewJobsSection jobs={[]} total={0} />);
+    expect(screen.getByText("No new jobs.")).toBeTruthy();
+  });
+
+  it("wraps each preview row in an anchor to /jobs/<id>", () => {
+    const jobs = [
+      makeJob({ id: "aaa", job_number: "J-A" }),
+      makeJob({ id: "bbb", job_number: "J-B" }),
+    ];
+    render(<NewJobsSection jobs={jobs} total={2} />);
+
+    const aRow = screen.getByText("J-A").closest("a");
+    const bRow = screen.getByText("J-B").closest("a");
+    expect(aRow?.getAttribute("href")).toBe("/jobs/aaa");
+    expect(bRow?.getAttribute("href")).toBe("/jobs/bbb");
+  });
+
+  it("renders a `View all jobs` link in the header pointing to /jobs", () => {
+    render(<NewJobsSection jobs={[makeJob()]} total={1} />);
+    const link = screen.getByRole("link", { name: /view all jobs/i });
+    expect(link.getAttribute("href")).toBe("/jobs");
+  });
+
+  it("does not render a `+ N more` tail when total ≤ 3", () => {
+    const jobs = [makeJob({ id: "a" }), makeJob({ id: "b" }), makeJob({ id: "c" })];
+    render(<NewJobsSection jobs={jobs} total={3} />);
+    expect(screen.queryByText(/\+ \d+ more/)).toBeNull();
+  });
+
+  it("renders `+ N more` linking to /jobs when total exceeds the preview cap", () => {
+    const jobs = [makeJob({ id: "a" }), makeJob({ id: "b" }), makeJob({ id: "c" })];
+    render(<NewJobsSection jobs={jobs} total={7} />);
+    const tail = screen.getByText("+ 4 more");
+    // Tail is wrapped in an anchor to /jobs.
+    const anchor = tail.closest("a");
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute("href")).toBe("/jobs");
+  });
+
+  it("renders up to 3 preview rows plus a count pill of the total", () => {
+    const jobs = [
+      makeJob({ id: "a", job_number: "J-A" }),
+      makeJob({ id: "b", job_number: "J-B" }),
+      makeJob({ id: "c", job_number: "J-C" }),
+    ];
+    render(<NewJobsSection jobs={jobs} total={3} />);
+
+    expect(screen.getByText("J-A")).toBeTruthy();
+    expect(screen.getByText("J-B")).toBeTruthy();
+    expect(screen.getByText("J-C")).toBeTruthy();
+
+    // Count pill — total reflected somewhere distinct from the rows.
+    const pill = screen.getByTestId("new-jobs-count");
+    expect(pill.textContent).toContain("3");
+  });
+});

--- a/src/components/dashboard/new-jobs-section.tsx
+++ b/src/components/dashboard/new-jobs-section.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import type { Job } from "@/lib/types";
+
+interface NewJobsSectionProps {
+  jobs: Job[];
+  total: number;
+}
+
+const PREVIEW_CAP = 3;
+
+export function NewJobsSection({ jobs, total }: NewJobsSectionProps) {
+  if (total === 0) {
+    return <p>No new jobs.</p>;
+  }
+
+  const preview = jobs.slice(0, PREVIEW_CAP);
+  const overflow = total - PREVIEW_CAP;
+
+  return (
+    <section>
+      <header>
+        <h2>New jobs</h2>
+        <span data-testid="new-jobs-count">{total}</span>
+        <Link href="/jobs">View all jobs →</Link>
+      </header>
+      <ul>
+        {preview.map((job) => (
+          <li key={job.id}>
+            <Link href={`/jobs/${job.id}`}>
+              <p>{job.job_number}</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+      {overflow > 0 && (
+        <Link href="/jobs">+ {overflow} more</Link>
+      )}
+    </section>
+  );
+}

--- a/src/components/dashboard/stat-strip.test.tsx
+++ b/src/components/dashboard/stat-strip.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatStrip } from "./stat-strip";
+
+describe("<StatStrip>", () => {
+  it("shows the new-jobs column when canViewJobs is true", () => {
+    render(<StatStrip newJobsCount={5} canViewJobs={true} />);
+    // Pluralised count: "5 new jobs".
+    expect(screen.getByText(/5 new jobs/i)).toBeTruthy();
+  });
+
+  it("hides the new-jobs column when canViewJobs is false", () => {
+    render(<StatStrip newJobsCount={5} canViewJobs={false} />);
+    // No count text — column is gone, not replaced with a permission notice.
+    expect(screen.queryByText(/new jobs/i)).toBeNull();
+    expect(screen.queryByText(/5/)).toBeNull();
+  });
+});

--- a/src/components/dashboard/stat-strip.tsx
+++ b/src/components/dashboard/stat-strip.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+interface StatStripProps {
+  newJobsCount: number;
+  canViewJobs: boolean;
+}
+
+export function StatStrip({ newJobsCount, canViewJobs }: StatStripProps) {
+  return (
+    <div role="presentation">
+      {canViewJobs && (
+        <span data-testid="stat-strip-new-jobs">{newJobsCount} new jobs</span>
+      )}
+    </div>
+  );
+}

--- a/src/lib/dashboard/use-dashboard-data.ts
+++ b/src/lib/dashboard/use-dashboard-data.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase";
+import { useAuth } from "@/lib/auth-context";
+import type { Job } from "@/lib/types";
+
+const POLL_INTERVAL_MS = 30_000;
+
+interface UseDashboardData {
+  newJobs: Job[];
+  newJobsCount: number;
+  loading: boolean;
+  error: string | null;
+  canViewJobs: boolean;
+}
+
+export function useDashboardData(): UseDashboardData {
+  const { hasPermission } = useAuth();
+  const canViewJobs = hasPermission("view_jobs");
+
+  const [newJobs, setNewJobs] = useState<Job[]>([]);
+  const [newJobsCount, setNewJobsCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!canViewJobs) return;
+
+    let cancelled = false;
+
+    async function load() {
+      const supabase = createClient();
+      // 'new' is the literal seed status name; no `is_initial` flag exists.
+      // Seed rows: supabase/migration-build14c.sql.
+      const [previewRes, countRes] = await Promise.all([
+        supabase
+          .from("jobs")
+          .select("*, contact:contacts!contact_id(*)")
+          .eq("status", "new")
+          .is("deleted_at", null)
+          .order("created_at", { ascending: false })
+          .limit(3),
+        supabase
+          .from("jobs")
+          .select("*", { count: "exact", head: true })
+          .eq("status", "new")
+          .is("deleted_at", null),
+      ]);
+
+      if (cancelled) return;
+
+      if (previewRes.error || countRes.error) {
+        setError(previewRes.error?.message ?? countRes.error?.message ?? "Failed to load");
+        setLoading(false);
+        return;
+      }
+
+      setNewJobs((previewRes.data ?? []) as Job[]);
+      setNewJobsCount(countRes.count ?? 0);
+      setError(null);
+      setLoading(false);
+    }
+
+    load();
+    const id = setInterval(load, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [canViewJobs]);
+
+  // When the viewer lacks view_jobs we skip the fetch entirely; the
+  // initial `loading=true` would be misleading there, so derive it.
+  return {
+    newJobs,
+    newJobsCount,
+    loading: canViewJobs ? loading : false,
+    error,
+    canViewJobs,
+  };
+}


### PR DESCRIPTION
## Summary

Slice 2 of PRD #246 (Dashboard Rebuild). Rewrites `/` from the legacy four hardcoded stat cards + Recent Jobs grid into the **action-hub layout** carrying the New jobs queue. Slice 3 will add the People-to-respond-to queue.

- `<StatStrip>` — single column for now (`<N> new jobs`); column hidden when the viewer lacks `view_jobs` (no "no permission" copy).
- `<NewJobsSection>` — header (title + count pill + `View all jobs →`), up to 3 preview rows linking to `/jobs/[id]`, `+ N more` tail linking to `/jobs` when total > 3, stable `No new jobs.` empty state when total = 0.
- `useDashboardData()` hook in `src/lib/dashboard/` owns the jobs fetch (`status='new'` AND `deleted_at IS NULL`, RLS-scoped via the existing User client, ordered `created_at DESC`, limit 3 preview + head-count companion) and the **30s polling cadence** — the only place owning it, matching the convention in `email-inbox.tsx`. Section gated by `view_jobs`; when missing, both the section and the strip column render `null`.
- Greeting from #292 (`Welcome back, <first>.`) is preserved.

## Test plan

- [x] `src/components/dashboard/new-jobs-section.test.tsx` — empty state copy; rows + count pill; `+ N more` only when total > 3 (link to `/jobs`); each row anchor → `/jobs/<id>`; header `View all jobs` → `/jobs`.
- [x] `src/components/dashboard/stat-strip.test.tsx` — column visible when `canViewJobs=true`; hidden when false (no permission-notice copy).
- [x] `src/app/page.test.tsx` — greeting from mocked `profile.full_name`; section + strip column both hidden when `canViewJobs=false`; `<StatStrip>` precedes `<NewJobsSection>` in DOM; legacy stat-card labels and `Recent Jobs` heading are absent.
- [x] Full suite: 1212 passing locally; the 6 pre-existing failures (`estimate-builder/estimate-drag-end.test.tsx` × 4, `api/email/accounts/route.test.ts` × 2) reproduce on `origin/main` and are unrelated to this slice.
- [x] `tsc --noEmit` clean on all touched files.
- [x] `eslint` clean on all touched files.
- [ ] Live browser verification (post-merge or via preview deploy) of the new layout, the polling, and the `crew_member` permission-gated view.

Closes #293.

🤖 Generated with [Claude Code](https://claude.com/claude-code)