### PR TITLE
feat(referral-partners): Worksheet 'Jobs sent' section (#301)

### DIFF
--- a/src/app/api/referral-partners/[id]/jobs/route.test.ts
+++ b/src/app/api/referral-partners/[id]/jobs/route.test.ts
@@ -1,0 +1,148 @@
+// GET /api/referral-partners/[id]/jobs — slice C2 (#301).
+//
+// Returns the Jobs attributed to a Referral Partner, newest first by intake
+// date, excluding trashed Jobs. The Worksheet's "Jobs sent" section is a
+// thin renderer over this response. Gated on VIEW_REFERRAL_PARTNERS — the
+// same rule the Worksheet page itself uses.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const PARAMS = { params: Promise.resolve({ id: "p-1" }) };
+
+describe("GET /api/referral-partners/[id]/jobs — auth + permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(
+      new Request("http://test/api/referral-partners/p-1/jobs"),
+      PARAMS,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a crew_member — Referral Partners are a gated surface", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member" }),
+    });
+    const res = await GET(
+      new Request("http://test/api/referral-partners/p-1/jobs"),
+      PARAMS,
+    );
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/referral-partners/[id]/jobs — Organization scoping", () => {
+  it("returns 404 when the partner id is not visible to this caller (RLS hid it / cross-org)", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "admin" }),
+        referral_partners: [], // RLS hides cross-org rows from the User client.
+      },
+    });
+    const res = await GET(
+      new Request("http://test/api/referral-partners/p-1/jobs"),
+      PARAMS,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("GET /api/referral-partners/[id]/jobs — response shape", () => {
+  it("returns each attributed Job with id, property_address, status, and created_at", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "admin" }),
+        referral_partners: [{ id: "p-1", organization_id: "org-1" }],
+        jobs: [
+          {
+            id: "j-1",
+            referral_partner_id: "p-1",
+            deleted_at: null,
+            property_address: "123 Main St",
+            status: "lead",
+            created_at: "2026-05-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+    const res = await GET(
+      new Request("http://test/api/referral-partners/p-1/jobs"),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobs).toEqual([
+      {
+        id: "j-1",
+        property_address: "123 Main St",
+        status: "lead",
+        created_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+  });
+
+  // AC #7 — link-preservation behaviour from slice B. A trashed Partner
+  // inside the 30-day grace period still has a Worksheet, and the
+  // Worksheet's Jobs sent section still resolves against the API.
+  it("still returns jobs when the Partner is trashed (30-day grace period)", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "admin" }),
+        referral_partners: [
+          {
+            id: "p-1",
+            organization_id: "org-1",
+            deleted_at: "2026-05-10T00:00:00Z", // trashed
+          },
+        ],
+        jobs: [
+          {
+            id: "j-1",
+            referral_partner_id: "p-1",
+            deleted_at: null,
+            property_address: "100 Trashed Partner Way",
+            status: "lead",
+            created_at: "2026-04-01T00:00:00Z",
+          },
+        ],
+      },
+    });
+    const res = await GET(
+      new Request("http://test/api/referral-partners/p-1/jobs"),
+      PARAMS,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.jobs).toHaveLength(1);
+    expect(body.jobs[0].id).toBe("j-1");
+  });
+});

--- a/src/app/api/referral-partners/[id]/jobs/route.ts
+++ b/src/app/api/referral-partners/[id]/jobs/route.ts
@@ -1,0 +1,80 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { VIEW_REFERRAL_PARTNERS } from "@/lib/referral-partners/permission";
+
+// GET /api/referral-partners/[id]/jobs — slice C2 (#301).
+//
+// Returns the Jobs attributed to this Referral Partner, newest first by
+// intake date (`created_at`), excluding trashed Jobs by default. Powers
+// the "Jobs sent" section of the Referral Partner Worksheet.
+//
+// Org-scoping rides on RLS: a partner id from another Organization
+// resolves to no `referral_partners` row and the route returns 404
+// before any `jobs` SELECT happens. Trashed Partners are NOT 404'd —
+// the Worksheet must keep loading the section during the 30-day grace
+// period (mirrors slice B's link-preservation behaviour, PRD #297).
+export const GET = withRequestContext(
+  VIEW_REFERRAL_PARTNERS,
+  async (
+    _request,
+    { supabase },
+    { params }: { params: Promise<{ id: string }> },
+  ) => {
+    const { id } = await params;
+
+    // Existence + Org-scope check — no `deleted_at` filter, so a trashed
+    // Partner inside the 30-day grace period still loads its Jobs list.
+    const { data: partner, error: partnerError } = await supabase
+      .from("referral_partners")
+      .select("id")
+      .eq("id", id)
+      .maybeSingle();
+    if (partnerError) {
+      return apiDbError(
+        partnerError.message,
+        "GET /api/referral-partners/[id]/jobs partner",
+      );
+    }
+    if (!partner) {
+      return NextResponse.json(
+        { error: "Referral Partner not found" },
+        { status: 404 },
+      );
+    }
+
+    // SQL drives the filter and the sort — the partial index
+    // `(referral_partner_id) WHERE deleted_at IS NULL` carries the
+    // workload. The pure rule in `src/lib/referral-partners/jobs.ts`
+    // (slice C1) is the unit-tested specification of the same shape.
+    const { data: rows, error: jobsError } = await supabase
+      .from("jobs")
+      .select("id, property_address, status, created_at")
+      .eq("referral_partner_id", id)
+      .is("deleted_at", null)
+      .order("created_at", { ascending: false });
+    if (jobsError) {
+      return apiDbError(
+        jobsError.message,
+        "GET /api/referral-partners/[id]/jobs jobs",
+      );
+    }
+
+    // Project to the documented contract so a future SELECT * mistake
+    // can't leak columns to the client.
+    const jobs = ((rows ?? []) as ReferralPartnerJobRow[]).map((j) => ({
+      id: j.id,
+      property_address: j.property_address,
+      status: j.status,
+      created_at: j.created_at,
+    }));
+    return NextResponse.json({ jobs });
+  },
+);
+
+interface ReferralPartnerJobRow {
+  id: string;
+  property_address: string;
+  status: string;
+  created_at: string;
+}

--- a/src/components/referral-partners/referral-partner-worksheet.test.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.test.tsx
@@ -280,7 +280,10 @@ describe("ReferralPartnerWorksheet — editable company info (PRD #249, issue #2
       // PATCH body" for this slice.
       const calls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls;
       const phoneCall = calls.find((c) => {
-        const body = JSON.parse((c[1] as RequestInit).body as string);
+        // The Jobs-sent section fires a bodyless GET on mount; skip it.
+        const init = c[1] as RequestInit | undefined;
+        if (!init?.body) return false;
+        const body = JSON.parse(init.body as string);
         return "office_phone" in body;
       });
       expect(phoneCall).toBeDefined();
@@ -292,7 +295,13 @@ describe("ReferralPartnerWorksheet — editable company info (PRD #249, issue #2
     fireEvent.blur(screen.getByLabelText(/^industry$/i));
     // Give any incidental Promises a chance to resolve.
     await Promise.resolve();
-    expect(fetch).not.toHaveBeenCalled();
+    // The Jobs-sent section fires a GET on mount; we only care here that
+    // no PATCH (or other body-bearing call) was triggered.
+    const calls = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls;
+    const mutationCalls = calls.filter(
+      (c) => (c[1] as RequestInit | undefined)?.body,
+    );
+    expect(mutationCalls).toEqual([]);
   });
 });
 
@@ -632,6 +641,81 @@ describe("ReferralPartnerWorksheet — + Add contact (PRD #249, issue #255)", ()
       /owner contact/i,
     ) as HTMLSelectElement;
     expect(within(ownerSelect).getByText("Pat Smith")).toBeDefined();
+  });
+});
+
+// ── Jobs sent section (PRD #297, slice C2 / issue #301) ───────────────
+describe("ReferralPartnerWorksheet — Jobs sent section", () => {
+  function stubJobsFetch(
+    jobs: Array<{
+      id: string;
+      property_address: string;
+      status: string;
+      created_at: string;
+    }>,
+  ) {
+    vi.unstubAllGlobals();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.endsWith("/jobs") && url.includes("/referral-partners/")) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ jobs }),
+          } as Response;
+        }
+        return { ok: true, status: 200, json: async () => ({}) } as Response;
+      }),
+    );
+  }
+
+  it("renders a 'Jobs sent' section with a count badge reflecting the number of attributed jobs", async () => {
+    stubJobsFetch([
+      { id: "j-1", property_address: "111 First St", status: "lead",        created_at: "2026-05-01T00:00:00Z" },
+      { id: "j-2", property_address: "222 Second Ave", status: "in_progress", created_at: "2026-04-01T00:00:00Z" },
+    ]);
+    renderWorksheet();
+
+    const section = await screen.findByTestId("worksheet-jobs-sent");
+    expect(section.textContent).toMatch(/jobs sent/i);
+    // Count badge mirrors the Contracts section pattern — a small number
+    // next to the section title.
+    await waitFor(() => {
+      expect(
+        within(section).getByTestId("worksheet-jobs-sent-count").textContent,
+      ).toBe("2");
+    });
+  });
+
+  it("renders one clickable row per Job linking to /jobs/[id] with address and status", async () => {
+    stubJobsFetch([
+      { id: "j-1", property_address: "111 First St", status: "lead", created_at: "2026-05-01T00:00:00Z" },
+    ]);
+    renderWorksheet();
+
+    const section = await screen.findByTestId("worksheet-jobs-sent");
+    const row = await within(section).findByTestId("worksheet-jobs-sent-row-j-1");
+    expect(row.getAttribute("href")).toBe("/jobs/j-1");
+    expect(row.textContent).toContain("111 First St");
+    expect(row.textContent).toMatch(/lead/i);
+  });
+
+  it("renders the empty-state copy 'No jobs attributed yet.' when the partner has no attributed jobs", async () => {
+    stubJobsFetch([]);
+    renderWorksheet();
+    const section = await screen.findByTestId("worksheet-jobs-sent");
+    await waitFor(() => {
+      expect(section.textContent).toMatch(/no jobs attributed yet\./i);
+    });
+  });
+
+  it("fetches GET /api/referral-partners/[id]/jobs on mount", async () => {
+    stubJobsFetch([]);
+    renderWorksheet();
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/api/referral-partners/p-1/jobs");
+    });
   });
 });
 

--- a/src/components/referral-partners/referral-partner-worksheet.tsx
+++ b/src/components/referral-partners/referral-partner-worksheet.tsx
@@ -10,7 +10,8 @@
 // new status with one click. No automated transitions of any kind —
 // every state change is a deliberate user action.
 
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Handshake, Trash2 } from "lucide-react";
 import { formatPhoneNumber } from "@/lib/phone";
@@ -513,6 +514,9 @@ export function ReferralPartnerWorksheet({
         )}
       </section>
 
+      {/* ── JOBS SENT (PRD #297, slice C2 / #301) ───────────────────── */}
+      <JobsSentSection partnerId={partner.id} />
+
       {/* ── CALL LOG ─────────────────────────────────────────────────── */}
       <CallLogSection
         partnerId={partner.id}
@@ -910,6 +914,102 @@ function CallLogSection({
                   Follow-up: {formatDate(c.follow_up_at)}
                 </p>
               )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// "Jobs sent" section (PRD #297, slice C2 / issue #301). Thin client-side
+// glue over GET /api/referral-partners/[id]/jobs — the endpoint owns the
+// trashed-job filter and the newest-first ordering (the pure rule in
+// `src/lib/referral-partners/jobs.ts` is the unit-tested specification of
+// both). Rows link out to /jobs/[id]; the empty state mirrors the AC copy.
+interface JobsSentRow {
+  id: string;
+  property_address: string;
+  status: string;
+  created_at: string;
+}
+
+function formatIntakeDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function JobsSentSection({ partnerId }: { partnerId: string }) {
+  const [jobs, setJobs] = useState<JobsSentRow[] | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      const res = await fetch(`/api/referral-partners/${partnerId}/jobs`);
+      if (!alive) return;
+      if (res.ok) {
+        const body = (await res.json()) as { jobs: JobsSentRow[] };
+        setJobs(body.jobs ?? []);
+      } else {
+        setJobs([]);
+      }
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [partnerId]);
+
+  const count = jobs?.length ?? 0;
+
+  return (
+    <section
+      data-testid="worksheet-jobs-sent"
+      className="rounded-lg border border-border bg-card px-5 py-4"
+    >
+      <div className="flex items-center justify-between mb-3 gap-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground flex items-center gap-2">
+          Jobs sent
+          {count > 0 && (
+            <span
+              data-testid="worksheet-jobs-sent-count"
+              className="text-[11px] px-1.5 py-0 rounded-full bg-muted text-muted-foreground font-medium normal-case tracking-normal"
+            >
+              {count}
+            </span>
+          )}
+        </p>
+      </div>
+
+      {jobs === null ? null : jobs.length === 0 ? (
+        <p className="text-sm italic text-muted-foreground">
+          No jobs attributed yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {jobs.map((j) => (
+            <li key={j.id} className="first:pt-0 last:pb-0">
+              <Link
+                href={`/jobs/${j.id}`}
+                data-testid={`worksheet-jobs-sent-row-${j.id}`}
+                className="flex items-baseline justify-between gap-3 py-2 hover:bg-accent/40 transition-colors px-2 -mx-2 rounded-md"
+              >
+                <span className="font-medium text-foreground text-sm truncate">
+                  {j.property_address}
+                </span>
+                <span className="flex items-center gap-3 shrink-0">
+                  <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {j.status}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatIntakeDate(j.created_at)}
+                  </span>
+                </span>
+              </Link>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

Slice C2 of PRD #297 — the Referral Partner Worksheet now lists every Job this Partner has referred, newest first.

- New `GET /api/referral-partners/[id]/jobs` returns the Jobs attributed to the Partner, newest first by `created_at`, excluding trashed Jobs by default. Thin SQL adapter; the trashed-job filter + ordering match the unit-tested pure rule in `src/lib/referral-partners/jobs.ts` (slice C1).
- Org-scoping rides on RLS: a partner from another Organization resolves to no `referral_partners` row → 404. A trashed Partner inside the 30-day grace period still loads its Jobs list (mirrors slice B's link-preservation behaviour).
- Worksheet renders a new "Jobs sent" section under the Contacts list with a count badge mirroring the Contracts pattern. Each row is a `<Link>` to `/jobs/[id]` showing property address, status, and intake date. Empty state: "No jobs attributed yet."

Closes #301.

## Acceptance criteria

- [x] New endpoint `GET /api/referral-partners/[id]/jobs` returns the Jobs attributed to this Partner, newest first by `created_at`, excluding trashed Jobs by default.
- [x] Response items include `id`, `property_address`, `status`, `created_at` (explicit projection in the route).
- [x] Endpoint enforces Organization scoping via `withRequestContext`. A request for a Partner in another Organization is rejected with 404 (matches existing PATCH route pattern).
- [x] Worksheet renders a new `Jobs sent` section beneath the existing sections, with a count badge.
- [x] Each row is clickable and navigates to `/jobs/[id]`.
- [x] Empty state reads `No jobs attributed yet.`
- [x] Trashed Partner: the Worksheet still loads the section against the trashed Partner during the 30-day grace period (route does not filter the partner on `deleted_at`).

## Test plan

- [x] `npx vitest run src/app/api/referral-partners/\[id\]/jobs/route.test.ts` — 5 tests pass (401, 403 crew_member, 404 cross-org, response shape, trashed-partner grace period)
- [x] `npx vitest run src/components/referral-partners/referral-partner-worksheet.test.tsx` — 36 tests pass (4 new Jobs-sent assertions + 32 existing)
- [x] `npx vitest run src/app/api/referral-partners src/lib/referral-partners src/components/referral-partners` — 112 referral-partner tests pass
- [x] `npx tsc --noEmit` clean on touched files (the 6 remaining errors are pre-existing on main, none in touched files)
- [x] `npx eslint` clean on the 4 touched files
- [ ] Browser-verify the new "Jobs sent" section on AAA prod after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)