### PR TITLE
feat(referral-partners): lifetime jobs count on list + Trash row (#300)

### DIFF
--- a/src/app/api/referral-partners/route.test.ts
+++ b/src/app/api/referral-partners/route.test.ts
@@ -72,7 +72,8 @@ describe("GET /api/referral-partners", () => {
     });
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.referral_partners).toEqual([partner]);
+    // job_count (slice C1) is attached to every row; defaults to 0.
+    expect(body.referral_partners).toEqual([{ ...partner, job_count: 0 }]);
   });
 
   it("returns the list of partners for a crew_lead", async () => {
@@ -87,6 +88,41 @@ describe("GET /api/referral-partners", () => {
       params: Promise.resolve({}),
     });
     expect(res.status).toBe(200);
+  });
+
+  // ── Slice C1 (#300) AC: each row carries a lifetime `job_count`. ──
+  it("attaches a job_count to each partner row, computed from non-trashed jobs", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", company_name: "Acme",  status: "green" },
+          { id: "p-2", organization_id: "org-1", company_name: "Beta",  status: "yellow" },
+          { id: "p-3", organization_id: "org-1", company_name: "Gamma", status: "grey" },
+        ],
+        // The route's SQL filters `deleted_at IS NULL`, so the rows that
+        // would flow into the count include only the three live jobs below.
+        // Three for Acme, one for Beta, zero for Gamma.
+        jobs: [
+          { id: "j-1", referral_partner_id: "p-1", deleted_at: null },
+          { id: "j-2", referral_partner_id: "p-1", deleted_at: null },
+          { id: "j-3", referral_partner_id: "p-1", deleted_at: null },
+          { id: "j-4", referral_partner_id: "p-2", deleted_at: null },
+        ],
+      },
+    });
+    const res = await GET(new Request("http://test/api/referral-partners"), {
+      params: Promise.resolve({}),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const byId = Object.fromEntries(
+      (body.referral_partners as Array<{ id: string; job_count: number }>).map(
+        (p) => [p.id, p.job_count],
+      ),
+    );
+    expect(byId).toEqual({ "p-1": 3, "p-2": 1, "p-3": 0 });
   });
 });
 

--- a/src/app/api/referral-partners/route.ts
+++ b/src/app/api/referral-partners/route.ts
@@ -12,18 +12,53 @@ import {
 } from "@/lib/referral-partners/permission";
 
 // GET /api/referral-partners — list every Referral Partner in the Active
-// Organization that isn't in the soft-delete bin. Gated to admin / crew_lead;
-// crew_member receives 403.
+// Organization that isn't in the soft-delete bin. Each row carries a
+// lifetime `job_count` of non-trashed Jobs attributed to that partner
+// (slice C1 / #300). The count query filters `deleted_at IS NULL` so it
+// uses the partial index `(referral_partner_id) WHERE deleted_at IS NULL`
+// added in slice B's migration. Gated to admin / crew_lead; crew_member
+// receives 403.
 export const GET = withRequestContext(
   VIEW_REFERRAL_PARTNERS,
   async (_request, { supabase }) => {
-    const { data, error } = await supabase
+    const { data: partners, error } = await supabase
       .from("referral_partners")
       .select("*")
       .is("deleted_at", null)
       .order("company_name", { ascending: true });
     if (error) return apiDbError(error.message, "GET /api/referral-partners list");
-    return NextResponse.json({ referral_partners: data ?? [] });
+
+    const rows = (partners ?? []) as Array<{ id: string }>;
+    if (rows.length === 0) {
+      return NextResponse.json({ referral_partners: [] });
+    }
+
+    // One batched read — `referral_partner_id IN (...)` AND `deleted_at IS
+    // NULL`. The aggregate is computed in the route, but the filtering
+    // happens in SQL and rides the partial index.
+    const partnerIds = rows.map((r) => r.id);
+    const { data: jobRows, error: jobsError } = await supabase
+      .from("jobs")
+      .select("referral_partner_id")
+      .in("referral_partner_id", partnerIds)
+      .is("deleted_at", null);
+    if (jobsError) {
+      return apiDbError(jobsError.message, "GET /api/referral-partners job_count");
+    }
+
+    const counts = new Map<string, number>();
+    for (const { referral_partner_id } of (jobRows ?? []) as Array<{
+      referral_partner_id: string | null;
+    }>) {
+      if (!referral_partner_id) continue;
+      counts.set(referral_partner_id, (counts.get(referral_partner_id) ?? 0) + 1);
+    }
+
+    const withCounts = rows.map((row) => ({
+      ...row,
+      job_count: counts.get(row.id) ?? 0,
+    }));
+    return NextResponse.json({ referral_partners: withCounts });
   },
 );
 

--- a/src/app/api/referral-partners/trash/route.test.ts
+++ b/src/app/api/referral-partners/trash/route.test.ts
@@ -71,4 +71,35 @@ describe("GET /api/referral-partners/trash — happy path", () => {
     expect(body.retentionDays).toBe(30);
     expect(Array.isArray(body.referral_partners)).toBe(true);
   });
+
+  // ── Slice C1 (#300) AC: Trash row shows `N jobs · X days remaining`. ──
+  it("attaches job_count to each trashed partner row from non-trashed jobs", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: {
+        ...memberTables({ userId: "user-1", role: "admin" }),
+        referral_partners: [
+          { id: "p-1", organization_id: "org-1", company_name: "Acme",  deleted_at: "2026-05-20T00:00:00.000Z" },
+          { id: "p-2", organization_id: "org-1", company_name: "Beta",  deleted_at: "2026-05-21T00:00:00.000Z" },
+        ],
+        jobs: [
+          // Trashed-partner FKs still point at the partner row (soft delete
+          // preserves the row); the count rule depends on the Job's own
+          // `deleted_at IS NULL`, not the partner's.
+          { id: "j-1", referral_partner_id: "p-1", deleted_at: null },
+          { id: "j-2", referral_partner_id: "p-1", deleted_at: null },
+          { id: "j-3", referral_partner_id: "p-1", deleted_at: null },
+        ],
+      },
+    });
+    const res = await GET(REQ, { params: Promise.resolve({}) });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const byId = Object.fromEntries(
+      (body.referral_partners as Array<{ id: string; job_count: number }>).map(
+        (p) => [p.id, p.job_count],
+      ),
+    );
+    expect(byId).toEqual({ "p-1": 3, "p-2": 0 });
+  });
 });

--- a/src/app/api/referral-partners/trash/route.ts
+++ b/src/app/api/referral-partners/trash/route.ts
@@ -65,8 +65,45 @@ export const GET = withRequestContext(
     if (error) {
       return apiDbError(error.message, "GET /api/referral-partners/trash list");
     }
+
+    // 4. Attach the lifetime job_count to each Trash row (slice C1 / #300)
+    //    so the row can render "N jobs · X days until permanent deletion".
+    //    A trashed partner's referred Jobs keep the FK (soft delete preserves
+    //    the row), so the count depends only on the Job's own deleted_at and
+    //    the same partial index `(referral_partner_id) WHERE deleted_at IS
+    //    NULL` is used.
+    const rows = (trashed ?? []) as Array<{ id: string }>;
+    let withCounts: Array<Record<string, unknown>> = rows as Array<
+      Record<string, unknown>
+    >;
+    if (rows.length > 0) {
+      const partnerIds = rows.map((r) => r.id);
+      const { data: jobRows, error: jobsError } = await supabase
+        .from("jobs")
+        .select("referral_partner_id")
+        .in("referral_partner_id", partnerIds)
+        .is("deleted_at", null);
+      if (jobsError) {
+        return apiDbError(
+          jobsError.message,
+          "GET /api/referral-partners/trash job_count",
+        );
+      }
+      const counts = new Map<string, number>();
+      for (const { referral_partner_id } of (jobRows ?? []) as Array<{
+        referral_partner_id: string | null;
+      }>) {
+        if (!referral_partner_id) continue;
+        counts.set(referral_partner_id, (counts.get(referral_partner_id) ?? 0) + 1);
+      }
+      withCounts = rows.map((row) => ({
+        ...row,
+        job_count: counts.get(row.id) ?? 0,
+      }));
+    }
+
     return NextResponse.json({
-      referral_partners: trashed ?? [],
+      referral_partners: withCounts,
       autoPurged,
       retentionDays: RETENTION_DAYS,
     });

--- a/src/app/referral-partners/page.test.tsx
+++ b/src/app/referral-partners/page.test.tsx
@@ -229,4 +229,71 @@ describe("/referral-partners list page", () => {
     expect(btn.getAttribute("data-slot")).toBe("button");
     expect(btn.className).not.toContain("btn-primary");
   });
+
+  // ── Slice C1 (#300) AC: each Active row shows `N jobs` on the right of
+  // line 1, in the slot reserved by slice A2 (testid:
+  // referral-partner-lifetime-count-<id>). Zero is rendered, not hidden. ──
+  it("shows the lifetime job count as `N jobs` on each Active row", async () => {
+    mockList([
+      { id: "p-1", company_name: "Acme Plumbing",    status: "green",  industry: "Plumbing", job_count: 47 },
+      { id: "p-2", company_name: "Beta Restoration", status: "yellow", industry: null,       job_count: 0 },
+    ]);
+
+    render(<ReferralPartnersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Plumbing")).toBeDefined();
+    });
+    const acmeCount = screen.getByTestId("referral-partner-lifetime-count-p-1");
+    expect(acmeCount.textContent).toBe("47 jobs");
+    // Zero is rendered, not hidden.
+    const betaCount = screen.getByTestId("referral-partner-lifetime-count-p-2");
+    expect(betaCount.textContent).toBe("0 jobs");
+  });
+
+  // ── Slice C1 (#300) AC: Trash row shows `N jobs` alongside the
+  // days-remaining countdown. ──
+  it("shows `N jobs` alongside the days-remaining countdown on each Trash row", async () => {
+    // First fetch is Active (kept empty), second is Trash.
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ referral_partners: [] }),
+    } as Response);
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        referral_partners: [
+          {
+            id: "p-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+            industry: "Plumbing",
+            // Two days ago — 28 days remaining at the 30-day retention.
+            deleted_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+            job_count: 12,
+          },
+        ],
+        retentionDays: 30,
+      }),
+    } as Response);
+
+    render(<ReferralPartnersPage />);
+
+    // Wait for the Active fetch to settle, then click the Trash tab.
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const trashTab = screen.getByTestId("referral-partners-trash-tab");
+    trashTab.click();
+
+    await waitFor(() => {
+      expect(screen.getByText("Acme Plumbing")).toBeDefined();
+    });
+    const row = screen.getByTestId("referral-partners-trash-row-p-1");
+    expect(row.textContent).toMatch(/12 jobs/);
+    // The countdown wording is preserved.
+    expect(row.textContent).toMatch(/until permanent deletion/);
+  });
 });

--- a/src/app/referral-partners/page.tsx
+++ b/src/app/referral-partners/page.tsx
@@ -38,6 +38,11 @@ interface ReferralPartner {
   last_call_outcome: CallOutcome | null;
   next_follow_up_at: string | null;
   deleted_at?: string | null;
+  // Lifetime count of non-trashed Jobs attributed to this partner. Computed
+  // by the list endpoint (slice C1 / #300) and always present on rows that
+  // come back from the API; defaulted to 0 in case an older client renders
+  // a row from elsewhere.
+  job_count?: number;
 }
 
 const OUTCOME_LABEL: Record<CallOutcome, string> = {
@@ -313,11 +318,15 @@ function PartnerRow({ partner: p }: { partner: ReferralPartner }) {
         >
           {style.label}
         </span>
+        {/* Lifetime jobs count — slice C1 (#300). Zero shows as "0 jobs",
+            not hidden, so a partner who has sent nothing reads the same as
+            one who has, plus zero. Populates the slot reserved by A2. */}
         <span
           data-testid={`referral-partner-lifetime-count-${p.id}`}
-          aria-hidden
           className="shrink-0 text-[11px] text-muted-foreground min-w-[2.5rem] text-right"
-        />
+        >
+          {p.job_count ?? 0} jobs
+        </span>
       </div>
 
       {/* Line 2: industry · office phone (either may be missing). */}
@@ -430,11 +439,19 @@ function TrashRow({
           <p className="text-sm text-muted-foreground truncate">{partner.industry}</p>
         )}
         <p className="text-xs text-muted-foreground/70 mt-1">
-          {daysRemaining !== null
-            ? daysRemaining === 0
-              ? "Auto-purges today"
-              : `${daysRemaining} day${daysRemaining === 1 ? "" : "s"} until permanent deletion`
-            : null}
+          {/* Lifetime jobs count — slice C1 (#300). Shown next to the
+              days-remaining countdown so the cost of permanently deleting
+              this partner is visible before the user confirms. Zero shows
+              as "0 jobs · …" so the row reads consistently. */}
+          {`${partner.job_count ?? 0} jobs`}
+          {daysRemaining !== null ? (
+            <>
+              {" · "}
+              {daysRemaining === 0
+                ? "Auto-purges today"
+                : `${daysRemaining} day${daysRemaining === 1 ? "" : "s"} until permanent deletion`}
+            </>
+          ) : null}
         </p>
       </div>
       <div className="flex items-center gap-2 shrink-0">

--- a/src/lib/referral-partners/jobs.test.ts
+++ b/src/lib/referral-partners/jobs.test.ts
@@ -1,0 +1,81 @@
+// Lifetime-jobs rule from PRD #297 / slice C1 (#300).
+//
+// Two pure functions consumed by:
+//   - the `GET /api/referral-partners` list endpoint (slice C1) for the
+//     `job_count` on each row — the SQL computes the count, this module
+//     is the unit-tested specification of *what the count means*;
+//   - slice C2's "Jobs sent" section on the Referral Partner Worksheet,
+//     which uses `listAttributed` to render the actual list.
+//
+// The trashed-job filter (`deleted_at IS NULL`) is the load-bearing rule.
+// A Job that has been moved to Trash does NOT count toward its Partner's
+// lifetime count — see PRD user-story #16.
+
+import { describe, expect, it } from "vitest";
+
+import { countAttributed, listAttributed } from "./jobs";
+
+type J = {
+  id: string;
+  referral_partner_id: string | null;
+  deleted_at: string | null;
+  created_at: string;
+};
+
+describe("countAttributed", () => {
+  it("returns 0 when the input list is empty", () => {
+    expect(countAttributed([], "p-1")).toBe(0);
+  });
+
+  it("returns 0 when no job is attributed to the given partner", () => {
+    const jobs: J[] = [
+      { id: "j-1", referral_partner_id: "p-2", deleted_at: null, created_at: "2026-01-01T00:00:00Z" },
+      { id: "j-2", referral_partner_id: null,  deleted_at: null, created_at: "2026-01-02T00:00:00Z" },
+    ];
+    expect(countAttributed(jobs, "p-1")).toBe(0);
+  });
+
+  it("excludes trashed jobs from the count even when their FK matches", () => {
+    const jobs: J[] = [
+      { id: "j-1", referral_partner_id: "p-1", deleted_at: null,                      created_at: "2026-01-01T00:00:00Z" },
+      { id: "j-2", referral_partner_id: "p-1", deleted_at: "2026-05-01T00:00:00Z",    created_at: "2026-01-02T00:00:00Z" },
+      { id: "j-3", referral_partner_id: "p-1", deleted_at: null,                      created_at: "2026-01-03T00:00:00Z" },
+    ];
+    expect(countAttributed(jobs, "p-1")).toBe(2);
+  });
+
+  it("counts only the matching partner's non-trashed jobs in a mixed list", () => {
+    const jobs: J[] = [
+      { id: "j-1", referral_partner_id: "p-1", deleted_at: null,                   created_at: "2026-01-01T00:00:00Z" },
+      { id: "j-2", referral_partner_id: "p-2", deleted_at: null,                   created_at: "2026-01-02T00:00:00Z" },
+      { id: "j-3", referral_partner_id: "p-1", deleted_at: "2026-05-01T00:00:00Z", created_at: "2026-01-03T00:00:00Z" },
+      { id: "j-4", referral_partner_id: null,  deleted_at: null,                   created_at: "2026-01-04T00:00:00Z" },
+      { id: "j-5", referral_partner_id: "p-1", deleted_at: null,                   created_at: "2026-01-05T00:00:00Z" },
+    ];
+    expect(countAttributed(jobs, "p-1")).toBe(2);
+  });
+});
+
+describe("listAttributed", () => {
+  it("returns an empty list when no job is attributed to the partner", () => {
+    const jobs: J[] = [
+      { id: "j-1", referral_partner_id: "p-2", deleted_at: null, created_at: "2026-01-01T00:00:00Z" },
+    ];
+    expect(listAttributed(jobs, "p-1")).toEqual([]);
+  });
+
+  it("orders attributed jobs newest-first by created_at", () => {
+    const oldest = { id: "j-1", referral_partner_id: "p-1", deleted_at: null, created_at: "2026-01-01T00:00:00Z" };
+    const middle = { id: "j-2", referral_partner_id: "p-1", deleted_at: null, created_at: "2026-03-15T00:00:00Z" };
+    const newest = { id: "j-3", referral_partner_id: "p-1", deleted_at: null, created_at: "2026-05-20T00:00:00Z" };
+    // Feed in an out-of-order list to prove the function sorts.
+    const out = listAttributed([middle, oldest, newest], "p-1");
+    expect(out.map((j) => j.id)).toEqual(["j-3", "j-2", "j-1"]);
+  });
+
+  it("excludes trashed jobs from the list", () => {
+    const live    = { id: "j-1", referral_partner_id: "p-1", deleted_at: null,                   created_at: "2026-01-01T00:00:00Z" };
+    const trashed = { id: "j-2", referral_partner_id: "p-1", deleted_at: "2026-05-01T00:00:00Z", created_at: "2026-02-01T00:00:00Z" };
+    expect(listAttributed([live, trashed], "p-1").map((j) => j.id)).toEqual(["j-1"]);
+  });
+});

--- a/src/lib/referral-partners/jobs.ts
+++ b/src/lib/referral-partners/jobs.ts
@@ -1,0 +1,41 @@
+// Lifetime-jobs rule. PRD #297 / slice C1 (#300).
+//
+// Encodes what "jobs attributed to a Referral Partner" means in one place:
+// the FK matches AND the Job has not been trashed (`deleted_at IS NULL`).
+// The list endpoint computes the count in SQL for the list page, but this
+// module is the unit-tested specification of the count's meaning and is the
+// keeper of the same rule for slice C2's Worksheet "Jobs sent" section.
+
+export interface AttributableJob {
+  referral_partner_id: string | null;
+  deleted_at: string | null;
+  created_at: string;
+}
+
+function isLiveAttribution<J extends AttributableJob>(
+  job: J,
+  partnerId: string,
+): boolean {
+  return job.referral_partner_id === partnerId && job.deleted_at === null;
+}
+
+export function countAttributed<J extends AttributableJob>(
+  jobs: ReadonlyArray<J>,
+  partnerId: string,
+): number {
+  let n = 0;
+  for (const job of jobs) {
+    if (isLiveAttribution(job, partnerId)) n += 1;
+  }
+  return n;
+}
+
+export function listAttributed<J extends AttributableJob>(
+  jobs: ReadonlyArray<J>,
+  partnerId: string,
+): J[] {
+  return jobs
+    .filter((j) => isLiveAttribution(j, partnerId))
+    .slice()
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
+}


### PR DESCRIPTION
## Summary

Slice C1 of PRD #297. Surfaces the lifetime jobs-referred count on the Referral Partners list page so the user can tell at a glance which partners are actually sending us work.

- Pure module `src/lib/referral-partners/jobs.ts` exports `countAttributed(jobs, partnerId)` and `listAttributed(jobs, partnerId)`, both encoding the trashed-job filter (`deleted_at IS NULL`). Slice C2 will consume `listAttributed` for the Worksheet's "Jobs sent" section; this slice uses the rule as the unit-tested specification of what the count means.
- `GET /api/referral-partners` and `GET /api/referral-partners/trash` each batch a second SQL read scoped via `referral_partner_id IN (...) AND deleted_at IS NULL` and attach `job_count` to every row. The filter rides the partial index added in slice B (#298).
- The list page populates the right-side slot reserved by slice A2 (#299) — `N jobs` next to the company name + status label, with `0 jobs` (not hidden) on partners who've sent nothing.
- The Trash row reads `12 jobs · 28 days until permanent deletion` so the cost of permanently deleting a partner is visible before the user confirms.

Closes #300.

## Test plan

- [x] `countAttributed` — zero jobs in input, other-partner-only, trashed excluded, mixed list (4 unit tests).
- [x] `listAttributed` — empty, newest-first ordering, trashed exclusion (3 unit tests).
- [x] `GET /api/referral-partners` returns `job_count` per row from non-trashed jobs.
- [x] `GET /api/referral-partners/trash` returns `job_count` per trashed-partner row (FK still points at the trashed partner).
- [x] Active list row shows `N jobs` in A2's reserved slot; `0 jobs` for zero-count.
- [x] Trash row shows `N jobs · X days until permanent deletion`.
- [ ] Manual: open `/referral-partners`, confirm each Active row shows the lifetime count on the right of line 1.
- [ ] Manual: switch to the Trash tab on a partner who'd been linked to jobs, confirm the count reads `N jobs · …`.

127/127 referral-partners suite green locally. The two failing tests across `src/app/api` (`email/accounts`) are pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)