### PR TITLE
feat(intake-form): referrer built-in field + Settings toggle (#302)

### DIFF
--- a/src/components/form-builder/palette.tsx
+++ b/src/components/form-builder/palette.tsx
@@ -3,7 +3,7 @@
 import { useDraggable } from "@dnd-kit/core";
 import {
   Type, AlignLeft, Hash, Calendar, Phone, Mail, ChevronDown,
-  CircleDot, CheckSquare, MapPin, ToggleRight, DollarSign,
+  CircleDot, CheckSquare, MapPin, ToggleRight, DollarSign, Users,
 } from "lucide-react";
 import { FIELD_PRESETS } from "@/lib/intake-form-presets";
 import type { FormField } from "@/lib/types";
@@ -25,7 +25,7 @@ const FIELD_TYPE_ITEMS: {
 ];
 
 const PRESET_ICONS = {
-  Phone, Mail, MapPin, ToggleRight, DollarSign, Calendar,
+  Phone, Mail, MapPin, ToggleRight, DollarSign, Calendar, Users,
 } as const;
 
 export function Palette({

--- a/src/components/intake-form.test.tsx
+++ b/src/components/intake-form.test.tsx
@@ -13,6 +13,11 @@ let contactsSearchResult: { data: unknown; error: unknown } = {
   data: [],
   error: null,
 };
+// Per-table select fixtures. The intake form fetches referral_partners when
+// the config carries a `job.referral_partner_id`-mapped field (slice D, #302);
+// every other awaited select still resolves through contactsSearchResult so
+// the existing insurance-picker tests keep working unchanged.
+let selectResults: Record<string, { data: unknown; error: unknown }> = {};
 // Insert payloads captured per table, plus the row each insert reads back.
 let inserts: Record<string, Record<string, unknown>[]> = {};
 let insertResults: Record<string, { data: unknown; error: unknown }> = {};
@@ -38,12 +43,15 @@ vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
     from: (table: string) => {
       const builder: Record<string, unknown> = {};
-      for (const method of ["select", "eq", "or", "limit", "order"]) {
+      for (const method of ["select", "eq", "or", "is", "limit", "order"]) {
         builder[method] = () => builder;
       }
-      // Awaiting the builder resolves the embedded picker's contacts search.
+      // Awaiting the builder resolves a select. Per-table fixtures take
+      // precedence (referral_partners for slice D, #302); otherwise we fall
+      // back to the contacts-picker fixture so insurance-picker tests keep
+      // working unchanged.
       builder.then = (resolve: (r: unknown) => void) =>
-        resolve(contactsSearchResult);
+        resolve(selectResults[table] ?? contactsSearchResult);
       // `.insert(payload)` records the payload and supports both a
       // `.select().single()` read-back (contacts, jobs) and a bare await
       // (job_custom_fields, job_activities).
@@ -80,6 +88,51 @@ function makeContact(overrides: Partial<Contact> = {}): Contact {
     created_at: "2026-05-21T00:00:00Z",
     updated_at: "2026-05-21T00:00:00Z",
     ...overrides,
+  };
+}
+
+// A form config carrying the referrer field on top of the three fields
+// the submit hard-requires. The toggle in Settings → Intake Form maps to
+// the presence (or visibility) of this field in the config; slice D
+// (#302) adds the special render + write path for it.
+function makeConfigWithReferrer(): FormConfig {
+  return {
+    sections: [
+      {
+        id: "s1",
+        title: "Job",
+        fields: [
+          {
+            id: "f-name",
+            type: "text",
+            label: "Full Name",
+            placeholder: "name-input",
+            maps_to: "contact.full_name",
+          },
+          {
+            id: "f-damage",
+            type: "text",
+            label: "Damage Type",
+            placeholder: "damage-input",
+            maps_to: "job.damage_type",
+          },
+          {
+            id: "f-addr",
+            type: "text",
+            label: "Property Address",
+            placeholder: "address-input",
+            maps_to: "job.property_address",
+          },
+          {
+            id: "referrer",
+            type: "text",
+            label: "Referred by",
+            maps_to: "job.referral_partner_id",
+            is_default: true,
+          },
+        ],
+      },
+    ],
   };
 }
 
@@ -133,6 +186,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   formConfigFixture = makeConfig();
   contactsSearchResult = { data: [], error: null };
+  selectResults = {};
   inserts = {};
   insertResults = {
     contacts: { data: { id: "contact-1" }, error: null },
@@ -279,5 +333,141 @@ describe("IntakeForm — typed search text is never persisted (#195)", () => {
       insurance_contact_id: null,
       insurance_company: null,
     });
+  });
+});
+
+// ─── Referrer field (slice D, #302) ────────────────────────────────────────
+// The Settings → Intake Form toggle enables a built-in `referrer` field
+// (maps_to: "job.referral_partner_id"). When the field is in the config the
+// intake form renders the shared `<ReferrerPicker>` and writes the picked
+// partner's id to `jobs.referral_partner_id` directly — NOT to the generic
+// `job_custom_fields` key/value table (acceptance criterion: FK column, not
+// custom_fields).
+
+describe("IntakeForm — referrer field renders ReferrerPicker (#302)", () => {
+  it("renders the picker (with active partners) for a field mapped to job.referral_partner_id", async () => {
+    formConfigFixture = makeConfigWithReferrer();
+    selectResults = {
+      referral_partners: {
+        data: [
+          {
+            id: "rp-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+            deleted_at: null,
+          },
+        ],
+        error: null,
+      },
+    };
+
+    render(<IntakeForm />);
+
+    // The active partner appears in the picker, proving ReferrerPicker
+    // (not the configured text input) was rendered for the referrer field.
+    expect(await screen.findByText("Acme Plumbing")).toBeDefined();
+  });
+});
+
+describe("IntakeForm — referrer routed to jobs.referral_partner_id, not custom_fields (#302)", () => {
+  it("writes the picked partner id to jobs.referral_partner_id and never to job_custom_fields", async () => {
+    formConfigFixture = makeConfigWithReferrer();
+    selectResults = {
+      referral_partners: {
+        data: [
+          {
+            id: "rp-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+            deleted_at: null,
+          },
+        ],
+        error: null,
+      },
+    };
+
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: /Acme Plumbing/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    expect(inserts.jobs[0]).toMatchObject({ referral_partner_id: "rp-1" });
+    // The FK lives on jobs; the referrer must NOT be persisted as a generic
+    // key/value pair on job_custom_fields.
+    expect(inserts.job_custom_fields).toBeUndefined();
+  });
+});
+
+describe("IntakeForm — referrer left blank (#302)", () => {
+  it("writes referral_partner_id: null when the picker is not used", async () => {
+    formConfigFixture = makeConfigWithReferrer();
+    selectResults = {
+      referral_partners: {
+        data: [
+          {
+            id: "rp-1",
+            company_name: "Acme Plumbing",
+            status: "green",
+            deleted_at: null,
+          },
+        ],
+        error: null,
+      },
+    };
+
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    expect(inserts.jobs[0]).toMatchObject({ referral_partner_id: null });
+  });
+});
+
+describe("IntakeForm — toggle off: referrer field absent (#302)", () => {
+  it("does not render the picker and submits exactly as today when the field is omitted from the config", async () => {
+    // Default `makeConfig()` is the today-shape (no referrer field).
+    render(<IntakeForm />);
+
+    // Picker is not in the DOM.
+    expect(screen.queryByText(/promote and attach/i)).toBeNull();
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(inserts.jobs).toBeDefined());
+    // The FK is absent from the insert payload (today's behavior preserved).
+    expect("referral_partner_id" in inserts.jobs[0]).toBe(false);
   });
 });

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -15,6 +15,9 @@ import { formatPhoneNumber, isValidUSPhone, normalizePhoneToE164 } from "@/lib/p
 import { isValidPastDate } from "@/lib/date-field";
 import { DateField } from "@/components/date-field";
 import InsuranceCompanyPicker from "@/components/insurance-company-picker";
+import ReferrerPicker, {
+  type ReferrerPickerPartner,
+} from "@/components/referral-partners/referrer-picker";
 import type { Contact, FormConfig, FormField } from "@/lib/types";
 
 export default function IntakeForm({ testMode = false }: { testMode?: boolean } = {}) {
@@ -30,6 +33,12 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
   // is mirrored into `values` so the existing required-field check and
   // the insurance_company write keep working unchanged (#195).
   const [insuranceContact, setInsuranceContact] = useState<Contact | null>(null);
+  // Slice D (#302): when the built-in `referrer` field is enabled in the
+  // config, the renderer surfaces it as a `<ReferrerPicker>` and writes the
+  // picked partner's id to `jobs.referral_partner_id` on submit — bypassing
+  // the generic `job_custom_fields` write path.
+  const [referralPartnerId, setReferralPartnerId] = useState<string | null>(null);
+  const [referralPartners, setReferralPartners] = useState<ReferrerPickerPartner[]>([]);
 
   // Load form config
   useEffect(() => {
@@ -51,6 +60,54 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
       .catch(() => {})
       .finally(() => setLoadingConfig(false));
   }, []);
+
+  // Fetch the picker's source-of-truth partner list (Active + yellow Targets,
+  // not trashed) once we know the form has a referrer field. The picker uses
+  // `eligibilityFor()` to slot rows into pickable / promote-then-pick / hidden
+  // groups — passing the unfiltered live list is what lets yellow Targets
+  // appear under the `+ Promote and attach` affordance.
+  const hasReferrerField = !!formConfig?.sections.some((s) =>
+    s.fields.some((f) => f.maps_to === "job.referral_partner_id"),
+  );
+  useEffect(() => {
+    if (!hasReferrerField) return;
+    let cancelled = false;
+    (async () => {
+      const supabase = createClient();
+      const { data } = await supabase
+        .from("referral_partners")
+        .select("id, company_name, status, deleted_at")
+        .is("deleted_at", null)
+        .order("company_name", { ascending: true });
+      if (!cancelled && data) {
+        setReferralPartners(data as ReferrerPickerPartner[]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [hasReferrerField]);
+
+  async function handlePromoteAndPick(partnerId: string) {
+    // Mirrors the Edit Job Info dialog flow (#298): flip the yellow Target
+    // to Active via PATCH so the server-side eligibility check has something
+    // to accept, then attach to the Job. The actual FK write happens at
+    // submit time — here we only flip the status and optimistically reflect
+    // it in local state so the picker re-renders the row as pickable.
+    const res = await fetch(`/api/referral-partners/${partnerId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "green" }),
+    });
+    if (!res.ok) {
+      toast.error("Couldn't promote the Target — try again.");
+      return;
+    }
+    setReferralPartners((prev) =>
+      prev.map((p) => (p.id === partnerId ? { ...p, status: "green" } : p)),
+    );
+    setReferralPartnerId(partnerId);
+  }
 
   function setValue(fieldId: string, value: string) {
     setValues((prev) => ({ ...prev, [fieldId]: value }));
@@ -176,24 +233,34 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
       const propertyStories = valueByMapsTo("job.property_stories");
       const damageSource = valueByMapsTo("job.damage_source");
 
+      const jobPayload: Record<string, unknown> = {
+        organization_id: orgId,
+        contact_id: contact.id,
+        damage_type: damageType,
+        damage_source: damageSource || null,
+        property_address: propertyAddress,
+        property_type: valueByMapsTo("job.property_type") || null,
+        property_sqft: propertySqft ? parseInt(propertySqft) : null,
+        property_stories: propertyStories ? parseInt(propertyStories) : null,
+        affected_areas: valueByMapsTo("job.affected_areas") || null,
+        urgency: valueByMapsTo("job.urgency") || "scheduled",
+        insurance_company: valueByMapsTo("job.insurance_company") || null,
+        insurance_contact_id: insuranceContact?.id ?? null,
+        claim_number: valueByMapsTo("job.claim_number") || null,
+        access_notes: valueByMapsTo("job.access_notes") || null,
+      };
+      // Only attach the FK when the referrer field is enabled in this org's
+      // config — preserves today's payload shape (no extra key) for orgs
+      // that haven't opted into the toggle. ADR-0002 eligibility still holds
+      // because the picker only exposes pickable partners and the server-
+      // side check runs whenever the FK is written.
+      if (hasReferrerField) {
+        jobPayload.referral_partner_id = referralPartnerId;
+      }
+
       const { data: job, error: jobErr } = await supabase
         .from("jobs")
-        .insert({
-          organization_id: orgId,
-          contact_id: contact.id,
-          damage_type: damageType,
-          damage_source: damageSource || null,
-          property_address: propertyAddress,
-          property_type: valueByMapsTo("job.property_type") || null,
-          property_sqft: propertySqft ? parseInt(propertySqft) : null,
-          property_stories: propertyStories ? parseInt(propertyStories) : null,
-          affected_areas: valueByMapsTo("job.affected_areas") || null,
-          urgency: valueByMapsTo("job.urgency") || "scheduled",
-          insurance_company: valueByMapsTo("job.insurance_company") || null,
-          insurance_contact_id: insuranceContact?.id ?? null,
-          claim_number: valueByMapsTo("job.claim_number") || null,
-          access_notes: valueByMapsTo("job.access_notes") || null,
-        })
+        .insert(jobPayload)
         .select()
         .single();
 
@@ -252,7 +319,19 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
       router.push(`/jobs/${job.id}`);
     } catch (err) {
       console.error(err);
-      toast.error("Something went wrong. Please try again.");
+      // The eligibility trigger from migration-302 raises an exception whose
+      // message begins with "RP-INELIGIBLE:" when a non-Active / trashed /
+      // cross-Organization Referral Partner is attached. Surface a clear
+      // toast so the office user knows to re-pick rather than retry blind.
+      const message =
+        err && typeof err === "object" && "message" in err
+          ? String((err as { message?: unknown }).message ?? "")
+          : "";
+      if (message.includes("RP-INELIGIBLE")) {
+        toast.error("That Referral Partner can't be attached. Please pick another.");
+      } else {
+        toast.error("Something went wrong. Please try again.");
+      }
     } finally {
       setSubmitting(false);
     }
@@ -299,6 +378,10 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
                     damageTypes={damageTypes}
                     insuranceContact={insuranceContact}
                     onInsuranceChange={(c) => setInsurance(field.id, c)}
+                    referralPartners={referralPartners}
+                    referralPartnerId={referralPartnerId}
+                    onReferralPartnerChange={setReferralPartnerId}
+                    onPromoteAndPickReferralPartner={handlePromoteAndPick}
                   />
                 ))}
             </div>
@@ -335,6 +418,10 @@ function DynamicField({
   damageTypes,
   insuranceContact,
   onInsuranceChange,
+  referralPartners,
+  referralPartnerId,
+  onReferralPartnerChange,
+  onPromoteAndPickReferralPartner,
 }: {
   field: FormField;
   value: string;
@@ -342,6 +429,10 @@ function DynamicField({
   damageTypes: { name: string; display_label: string; bg_color: string; text_color: string }[];
   insuranceContact: Contact | null;
   onInsuranceChange: (c: Contact | null) => void;
+  referralPartners: ReferrerPickerPartner[];
+  referralPartnerId: string | null;
+  onReferralPartnerChange: (id: string | null) => void;
+  onPromoteAndPickReferralPartner: (id: string) => void;
 }) {
   // Get options — from damage_types config or field.options
   let options = field.options || [];
@@ -358,6 +449,12 @@ function DynamicField({
   // its configured plain input — same idea as the damage_types option
   // source above, no new field type, no form-config change (#195).
   const isInsuranceCompany = field.maps_to === "job.insurance_company";
+  // Slice D (#302): the built-in `referrer` field is special — its value is
+  // a Referral Partner id, not free text, and it persists to the FK column
+  // on jobs rather than to `job_custom_fields`. The renderer surfaces the
+  // shared `<ReferrerPicker>` (same component the Edit Job Info dialog uses)
+  // so the eligibility rule from ADR-0002 stays the single source of truth.
+  const isReferrer = field.maps_to === "job.referral_partner_id";
 
   return (
     <div>
@@ -379,7 +476,16 @@ function DynamicField({
         />
       )}
 
-      {!isInsuranceCompany &&
+      {isReferrer && (
+        <ReferrerPicker
+          partners={referralPartners}
+          value={referralPartnerId}
+          onChange={onReferralPartnerChange}
+          onPromoteAndPick={onPromoteAndPickReferralPartner}
+        />
+      )}
+
+      {!isInsuranceCompany && !isReferrer &&
         (field.type === "text" || field.type === "phone" || field.type === "email") && (
         <Input
           type={field.type === "phone" ? "tel" : field.type === "email" ? "email" : "text"}

--- a/src/lib/intake-form-presets.ts
+++ b/src/lib/intake-form-presets.ts
@@ -88,4 +88,24 @@ export const FIELD_PRESETS: FieldPreset[] = [
       visible: true,
     }),
   },
+  {
+    // Slice D (#302): the built-in `referrer` field. `maps_to` routes the
+    // picked value to `jobs.referral_partner_id` on submit (not to
+    // `job_custom_fields`); `is_default: true` lets the renderer treat it
+    // as a special FK-backed field rather than a free-text question.
+    // Off-by-default per Organization is achieved by not seeding the field
+    // into existing configs — admins opt in by adding it from this palette.
+    key: "referrer",
+    name: "Referred by",
+    icon: "Users",
+    description: "Picker for the Referral Partner who sent us this Job",
+    makeField: () => ({
+      type: "text",
+      label: "Referred by",
+      maps_to: "job.referral_partner_id",
+      required: false,
+      is_default: true,
+      visible: true,
+    }),
+  },
 ];

--- a/supabase/migration-302-jobs-referral-partner-eligibility-trigger.sql
+++ b/supabase/migration-302-jobs-referral-partner-eligibility-trigger.sql
@@ -1,0 +1,87 @@
+-- issue #302 (PRD #297, slice D) — server-side eligibility for the
+-- Referral Partner FK on `jobs`.
+--
+-- Slice B (#298) added eligibility enforcement to PATCH /api/jobs/[id]
+-- via `eligibilityFor()` in src/lib/referral-partners/eligibility.ts.
+-- Slice D wires the same FK into the intake form, which writes the row
+-- with a direct supabase-js INSERT — there is no app-server endpoint in
+-- that path. This trigger is the defense-in-depth backstop: it enforces
+-- the ADR-0002 rule at the database, so any client that tries to attach
+-- a non-Active or trashed Referral Partner is rejected regardless of
+-- which route the write came through.
+--
+-- Rule (mirrors `eligibilityFor()`):
+--   1. The partner must exist.
+--   2. The partner must not be trashed (`deleted_at IS NULL`).
+--   3. The partner's Lifecycle status must be 'green' (Active).
+--   4. The partner must belong to the same Organization as the Job.
+--
+-- A NULL FK clears the attribution and is always allowed (mirrors the
+-- "clearing the FK" path on PATCH /api/jobs/[id]).
+--
+-- The exception text starts with `RP-INELIGIBLE:` so the API layer (and
+-- any future client error mapping) can recognize it and turn it into an
+-- HTTP 422 with a clear reason. supabase-js surfaces the raw message on
+-- the PostgrestError; the intake form's submit catch block falls back to
+-- a generic toast today, which is acceptable until the message-mapping
+-- pass lands alongside the next intake-form refactor.
+
+CREATE OR REPLACE FUNCTION public.enforce_referral_partner_eligibility()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  partner_row record;
+BEGIN
+  -- Clearing the FK or no change to the FK: nothing to validate.
+  IF NEW.referral_partner_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' AND NEW.referral_partner_id IS NOT DISTINCT FROM OLD.referral_partner_id THEN
+    RETURN NEW;
+  END IF;
+
+  SELECT id, status, deleted_at, organization_id
+    INTO partner_row
+    FROM public.referral_partners
+   WHERE id = NEW.referral_partner_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'RP-INELIGIBLE: Referral Partner not found (id=%)', NEW.referral_partner_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF partner_row.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'RP-INELIGIBLE: Referral Partner is trashed (id=%)', NEW.referral_partner_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF partner_row.status <> 'green' THEN
+    RAISE EXCEPTION 'RP-INELIGIBLE: Referral Partner Lifecycle status must be green (id=%, status=%)',
+      NEW.referral_partner_id, partner_row.status
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  IF partner_row.organization_id IS DISTINCT FROM NEW.organization_id THEN
+    RAISE EXCEPTION 'RP-INELIGIBLE: Referral Partner belongs to a different Organization (id=%)',
+      NEW.referral_partner_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_jobs_referral_partner_eligibility ON public.jobs;
+
+CREATE TRIGGER trg_jobs_referral_partner_eligibility
+  BEFORE INSERT OR UPDATE OF referral_partner_id, organization_id
+  ON public.jobs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_referral_partner_eligibility();
+
+-- ROLLBACK ---
+-- DROP TRIGGER IF EXISTS trg_jobs_referral_partner_eligibility ON public.jobs;
+-- DROP FUNCTION IF EXISTS public.enforce_referral_partner_eligibility();


### PR DESCRIPTION
## Summary

Slice D of PRD #297 — wires the shared `<ReferrerPicker>` into the intake form and adds the matching Settings → Intake Form toggle.

- Intake form recognises `maps_to: \"job.referral_partner_id\"` as a special FK-backed field, renders `<ReferrerPicker>` (Active partners pickable, yellow Targets behind \"+ Promote and attach\"), and writes the picked id to `jobs.referral_partner_id` — **not** to `job_custom_fields`.
- New \"Referred by\" preset in the Settings → Intake Form palette (Users icon). Off-by-default per Organization: admins opt in by adding it from the palette; no migration auto-seeds the field.
- DB trigger `trg_jobs_referral_partner_eligibility` mirrors `eligibilityFor()` (ADR-0002) on INSERT/UPDATE so the rule holds for direct supabase-js inserts that bypass `PATCH /api/jobs/[id]`. **Already applied to AAA prod** (`rzzprgidqbnqcdupmpfe`) via Supabase MCP with plain-text approval — the SQL file is in the repo for the record.

Closes #302.

## Test plan

- [x] `npx vitest run src/components/intake-form.test.tsx` — 9 pass (4 new for referrer)
- [x] `npx vitest run src/app/api/jobs/ src/components/referral-partners/` — 88 pass
- [x] Trigger verified in prod via `pg_trigger` lookup
- [ ] Manually: open intake form with the toggle on, pick an Active partner, submit → Job page shows \"Referred by\" line
- [ ] Manually: pick a yellow Target via \"+ Promote and attach\" on the intake form, submit → partner is flipped to green and the FK is set on the new Job
- [ ] Manually: leave the picker empty, submit → Job is created with `referral_partner_id = null`
- [ ] Manually: remove the field from Settings → Intake Form, submit → no `referral_partner_id` written, existing intake behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)