### PR TITLE
feat(referral-partners): list row redesign + Add Target Button swap (#299)

### DIFF
--- a/src/app/referral-partners/page.test.tsx
+++ b/src/app/referral-partners/page.test.tsx
@@ -9,6 +9,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
 import ReferralPartnersPage from "./page";
+import { STATUS_ROW_STYLES } from "@/lib/referral-partner-row-styles";
 
 const fetchMock = vi.fn();
 
@@ -98,5 +99,134 @@ describe("/referral-partners list page", () => {
     await waitFor(() => {
       expect(screen.getByText("Acme Plumbing")).toBeDefined();
     });
+  });
+
+  // ── Issue #299: row redesign mirroring the contracts row pattern ──────
+
+  it("tints each row card with the per-Lifecycle-status palette", async () => {
+    mockList([
+      { id: "p-grey",   company_name: "Grey Co",   status: "grey",   industry: null },
+      { id: "p-yellow", company_name: "Yellow Co", status: "yellow", industry: null },
+      { id: "p-green",  company_name: "Green Co",  status: "green",  industry: null },
+      { id: "p-red",    company_name: "Red Co",    status: "red",    industry: null },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Grey Co")).toBeDefined();
+    });
+
+    const cases = [
+      { name: "Grey Co",   status: "grey"   as const },
+      { name: "Yellow Co", status: "yellow" as const },
+      { name: "Green Co",  status: "green"  as const },
+      { name: "Red Co",    status: "red"    as const },
+    ];
+    for (const c of cases) {
+      const link = screen.getByText(c.name).closest("a");
+      expect(link).not.toBeNull();
+      const wrapClasses = STATUS_ROW_STYLES[c.status].wrap.split(/\s+/).filter(Boolean);
+      for (const cls of wrapClasses) {
+        expect(link?.className).toContain(cls);
+      }
+    }
+  });
+
+  it("renders the status label as colored uppercase text inside the row, not as a left-side pill", async () => {
+    mockList([
+      { id: "p-1", company_name: "Acme Plumbing", status: "green", industry: "Plumbing" },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    // The row link wraps the partner name; the row's status label is the
+    // "Active" string inside that link (not the filter chip at the top).
+    const row = (await waitFor(() => {
+      const text = screen.getByText("Acme Plumbing");
+      return text.closest("a");
+    })) as HTMLAnchorElement;
+    const candidates = Array.from(row.querySelectorAll("span")).filter(
+      (el) => el.textContent === "Active",
+    );
+    expect(candidates).toHaveLength(1);
+    const label = candidates[0]!;
+    expect(label.className).toContain("uppercase");
+    expect(label.className).toContain("text-[#5DCAA5]");
+    // The old pill chip class must be gone from inside the row.
+    expect(row.innerHTML).not.toContain("rounded-full");
+  });
+
+  it("shows the formatted office phone on the industry line", async () => {
+    mockList([
+      {
+        id: "p-1",
+        company_name: "Acme Plumbing",
+        status: "yellow",
+        industry: "Plumbing",
+        office_phone: "5125551234",
+      },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    const row = await waitFor(() => {
+      const text = screen.getByText("Acme Plumbing");
+      return text.closest("a") as HTMLAnchorElement;
+    });
+    expect(row.textContent).toContain("Plumbing");
+    expect(row.textContent).toContain("(512) 555-1234");
+  });
+
+  it("renders notes truncated to one line with the full text in the title attribute", async () => {
+    const fullNote =
+      "Spoke with Sarah at the front desk; she said the owner Dave handles all referrals and prefers Thursday calls after 2pm.";
+    mockList([
+      {
+        id: "p-1",
+        company_name: "Acme Plumbing",
+        status: "green",
+        industry: "Plumbing",
+        notes: fullNote,
+      },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    const notesEl = await screen.findByTestId("referral-partner-notes-p-1");
+    expect(notesEl.textContent).toContain(fullNote);
+    expect(notesEl.getAttribute("title")).toBe(fullNote);
+    expect(notesEl.className).toMatch(/truncate/);
+  });
+
+  it("omits the office phone and notes lines gracefully when both are missing", async () => {
+    mockList([
+      {
+        id: "p-1",
+        company_name: "Acme Plumbing",
+        status: "grey",
+        industry: "Plumbing",
+        office_phone: null,
+        notes: null,
+      },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Plumbing")).toBeDefined();
+    });
+    expect(screen.queryByTestId("referral-partner-notes-p-1")).toBeNull();
+  });
+
+  it("uses the shared <Button> component for the Add Target CTA (no raw btn-primary classes)", async () => {
+    mockList([]);
+    render(<ReferralPartnersPage />);
+
+    const btn = await screen.findByRole("button", { name: /add target/i });
+    // Shared Button is Base-UI-backed; its root carries data-slot="button"
+    // (same signal PR #284 used to verify the swap from raw btn classes).
+    expect(btn.getAttribute("data-slot")).toBe("button");
+    expect(btn.className).not.toContain("btn-primary");
   });
 });

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -14,12 +14,16 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Handshake, Loader2, Plus, RotateCcw, Search, Trash2 } from "lucide-react";
 import NewTargetDialog from "@/components/referral-partners/new-target-dialog";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   distinctIndustries,
   filterReferralPartners,
   type LifecycleStatus,
 } from "@/lib/referral-partner-filter";
 import type { CallOutcome } from "@/lib/referral-partner-call";
+import { STATUS_ROW_STYLES } from "@/lib/referral-partner-row-styles";
+import { formatPhoneNumber } from "@/lib/phone";
 
 const RETENTION_DAYS = 30;
 
@@ -28,6 +32,8 @@ interface ReferralPartner {
   company_name: string;
   status: LifecycleStatus;
   industry: string | null;
+  office_phone?: string | null;
+  notes?: string | null;
   last_called_at: string | null;
   last_call_outcome: CallOutcome | null;
   next_follow_up_at: string | null;
@@ -146,13 +152,13 @@ export default function ReferralPartnersPage() {
           <h1 className="text-2xl font-heading font-semibold">Referral Partners</h1>
         </div>
         {view === "active" && (
-          <button
+          <Button
+            variant="gradient"
             onClick={() => setDialogOpen(true)}
-            className="btn btn-primary inline-flex items-center gap-2"
           >
-            <Plus size={16} />
+            <Plus />
             Add Target
-          </button>
+          </Button>
         )}
       </header>
 
@@ -262,46 +268,11 @@ export default function ReferralPartnersPage() {
           No partners match the current filters.
         </p>
       ) : (
-        <ul className="divide-y rounded-lg border border-border bg-card">
+        <div className="space-y-2">
           {visiblePartners.map((p) => (
-            <li key={p.id}>
-              <Link
-                href={`/referral-partners/${p.id}`}
-                className="flex items-center gap-4 px-4 py-3 hover:bg-muted/40 transition-colors"
-              >
-                <span
-                  className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_CHIP_CLASS[p.status]}`}
-                >
-                  {STATUS_LABEL[p.status]}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium truncate">{p.company_name}</p>
-                  {p.industry && (
-                    <p className="text-xs text-muted-foreground truncate">{p.industry}</p>
-                  )}
-                </div>
-                {/* Denormalized last-call / next-follow-up surface
-                    (PRD #249, issue #254 AC: list page surfaces last
-                    called, last call outcome, next follow-up). */}
-                <div className="hidden sm:flex flex-col text-right text-xs text-muted-foreground min-w-[12rem]">
-                  {p.last_called_at && (
-                    <span>
-                      Last call: {formatDate(p.last_called_at)}
-                      {p.last_call_outcome && (
-                        <> — {OUTCOME_LABEL[p.last_call_outcome]}</>
-                      )}
-                    </span>
-                  )}
-                  {p.next_follow_up_at && (
-                    <span>
-                      Next follow-up: {formatDate(p.next_follow_up_at)}
-                    </span>
-                  )}
-                </div>
-              </Link>
-            </li>
+            <PartnerRow key={p.id} partner={p} />
           ))}
-        </ul>
+        </div>
       )}
 
       <NewTargetDialog
@@ -310,6 +281,82 @@ export default function ReferralPartnersPage() {
         onCreated={() => void load()}
       />
     </div>
+  );
+}
+
+// One Active-view row — tinted card mirroring the contracts row pattern
+// from src/components/contracts/contracts-section.tsx. Background+border
+// comes from STATUS_ROW_STYLES.wrap; the status label is colored uppercase
+// text inside the row (no left-side pill). PRD #297 / issue #299.
+function PartnerRow({ partner: p }: { partner: ReferralPartner }) {
+  const style = STATUS_ROW_STYLES[p.status];
+  const officePhone = p.office_phone ? formatPhoneNumber(p.office_phone) : "";
+  const notes = p.notes?.trim() ?? "";
+  return (
+    <Link
+      href={`/referral-partners/${p.id}`}
+      className={cn(
+        "block border rounded-lg px-4 py-3 transition-colors hover:brightness-105",
+        style.wrap,
+      )}
+    >
+      {/* Line 1: company name · status label · right-aligned lifetime-count slot (filled by slice C1). */}
+      <div className="flex items-baseline gap-2 min-w-0">
+        <p className="text-sm font-medium text-foreground truncate flex-1 min-w-0">
+          {p.company_name}
+        </p>
+        <span
+          className={cn(
+            "text-[10px] uppercase tracking-wider font-semibold px-1.5 py-0 rounded",
+            style.text,
+          )}
+        >
+          {style.label}
+        </span>
+        <span
+          data-testid={`referral-partner-lifetime-count-${p.id}`}
+          aria-hidden
+          className="shrink-0 text-[11px] text-muted-foreground min-w-[2.5rem] text-right"
+        />
+      </div>
+
+      {/* Line 2: industry · office phone (either may be missing). */}
+      {(p.industry || officePhone) && (
+        <div className="text-xs text-muted-foreground mt-0.5 truncate">
+          {p.industry}
+          {p.industry && officePhone && <span> · </span>}
+          {officePhone}
+        </div>
+      )}
+
+      {/* Line 3: notes (one-line truncation, full text in title). */}
+      {notes && (
+        <div
+          data-testid={`referral-partner-notes-${p.id}`}
+          title={notes}
+          className="text-xs text-muted-foreground/80 mt-0.5 truncate"
+        >
+          {notes}
+        </div>
+      )}
+
+      {/* Line 4: existing last-call / next-follow-up surface (preserved). */}
+      {(p.last_called_at || p.next_follow_up_at) && (
+        <div className="text-xs text-muted-foreground/80 mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+          {p.last_called_at && (
+            <span>
+              Last call: {formatDate(p.last_called_at)}
+              {p.last_call_outcome && (
+                <> — {OUTCOME_LABEL[p.last_call_outcome]}</>
+              )}
+            </span>
+          )}
+          {p.next_follow_up_at && (
+            <span>Next follow-up: {formatDate(p.next_follow_up_at)}</span>
+          )}
+        </div>
+      )}
+    </Link>
   );
 }
 

--- a/src/lib/referral-partner-row-styles.test.ts
+++ b/src/lib/referral-partner-row-styles.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  STATUS_ROW_STYLES,
+  type LifecycleStatus,
+} from "./referral-partner-row-styles";
+
+// PRD #297 / issue #299 — every LifecycleStatus must have a complete
+// row-tint palette (background+border class, label, text class). The map
+// is the single keeper of the four palettes on the Referral Partners
+// list, so adding a new status without a palette must be impossible to
+// ship.
+const ALL_STATUSES: ReadonlyArray<LifecycleStatus> = [
+  "grey",
+  "yellow",
+  "green",
+  "red",
+];
+
+describe("STATUS_ROW_STYLES", () => {
+  it.each(ALL_STATUSES)(
+    "has a non-empty wrap, label, and text entry for %s",
+    (status) => {
+      const palette = STATUS_ROW_STYLES[status];
+      expect(palette.wrap.trim().length).toBeGreaterThan(0);
+      expect(palette.label.trim().length).toBeGreaterThan(0);
+      expect(palette.text.trim().length).toBeGreaterThan(0);
+    },
+  );
+});

--- a/src/lib/referral-partner-row-styles.ts
+++ b/src/lib/referral-partner-row-styles.ts
@@ -1,0 +1,43 @@
+// Row-tint palette for the Referral Partners list page (PRD #297, issue
+// #299). Each Lifecycle status maps to a `wrap` (background + border
+// classes for the card), a `label` (the uppercase string shown inside the
+// row), and a `text` class (the colored text used to render the label).
+//
+// This map lives in its own pure module so the four palettes have a
+// single home and a completeness test can guard against a new status
+// shipping without a palette. The shape mirrors the STATUS_STYLES pattern
+// from `src/components/contracts/contracts-section.tsx`.
+
+export type LifecycleStatus = "grey" | "yellow" | "green" | "red";
+
+export interface RowStyle {
+  /** Background + border classes for the row card. */
+  wrap: string;
+  /** Uppercase label rendered inside the row. */
+  label: string;
+  /** Text-color class for the label. */
+  text: string;
+}
+
+export const STATUS_ROW_STYLES: Record<LifecycleStatus, RowStyle> = {
+  grey: {
+    wrap: "bg-muted/30 border-border",
+    label: "Uncontacted",
+    text: "text-muted-foreground",
+  },
+  yellow: {
+    wrap: "bg-[rgba(239,159,39,0.10)] border-[rgba(239,159,39,0.30)]",
+    label: "In progress",
+    text: "text-[#FAC775]",
+  },
+  green: {
+    wrap: "bg-[rgba(29,158,117,0.10)] border-[rgba(29,158,117,0.30)]",
+    label: "Active",
+    text: "text-[#5DCAA5]",
+  },
+  red: {
+    wrap: "bg-[rgba(228,75,74,0.08)] border-[rgba(228,75,74,0.30)]",
+    label: "Declined",
+    text: "text-[#F09595]",
+  },
+};


### PR DESCRIPTION
Closes #299. Parent PRD: #297 (slice A — list visual redesign).

## Summary

- Rewrites Active-view rows on `/referral-partners` to mirror the contracts row pattern in `src/components/contracts/contracts-section.tsx`. Each row becomes a tinted card whose background and border are determined by Lifecycle status (grey / yellow / green / red); the status label is rendered as colored uppercase text inside the row instead of a pill on the left.
- Four lines per row: (1) company name · status label · reserved right-aligned slot for the lifetime job count (populated by slice C1), (2) industry · formatted office phone, (3) notes truncated to one line with the full text in the `title` attribute, (4) existing last-call / next-follow-up surface, preserved as-is.
- New pure module `src/lib/referral-partner-row-styles.ts` houses the four palettes (`{wrap, label, text}` per `LifecycleStatus`) so the colors have a single home and a completeness test makes it impossible to ship a new status without a palette.
- `Add Target` swapped from raw `<button className="btn btn-primary ...">` to the shared `<Button variant="gradient">` component, mirroring PR #284. Label unchanged (Target is a glossary term).
- Trash view and filter chips are untouched.

## Test plan

- [x] `npx vitest run src/lib/referral-partner-row-styles.test.ts` — 4 passing (one per status)
- [x] `npx vitest run src/app/referral-partners/page.test.tsx` — 9 passing (3 existing + 6 new)
- [ ] Visual check on `/referral-partners`: rows tinted by status, label is uppercase text inside the row (no left-side pill), industry + office phone on line 2, notes truncate with tooltip on line 3, last-call / next-follow-up on line 4, `Add Target` matches other primary CTAs
- [ ] Filter chips at the top still narrow the list as before
- [ ] Trash view rows render unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)