### PR TITLE
feat(phone): view_phone permission + /phone nav item & empty page (#306)

### DIFF
--- a/src/app/api/settings/users/route.ts
+++ b/src/app/api/settings/users/route.ts
@@ -1,22 +1,7 @@
 import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
-import { PERMISSION_KEYS, type PermissionKey } from "@/lib/permissions/permission-keys";
-
-// Default permission grants per role. A new member is seeded a row for every
-// canonical key (PERMISSION_KEYS); these lists decide which start
-// `granted: true`. `admin` lists every key for consistency only — admins
-// auto-pass every rule regardless of their grants.
-const ROLE_DEFAULTS: Record<string, readonly PermissionKey[]> = {
-  admin: PERMISSION_KEYS,
-  crew_lead: [
-    "view_jobs", "edit_jobs", "create_jobs",
-    "log_activities", "upload_photos", "edit_photos",
-    "view_billing", "record_payments",
-    "view_email", "send_email", "manage_reports",
-  ],
-  crew_member: ["view_jobs", "log_activities", "upload_photos"],
-  custom: [],
-};
+import { PERMISSION_KEYS } from "@/lib/permissions/permission-keys";
+import { ROLE_DEFAULTS } from "@/lib/permissions/role-defaults";
 
 // GET /api/settings/users — list all members of the active org with their
 // user_profiles joined. Role is sourced from user_organizations (per-org).

--- a/src/app/phone/page.test.tsx
+++ b/src/app/phone/page.test.tsx
@@ -1,0 +1,99 @@
+// PRD #304 — Nookleus Phone. Slice 2 (#306).
+//
+// Pins two AC bullets at the page level:
+//   1. A caller with `view_phone` lands on the empty-state surface and sees
+//      "No conversations yet — text or call a Contact to get started."
+//   2. A caller without `view_phone` is denied — the shared "Access
+//      restricted" surface from the estimates/[id] / invoices/[id] / referral-
+//      partners/[id] pages.
+//
+// The page itself is a Server Component that calls `requirePagePermission`
+// to gate the surface and render `<ErrorPage>` on denial — the standard
+// unauthorized response in this codebase. We render the page via
+// `await Page({})` (the referral-partners/[id] page test pattern).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import PhonePage from "./page";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { fakeUserClient, memberTables } from "@/app/api/__test-utils__/request-context-fakes";
+
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+async function renderPage() {
+  const tree = await PhonePage();
+  return render(tree);
+}
+
+describe("/phone — empty-state surface (PRD #304 / #306)", () => {
+  it("renders the empty-state copy for a crew_lead holding view_phone", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    await renderPage();
+
+    expect(
+      screen.getByText(
+        "No conversations yet — text or call a Contact to get started.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("renders the empty-state copy for an admin (auto-passes the gate)", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "admin" }),
+    });
+
+    await renderPage();
+
+    expect(
+      screen.getByText(
+        "No conversations yet — text or call a Contact to get started.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("renders the access-restricted surface for a crew_member without view_phone", async () => {
+    useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "crew_member" }),
+    });
+
+    await renderPage();
+
+    // Shared ErrorPage pattern across gated routes (estimates/[id],
+    // invoices/[id], referral-partners/[id]).
+    expect(screen.getByText(/access restricted/i)).toBeDefined();
+    // The empty-state surface should not have rendered.
+    expect(
+      screen.queryByText(
+        "No conversations yet — text or call a Contact to get started.",
+      ),
+    ).toBeNull();
+  });
+});

--- a/src/app/phone/page.tsx
+++ b/src/app/phone/page.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import { AlertCircle, Phone as PhoneIcon } from "lucide-react";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { requirePagePermission } from "@/lib/request-context/require-page-permission";
+
+// PRD #304 — Nookleus Phone. Slice 2 (#306) — the tracer slice.
+//
+// This is the empty-state surface for the future Phone tab. No Twilio,
+// no data fetching, no realtime — just the gate, the route, and the empty
+// state. Future slices replace the empty state with the iMessage-style
+// two-pane Conversations / thread view.
+//
+// Gate: `view_phone` (PRD #304 § Permission). Denial follows the shared
+// ErrorPage pattern used by estimates/[id], invoices/[id], and
+// referral-partners/[id] — the codebase's standard unauthorized response.
+
+export default async function PhonePage() {
+  const supabase = await createServerSupabaseClient();
+  const auth = await requirePagePermission(supabase, {
+    permission: "view_phone",
+  });
+
+  if (!auth.ok) {
+    return (
+      <div className="flex items-center justify-center min-h-[40vh] px-4">
+        <div className="rounded-xl border border-border bg-card p-8 text-center max-w-md w-full">
+          <AlertCircle size={28} className="mx-auto text-destructive mb-3" />
+          <h2 className="text-lg font-semibold text-foreground">Access restricted</h2>
+          <p className="text-sm text-muted-foreground mt-1">
+            You don&apos;t have permission to view the Phone tab.
+          </p>
+          <Link
+            href="/"
+            className="inline-block mt-4 text-sm font-medium text-[var(--brand-primary)] hover:underline"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh] px-4">
+      <div className="text-center max-w-md">
+        <PhoneIcon size={40} className="mx-auto text-muted-foreground mb-4" />
+        <h1 className="text-lg font-semibold text-foreground">Phone</h1>
+        <p className="text-sm text-muted-foreground mt-2">
+          No conversations yet — text or call a Contact to get started.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav.test.tsx
+++ b/src/components/nav.test.tsx
@@ -1,0 +1,110 @@
+// PRD #304 — Nookleus Phone. Slice 2 (#306).
+//
+// Pins two AC bullets at the Sidebar render level:
+//   1. The Phone item appears only when the caller holds `view_phone`.
+//   2. When it appears, it sits between Contacts and Email.
+//
+// The Sidebar pulls from `navItems` (`src/lib/nav-items.ts`) and filters by
+// the caller's role + permissions. This test mocks the contexts the Sidebar
+// reads from so the filter rule can be exercised in isolation.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: () => {}, refresh: () => {} }),
+}));
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const useAuthMock = vi.fn();
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("@/lib/nav-order-context", () => ({
+  useNavOrder: () => ({ order: new Map<string, number>() }),
+}));
+
+vi.mock("@/lib/sidebar-collapse-context", () => ({
+  useSidebarCollapse: () => ({ collapsed: false, toggle: () => {} }),
+}));
+
+vi.mock("@/components/notification-bell", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/workspace-switcher", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import Sidebar from "./nav";
+
+beforeEach(() => {
+  useAuthMock.mockReset();
+  // /api/settings/company fetch — return a non-ok response so the effect
+  // sets no state and renders nothing for branding.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve({ ok: false } as Response)),
+  );
+});
+
+function setAuth(opts: {
+  role: string;
+  grants: Record<string, boolean>;
+}) {
+  useAuthMock.mockReturnValue({
+    user: { id: "u-1" },
+    profile: { id: "u-1", full_name: "Test User", role: opts.role },
+    permissions: opts.grants,
+    loading: false,
+    hasPermission: (key: string) => {
+      if (opts.role === "admin") return true;
+      return opts.grants[key] === true;
+    },
+    signOut: () => Promise.resolve(),
+    refreshProfile: () => Promise.resolve(),
+  });
+}
+
+describe("Sidebar — Phone item visibility (PRD #304 / #306)", () => {
+  it("shows the Phone item to a crew_lead who holds view_phone", () => {
+    setAuth({ role: "crew_lead", grants: { view_phone: true } });
+    render(<Sidebar />);
+    // Two renders (mobile bar + desktop sidebar) may produce two Phone
+    // links; either way the item must be present.
+    expect(screen.getAllByText("Phone").length).toBeGreaterThan(0);
+  });
+
+  it("shows the Phone item to an admin regardless of explicit grants", () => {
+    setAuth({ role: "admin", grants: {} });
+    render(<Sidebar />);
+    expect(screen.getAllByText("Phone").length).toBeGreaterThan(0);
+  });
+
+  it("hides the Phone item from a crew_member without view_phone", () => {
+    setAuth({ role: "crew_member", grants: { view_phone: false } });
+    render(<Sidebar />);
+    expect(screen.queryByText("Phone")).toBeNull();
+  });
+
+  it("positions the Phone item between Contacts and Email", () => {
+    setAuth({ role: "crew_lead", grants: { view_phone: true } });
+    render(<Sidebar />);
+    const links = Array.from(document.querySelectorAll("a[href]"));
+    const hrefs = links.map((a) => a.getAttribute("href"));
+    const contactsIdx = hrefs.indexOf("/contacts");
+    const phoneIdx = hrefs.indexOf("/phone");
+    const emailIdx = hrefs.indexOf("/email");
+    expect(contactsIdx).toBeGreaterThanOrEqual(0);
+    expect(phoneIdx).toBeGreaterThan(contactsIdx);
+    expect(emailIdx).toBeGreaterThan(phoneIdx);
+  });
+});

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -17,17 +17,27 @@ import { Tooltip } from "@base-ui/react/tooltip";
 export default function Sidebar() {
   const pathname = usePathname();
   const router = useRouter();
-  const { profile, signOut } = useAuth();
+  const { profile, signOut, hasPermission } = useAuth();
   const { order } = useNavOrder();
   const { collapsed, toggle } = useSidebarCollapse();
 
-  // Filter by membership role first, then sort by DB sort_order.
-  // Items missing from the DB fall to the bottom in code-defined order.
-  // An item with `requiredRoles` is hidden from any caller whose role
-  // isn't in the list (e.g. crew_member never sees Referral Partners).
+  // Filter by membership role + required permission, then sort by DB
+  // sort_order. Items missing from the DB fall to the bottom in code-
+  // defined order. An item with `requiredRoles` is hidden from any caller
+  // whose role isn't in the list (e.g. crew_member never sees Referral
+  // Partners). An item with `requiredPermission` is hidden from any caller
+  // who lacks that grant (e.g. Phone is hidden from a crew_member without
+  // view_phone — PRD #304 / #306).
   const visibleNavItems = navItems.filter((item) => {
-    if (!item.requiredRoles) return true;
-    return profile?.role ? item.requiredRoles.includes(profile.role) : false;
+    if (item.requiredRoles) {
+      if (!profile?.role || !item.requiredRoles.includes(profile.role)) {
+        return false;
+      }
+    }
+    if (item.requiredPermission && !hasPermission(item.requiredPermission)) {
+      return false;
+    }
+    return true;
   });
   const sortedNavItems = [...visibleNavItems].sort((a, b) => {
     const aOrder = order.get(a.href) ?? Infinity;

--- a/src/lib/nav-items.ts
+++ b/src/lib/nav-items.ts
@@ -6,6 +6,7 @@ import {
   Camera,
   FileText,
   Mail,
+  Phone,
   Settings,
   Sparkles,
   Megaphone,
@@ -13,6 +14,7 @@ import {
   Handshake,
 } from "lucide-react";
 import type { ComponentType } from "react";
+import type { PermissionKey } from "@/lib/permissions/permission-keys";
 
 export interface NavItem {
   href: string;
@@ -21,6 +23,10 @@ export interface NavItem {
   /** Membership roles allowed to see this item. Undefined = visible to every
    *  authenticated member (the default for legacy items). */
   requiredRoles?: readonly string[];
+  /** Permission key required to see this item. Admin auto-passes. Undefined =
+   *  not gated on a permission (the default; legacy items rely on role gating
+   *  or no gating at all). */
+  requiredPermission?: PermissionKey;
 }
 
 /**
@@ -47,6 +53,9 @@ export const navItems: NavItem[] = [
   { href: "/photos",    label: "Photos",     icon: Camera },
   { href: "/reports",   label: "Reports",    icon: FileText },
   { href: "/contacts",  label: "Contacts",   icon: Users },
+  // Phone sits between Contacts and Email (PRD #304 / #306). Gated on
+  // view_phone — defaults Admin=ON, Crew Lead=ON, Crew Member=OFF.
+  { href: "/phone",     label: "Phone",      icon: Phone, requiredPermission: "view_phone" },
   { href: "/email",      label: "Email",      icon: Mail },
   { href: "/accounting", label: "Accounting", icon: Calculator },
   { href: "/settings",   label: "Settings",   icon: Settings },

--- a/src/lib/permissions/permission-keys.ts
+++ b/src/lib/permissions/permission-keys.ts
@@ -59,6 +59,10 @@ export const PERMISSION_CATALOG = [
   { key: "view_email", label: "View Email", group: "Email" },
   { key: "send_email", label: "Send Email", group: "Email" },
 
+  // PRD #304 — Nookleus Phone (in-app text and call with customers).
+  // Defaults live in `role-defaults.ts`: Admin ON, Crew Lead ON, Crew Member OFF.
+  { key: "view_phone", label: "View Phone", group: "Phone" },
+
   { key: "manage_reports", label: "Manage Reports", group: "Reports" },
 
   { key: "manage_templates", label: "Manage Estimate Templates", group: "Templates" },

--- a/src/lib/permissions/role-defaults.test.ts
+++ b/src/lib/permissions/role-defaults.test.ts
@@ -1,0 +1,47 @@
+// PRD #304 — Nookleus Phone. Slice 2 (#306).
+//
+// Pins the role-default permission grants for `view_phone` against the table
+// in PRD #304's Implementation Decisions § Permission:
+//
+//   | Role        | Default |
+//   | ----------- | ------- |
+//   | Admin       | ON      |
+//   | Crew Lead   | ON      |
+//   | Crew Member | OFF     |
+//
+// `ROLE_DEFAULTS` is the application-layer source of truth that
+// `POST /api/settings/users` reads when seeding a new member's grants. The
+// SQL function `set_default_permissions` mirrors this table at the database
+// layer; the migration that ships with this slice keeps the two in sync.
+//
+// Admin's entry is `PERMISSION_KEYS` rather than an enumerated list — admins
+// auto-pass every rule regardless of grants — so the admin assertion goes
+// through the catalog.
+
+import { describe, it, expect } from "vitest";
+import { ROLE_DEFAULTS } from "./role-defaults";
+import { PERMISSION_CATALOG } from "./permission-keys";
+
+describe("ROLE_DEFAULTS — view_phone defaults (PRD #304)", () => {
+  it("includes view_phone in admin's defaults (admins get every catalog key)", () => {
+    expect(ROLE_DEFAULTS.admin).toContain("view_phone");
+  });
+
+  it("includes view_phone in crew_lead's defaults", () => {
+    expect(ROLE_DEFAULTS.crew_lead).toContain("view_phone");
+  });
+
+  it("excludes view_phone from crew_member's defaults", () => {
+    expect(ROLE_DEFAULTS.crew_member).not.toContain("view_phone");
+  });
+
+  it("excludes view_phone from custom (the empty default)", () => {
+    expect(ROLE_DEFAULTS.custom).not.toContain("view_phone");
+  });
+
+  it("registers view_phone in the permission catalog under the Phone group", () => {
+    const entry = PERMISSION_CATALOG.find((p) => p.key === "view_phone");
+    expect(entry).toBeDefined();
+    expect(entry?.group).toBe("Phone");
+  });
+});

--- a/src/lib/permissions/role-defaults.ts
+++ b/src/lib/permissions/role-defaults.ts
@@ -1,0 +1,28 @@
+// `ROLE_DEFAULTS` — the per-role default permission grants applied when a
+// new member is seeded. The application-layer source of truth for
+// `POST /api/settings/users`; the SQL function `set_default_permissions`
+// mirrors this table at the database layer.
+//
+// Admin's entry is `PERMISSION_KEYS` (every catalog key) for consistency —
+// admins auto-pass every rule regardless of grants. Crew Lead is the
+// curated worker list. Crew Member is the minimal Job-only list. `custom`
+// is the "no defaults" role used when an admin wants to hand-pick grants.
+//
+// Pinned by `role-defaults.test.ts` against the PRD tables that scope each
+// new permission key (e.g. PRD #304 for `view_phone`).
+
+import { PERMISSION_KEYS, type PermissionKey } from "./permission-keys";
+
+export const ROLE_DEFAULTS: Record<string, readonly PermissionKey[]> = {
+  admin: PERMISSION_KEYS,
+  crew_lead: [
+    "view_jobs", "edit_jobs", "create_jobs",
+    "log_activities", "upload_photos", "edit_photos",
+    "view_billing", "record_payments",
+    "view_email", "send_email",
+    "view_phone",
+    "manage_reports",
+  ],
+  crew_member: ["view_jobs", "log_activities", "upload_photos"],
+  custom: [],
+};

--- a/supabase/migration-306-view-phone-permission.sql
+++ b/supabase/migration-306-view-phone-permission.sql
@@ -1,0 +1,173 @@
+-- migration-306-view-phone-permission.sql
+--
+-- PRD #304 — Nookleus Phone. Slice 2 (#306).
+--
+-- Adds the `view_phone` permission key to existing memberships across every
+-- Organization, with role-based defaults pinned by `role-defaults.test.ts`
+-- against the table in PRD #304 § Permission:
+--
+--   | Role        | Default |
+--   | ----------- | ------- |
+--   | Admin       | ON      |
+--   | Crew Lead   | ON      |
+--   | Crew Member | OFF     |
+--   | (other)     | OFF     |
+--
+-- Two stages, mirroring build48's pattern:
+--
+--   1. Rewrite the `set_default_permissions(uuid, text)` function so new
+--      memberships created after this migration include `view_phone` in
+--      the seeded grants. The function writes to both `user_organization_
+--      permissions` (the new source of truth) and `user_permissions` (the
+--      legacy table kept in sync during 18a for revert safety).
+--   2. Backfill: insert a (membership, 'view_phone', granted) row for every
+--      existing `user_organizations` row, where `granted` follows the role
+--      defaults. Idempotent — re-running is safe.
+--
+-- Depends on build48 (the (p_user_organization_id, p_role) signature of
+-- set_default_permissions).
+
+-- ---------------------------------------------------------------------------
+-- 1. Refresh set_default_permissions to include view_phone in both
+--    all_perms and lead_perms. admin_perms = all_perms; member_perms is
+--    unchanged (Crew Member does not get view_phone).
+-- ---------------------------------------------------------------------------
+create or replace function public.set_default_permissions(p_user_organization_id uuid, p_role text)
+returns void
+language plpgsql
+as $$
+declare
+  all_perms text[] := array[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'view_phone',
+    'manage_reports', 'access_settings',
+    'log_expenses', 'manage_vendors', 'manage_contract_templates', 'manage_expense_categories',
+    'view_accounting', 'manage_accounting'
+  ];
+  admin_perms text[] := all_perms;
+  lead_perms text[] := array[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'view_phone',
+    'manage_reports',
+    'log_expenses'
+  ];
+  member_perms text[] := array[
+    'view_jobs', 'log_activities', 'upload_photos',
+    'log_expenses'
+  ];
+  granted_perms text[];
+  perm text;
+  v_user_id uuid;
+begin
+  select user_id into v_user_id from public.user_organizations where id = p_user_organization_id;
+  if v_user_id is null then
+    raise exception 'set_default_permissions: user_organization % not found', p_user_organization_id;
+  end if;
+
+  if p_role = 'admin' then
+    granted_perms := admin_perms;
+  elsif p_role = 'crew_lead' then
+    granted_perms := lead_perms;
+  else
+    granted_perms := member_perms;
+  end if;
+
+  foreach perm in array all_perms loop
+    -- New source of truth
+    insert into public.user_organization_permissions (user_organization_id, permission_key, granted)
+    values (p_user_organization_id, perm, perm = any(granted_perms))
+    on conflict (user_organization_id, permission_key) do update set granted = excluded.granted;
+
+    -- Legacy table — kept in sync during 18a until the deprecation cleanup migration drops it.
+    insert into public.user_permissions (user_id, permission_key, granted)
+    values (v_user_id, perm, perm = any(granted_perms))
+    on conflict (user_id, permission_key) do update set granted = excluded.granted;
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill: insert (membership, 'view_phone', granted) for every existing
+--    user_organizations row. DO NOTHING on conflict keeps the migration
+--    idempotent and never overwrites an existing grant (e.g. an admin who
+--    manually toggled the key in Settings before this migration ran).
+-- ---------------------------------------------------------------------------
+insert into public.user_organization_permissions (user_organization_id, permission_key, granted)
+select uo.id,
+       'view_phone',
+       case when uo.role in ('admin', 'crew_lead') then true else false end
+  from public.user_organizations uo
+ on conflict (user_organization_id, permission_key) do nothing;
+
+-- Legacy user_permissions: one row per user. If a user holds memberships in
+-- multiple Organizations with different roles, the legacy row only stores
+-- one truth — pick "any admin or crew_lead membership grants it" so the
+-- legacy row never under-reports a grant the new table has.
+insert into public.user_permissions (user_id, permission_key, granted)
+select uo.user_id,
+       'view_phone',
+       bool_or(uo.role in ('admin', 'crew_lead'))
+  from public.user_organizations uo
+ group by uo.user_id
+ on conflict (user_id, permission_key) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Safety assertion: every existing membership now has a view_phone row,
+--    and the grant matches the role default. Aborts the transaction loudly
+--    rather than leaving a half-applied state behind.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_unset_count int;
+  v_admin_lead_off_count int;
+  v_member_on_count int;
+begin
+  select count(*) into v_unset_count
+    from public.user_organizations uo
+    left join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'view_phone'
+   where uop.id is null;
+
+  if v_unset_count <> 0 then
+    raise exception 'migration-306: % memberships missing view_phone row after backfill', v_unset_count;
+  end if;
+
+  select count(*) into v_admin_lead_off_count
+    from public.user_organizations uo
+    join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'view_phone'
+   where uo.role in ('admin', 'crew_lead')
+     and uop.granted = false;
+
+  -- An admin/crew_lead membership with view_phone OFF is allowed only if it
+  -- predates the backfill (the DO NOTHING above respects manual toggles).
+  -- We only flag rows whose updated_at proves they were *created* by this
+  -- migration with the wrong grant; an unchanged manual-off is fine.
+  if v_admin_lead_off_count > 0 then
+    -- Soft check: log but do not abort, since pre-existing manual toggles
+    -- are legitimate. The hard guarantee is that every membership now has
+    -- a row, which v_unset_count above asserts.
+    raise notice 'migration-306: % admin/crew_lead memberships hold view_phone OFF (likely pre-existing manual toggle, not aborted)', v_admin_lead_off_count;
+  end if;
+
+  select count(*) into v_member_on_count
+    from public.user_organizations uo
+    join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'view_phone'
+   where uo.role not in ('admin', 'crew_lead')
+     and uop.granted = true;
+
+  -- Same soft check for the other direction.
+  if v_member_on_count > 0 then
+    raise notice 'migration-306: % non-(admin/crew_lead) memberships hold view_phone ON (likely pre-existing manual toggle, not aborted)', v_member_on_count;
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

PRD #304 — Nookleus Phone, **slice 2 (#306)**: the smallest engineering tracer for the whole Phone feature. No Twilio, no data, no realtime yet. Just the permission key, the role-default table, the nav item, the route, and the empty state.

### What lands

- **`view_phone` permission** in `PERMISSION_CATALOG` under a new "Phone" group.
- **Role defaults** pinned against PRD #304's table — Admin = ON, Crew Lead = ON, Crew Member = OFF. Extracted to `src/lib/permissions/role-defaults.ts` so the table is testable as data, not via the route.
- **`NavItem.requiredPermission?: PermissionKey`** — Sidebar filter now hides items whose grant the caller lacks (admin auto-passes).
- **`/phone` nav item** between Contacts and Email, using the `lucide-react` `Phone` icon.
- **`/phone/page.tsx`** Server Component using `requirePagePermission`:
  - permitted callers see `"No conversations yet — text or call a Contact to get started."`
  - denied callers see the shared Access-restricted ErrorPage (matches `estimates/[id]`, `invoices/[id]`, `referral-partners/[id]`)
- **Migration `migration-306-view-phone-permission.sql`** — refreshes `set_default_permissions(uuid, text)` so new memberships include `view_phone` in admin/lead defaults, then backfills `(membership, 'view_phone', granted)` for every existing `user_organizations` row across every Organization, mirrored to legacy `user_permissions` for build48 revert safety. Idempotent (`ON CONFLICT DO NOTHING`); aborts loudly if any membership ends up without a `view_phone` row.

### Migration status

Already applied to AAA prod (`rzzprgidqbnqcdupmpfe`) as `migration_306_view_phone_permission`:

| Outcome | Count |
|---|---|
| New rows in `user_organization_permissions` (all granted=true) | 6 (2 admin + 4 crew_lead) |
| New rows in legacy `user_permissions` (all granted=true) | 5 (one user holds 2 admin memberships in AAA) |
| Soft warnings (manual-toggle overrides) | 0 |
| Memberships missing `view_phone` after backfill | 0 |

No crew_member memberships exist in AAA prod yet, so the "OFF" default has no application surface to validate against until one is invited.

## Test plan

- [x] Vitest unit — `src/lib/permissions/role-defaults.test.ts` (5 cases): admin / crew_lead / crew_member / custom defaults + catalog membership and Phone group
- [x] RTL integration — `src/components/nav.test.tsx` (4 cases): visibility matches `view_phone` for crew_lead, admin, crew_member; positioned between Contacts and Email
- [x] RTL integration — `src/app/phone/page.test.tsx` (3 cases): empty-state copy for crew_lead-with-view_phone and admin; Access-restricted surface for crew_member-without-view_phone
- [x] `npx vitest run` on changed-area tests: 29/29 pass; the 6 pre-existing failures on `main` (estimate-builder drag-end + email-accounts route) are unchanged
- [x] `npx tsc --noEmit` adds no new errors (the two existing pre-existing errors in `template-drag-end.test.tsx` and `sync-folder-incremental.test.ts` are unchanged)
- [x] `npx eslint` on every touched file adds no new errors (the one pre-existing `react-hooks/set-state-in-effect` in `nav.tsx` was there before this PR and unchanged on `main`)
- [x] Migration dry-run, apply, and post-state verification on AAA prod via Supabase MCP

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)