### PR TITLE
feat(phone): Inbound SMS → Conversation thread in Phone tab (#308)

### DIFF
--- a/src/app/api/phone/conversations/[id]/messages/route.test.ts
+++ b/src/app/api/phone/conversations/[id]/messages/route.test.ts
@@ -1,0 +1,96 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// GET /api/phone/conversations/[id]/messages — return the messages in the
+// conversation, sorted by `sent_at` ascending. RLS enforces the ADR 0003
+// matrix; the route is a thin pass-through.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/phone/conversations/[id]/messages", () => {
+  it("returns 401 unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/messages"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller lacks view_phone", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/messages"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the conversation's messages for an authorized caller", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_messages = [
+      {
+        id: "m-1",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "in",
+        from_e164: "+15551234567",
+        to_e164: "+15125550000",
+        body: "Hi",
+        media_urls: [],
+        twilio_sid: "SM-1",
+        status: "received",
+        job_tag: null,
+        tagged_by_user_id: null,
+        sent_by_user_id: null,
+        sent_at: "2026-05-27T10:00:00Z",
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/messages"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([expect.objectContaining({ id: "m-1", body: "Hi" })]);
+  });
+});

--- a/src/app/api/phone/conversations/[id]/messages/route.ts
+++ b/src/app/api/phone/conversations/[id]/messages/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — thread render.
+//
+// Returns every message in the named conversation, sorted by `sent_at`
+// ascending (chronological). RLS (migration-308) enforces the ADR 0003
+// matrix; the route is a thin pass-through. A caller who cannot see a
+// row simply does not get it back.
+
+const FIELDS =
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, body, media_urls, twilio_sid, status, job_tag, tagged_by_user_id, sent_by_user_id, sent_at, created_at";
+
+export const GET = withRequestContext(
+  { permission: "view_phone" },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { data, error } = await ctx.supabase
+      .from("phone_messages")
+      .select(FIELDS)
+      .eq("conversation_id", id)
+      .order("sent_at", { ascending: true });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  },
+);

--- a/src/app/api/phone/conversations/[id]/save-as-contact/route.test.ts
+++ b/src/app/api/phone/conversations/[id]/save-as-contact/route.test.ts
@@ -1,0 +1,179 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// POST /api/phone/conversations/[id]/save-as-contact — convert a raw-number
+// thread into a real Contact. The thread's `outside_e164` becomes the new
+// Contact's `phone`; the body provides the `full_name`. The conversation's
+// `contact_id` is then re-pointed at the new Contact.
+//
+// AC bullet: "An inbound SMS from an unknown number creates a 'raw number'
+// thread with contact_id IS NULL; Save as Contact converts it"
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function postReq(body: Record<string, unknown>) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: {} }) as never,
+  );
+});
+
+describe("POST /api/phone/conversations/[id]/save-as-contact — gated on view_phone", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const res = await POST(postReq({ fullName: "Jane" }), params("conv-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller lacks view_phone (crew_member default)", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+    const res = await POST(postReq({ fullName: "Jane" }), params("conv-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when fullName is missing or empty", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    expect(
+      (await POST(postReq({ fullName: "" }), params("conv-1"))).status,
+    ).toBe(400);
+    expect(
+      (await POST(postReq({}), params("conv-1"))).status,
+    ).toBe(400);
+  });
+
+  it("returns 404 when the conversation does not exist or is in another org", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: { phone_conversations: [] },
+      }) as never,
+    );
+    const res = await POST(postReq({ fullName: "Jane" }), params("conv-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when the conversation already has a contact_id", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: {
+          phone_conversations: [
+            {
+              id: "conv-1",
+              organization_id: "org-1",
+              outside_e164: "+15551234567",
+              contact_id: "c-existing",
+            },
+          ],
+        },
+      }) as never,
+    );
+    const res = await POST(postReq({ fullName: "Jane" }), params("conv-1"));
+    expect(res.status).toBe(409);
+  });
+
+  it("creates a Contact and re-points the conversation when fullName is valid", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: {
+          phone_conversations: [
+            {
+              id: "conv-1",
+              organization_id: "org-1",
+              outside_e164: "+15551234567",
+              contact_id: null,
+            },
+          ],
+          contacts: [
+            // Will be present after the INSERT (the fake's single()
+            // returns the first row, so we seed the resulting row).
+            { id: "c-new", full_name: "Jane Doe", phone: "+15551234567" },
+          ],
+        },
+      }) as never,
+    );
+
+    const res = await POST(
+      postReq({ fullName: "Jane Doe" }),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      contact: { id: "c-new", full_name: "Jane Doe", phone: "+15551234567" },
+    });
+  });
+});

--- a/src/app/api/phone/conversations/[id]/save-as-contact/route.ts
+++ b/src/app/api/phone/conversations/[id]/save-as-contact/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — Save as Contact.
+//
+// Converts a raw-number Conversation (one whose `contact_id` is NULL) into
+// a real Contact. The Conversation is re-pointed at the new Contact and
+// the surface stops showing the "Save as Contact" button on the header.
+//
+// ADR 0002 carve-out: this does NOT create a Target on the Referral
+// Partners list. Target creation stays a deliberate action on the
+// existing Add Target dialog.
+//
+// Gating:
+//   - view_phone permission required (the broadest phone perm).
+//   - The conversation must be in the caller's active org.
+//   - 409 when the conversation already has a contact_id (refuse to
+//     overwrite — Save as Contact is one-shot per thread; future re-
+//     pointing belongs in a different action that we have not designed).
+
+interface ConversationRow {
+  id: string;
+  organization_id: string;
+  outside_e164: string;
+  contact_id: string | null;
+}
+
+interface ContactRow {
+  id: string;
+  full_name: string;
+  phone: string | null;
+}
+
+export const POST = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = (await request.json().catch(() => null)) as
+      | { fullName?: string }
+      | null;
+    const fullName = body?.fullName?.trim();
+    if (!fullName) {
+      return NextResponse.json(
+        { error: "fullName is required" },
+        { status: 400 },
+      );
+    }
+
+    // Look up via the Service client. The active-org check is enforced
+    // below — the Service-client read sees rows from any org, and we
+    // 404 anything outside the caller's active org. Same pattern as
+    // `resolveEmailAccountAccess`.
+    const { data: conv } = await ctx.serviceClient!
+      .from("phone_conversations")
+      .select("id, organization_id, outside_e164, contact_id")
+      .eq("id", id)
+      .maybeSingle<ConversationRow>();
+
+    if (!conv || conv.organization_id !== ctx.orgId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    if (conv.contact_id) {
+      return NextResponse.json(
+        { error: "Conversation already has a contact" },
+        { status: 409 },
+      );
+    }
+
+    // Insert the Contact via the Service client. `contacts` has no
+    // organization_id column in schema.sql; the org scoping for contacts
+    // happens via the jobs join. Slice 4 follows the existing convention.
+    const { data: newContact, error: insertErr } = await ctx.serviceClient!
+      .from("contacts")
+      .insert({ full_name: fullName, phone: conv.outside_e164 })
+      .select("id, full_name, phone")
+      .single<ContactRow>();
+    if (insertErr || !newContact) {
+      return NextResponse.json(
+        { error: insertErr?.message ?? "Failed to create contact" },
+        { status: 500 },
+      );
+    }
+
+    // Re-point the conversation. Service client so the update is not
+    // re-evaluated by RLS — the route's gate (view_phone) is the
+    // authority for this action.
+    const { error: updateErr } = await ctx.serviceClient!
+      .from("phone_conversations")
+      .update({ contact_id: newContact.id })
+      .eq("id", conv.id);
+    if (updateErr) {
+      return NextResponse.json({ error: updateErr.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ contact: newContact });
+  },
+);

--- a/src/app/api/phone/conversations/route.test.ts
+++ b/src/app/api/phone/conversations/route.test.ts
@@ -1,0 +1,96 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// GET /api/phone/conversations — list every Conversation in the active org
+// sorted by `last_event_at` desc, with unread on top. RLS handles org
+// scoping and Personal-number visibility. The route is a thin pass-through.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/phone/conversations", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations"),
+      noParams,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller lacks view_phone", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations"),
+      noParams,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns conversations seeded in the org for the caller", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_conversations = [
+      {
+        id: "conv-1",
+        organization_id: "org-1",
+        phone_number_id: "pn-1",
+        outside_e164: "+15551234567",
+        contact_id: null,
+        last_event_at: "2026-05-27T10:00:00Z",
+        unread_count: 2,
+        deleted_at: null,
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations"),
+      noParams,
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: "conv-1",
+        outside_e164: "+15551234567",
+        unread_count: 2,
+      }),
+    ]);
+  });
+});

--- a/src/app/api/phone/conversations/route.ts
+++ b/src/app/api/phone/conversations/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — list conversations.
+//
+// Returns every Conversation visible to the caller in their active org,
+// sorted by `last_event_at` desc. RLS (migration-308) does the heavy
+// lifting: cross-org rows hidden, Personal-number-untagged rows hidden
+// from non-owners, etc. The route is a thin pass-through.
+
+const FIELDS =
+  "id, organization_id, phone_number_id, outside_e164, contact_id, last_event_at, unread_count, deleted_at, created_at, updated_at";
+
+export const GET = withRequestContext(
+  { permission: "view_phone" },
+  async (_request, ctx) => {
+    const { data, error } = await ctx.supabase
+      .from("phone_conversations")
+      .select(FIELDS)
+      .eq("organization_id", ctx.orgId ?? "")
+      .order("last_event_at", { ascending: false });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  },
+);

--- a/src/app/api/phone/messages/[id]/tag/route.test.ts
+++ b/src/app/api/phone/messages/[id]/tag/route.test.ts
@@ -1,0 +1,160 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// POST /api/phone/messages/[id]/tag — tag (or re-tag) a message to a Job
+// from the prompt-chips banner. Body: { jobId } or { jobId: null } to
+// remove the tag. The caller's user_id is recorded in `tagged_by_user_id`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function postReq(body: Record<string, unknown>) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: {} }) as never,
+  );
+});
+
+describe("POST /api/phone/messages/[id]/tag", () => {
+  it("returns 401 unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const res = await POST(postReq({ jobId: "job-1" }), params("m-1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller lacks view_phone", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+    const res = await POST(postReq({ jobId: "job-1" }), params("m-1"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when jobId is undefined (missing)", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    const res = await POST(postReq({}), params("m-1"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when the message does not exist in the active org", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({ tables: { phone_messages: [] } }) as never,
+    );
+    const res = await POST(postReq({ jobId: "job-1" }), params("m-1"));
+    expect(res.status).toBe(404);
+  });
+
+  it("updates job_tag + tagged_by_user_id when jobId is provided", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: {
+          phone_messages: [
+            {
+              id: "m-1",
+              organization_id: "org-1",
+              job_tag: null,
+              tagged_by_user_id: null,
+            },
+          ],
+        },
+      }) as never,
+    );
+
+    const res = await POST(postReq({ jobId: "job-1" }), params("m-1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true });
+  });
+
+  it("accepts jobId: null to remove the tag", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({
+          userId: "u-1",
+          role: "crew_lead",
+          grants: ["view_phone"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: {
+          phone_messages: [
+            {
+              id: "m-1",
+              organization_id: "org-1",
+              job_tag: "job-old",
+              tagged_by_user_id: null,
+            },
+          ],
+        },
+      }) as never,
+    );
+
+    const res = await POST(postReq({ jobId: null }), params("m-1"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/phone/messages/[id]/tag/route.ts
+++ b/src/app/api/phone/messages/[id]/tag/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — tag (or re-tag) a message.
+//
+// Body: `{ jobId: string | null }`. A non-null jobId tags the message to
+// that Job; null removes the tag. `tagged_by_user_id` is set to the
+// caller, so the UI can render "tagged by Alice" later.
+//
+// AC bullet: "An inbound SMS from a known Contact with multiple Active
+// jobs lands untagged with the prompt-chips state captured" — the chips
+// POST to this route.
+//
+// Re-tagging an auto-tagged message also flows through here (slice 9).
+
+interface MessageRow {
+  id: string;
+  organization_id: string;
+  job_tag: string | null;
+  tagged_by_user_id: string | null;
+}
+
+export const POST = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = (await request.json().catch(() => null)) as
+      | { jobId?: string | null }
+      | null;
+    if (!body || !("jobId" in body)) {
+      return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+    }
+    const jobId = body.jobId;
+
+    const { data: msg } = await ctx.serviceClient!
+      .from("phone_messages")
+      .select("id, organization_id, job_tag, tagged_by_user_id")
+      .eq("id", id)
+      .maybeSingle<MessageRow>();
+    if (!msg || msg.organization_id !== ctx.orgId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const { error } = await ctx.serviceClient!
+      .from("phone_messages")
+      .update({ job_tag: jobId, tagged_by_user_id: ctx.userId })
+      .eq("id", id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/phone/webhook/sms-inbound/route.test.ts
+++ b/src/app/api/phone/webhook/sms-inbound/route.test.ts
@@ -1,0 +1,344 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// Tests for the inbound-SMS webhook route. Twilio calls this URL when a
+// customer texts one of our numbers. The route:
+//   1. Validates X-Twilio-Signature.
+//   2. Parses the form-encoded payload (Twilio sends application/x-www-form-urlencoded).
+//   3. Queries the org's phone_numbers, contacts, jobs via the Service client.
+//   4. Calls route-inbound (pure) for the routing decision.
+//   5. Upserts a phone_conversations row, inserts a phone_messages row,
+//      bumps last_event_at + unread_count.
+//   6. Returns TwiML (<Response/>) with 200.
+//
+// Twilio and Supabase are mocked at the module boundary. The pure routing
+// modules are NOT mocked — they exercise the real decision logic.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  validateTwilioSignature: (...args: unknown[]) => validateSignatureMock(...args),
+}));
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+interface Row { [key: string]: unknown }
+
+interface BuilderTables {
+  phone_numbers: Row[];
+  contacts: Row[];
+  jobs: Row[];
+  phone_conversations: Row[];
+  phone_messages: Row[];
+}
+
+function makeServiceClient(tables: BuilderTables) {
+  // Records every insert / upsert so tests can assert on them. The
+  // builder is intentionally small — eq filtering, maybeSingle, single,
+  // insert(...).select().single(), upsert(...).select().single().
+  const inserts: { table: string; row: Row }[] = [];
+  const upserts: { table: string; row: Row; onConflict: string | undefined }[] =
+    [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = (tables as unknown as Record<string, Row[]>)[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.order = () => b;
+    b.limit = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.in = (col: string, vals: unknown[]) => {
+      rows = rows.filter((r) => vals.includes(r[col]));
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opts?: { onConflict?: string }) => {
+      pendingInsert = row;
+      upserts.push({ table, row, onConflict: opts?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.single = async () => {
+      if (pendingInsert) {
+        const row = { id: `new-${inserts.length + upserts.length}`, ...pendingInsert };
+        (tables as unknown as Record<string, Row[]>)[table].push(row);
+        return { data: row, error: null };
+      }
+      return { data: rows[0] ?? null, error: rows[0] ? null : { message: "no rows" } };
+    };
+    b.then = (resolve: (v: unknown) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  return {
+    client: { from: builder },
+    inserts,
+    upserts,
+    updates,
+  };
+}
+
+function inboundForm(opts: {
+  From?: string;
+  To?: string;
+  Body?: string;
+  MessageSid?: string;
+}): { req: Request; bodyString: string } {
+  const params = new URLSearchParams();
+  params.set("From", opts.From ?? "+15551234567");
+  params.set("To", opts.To ?? "+15125550000");
+  params.set("Body", opts.Body ?? "hello");
+  params.set("MessageSid", opts.MessageSid ?? "SM-abc");
+  const bodyString = params.toString();
+  const req = new Request("http://test/api/phone/webhook/sms-inbound", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid-sig",
+    },
+    body: bodyString,
+  });
+  return { req, bodyString };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+describe("POST /api/phone/webhook/sms-inbound — signature validation", () => {
+  it("returns 403 when the X-Twilio-Signature header is missing or invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client } = makeServiceClient({
+      phone_numbers: [],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({});
+    const res = await POST(req);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/phone/webhook/sms-inbound — happy path", () => {
+  it("returns 200 with TwiML when the To address matches no org number (Twilio expects 200 either way)", async () => {
+    const { client } = makeServiceClient({
+      phone_numbers: [],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({ To: "+19999999999" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/xml/);
+    expect(await res.text()).toContain("<Response");
+  });
+
+  it("inserts a conversation + message for an inbound from an unknown number", async () => {
+    const { client, upserts, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({
+      From: "+15551234567",
+      To: "+15125550000",
+      Body: "Hello!",
+      MessageSid: "SMabc",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      table: "phone_conversations",
+      onConflict: "phone_number_id,outside_e164",
+      row: {
+        organization_id: "org-1",
+        phone_number_id: "pn-1",
+        outside_e164: "+15551234567",
+      },
+    });
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0]).toMatchObject({
+      table: "phone_messages",
+      row: {
+        organization_id: "org-1",
+        direction: "in",
+        from_e164: "+15551234567",
+        to_e164: "+15125550000",
+        body: "Hello!",
+        twilio_sid: "SMabc",
+        job_tag: null,
+      },
+    });
+  });
+
+  it("auto-tags the message when the inbound is from a Contact with exactly one Active job", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [
+        {
+          id: "c-1",
+          organization_id: "org-1",
+          phone: "(555) 123-4567",
+        },
+      ],
+      jobs: [
+        {
+          id: "job-1",
+          organization_id: "org-1",
+          contact_id: "c-1",
+          status: "in_progress",
+          job_number: "WTR-2026-0001",
+        },
+      ],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({
+      From: "+15551234567",
+      To: "+15125550000",
+      Body: "On my way",
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const msg = inserts.find((i) => i.table === "phone_messages");
+    expect(msg).toBeDefined();
+    expect(msg!.row).toMatchObject({
+      job_tag: "job-1",
+      tagged_by_user_id: null, // auto-tagged
+    });
+  });
+
+  it("leaves job_tag null when the contact has 2+ Active jobs (prompt branch)", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [
+        { id: "c-1", organization_id: "org-1", phone: "5551234567" },
+      ],
+      jobs: [
+        { id: "job-1", organization_id: "org-1", contact_id: "c-1", status: "in_progress", job_number: "WTR-2026-0001" },
+        { id: "job-2", organization_id: "org-1", contact_id: "c-1", status: "new", job_number: "FYR-2026-0005" },
+      ],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({ From: "+15551234567" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const msg = inserts.find((i) => i.table === "phone_messages");
+    expect(msg!.row.job_tag).toBeNull();
+  });
+
+  it("ignores Completed and Cancelled jobs when collecting Active jobs", async () => {
+    // The smart-attach module receives `activeJobs`; the webhook is
+    // responsible for filtering jobs by `status NOT IN ('completed',
+    // 'cancelled')` before passing them in. A contact with 1 Active +
+    // 1 Completed job is auto-tagged to the Active job.
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [
+        { id: "c-1", organization_id: "org-1", phone: "+15551234567" },
+      ],
+      jobs: [
+        { id: "job-1", organization_id: "org-1", contact_id: "c-1", status: "completed", job_number: "WTR-2026-0001" },
+        { id: "job-2", organization_id: "org-1", contact_id: "c-1", status: "in_progress", job_number: "FYR-2026-0005" },
+      ],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({ From: "+15551234567" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    const msg = inserts.find((i) => i.table === "phone_messages");
+    expect(msg!.row.job_tag).toBe("job-2");
+  });
+});

--- a/src/app/api/phone/webhook/sms-inbound/route.ts
+++ b/src/app/api/phone/webhook/sms-inbound/route.ts
@@ -1,0 +1,174 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { validateTwilioSignature } from "@/lib/phone/twilio-client";
+import { normalizePhoneToE164 } from "@/lib/phone";
+import {
+  routeInbound,
+  type ContactForRoute,
+  type PhoneNumberForRoute,
+} from "@/lib/phone/route-inbound";
+import type { ActiveJob } from "@/lib/phone/smart-attach";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — Inbound SMS webhook.
+//
+// Twilio calls this URL when an inbound SMS hits one of our numbers. The
+// route is unauthenticated (Twilio is not a logged-in user); it gates by
+// the X-Twilio-Signature HMAC instead.
+//
+// Flow:
+//   1. Read the form-encoded body (Twilio sends application/x-www-form-urlencoded).
+//   2. Validate the signature against the (URL, params) pair using
+//      `validateTwilioSignature`. Reject 403 on invalid.
+//   3. Look up the `phone_numbers` row whose e164 matches `To` to discover
+//      the org. If no match, return 200 with empty TwiML (a Twilio webhook
+//      always returns 200 unless we want to retry — silent drop is the
+//      right behavior for a stale or wrong-org webhook URL).
+//   4. Pull the org's contacts + Active jobs. Pass everything to
+//      `routeInbound` (pure) for the smart-attach decision.
+//   5. Upsert the `phone_conversations` row (by phone_number_id +
+//      outside_e164 — the natural key), insert the `phone_messages` row,
+//      bump `last_event_at` and `unread_count`.
+//   6. Return 200 with an empty TwiML `<Response/>`.
+//
+// All DB work uses the Service client — the webhook has no auth user, so
+// RLS would refuse every read otherwise.
+
+const EMPTY_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+
+const ACTIVE_STATUSES = ["new", "in_progress", "pending_invoice"] as const;
+
+function twimlResponse(status = 200): Response {
+  return new Response(EMPTY_TWIML, {
+    status,
+    headers: { "content-type": "text/xml; charset=utf-8" },
+  });
+}
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const fromE164 = normalizePhoneToE164(params.From ?? "");
+  const toE164 = normalizePhoneToE164(params.To ?? "");
+  if (!fromE164 || !toE164) {
+    return twimlResponse();
+  }
+
+  const supabase = createServiceClient();
+
+  // 1. Resolve the org from the To address.
+  const { data: numberRow } = await supabase
+    .from("phone_numbers")
+    .select("id, organization_id, e164, kind, user_id, released_at")
+    .eq("e164", toE164)
+    .maybeSingle<PhoneNumberForRoute>();
+
+  if (!numberRow || numberRow.released_at) {
+    return twimlResponse();
+  }
+
+  // 2. Load the org's contacts (slice 4: every contact in the org —
+  //    `contacts` has no organization_id surfaced via FK; the schema
+  //    relies on jobs → contacts and org scoping through jobs. We use
+  //    contacts referenced by org's jobs as the candidate pool).
+  const { data: jobRows } = await supabase
+    .from("jobs")
+    .select("id, contact_id, status, job_number")
+    .eq("organization_id", numberRow.organization_id);
+  const jobsList = (jobRows ?? []) as Array<{
+    id: string;
+    contact_id: string;
+    status: string;
+    job_number: string;
+  }>;
+
+  const contactIds = Array.from(new Set(jobsList.map((j) => j.contact_id)));
+  let contacts: ContactForRoute[] = [];
+  if (contactIds.length > 0) {
+    const { data: contactRows } = await supabase
+      .from("contacts")
+      .select("id, phone")
+      .in("id", contactIds);
+    contacts = (contactRows ?? []) as ContactForRoute[];
+  }
+
+  // 3. Group Active jobs by contact. Active = status NOT IN
+  //    ('completed', 'cancelled') — see schema.sql jobs.status CHECK.
+  const activeJobsByContact: Record<string, ActiveJob[]> = {};
+  for (const j of jobsList) {
+    if (!ACTIVE_STATUSES.includes(j.status as (typeof ACTIVE_STATUSES)[number])) {
+      continue;
+    }
+    (activeJobsByContact[j.contact_id] ??= []).push({
+      id: j.id,
+      label: j.job_number,
+    });
+  }
+
+  // 4. Pure routing decision.
+  const decision = routeInbound({
+    payload: { From: fromE164, To: toE164, Body: params.Body ?? "" },
+    orgNumbers: [numberRow],
+    contacts,
+    activeJobsByContact,
+  });
+  if (!decision) return twimlResponse();
+
+  // 5. Upsert the conversation. ON CONFLICT on (phone_number_id,
+  //    outside_e164) — see migration-308 `phone_conversations_pair_unique`.
+  const now = new Date().toISOString();
+  const { data: conv } = await supabase
+    .from("phone_conversations")
+    .upsert(
+      {
+        organization_id: decision.organizationId,
+        phone_number_id: decision.phoneNumberId,
+        outside_e164: decision.outsideE164,
+        contact_id: decision.contactId,
+        last_event_at: now,
+      },
+      { onConflict: "phone_number_id,outside_e164" },
+    )
+    .select("id, unread_count")
+    .single<{ id: string; unread_count: number }>();
+  if (!conv) return twimlResponse();
+
+  // 6. Insert the message.
+  const jobTag =
+    decision.smartAttach.kind === "auto" ? decision.smartAttach.jobId : null;
+  await supabase.from("phone_messages").insert({
+    organization_id: decision.organizationId,
+    conversation_id: conv.id,
+    direction: "in",
+    from_e164: decision.outsideE164,
+    to_e164: toE164,
+    body: params.Body ?? null,
+    media_urls: [],
+    twilio_sid: params.MessageSid ?? null,
+    status: params.SmsStatus ?? null,
+    job_tag: jobTag,
+    tagged_by_user_id: null,
+    sent_by_user_id: null,
+    sent_at: now,
+  });
+
+  // 7. Bump the unread count + last_event_at on the conversation. The
+  //    upsert above already set last_event_at; we update unread_count
+  //    here because Supabase's PostgREST upsert path can't atomically
+  //    increment an existing row's column.
+  await supabase
+    .from("phone_conversations")
+    .update({ unread_count: (conv.unread_count ?? 0) + 1, last_event_at: now })
+    .eq("id", conv.id);
+
+  return twimlResponse();
+}

--- a/src/app/phone/page.test.tsx
+++ b/src/app/phone/page.test.tsx
@@ -21,6 +21,18 @@ vi.mock("@/lib/supabase-server", () => ({
 vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(),
 }));
+// Slice 4 — PhonePageClient instantiates the browser Supabase client for
+// the realtime subscription. The tests don't exercise realtime; this stub
+// keeps `createClient()` from reading process.env at module-eval time.
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    channel: () => ({
+      on: () => ({ subscribe: () => ({ unsubscribe: () => undefined }) }),
+      subscribe: () => ({ unsubscribe: () => undefined }),
+      unsubscribe: () => undefined,
+    }),
+  }),
+}));
 
 import PhonePage from "./page";
 import { createServerSupabaseClient } from "@/lib/supabase-server";

--- a/src/app/phone/page.tsx
+++ b/src/app/phone/page.tsx
@@ -1,18 +1,24 @@
 import Link from "next/link";
-import { AlertCircle, Phone as PhoneIcon } from "lucide-react";
+import { AlertCircle } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
+import {
+  PhonePageClient,
+  type PhoneConversationItem,
+} from "./phone-page-client";
 
-// PRD #304 — Nookleus Phone. Slice 2 (#306) — the tracer slice.
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — Phone-tab two-pane UI.
 //
-// This is the empty-state surface for the future Phone tab. No Twilio,
-// no data fetching, no realtime — just the gate, the route, and the empty
-// state. Future slices replace the empty state with the iMessage-style
-// two-pane Conversations / thread view.
+// Server Component:
+//   1. Gates on `view_phone`.
+//   2. Side-loads the active org's conversations + each contact's name
+//      + each contact's Active jobs in one server hop, then hands the
+//      bundle to the client component.
 //
-// Gate: `view_phone` (PRD #304 § Permission). Denial follows the shared
-// ErrorPage pattern used by estimates/[id], invoices/[id], and
-// referral-partners/[id] — the codebase's standard unauthorized response.
+// Empty state from slice 2 still renders when the org has no
+// conversations yet — the client component shows it.
+
+const ACTIVE_STATUSES = ["new", "in_progress", "pending_invoice"] as const;
 
 export default async function PhonePage() {
   const supabase = await createServerSupabaseClient();
@@ -20,7 +26,7 @@ export default async function PhonePage() {
     permission: "view_phone",
   });
 
-  if (!auth.ok) {
+  if (!auth.ok || !auth.orgId) {
     return (
       <div className="flex items-center justify-center min-h-[40vh] px-4">
         <div className="rounded-xl border border-border bg-card p-8 text-center max-w-md w-full">
@@ -40,15 +46,82 @@ export default async function PhonePage() {
     );
   }
 
-  return (
-    <div className="flex items-center justify-center min-h-[60vh] px-4">
-      <div className="text-center max-w-md">
-        <PhoneIcon size={40} className="mx-auto text-muted-foreground mb-4" />
-        <h1 className="text-lg font-semibold text-foreground">Phone</h1>
-        <p className="text-sm text-muted-foreground mt-2">
-          No conversations yet — text or call a Contact to get started.
-        </p>
-      </div>
-    </div>
+  const orgId = auth.orgId;
+
+  const { data: convoRows } = await supabase
+    .from("phone_conversations")
+    .select(
+      "id, organization_id, phone_number_id, outside_e164, contact_id, last_event_at, unread_count, deleted_at",
+    )
+    .eq("organization_id", orgId)
+    .is("deleted_at", null)
+    .order("last_event_at", { ascending: false });
+  const conversations = (convoRows ?? []) as Array<{
+    id: string;
+    organization_id: string;
+    phone_number_id: string;
+    outside_e164: string;
+    contact_id: string | null;
+    last_event_at: string;
+    unread_count: number;
+  }>;
+
+  const contactIds = Array.from(
+    new Set(
+      conversations
+        .map((c) => c.contact_id)
+        .filter((id): id is string => id !== null),
+    ),
   );
+
+  let contactsById: Record<string, { full_name: string }> = {};
+  if (contactIds.length > 0) {
+    const { data: contactRows } = await supabase
+      .from("contacts")
+      .select("id, full_name")
+      .in("id", contactIds);
+    contactsById = Object.fromEntries(
+      (contactRows ?? []).map((c) => [
+        c.id as string,
+        { full_name: c.full_name as string },
+      ]),
+    );
+  }
+
+  let activeJobsByContact: Record<string, Array<{ id: string; label: string }>> =
+    {};
+  if (contactIds.length > 0) {
+    const { data: jobRows } = await supabase
+      .from("jobs")
+      .select("id, contact_id, status, job_number")
+      .eq("organization_id", orgId)
+      .in("contact_id", contactIds)
+      .in("status", ACTIVE_STATUSES as unknown as string[]);
+    activeJobsByContact = (jobRows ?? []).reduce<
+      Record<string, Array<{ id: string; label: string }>>
+    >((acc, j) => {
+      const cid = j.contact_id as string;
+      (acc[cid] ??= []).push({
+        id: j.id as string,
+        label: j.job_number as string,
+      });
+      return acc;
+    }, {});
+  }
+
+  const items: PhoneConversationItem[] = conversations.map((c) => ({
+    id: c.id,
+    organization_id: c.organization_id,
+    phone_number_id: c.phone_number_id,
+    outside_e164: c.outside_e164,
+    contact_id: c.contact_id,
+    contact_name: c.contact_id
+      ? contactsById[c.contact_id]?.full_name ?? null
+      : null,
+    last_event_at: c.last_event_at,
+    unread_count: c.unread_count,
+    active_jobs: c.contact_id ? activeJobsByContact[c.contact_id] ?? [] : [],
+  }));
+
+  return <PhonePageClient organizationId={orgId} initialConversations={items} />;
 }

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -1,0 +1,246 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// Integration tests for the two-pane Phone-tab client component. Verifies:
+//   - The conversation list renders, sorted by last_event_at desc with
+//     unread on top.
+//   - Selecting a conversation fetches and renders its messages.
+//   - A conversation whose contact_id is NULL renders a "Save as Contact"
+//     button on the thread header; clicking it POSTs and re-points the
+//     conversation.
+//   - For inbound messages whose contact has 2+ Active jobs, the chip
+//     banner renders one chip per Active job.
+//
+// We mock `fetch` at the global boundary and pass the realtime hook a
+// no-op `supabase` via the supabase module's `createClient`.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    channel: () => ({
+      on: () => ({ subscribe: () => ({ unsubscribe: () => undefined }) }),
+      subscribe: () => ({ unsubscribe: () => undefined }),
+      unsubscribe: () => undefined,
+    }),
+  }),
+}));
+
+import { PhonePageClient } from "./phone-page-client";
+
+interface MockResponse {
+  ok: boolean;
+  status?: number;
+  body: unknown;
+}
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Use globalThis to type-narrow as `unknown`, then cast at the
+  // assignment site. Avoids the `any` lint hit on the `global.fetch =`
+  // shorthand.
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch as never;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function respondWith(routes: Record<string, MockResponse>) {
+  mockFetch.mockImplementation(async (input: RequestInfo) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const path = url.replace(/^https?:\/\/[^/]+/, "");
+    const r = routes[path];
+    if (!r) throw new Error(`unmocked fetch: ${path}`);
+    return {
+      ok: r.ok,
+      status: r.status ?? (r.ok ? 200 : 500),
+      json: async () => r.body,
+    };
+  });
+}
+
+function convo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "conv-1",
+    organization_id: "org-1",
+    phone_number_id: "pn-1",
+    outside_e164: "+15551234567",
+    contact_id: null as string | null,
+    contact_name: null as string | null,
+    last_event_at: "2026-05-27T10:00:00Z",
+    unread_count: 0,
+    active_jobs: [] as Array<{ id: string; label: string }>,
+    ...overrides,
+  };
+}
+
+describe("PhonePageClient", () => {
+  it("renders each conversation in the list, sorted by last_event_at desc with unread on top", () => {
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({
+            id: "c-old",
+            outside_e164: "+15550000001",
+            last_event_at: "2026-05-20T00:00:00Z",
+            unread_count: 0,
+          }),
+          convo({
+            id: "c-new",
+            outside_e164: "+15550000002",
+            last_event_at: "2026-05-27T00:00:00Z",
+            unread_count: 0,
+          }),
+          convo({
+            id: "c-unread",
+            outside_e164: "+15550000003",
+            last_event_at: "2026-05-15T00:00:00Z",
+            unread_count: 3,
+          }),
+        ]}
+      />,
+    );
+
+    const items = screen.getAllByRole("button", { name: /\(555\)/ });
+    // unread on top, then by last_event_at desc
+    expect(items[0].textContent).toContain("(555) 000-0003"); // unread
+    expect(items[1].textContent).toContain("(555) 000-0002"); // newer
+    expect(items[2].textContent).toContain("(555) 000-0001"); // older
+  });
+
+  it("renders the empty-state when there are no conversations", () => {
+    render(
+      <PhonePageClient organizationId="org-1" initialConversations={[]} />,
+    );
+    expect(
+      screen.getByText(
+        "No conversations yet — text or call a Contact to get started.",
+      ),
+    ).toBeDefined();
+  });
+
+  it("loads and renders the selected conversation's messages chronologically", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": {
+        ok: true,
+        body: [
+          {
+            id: "m-1",
+            conversation_id: "conv-1",
+            direction: "in",
+            body: "Hello first",
+            sent_at: "2026-05-27T10:00:00Z",
+            job_tag: null,
+          },
+          {
+            id: "m-2",
+            conversation_id: "conv-1",
+            direction: "out",
+            body: "Hi back",
+            sent_at: "2026-05-27T10:05:00Z",
+            job_tag: null,
+          },
+        ],
+      },
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[convo({ id: "conv-1" })]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /\(555\) 123-4567/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Hello first")).toBeDefined();
+      expect(screen.getByText("Hi back")).toBeDefined();
+    });
+  });
+
+  it("renders Save as Contact button on the header when contact_id is null", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": { ok: true, body: [] },
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: null, contact_name: null }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /\(555\)/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /save as contact/i })).toBeDefined(),
+    );
+  });
+
+  it("does NOT render Save as Contact when contact_id is set", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": { ok: true, body: [] },
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /save as contact/i })).toBeNull(),
+    );
+  });
+
+  it("renders prompt chips above an untagged inbound message when contact has 2+ Active jobs", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": {
+        ok: true,
+        body: [
+          {
+            id: "m-untagged",
+            conversation_id: "conv-1",
+            direction: "in",
+            body: "ambiguous",
+            sent_at: "2026-05-27T10:00:00Z",
+            job_tag: null,
+          },
+        ],
+      },
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({
+            id: "conv-1",
+            contact_id: "c-1",
+            contact_name: "Alice",
+            active_jobs: [
+              { id: "job-1", label: "WTR-2026-0001" },
+              { id: "job-2", label: "FYR-2026-0005" },
+            ],
+          }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /WTR-2026-0001/ }),
+      ).toBeDefined();
+      expect(
+        screen.getByRole("button", { name: /FYR-2026-0005/ }),
+      ).toBeDefined();
+    });
+  });
+});

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -1,0 +1,283 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Phone as PhoneIcon, UserPlus } from "lucide-react";
+import { createClient } from "@/lib/supabase";
+import { formatPhoneNumber } from "@/lib/phone";
+import { usePhoneSync } from "@/lib/phone/use-phone-sync";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308) — two-pane Phone-tab UI.
+//
+// Left pane: Conversations list, sorted by `last_event_at` desc with
+// unread on top. Right pane: the selected thread, messages
+// chronologically. Empty state when no conversations.
+//
+// AC bullets satisfied here:
+//   - Phone-tab list renders sorted by last_event_at desc, unread on top.
+//   - Thread renders chronologically.
+//   - Save as Contact button on the header when `contact_id` is NULL.
+//   - Tag-chips banner above untagged inbound messages when the contact
+//     has 2+ Active jobs (the `smartAttach.kind = 'prompt'` state).
+//   - Realtime via use-phone-sync subscribed to phone_messages INSERTs.
+
+export interface PhoneConversationItem {
+  id: string;
+  organization_id: string;
+  phone_number_id: string;
+  outside_e164: string;
+  contact_id: string | null;
+  // Server-side joined name when contact_id is set; null until "Save as Contact".
+  contact_name: string | null;
+  last_event_at: string;
+  unread_count: number;
+  active_jobs: Array<{ id: string; label: string }>;
+}
+
+interface PhoneMessage {
+  id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  body: string | null;
+  sent_at: string;
+  job_tag: string | null;
+}
+
+export interface PhonePageClientProps {
+  organizationId: string;
+  initialConversations: PhoneConversationItem[];
+}
+
+function sortConversations(
+  list: PhoneConversationItem[],
+): PhoneConversationItem[] {
+  // Unread on top, then by last_event_at desc. Stable.
+  return [...list].sort((a, b) => {
+    const aUnread = a.unread_count > 0 ? 1 : 0;
+    const bUnread = b.unread_count > 0 ? 1 : 0;
+    if (aUnread !== bUnread) return bUnread - aUnread;
+    return (
+      new Date(b.last_event_at).getTime() - new Date(a.last_event_at).getTime()
+    );
+  });
+}
+
+function conversationLabel(c: PhoneConversationItem): string {
+  return c.contact_name ?? formatPhoneNumber(c.outside_e164);
+}
+
+export function PhonePageClient({
+  organizationId,
+  initialConversations,
+}: PhonePageClientProps) {
+  const [conversations, setConversations] = useState(
+    sortConversations(initialConversations),
+  );
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<PhoneMessage[]>([]);
+  const [loadingThread, setLoadingThread] = useState(false);
+
+  const selected = useMemo(
+    () => conversations.find((c) => c.id === selectedId) ?? null,
+    [conversations, selectedId],
+  );
+
+  const loadMessages = useCallback(async (convId: string) => {
+    setLoadingThread(true);
+    try {
+      const res = await fetch(`/api/phone/conversations/${convId}/messages`);
+      if (!res.ok) return;
+      const data = (await res.json()) as PhoneMessage[];
+      setMessages(data);
+    } finally {
+      setLoadingThread(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!selectedId) return;
+    void loadMessages(selectedId);
+  }, [selectedId, loadMessages]);
+
+  // Realtime: when a new inbound lands, reload the affected thread and
+  // bump the conversation in the list. Slice 4's update is intentionally
+  // coarse — a full thread re-fetch on each incoming message — because
+  // it is the simplest correct thing. Later slices can optimize.
+  const supabase = useMemo(() => createClient(), []);
+  usePhoneSync({
+    supabase,
+    organizationId,
+    onNewMessage: (row) => {
+      if (selectedId === row.conversation_id) {
+        void loadMessages(row.conversation_id);
+      }
+      setConversations((prev) => {
+        const next = prev.map((c) =>
+          c.id === row.conversation_id
+            ? {
+                ...c,
+                last_event_at: row.sent_at,
+                unread_count:
+                  selectedId === row.conversation_id
+                    ? c.unread_count
+                    : c.unread_count + 1,
+              }
+            : c,
+        );
+        return sortConversations(next);
+      });
+    },
+  });
+
+  const onSaveAsContact = useCallback(async () => {
+    if (!selected || selected.contact_id) return;
+    const fullName = window.prompt("Name for new Contact?");
+    if (!fullName) return;
+    const res = await fetch(
+      `/api/phone/conversations/${selected.id}/save-as-contact`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ fullName }),
+      },
+    );
+    if (!res.ok) return;
+    const { contact } = (await res.json()) as {
+      contact: { id: string; full_name: string };
+    };
+    setConversations((prev) =>
+      prev.map((c) =>
+        c.id === selected.id
+          ? { ...c, contact_id: contact.id, contact_name: contact.full_name }
+          : c,
+      ),
+    );
+  }, [selected]);
+
+  const onTagJob = useCallback(
+    async (messageId: string, jobId: string) => {
+      const res = await fetch(`/api/phone/messages/${messageId}/tag`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jobId }),
+      });
+      if (!res.ok) return;
+      setMessages((prev) =>
+        prev.map((m) => (m.id === messageId ? { ...m, job_tag: jobId } : m)),
+      );
+    },
+    [],
+  );
+
+  if (conversations.length === 0) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh] px-4">
+        <div className="text-center max-w-md">
+          <PhoneIcon size={40} className="mx-auto text-muted-foreground mb-4" />
+          <h1 className="text-lg font-semibold text-foreground">Phone</h1>
+          <p className="text-sm text-muted-foreground mt-2">
+            No conversations yet — text or call a Contact to get started.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)]">
+      {/* Left pane — Conversations list */}
+      <aside className="w-80 border-r border-border overflow-y-auto">
+        <ul role="list">
+          {conversations.map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => setSelectedId(c.id)}
+                className={`w-full text-left px-4 py-3 border-b border-border hover:bg-accent ${
+                  selectedId === c.id ? "bg-accent" : ""
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-foreground">
+                    {conversationLabel(c)}
+                  </span>
+                  {c.unread_count > 0 ? (
+                    <span className="ml-2 inline-flex items-center justify-center rounded-full bg-[var(--brand-primary)] text-white text-xs px-2 min-w-[20px]">
+                      {c.unread_count}
+                    </span>
+                  ) : null}
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </aside>
+
+      {/* Right pane — selected thread */}
+      <section className="flex-1 flex flex-col">
+        {selected ? (
+          <>
+            <header className="flex items-center justify-between border-b border-border px-4 py-3">
+              <div className="font-medium text-foreground">
+                {conversationLabel(selected)}
+              </div>
+              {selected.contact_id === null ? (
+                <button
+                  type="button"
+                  onClick={onSaveAsContact}
+                  className="inline-flex items-center gap-2 text-sm font-medium text-[var(--brand-primary)] hover:underline"
+                >
+                  <UserPlus size={16} /> Save as Contact
+                </button>
+              ) : null}
+            </header>
+            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+              {loadingThread ? (
+                <p className="text-sm text-muted-foreground">Loading…</p>
+              ) : null}
+              {messages.map((m) => {
+                const showChips =
+                  m.direction === "in" &&
+                  m.job_tag === null &&
+                  selected.active_jobs.length >= 2;
+                return (
+                  <div key={m.id} className="flex flex-col gap-1">
+                    {showChips ? (
+                      <div className="flex flex-wrap gap-2 text-xs">
+                        <span className="text-muted-foreground self-center">
+                          Tag to:
+                        </span>
+                        {selected.active_jobs.map((j) => (
+                          <button
+                            key={j.id}
+                            type="button"
+                            onClick={() => onTagJob(m.id, j.id)}
+                            className="rounded-full bg-accent px-3 py-1 hover:bg-accent/70"
+                          >
+                            {j.label}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                    <div
+                      className={`max-w-[70%] rounded-lg px-3 py-2 text-sm ${
+                        m.direction === "in"
+                          ? "self-start bg-muted"
+                          : "self-end bg-[var(--brand-primary)] text-white"
+                      }`}
+                    >
+                      {m.body}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        ) : (
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Select a conversation
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/lib/phone.test.ts
+++ b/src/lib/phone.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  findContactByPhone,
   formatPhoneNumber,
   isValidUSPhone,
   normalizePhoneToE164,
@@ -117,6 +118,77 @@ describe("phoneMatchesQuery", () => {
 
   it("matches across formats — a country-code query against a 10-digit stored value", () => {
     expect(phoneMatchesQuery("5551234567", "1 (555) 123-4567")).toBe(true);
+  });
+});
+
+describe("findContactByPhone (PRD #304, slice 4 — outside-E.164 → Contact)", () => {
+  // The inbound webhook gets a Twilio E.164 (`+15551234567`) and needs to
+  // resolve it to one of the org's contacts whose stored phone may be in
+  // any user-typed form (`(555) 123-4567`, `555-123-4567`, bare digits,
+  // E.164, or null). The match is digits-equal on the canonical 10-digit
+  // form — never substring (so the area code "555" doesn't match the
+  // local "555" of a different number).
+
+  it("returns the contact whose stored phone matches the E.164 input", () => {
+    const alice = { id: "c-1", phone: "(555) 123-4567" };
+    const bob = { id: "c-2", phone: "(555) 987-6543" };
+
+    expect(findContactByPhone([alice, bob], "+15551234567")).toEqual(alice);
+  });
+
+  it("returns null when no contact matches", () => {
+    const alice = { id: "c-1", phone: "(555) 123-4567" };
+
+    expect(findContactByPhone([alice], "+15559999999")).toBeNull();
+  });
+
+  it("returns null when the input is not a valid E.164 (defensive)", () => {
+    const alice = { id: "c-1", phone: "(555) 123-4567" };
+
+    expect(findContactByPhone([alice], "not-a-number")).toBeNull();
+    expect(findContactByPhone([alice], "")).toBeNull();
+  });
+
+  it("skips contacts whose phone is null or empty", () => {
+    const noPhone = { id: "c-1", phone: null };
+    const empty = { id: "c-2", phone: "" };
+    const match = { id: "c-3", phone: "+15551234567" };
+
+    expect(findContactByPhone([noPhone, empty, match], "+15551234567"))
+      .toEqual(match);
+  });
+
+  it("matches across stored formats — bare digits, E.164, formatted", () => {
+    expect(
+      findContactByPhone([{ id: "c-1", phone: "5551234567" }], "+15551234567"),
+    ).toEqual({ id: "c-1", phone: "5551234567" });
+    expect(
+      findContactByPhone([{ id: "c-2", phone: "+15551234567" }], "+15551234567"),
+    ).toEqual({ id: "c-2", phone: "+15551234567" });
+    expect(
+      findContactByPhone(
+        [{ id: "c-3", phone: "555.123.4567" }],
+        "+15551234567",
+      ),
+    ).toEqual({ id: "c-3", phone: "555.123.4567" });
+  });
+
+  it("does NOT do substring matching — a query for an area code should not match a local block", () => {
+    // Stored "(555) 123-4567" must not match the input "+15125555000" just
+    // because both have "555" somewhere. The match is digits-equal on the
+    // 10-digit canonical, not substring.
+    const c = { id: "c-1", phone: "(555) 123-4567" };
+    expect(findContactByPhone([c], "+15125555000")).toBeNull();
+  });
+
+  it("returns the first match when multiple contacts share the same number", () => {
+    // The data model permits duplicates (e.g., a homeowner and adjuster
+    // with the same office line). The webhook routes to the first; future
+    // slices may surface ambiguity in the UI.
+    const a = { id: "c-1", phone: "+15551234567" };
+    const b = { id: "c-2", phone: "5551234567" };
+
+    expect(findContactByPhone([a, b], "+15551234567")).toEqual(a);
   });
 });
 

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -40,3 +40,24 @@ export function phoneMatchesQuery(phone: string | null | undefined, query: strin
   if (queryDigits.length === 0) return false;
   return tenDigits(phone ?? "").includes(queryDigits);
 }
+
+/**
+ * Find the first contact whose stored phone matches the given E.164 input.
+ * The match is digits-equal on the canonical 10-digit form (NOT substring),
+ * so an area code "555" cannot match the local block "555" of an unrelated
+ * number. Returns null when the input is not a valid E.164 or no contact
+ * matches. Used by `route-inbound` to map a Twilio inbound to a Contact.
+ */
+export function findContactByPhone<T extends { phone: string | null | undefined }>(
+  contacts: readonly T[],
+  e164Input: string,
+): T | null {
+  const inputE164 = normalizePhoneToE164(e164Input);
+  if (!inputE164) return null;
+  const inputDigits = tenDigits(inputE164);
+  for (const c of contacts) {
+    if (!c.phone) continue;
+    if (tenDigits(c.phone) === inputDigits) return c;
+  }
+  return null;
+}

--- a/src/lib/phone/phone-event-access.test.ts
+++ b/src/lib/phone/phone-event-access.test.ts
@@ -14,7 +14,10 @@
 import { describe, it, expect } from "vitest";
 import {
   canManage,
+  canRead,
   type PhoneEventCaller,
+  type PhoneEventForRead,
+  type PhoneEventReadCaller,
   type PhoneNumberForManage,
 } from "./phone-event-access";
 
@@ -124,6 +127,227 @@ describe("canManage (PRD #304, ADR 0003)", () => {
       expect(() => canManage(caller({ role: "admin" }), bogus)).toThrow(
         /unknown phone number kind "service"/,
       );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// canRead — the read-path matrix from ADR 0003. PRD #304 § Privacy rule:
+//
+//   Job-tagged content is team-visible to anyone with view_phone who can
+//   see the Job, across all numbers (Shared or Personal).
+//   Untagged content on a Shared number is team-visible.
+//   Untagged content on a Personal number is owner-only — including
+//   hidden from admins.
+//
+// Cross-org callers are denied regardless of permission. The matrix is
+// total: every cell of {Shared, Personal} × {tagged, untagged} ×
+// {admin, owner, other-team-member, cross-org} × {job-visible, not} is
+// pinned by a test below.
+// ---------------------------------------------------------------------------
+
+function readCaller(overrides: Partial<PhoneEventReadCaller> = {}): PhoneEventReadCaller {
+  return {
+    userId: ALICE,
+    organizationId: ORG,
+    role: "crew_lead",
+    grantedPermissions: ["view_phone"],
+    ...overrides,
+  };
+}
+
+function sharedEvent(overrides: Partial<PhoneEventForRead> = {}): PhoneEventForRead {
+  return {
+    organizationId: ORG,
+    numberKind: "shared",
+    numberOwnerId: null,
+    jobTag: null,
+    ...overrides,
+  };
+}
+
+function personalEvent(
+  owner: string,
+  overrides: Partial<PhoneEventForRead> = {},
+): PhoneEventForRead {
+  return {
+    organizationId: ORG,
+    numberKind: "personal",
+    numberOwnerId: owner,
+    jobTag: null,
+    ...overrides,
+  };
+}
+
+describe("canRead (PRD #304, ADR 0003) — full access matrix", () => {
+  describe("permission gate (no view_phone)", () => {
+    it("returns false when the caller lacks view_phone, even on Shared", () => {
+      expect(
+        canRead(readCaller({ grantedPermissions: [] }), sharedEvent(), {
+          jobVisibleToCaller: false,
+        }),
+      ).toBe(false);
+    });
+
+    it("returns true for admin without explicit view_phone (admin role grants it)", () => {
+      // ADR 0001 / 0003 pattern: admin role is the broadest permission;
+      // we treat admin role as carrying view_phone by default. The
+      // permission catalog separately defaults `view_phone` ON for admin.
+      expect(
+        canRead(readCaller({ role: "admin", grantedPermissions: [] }), sharedEvent(), {
+          jobVisibleToCaller: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("Shared number, untagged", () => {
+    it("same-org crew_lead with view_phone: read allowed (team-visible)", () => {
+      expect(
+        canRead(readCaller({ role: "crew_lead" }), sharedEvent(), {
+          jobVisibleToCaller: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("same-org admin: read allowed", () => {
+      expect(
+        canRead(readCaller({ role: "admin" }), sharedEvent(), {
+          jobVisibleToCaller: false,
+        }),
+      ).toBe(true);
+    });
+
+    it("cross-org caller: read denied (org boundary holds before permission)", () => {
+      expect(
+        canRead(
+          readCaller({ organizationId: OTHER_ORG }),
+          sharedEvent(),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("Shared number, Job-tagged", () => {
+    it("caller can see the Job: read allowed", () => {
+      expect(
+        canRead(readCaller(), sharedEvent({ jobTag: "job-1" }), {
+          jobVisibleToCaller: true,
+        }),
+      ).toBe(true);
+    });
+
+    it("caller cannot see the Job: still read allowed (Shared is team-visible regardless)", () => {
+      // The ADR 0003 SELECT rule is OR — Job-tagged AND job-visible OR
+      // Shared OR Personal-owner. Shared alone wins; the job-tag branch
+      // is independent.
+      expect(
+        canRead(readCaller(), sharedEvent({ jobTag: "job-1" }), {
+          jobVisibleToCaller: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("Personal number, untagged", () => {
+    it("owner: read allowed", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE }),
+          personalEvent(ALICE),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(true);
+    });
+
+    it("non-owner crew_lead: read denied (content-private)", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE }),
+          personalEvent(BOB),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+
+    it("admin (not the owner): read denied — admins cannot read untagged Personal content", () => {
+      expect(
+        canRead(
+          readCaller({ role: "admin", userId: ALICE }),
+          personalEvent(BOB),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+
+    it("cross-org owner-by-userId: read denied (owner check is org-scoped)", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE, organizationId: OTHER_ORG }),
+          personalEvent(ALICE),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("Personal number, Job-tagged", () => {
+    it("owner: read allowed (owner can always read their own number's events)", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE }),
+          personalEvent(ALICE, { jobTag: "job-1" }),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(true);
+    });
+
+    it("non-owner with Job visibility: read allowed (Job-tagged is team-visible)", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE }),
+          personalEvent(BOB, { jobTag: "job-1" }),
+          { jobVisibleToCaller: true },
+        ),
+      ).toBe(true);
+    });
+
+    it("non-owner without Job visibility: read denied", () => {
+      expect(
+        canRead(
+          readCaller({ userId: ALICE }),
+          personalEvent(BOB, { jobTag: "job-1" }),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+
+    it("admin (not owner) without Job visibility: read denied", () => {
+      // Job-tag escapes content-privacy only when paired with Job
+      // visibility. An admin who happens not to have access to the Job
+      // still cannot read a Personal-number tagged event.
+      expect(
+        canRead(
+          readCaller({ role: "admin", userId: ALICE }),
+          personalEvent(BOB, { jobTag: "job-1" }),
+          { jobVisibleToCaller: false },
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("guard rails", () => {
+    it("throws for an unknown number kind on the read path too", () => {
+      const bogus = {
+        organizationId: ORG,
+        numberKind: "service" as unknown as PhoneEventForRead["numberKind"],
+        numberOwnerId: null,
+        jobTag: null,
+      };
+      expect(() =>
+        canRead(readCaller({ role: "admin" }), bogus, { jobVisibleToCaller: false }),
+      ).toThrow(/unknown phone number kind "service"/);
     });
   });
 });

--- a/src/lib/phone/phone-event-access.ts
+++ b/src/lib/phone/phone-event-access.ts
@@ -76,3 +76,96 @@ export function canManage(
   }
   return evaluator(caller, number);
 }
+
+// ---------------------------------------------------------------------------
+// canRead — the read-path matrix from ADR 0003. PRD #304 § Privacy rule:
+//
+//   Job-tagged content is team-visible to anyone with view_phone who can
+//   see the Job, across all numbers (Shared or Personal).
+//   Untagged content on a Shared number is team-visible.
+//   Untagged content on a Personal number is owner-only — including
+//   hidden from admins.
+//
+// Cross-org callers are denied regardless of permission. The matrix lives
+// in `phone-event-access` for the Service-client paths and in mirrored
+// RLS policies (migration-308) for the User-client paths; tests pin both
+// stay in sync.
+// ---------------------------------------------------------------------------
+
+// The caller, with permission grants — needed for the view_phone gate that
+// canManage did not have to consider. Admin role grants view_phone by
+// default (matches PRD § Permission), regardless of an explicit grant
+// list.
+export interface PhoneEventReadCaller extends PhoneEventCaller {
+  grantedPermissions: string[];
+}
+
+// The fields of a `phone_messages` / `phone_calls` row this module needs.
+// `numberKind` and `numberOwnerId` are joined from `phone_numbers`; the
+// caller of this module is responsible for that join (the Service-client
+// route reads both rows; the RLS-policy SQL inlines the join).
+export interface PhoneEventForRead {
+  organizationId: string;
+  numberKind: PhoneNumberKind;
+  numberOwnerId: string | null; // null for Shared
+  jobTag: string | null;        // null when not tagged to a Job
+}
+
+// Job visibility is supplied by the caller. Slice 4 callers use the
+// default "every authenticated user can see every Job in their active
+// org" policy from schema.sql; later slices can refine this (per-user
+// Job ACLs).
+export interface CanReadContext {
+  jobVisibleToCaller: boolean;
+}
+
+type ReadEvaluator = (
+  caller: PhoneEventReadCaller,
+  event: PhoneEventForRead,
+  context: CanReadContext,
+) => boolean;
+
+const evaluateSharedRead: ReadEvaluator = () => {
+  // Untagged Shared is team-visible; tagged Shared is also team-visible
+  // (the Job-tag branch only ever adds access, never removes it).
+  return true;
+};
+
+const evaluatePersonalRead: ReadEvaluator = (caller, event, context) => {
+  // Owner can always read their own Personal-number content.
+  if (event.numberOwnerId === caller.userId) return true;
+  // Non-owners can read only when the event is Job-tagged AND they can
+  // see the Job. Admin role does not bypass this — content-private.
+  if (event.jobTag !== null && context.jobVisibleToCaller) return true;
+  return false;
+};
+
+const READ_EVALUATORS: Record<PhoneNumberKind, ReadEvaluator> = {
+  shared: evaluateSharedRead,
+  personal: evaluatePersonalRead,
+};
+
+/**
+ * Decides whether a caller may read a phone message or call event. The
+ * matrix is the ADR 0003 OR-tree: Shared-team OR Personal-owner OR
+ * (Job-tagged AND Job-visible). Cross-org denied. Lack of view_phone (or
+ * admin role) denied. An unknown number kind throws.
+ */
+export function canRead(
+  caller: PhoneEventReadCaller,
+  event: PhoneEventForRead,
+  context: CanReadContext,
+): boolean {
+  if (caller.organizationId !== event.organizationId) return false;
+  // view_phone gate — admin role carries it implicitly.
+  const hasViewPhone =
+    caller.role === "admin" || caller.grantedPermissions.includes("view_phone");
+  if (!hasViewPhone) return false;
+  const evaluator = READ_EVALUATORS[event.numberKind];
+  if (!evaluator) {
+    throw new Error(
+      `canRead: unknown phone number kind "${event.numberKind}"`,
+    );
+  }
+  return evaluator(caller, event, context);
+}

--- a/src/lib/phone/route-inbound.test.ts
+++ b/src/lib/phone/route-inbound.test.ts
@@ -1,0 +1,172 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// `route-inbound` — the pure decision tree for an inbound SMS. Given the
+// Twilio payload (which contains a `From` E.164 of the outside party and a
+// `To` E.164 of one of our `phone_numbers`), the org's `phone_numbers`
+// rows, the org's contacts indexed by phone, and the contacts' Active
+// jobs, it decides:
+//
+//   - which `phone_numbers` row received the inbound (matched by `To`),
+//   - which Contact (if any) sent it (matched by `From` via phone-format),
+//   - which conversation-key it lands in (by `phone_number_id` +
+//     outside_e164), and
+//   - what the smart-attach decision is (delegated).
+//
+// I/O (signature validation, persistence) is separate: the webhook route
+// is a thin shell on top of this function.
+
+import { describe, it, expect } from "vitest";
+import { routeInbound, type RouteInboundInput } from "./route-inbound";
+
+const ORG = "org-1";
+const SHARED_NUMBER_ID = "pn-shared-1";
+const SHARED_E164 = "+15125550000";
+const OUTSIDE_E164 = "+15551234567";
+const CONTACT_ID = "c-1";
+
+function defaultInput(overrides: Partial<RouteInboundInput> = {}): RouteInboundInput {
+  return {
+    payload: {
+      From: OUTSIDE_E164,
+      To: SHARED_E164,
+      Body: "hello",
+    },
+    orgNumbers: [
+      {
+        id: SHARED_NUMBER_ID,
+        organization_id: ORG,
+        e164: SHARED_E164,
+        kind: "shared",
+        user_id: null,
+      },
+    ],
+    contacts: [],
+    activeJobsByContact: {},
+    ...overrides,
+  };
+}
+
+describe("routeInbound", () => {
+  it("returns null when no org number matches the To address", () => {
+    expect(
+      routeInbound({
+        payload: { From: OUTSIDE_E164, To: "+19999999999", Body: "x" },
+        orgNumbers: [
+          {
+            id: SHARED_NUMBER_ID,
+            organization_id: ORG,
+            e164: SHARED_E164,
+            kind: "shared",
+            user_id: null,
+          },
+        ],
+        contacts: [],
+        activeJobsByContact: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("unknown contact: returns null contactId + untagged smart-attach", () => {
+    const result = routeInbound(defaultInput());
+    expect(result).not.toBeNull();
+    expect(result).toEqual({
+      organizationId: ORG,
+      phoneNumberId: SHARED_NUMBER_ID,
+      phoneNumberKind: "shared",
+      phoneNumberOwnerId: null,
+      outsideE164: OUTSIDE_E164,
+      conversationKey: { phoneNumberId: SHARED_NUMBER_ID, outsideE164: OUTSIDE_E164 },
+      contactId: null,
+      smartAttach: { kind: "untagged" },
+    });
+  });
+
+  it("known contact, one Active job: auto-tag", () => {
+    const result = routeInbound(
+      defaultInput({
+        contacts: [{ id: CONTACT_ID, phone: "(555) 123-4567" }],
+        activeJobsByContact: {
+          [CONTACT_ID]: [{ id: "job-1", label: "WTR-2026-0001" }],
+        },
+      }),
+    );
+    expect(result).not.toBeNull();
+    expect(result!.contactId).toBe(CONTACT_ID);
+    expect(result!.smartAttach).toEqual({ kind: "auto", jobId: "job-1" });
+  });
+
+  it("known contact, two Active jobs: prompt with both candidates", () => {
+    const result = routeInbound(
+      defaultInput({
+        contacts: [{ id: CONTACT_ID, phone: "+15551234567" }],
+        activeJobsByContact: {
+          [CONTACT_ID]: [
+            { id: "job-1", label: "WTR-2026-0001" },
+            { id: "job-2", label: "FYR-2026-0005" },
+          ],
+        },
+      }),
+    );
+    expect(result!.contactId).toBe(CONTACT_ID);
+    expect(result!.smartAttach).toEqual({
+      kind: "prompt",
+      candidates: [
+        { jobId: "job-1", label: "WTR-2026-0001" },
+        { jobId: "job-2", label: "FYR-2026-0005" },
+      ],
+    });
+  });
+
+  it("known contact, zero Active jobs: untagged", () => {
+    const result = routeInbound(
+      defaultInput({
+        contacts: [{ id: CONTACT_ID, phone: "5551234567" }],
+        activeJobsByContact: { [CONTACT_ID]: [] },
+      }),
+    );
+    expect(result!.contactId).toBe(CONTACT_ID);
+    expect(result!.smartAttach).toEqual({ kind: "untagged" });
+  });
+
+  it("inbound to a Personal number: phoneNumberOwnerId is the owner", () => {
+    const result = routeInbound({
+      payload: { From: OUTSIDE_E164, To: "+15125550001", Body: "x" },
+      orgNumbers: [
+        {
+          id: "pn-personal-1",
+          organization_id: ORG,
+          e164: "+15125550001",
+          kind: "personal",
+          user_id: "user-alice",
+        },
+      ],
+      contacts: [],
+      activeJobsByContact: {},
+    });
+    expect(result).not.toBeNull();
+    expect(result!.phoneNumberKind).toBe("personal");
+    expect(result!.phoneNumberOwnerId).toBe("user-alice");
+  });
+
+  it("ignores released numbers when matching", () => {
+    // A released number's row stays for audit but should not receive
+    // new inbound. The webhook should treat a To-match against a released
+    // row as a no-op.
+    const result = routeInbound({
+      payload: { From: OUTSIDE_E164, To: SHARED_E164, Body: "x" },
+      orgNumbers: [
+        {
+          id: SHARED_NUMBER_ID,
+          organization_id: ORG,
+          e164: SHARED_E164,
+          kind: "shared",
+          user_id: null,
+          released_at: "2026-05-01T00:00:00Z",
+        },
+      ],
+      contacts: [],
+      activeJobsByContact: {},
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/phone/route-inbound.ts
+++ b/src/lib/phone/route-inbound.ts
@@ -1,0 +1,110 @@
+// PRD #304 — Nookleus Phone. The inbound-event decision tree. Pure: no
+// I/O, no Supabase, no HTTP. The webhook route is a thin shell that
+// validates the Twilio signature, calls this function, and persists.
+//
+// Inputs the route hands in:
+//   - the Twilio webhook payload (From, To, Body),
+//   - every active `phone_numbers` row in the org (the webhook narrows by
+//     `To`),
+//   - the org's contacts (the webhook narrows by `From` via phone-format),
+//   - the contacts' Active jobs (the webhook narrows by contactId).
+//
+// Outputs a `RouteInboundDecision` the webhook then turns into row writes,
+// or null when the inbound does not target any of the org's numbers.
+
+import { findContactByPhone, normalizePhoneToE164 } from "@/lib/phone";
+import {
+  decideJobTag,
+  type ActiveJob,
+  type SmartAttachDecision,
+} from "./smart-attach";
+
+// The slice of `phone_numbers` rows this module needs. The webhook hands
+// in the org's full set; the module narrows on `To`.
+export interface PhoneNumberForRoute {
+  id: string;
+  organization_id: string;
+  e164: string;
+  kind: "shared" | "personal";
+  user_id: string | null;
+  released_at?: string | null;
+}
+
+// The slice of `contacts` rows this module needs.
+export interface ContactForRoute {
+  id: string;
+  phone: string | null | undefined;
+}
+
+// The Twilio inbound webhook fields this module reads. Twilio sends many
+// more (FromCity, FromZip, MessageSid, etc.); the route is responsible
+// for persisting whatever else it cares about — this module only needs
+// the three routing fields.
+export interface TwilioInboundPayload {
+  From: string;
+  To: string;
+  Body: string;
+}
+
+export interface RouteInboundInput {
+  payload: TwilioInboundPayload;
+  orgNumbers: PhoneNumberForRoute[];
+  contacts: ContactForRoute[];
+  activeJobsByContact: Record<string, ActiveJob[]>;
+}
+
+export interface ConversationKey {
+  phoneNumberId: string;
+  outsideE164: string;
+}
+
+export interface RouteInboundDecision {
+  organizationId: string;
+  phoneNumberId: string;
+  phoneNumberKind: "shared" | "personal";
+  phoneNumberOwnerId: string | null;
+  outsideE164: string;
+  conversationKey: ConversationKey;
+  contactId: string | null;
+  smartAttach: SmartAttachDecision;
+}
+
+export function routeInbound(input: RouteInboundInput): RouteInboundDecision | null {
+  const toE164 = normalizePhoneToE164(input.payload.To);
+  const fromE164 = normalizePhoneToE164(input.payload.From);
+  if (!toE164 || !fromE164) return null;
+
+  // Match the To address to one of the org's active numbers. Released
+  // numbers are dead to us — Twilio still has them for a short window,
+  // and the row stays for audit, but new inbound on a released number
+  // is a no-op.
+  const number = input.orgNumbers.find(
+    (n) => n.e164 === toE164 && !n.released_at,
+  );
+  if (!number) return null;
+
+  // Match the From address to a Contact. May be null (unknown number).
+  const contact = findContactByPhone(input.contacts, fromE164);
+  const contactId = contact ? contact.id : null;
+  const activeJobs = contactId
+    ? input.activeJobsByContact[contactId] ?? []
+    : [];
+
+  const smartAttach = decideJobTag({
+    direction: "in",
+    sourceContext: { kind: "inbound" },
+    contactId,
+    activeJobs,
+  });
+
+  return {
+    organizationId: number.organization_id,
+    phoneNumberId: number.id,
+    phoneNumberKind: number.kind,
+    phoneNumberOwnerId: number.user_id,
+    outsideE164: fromE164,
+    conversationKey: { phoneNumberId: number.id, outsideE164: fromE164 },
+    contactId,
+    smartAttach,
+  };
+}

--- a/src/lib/phone/smart-attach.test.ts
+++ b/src/lib/phone/smart-attach.test.ts
@@ -1,0 +1,135 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// `smart-attach` — the Job-tag decision module. Pure: no I/O.
+//
+// PRD § Smart-attach rule (locked in #304):
+//   - Outbound from a Job page          → auto-tag to that Job.
+//   - Outbound from Phone tab / Contact → no auto-tag; prompt chips.
+//   - Inbound from Contact with 1 Active job → auto-tag.
+//   - Inbound from Contact with 2+ Active jobs → untagged + prompt chips.
+//   - Inbound from unknown phone number → untagged.
+//   - Inbound from Contact with 0 Active jobs → untagged.
+//
+// Slice 4 exercises the inbound branches; outbound branches land with the
+// compose slice (#5+). The module is built for both directions from day
+// one so the compose slice is a delivery, not a refactor.
+//
+// Bias is toward under-tagging: a false attribution (flood-job text on a
+// roof-job's page) is worse than the friction of one click. The rule
+// never breaks ties by recency.
+
+import { describe, it, expect } from "vitest";
+import {
+  decideJobTag,
+  type SmartAttachInput,
+  type ActiveJob,
+} from "./smart-attach";
+
+const CONTACT_ID = "c-1";
+
+function inbound(overrides: Partial<SmartAttachInput> = {}): SmartAttachInput {
+  return {
+    direction: "in",
+    sourceContext: { kind: "inbound" },
+    contactId: CONTACT_ID,
+    activeJobs: [],
+    ...overrides,
+  };
+}
+
+function job(id: string, label: string): ActiveJob {
+  return { id, label };
+}
+
+describe("decideJobTag — inbound branches (PRD #304, slice 4)", () => {
+  it("unknown contact (contactId null): untagged", () => {
+    expect(decideJobTag(inbound({ contactId: null, activeJobs: [] }))).toEqual({
+      kind: "untagged",
+    });
+  });
+
+  it("known contact, zero Active jobs: untagged", () => {
+    expect(
+      decideJobTag(inbound({ contactId: CONTACT_ID, activeJobs: [] })),
+    ).toEqual({ kind: "untagged" });
+  });
+
+  it("known contact, exactly one Active job: auto-tag", () => {
+    expect(
+      decideJobTag(
+        inbound({
+          contactId: CONTACT_ID,
+          activeJobs: [job("job-1", "WTR-2026-0001")],
+        }),
+      ),
+    ).toEqual({ kind: "auto", jobId: "job-1" });
+  });
+
+  it("known contact, two Active jobs: prompt with both candidates", () => {
+    expect(
+      decideJobTag(
+        inbound({
+          contactId: CONTACT_ID,
+          activeJobs: [
+            job("job-1", "WTR-2026-0001"),
+            job("job-2", "FYR-2026-0005"),
+          ],
+        }),
+      ),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [
+        { jobId: "job-1", label: "WTR-2026-0001" },
+        { jobId: "job-2", label: "FYR-2026-0005" },
+      ],
+    });
+  });
+
+  it("known contact, three Active jobs: prompt preserves order", () => {
+    // Order matters for the chip-banner UI. The caller passes jobs in
+    // whatever order they want them shown (typically newest-first or
+    // active-status sort); the module never reorders.
+    expect(
+      decideJobTag(
+        inbound({
+          contactId: CONTACT_ID,
+          activeJobs: [
+            job("job-3", "BLD-2026-0010"),
+            job("job-1", "WTR-2026-0001"),
+            job("job-2", "FYR-2026-0005"),
+          ],
+        }),
+      ),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [
+        { jobId: "job-3", label: "BLD-2026-0010" },
+        { jobId: "job-1", label: "WTR-2026-0001" },
+        { jobId: "job-2", label: "FYR-2026-0005" },
+      ],
+    });
+  });
+
+  it("inbound never auto-tags from a Job-page source context (inbound has no source page)", () => {
+    // The `sourceContext.kind === 'job'` branch is outbound-only; inbound
+    // always uses { kind: 'inbound' }. Test pinning that a malformed
+    // input does not silently auto-tag.
+    expect(
+      decideJobTag({
+        direction: "in",
+        sourceContext: { kind: "inbound" },
+        contactId: CONTACT_ID,
+        activeJobs: [
+          job("job-1", "WTR-2026-0001"),
+          job("job-2", "FYR-2026-0005"),
+        ],
+      }),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [
+        { jobId: "job-1", label: "WTR-2026-0001" },
+        { jobId: "job-2", label: "FYR-2026-0005" },
+      ],
+    });
+  });
+});

--- a/src/lib/phone/smart-attach.ts
+++ b/src/lib/phone/smart-attach.ts
@@ -1,0 +1,77 @@
+// PRD #304 — Nookleus Phone. The Job-tag decision module. Pure: no I/O,
+// no Supabase, no HTTP. Given a message direction, source context,
+// contact, and the contact's Active jobs, decide whether to auto-tag,
+// prompt with chips, or leave untagged.
+//
+// Locked rule (PRD #304):
+//   Outbound from a Job page                      → auto-tag to that Job.
+//   Outbound from Phone tab / Contact card        → prompt chips.
+//   Inbound from Contact with 1 Active job        → auto-tag.
+//   Inbound from Contact with 2+ Active jobs      → prompt chips.
+//   Inbound from Contact with 0 Active jobs       → untagged.
+//   Inbound from an unknown number (contactId null) → untagged.
+//
+// Bias toward under-tagging: never break ties by recency. A false
+// attribution (flood-job text on a roof-job's page) is worse than the
+// friction of one click. The decision is reversible — slice 9 wires the
+// "re-tag" action that overrides any auto / prompt outcome.
+
+export type SmartAttachDirection = "in" | "out";
+
+// The source context the message was composed from. Outbound has three
+// shapes (Job page, Phone tab, Contact card); inbound always carries
+// `{ kind: 'inbound' }`. Slice 4 exercises only the inbound shape; the
+// outbound shapes ship now so slice 5+ is a delivery.
+export type SmartAttachSource =
+  | { kind: "inbound" }
+  | { kind: "job"; jobId: string }
+  | { kind: "phone-tab" }
+  | { kind: "contact-card" };
+
+export interface ActiveJob {
+  id: string;
+  // Human-readable label shown in the chip banner (the job_number).
+  label: string;
+}
+
+export interface SmartAttachInput {
+  direction: SmartAttachDirection;
+  sourceContext: SmartAttachSource;
+  // Null when inbound from an unknown phone number; the route-inbound
+  // module is responsible for the lookup.
+  contactId: string | null;
+  // The Contact's Active jobs (status not in 'completed' | 'cancelled');
+  // empty when the contact has none. Order is preserved into the
+  // `candidates` array for the chip banner.
+  activeJobs: ActiveJob[];
+}
+
+export type SmartAttachDecision =
+  | { kind: "auto"; jobId: string }
+  | { kind: "prompt"; candidates: Array<{ jobId: string; label: string }> }
+  | { kind: "untagged" };
+
+export function decideJobTag(input: SmartAttachInput): SmartAttachDecision {
+  // Outbound from a Job page is definite — auto-tag regardless of
+  // contact's Active-job count.
+  if (input.direction === "out" && input.sourceContext.kind === "job") {
+    return { kind: "auto", jobId: input.sourceContext.jobId };
+  }
+
+  // Unknown contact: nothing to tag against.
+  if (input.contactId === null) {
+    return { kind: "untagged" };
+  }
+
+  // Known contact: depends on Active-job count.
+  if (input.activeJobs.length === 0) {
+    return { kind: "untagged" };
+  }
+  if (input.activeJobs.length === 1) {
+    return { kind: "auto", jobId: input.activeJobs[0].id };
+  }
+  return {
+    kind: "prompt",
+    candidates: input.activeJobs.map((j) => ({ jobId: j.id, label: j.label })),
+  };
+}

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -16,7 +16,7 @@
 // of the same shape. The helpers themselves never import twilio, so they
 // stay testable without network and without the Node SDK eval-time setup.
 
-import twilio from "twilio";
+import twilio, { validateRequest } from "twilio";
 
 // A narrowed slice of an item returned by `availablePhoneNumbers.list` —
 // the four fields the UI's "pick a number" step actually shows. Twilio
@@ -143,4 +143,27 @@ export function createTwilioClient(): TwilioClientLike {
     );
   }
   return twilio(accountSid, authToken) as unknown as TwilioClientLike;
+}
+
+/**
+ * Verify an inbound webhook came from Twilio. Twilio signs the request
+ * with the account auth token; we recompute the signature over the
+ * (url, params) pair and compare. Returns true on match. The webhook
+ * route should 403 on false.
+ *
+ * Reads `TWILIO_AUTH_TOKEN` from the environment — tests should not
+ * call this; instead they verify the webhook's wiring with the auth
+ * token mocked.
+ */
+export function validateTwilioSignature(
+  url: string,
+  twilioSignatureHeader: string | null,
+  params: Record<string, string>,
+): boolean {
+  if (!twilioSignatureHeader) return false;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  if (!authToken) {
+    throw new Error("twilio-client: TWILIO_AUTH_TOKEN must be set");
+  }
+  return validateRequest(authToken, twilioSignatureHeader, url, params);
 }

--- a/src/lib/phone/use-phone-sync.test.ts
+++ b/src/lib/phone/use-phone-sync.test.ts
@@ -1,0 +1,162 @@
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// `use-phone-sync` — React hook that subscribes to Supabase realtime
+// `phone_messages` INSERT events for the active org and fires a callback.
+// The Phone-tab UI uses this to live-update the Conversations list and
+// the open thread without a manual refresh.
+//
+// Mirror of `src/lib/email/use-email-sync.ts` in shape (caller-supplied
+// callback, hook returns a `connected` flag), but realtime instead of
+// polling. The hook is a thin shell over the Supabase channel — most of
+// the logic is unsubscribing on unmount and re-subscribing when the org
+// changes.
+//
+// AC bullet: "Realtime updates via Supabase realtime subscription, hooked
+// up through a new use-phone-sync hook"
+
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePhoneSync } from "./use-phone-sync";
+
+interface FakeChannel {
+  on: ReturnType<typeof vi.fn>;
+  subscribe: ReturnType<typeof vi.fn>;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+function fakeSupabase() {
+  const channels: FakeChannel[] = [];
+  const channel = vi.fn((): FakeChannel => {
+    const ch: FakeChannel = {
+      on: vi.fn(() => ch),
+      subscribe: vi.fn(() => ch),
+      unsubscribe: vi.fn(),
+    };
+    channels.push(ch);
+    return ch;
+  });
+  return { channel, channels };
+}
+
+describe("usePhoneSync", () => {
+  it("subscribes to phone_messages INSERTs for the active org on mount", () => {
+    const supabase = fakeSupabase();
+    const onNewMessage = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage,
+      }),
+    );
+
+    expect(supabase.channel).toHaveBeenCalledTimes(1);
+    const ch = supabase.channels[0];
+    expect(ch.on).toHaveBeenCalledWith(
+      "postgres_changes",
+      expect.objectContaining({
+        event: "INSERT",
+        schema: "public",
+        table: "phone_messages",
+        filter: "organization_id=eq.org-1",
+      }),
+      expect.any(Function),
+    );
+    expect(ch.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onNewMessage with the inserted row when the realtime payload arrives", () => {
+    const supabase = fakeSupabase();
+    const onNewMessage = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage,
+      }),
+    );
+
+    // Pull the handler the hook registered, then simulate Twilio→Supabase
+    // delivering a new row.
+    const ch = supabase.channels[0];
+    const handler = ch.on.mock.calls[0][2] as (payload: {
+      new: Record<string, unknown>;
+    }) => void;
+
+    act(() => {
+      handler({
+        new: {
+          id: "m-1",
+          organization_id: "org-1",
+          conversation_id: "conv-1",
+          direction: "in",
+          body: "Hi",
+        },
+      });
+    });
+
+    expect(onNewMessage).toHaveBeenCalledWith({
+      id: "m-1",
+      organization_id: "org-1",
+      conversation_id: "conv-1",
+      direction: "in",
+      body: "Hi",
+    });
+  });
+
+  it("unsubscribes the channel on unmount", () => {
+    const supabase = fakeSupabase();
+    const { unmount } = renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    expect(ch.unsubscribe).not.toHaveBeenCalled();
+    unmount();
+    expect(ch.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-subscribes when organizationId changes (and unsubscribes the old channel)", () => {
+    const supabase = fakeSupabase();
+    const { rerender } = renderHook(
+      ({ orgId }) =>
+        usePhoneSync({
+          supabase: supabase as never,
+          organizationId: orgId,
+          onNewMessage: vi.fn(),
+        }),
+      { initialProps: { orgId: "org-1" } },
+    );
+
+    expect(supabase.channel).toHaveBeenCalledTimes(1);
+
+    rerender({ orgId: "org-2" });
+    expect(supabase.channel).toHaveBeenCalledTimes(2);
+    // Old channel was unsubscribed.
+    expect(supabase.channels[0].unsubscribe).toHaveBeenCalledTimes(1);
+    // New channel filter is org-2.
+    expect(supabase.channels[1].on).toHaveBeenCalledWith(
+      "postgres_changes",
+      expect.objectContaining({ filter: "organization_id=eq.org-2" }),
+      expect.any(Function),
+    );
+  });
+
+  it("does not subscribe when organizationId is null (no active org yet)", () => {
+    const supabase = fakeSupabase();
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: null,
+        onNewMessage: vi.fn(),
+      }),
+    );
+    expect(supabase.channel).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/phone/use-phone-sync.ts
+++ b/src/lib/phone/use-phone-sync.ts
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef } from "react";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+// PRD #304 — Nookleus Phone. Slice 4 (#308).
+//
+// Subscribe to Supabase realtime `phone_messages` INSERT events for the
+// active org and fire `onNewMessage` for each. The Phone-tab UI uses this
+// to live-update the Conversations list and the open thread.
+//
+// Mirror of `src/lib/email/use-email-sync.ts` in shape but realtime
+// instead of polling. The hook itself is a thin wrapper around the
+// Supabase channel; the org filter (`organization_id=eq.<id>`) is
+// applied server-side so we never receive events for other orgs even
+// if the page somehow had a stale subscription.
+
+interface PhoneMessageRow {
+  id: string;
+  organization_id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  body: string | null;
+  job_tag: string | null;
+  sent_at: string;
+  [key: string]: unknown;
+}
+
+export interface UsePhoneSyncInput {
+  supabase: SupabaseClient;
+  // The active org. Null while loading or when the user is logged out;
+  // the hook holds no subscription in that state.
+  organizationId: string | null;
+  onNewMessage: (row: PhoneMessageRow) => void;
+}
+
+export function usePhoneSync(input: UsePhoneSyncInput): void {
+  const onNewMessageRef = useRef(input.onNewMessage);
+  // useLayoutEffect (or useEffect — either works since the effect runs
+  // before the next event-loop tick that fires the subscription handler)
+  // keeps the ref read-only during render, satisfying react-hooks/refs.
+  useLayoutEffect(() => {
+    onNewMessageRef.current = input.onNewMessage;
+  }, [input.onNewMessage]);
+
+  const { supabase, organizationId } = input;
+
+  useEffect(() => {
+    if (!organizationId) return;
+    const channel = supabase
+      .channel(`phone-messages-${organizationId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "phone_messages",
+          filter: `organization_id=eq.${organizationId}`,
+        },
+        (payload: { new: PhoneMessageRow }) => {
+          onNewMessageRef.current(payload.new);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [supabase, organizationId]);
+}

--- a/supabase/migration-308-phone-conversations-messages.sql
+++ b/supabase/migration-308-phone-conversations-messages.sql
@@ -1,0 +1,267 @@
+-- issue #308 (PRD #304, ADR 0003) — phone_conversations + phone_messages.
+--
+-- Purpose:   The two largest tables of Nookleus Phone — one row per
+--            (Organization number, outside number) Conversation, and one
+--            row per inbound/outbound SMS/MMS within it. Together these
+--            land the entire read path of slice 4: inbound texts surface
+--            as threaded messages in the Phone tab.
+--
+--            phone_conversations is iMessage-style: one row per Contact
+--            (or per outside-E.164 when contact_id is NULL until "Save
+--            as Contact" runs). phone_messages is the event row each
+--            inbound webhook writes; the index on (conversation_id,
+--            sent_at) renders the thread, and the index on
+--            (organization_id, job_tag, sent_at) feeds the future
+--            Job-page Messages section.
+--
+-- Shape:     Schema is PRD #304 § Schema verbatim, narrowed to the two
+--            tables this slice needs. CASCADE deletes from
+--            phone_conversations clear phone_messages along with them;
+--            the conversation row is the unit of "delete this thread"
+--            (soft-deleted via `deleted_at`).
+--
+-- RLS:       Encodes ADR 0003 — Job-tagged content is team-visible to
+--            anyone with view_phone who can see the Job (across Shared
+--            and Personal numbers), untagged content on a Shared number
+--            is team-visible, untagged content on a Personal number is
+--            owner-only. The matrix lives in `phone-event-access.canRead`
+--            for the Service-client paths and in these RLS policies for
+--            the User-client paths; tests pin them in sync.
+--
+--            Slice 4's UI uses the Service-client + access-module for
+--            reads (the webhook persists with the Service client). The
+--            RLS policies are the backstop and the source of truth for
+--            slice 13's Personal-number branches.
+--
+-- Depends on: schema.sql (organizations, contacts, jobs), migration-307
+--            (phone_numbers), migration-build45 (org_id columns), schema
+--            for `nookleus.active_organization_id()` / `is_member_of()`.
+--
+-- Smoke test: supabase/migration-308-smoke-test.sql exercises every cell
+--            of the ADR 0003 access matrix on phone_messages (Shared and
+--            Personal, tagged and untagged, owner / non-owner / cross-org)
+--            in the spirit of migration-222-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. phone_conversations. One row per (phone_number_id, outside_e164)
+--    pair. The Conversation is the thread head; deleting it cascades to
+--    every message in the thread.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_conversations (
+  id                  uuid primary key default gen_random_uuid(),
+  organization_id     uuid not null references public.organizations(id) on delete cascade,
+  -- The Nookleus number this Conversation is anchored on (Shared or
+  -- Personal). FK CASCADE — releasing a number cascades its
+  -- Conversations, but in practice the number row stays for audit via
+  -- `released_at` soft-delete, so this cascade is a defense-in-depth
+  -- for hard deletes only.
+  phone_number_id     uuid not null references public.phone_numbers(id) on delete cascade,
+  outside_e164        text not null,
+  -- NULL until "Save as Contact" runs. Slice 7 (Save as Contact API
+  -- route) sets this. Once set, the thread header replaces "Save as
+  -- Contact" with the Contact's name.
+  contact_id          uuid references public.contacts(id) on delete set null,
+  -- Denormalized for the Phone-tab list sort (newest activity on top).
+  -- Webhook + outbound paths both bump this on every message.
+  last_event_at       timestamptz not null default now(),
+  -- Denormalized count of unread inbound messages. Slice 4 increments
+  -- this on every inbound; slice 8 (mark-read) decrements it. Stored
+  -- rather than computed so the list query is a single-row read per
+  -- conversation.
+  unread_count        integer not null default 0,
+  deleted_at          timestamptz,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  constraint phone_conversations_pair_unique unique (phone_number_id, outside_e164)
+);
+
+create index if not exists idx_phone_conversations_org_active
+  on public.phone_conversations (organization_id, last_event_at desc)
+  where deleted_at is null;
+
+create index if not exists idx_phone_conversations_contact
+  on public.phone_conversations (contact_id)
+  where contact_id is not null;
+
+drop trigger if exists trg_phone_conversations_updated_at on public.phone_conversations;
+create trigger trg_phone_conversations_updated_at
+  before update on public.phone_conversations
+  for each row execute function public.update_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- 2. phone_messages. One row per inbound or outbound text/MMS. The
+--    (conversation_id, sent_at) index renders the thread chronologically;
+--    the (organization_id, job_tag, sent_at) index feeds the future
+--    Job-page Messages section.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_messages (
+  id                  uuid primary key default gen_random_uuid(),
+  organization_id     uuid not null references public.organizations(id) on delete cascade,
+  conversation_id     uuid not null references public.phone_conversations(id) on delete cascade,
+  direction           text not null check (direction in ('in', 'out')),
+  from_e164           text not null,
+  to_e164             text not null,
+  body                text,
+  -- MMS attachments — array of Twilio MediaUrl values. Empty array for
+  -- plain SMS. JSONB rather than text[] so the per-item shape can grow
+  -- (mime, size) without a schema change.
+  media_urls          jsonb not null default '[]'::jsonb,
+  twilio_sid          text,
+  status              text,
+  -- The Job tag from smart-attach. NULL when untagged (the default for
+  -- inbound from contact with 0 or 2+ Active jobs). Slice 9 (tag chips)
+  -- lets the user fill or change this; slice 13 makes Personal-number
+  -- access depend on whether this is non-null.
+  job_tag             uuid references public.jobs(id) on delete set null,
+  -- Null when auto-tagged by smart-attach (the inbound branch); set when
+  -- a user tagged via the chips UI. Slice 9 reads this for the "tagged
+  -- by Alice" badge.
+  tagged_by_user_id   uuid references auth.users(id) on delete set null,
+  -- Null for inbound; set to the sending user for outbound. Slice 5
+  -- (compose) writes this.
+  sent_by_user_id     uuid references auth.users(id) on delete set null,
+  sent_at             timestamptz not null default now(),
+  created_at          timestamptz not null default now()
+);
+
+create index if not exists idx_phone_messages_conversation_sent_at
+  on public.phone_messages (conversation_id, sent_at);
+
+create index if not exists idx_phone_messages_org_job_sent_at
+  on public.phone_messages (organization_id, job_tag, sent_at)
+  where job_tag is not null;
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS. ENABLE first, then policies on each table.
+--
+--    phone_conversations: SELECT mirrors phone_messages' rule — a
+--      Conversation is visible when any of its messages would be (any
+--      Shared, any Personal owned by you, any Job-tagged where you see
+--      the Job). For slice 4's all-Shared world this collapses to "every
+--      member of the active org sees every Shared Conversation"; the
+--      Personal/tagged branches ship now for slice 13 readiness.
+--
+--    phone_messages: encodes the full ADR 0003 matrix at the database
+--      level. The check is OR-tree:
+--        - Shared number (untagged or tagged) — visible to every member.
+--        - Personal number, owner — visible to owner.
+--        - Job-tagged, any number — visible when the caller can see the
+--          Job (slice 4 uses the schema.sql "every member sees every
+--          Job in their active org" policy; future slices can add a
+--          per-user Job ACL and this RLS stays unchanged).
+--
+--    Both tables: INSERT / UPDATE require organization_id match and
+--      caller membership. Routes use the Service client for writes
+--      (the webhook is admin-equivalent on the inbound surface); the
+--      INSERT policy is a defense-in-depth for the User-client path.
+-- ---------------------------------------------------------------------------
+alter table public.phone_conversations enable row level security;
+alter table public.phone_messages      enable row level security;
+
+drop policy if exists phone_conversations_select on public.phone_conversations;
+create policy phone_conversations_select on public.phone_conversations
+  for select to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1
+        from public.phone_numbers pn
+       where pn.id = phone_conversations.phone_number_id
+         and pn.organization_id = phone_conversations.organization_id
+         and (
+           pn.user_id is null                   -- Shared
+           or pn.user_id = auth.uid()           -- Personal-owner
+         )
+    )
+  );
+
+drop policy if exists phone_conversations_insert on public.phone_conversations;
+create policy phone_conversations_insert on public.phone_conversations
+  for insert to authenticated
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  );
+
+drop policy if exists phone_conversations_update on public.phone_conversations;
+create policy phone_conversations_update on public.phone_conversations
+  for update to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+  );
+
+drop policy if exists phone_messages_select on public.phone_messages;
+create policy phone_messages_select on public.phone_messages
+  for select to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1
+        from public.phone_numbers pn
+        join public.phone_conversations pc on pc.phone_number_id = pn.id
+       where pc.id = phone_messages.conversation_id
+         and pn.organization_id = phone_messages.organization_id
+         and (
+           -- Shared number: team-visible regardless of job_tag.
+           pn.user_id is null
+           -- Personal number, owner: visible regardless of job_tag.
+           or pn.user_id = auth.uid()
+           -- Job-tagged, caller can see the Job. Slice 4's job-access
+           -- policy is "every authenticated user in the active org" via
+           -- schema.sql's "Allow all on jobs" — the EXISTS below mirrors
+           -- that. When a per-user Job ACL lands, replace this clause
+           -- with the corresponding access query.
+           or (
+             phone_messages.job_tag is not null
+             and exists (
+               select 1
+                 from public.jobs j
+                where j.id = phone_messages.job_tag
+                  and j.organization_id = phone_messages.organization_id
+             )
+           )
+         )
+    )
+  );
+
+drop policy if exists phone_messages_insert on public.phone_messages;
+create policy phone_messages_insert on public.phone_messages
+  for insert to authenticated
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  );
+
+drop policy if exists phone_messages_update on public.phone_messages;
+create policy phone_messages_update on public.phone_messages
+  for update to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+  );
+
+-- ROLLBACK ---
+-- drop policy if exists phone_messages_update on public.phone_messages;
+-- drop policy if exists phone_messages_insert on public.phone_messages;
+-- drop policy if exists phone_messages_select on public.phone_messages;
+-- drop policy if exists phone_conversations_update on public.phone_conversations;
+-- drop policy if exists phone_conversations_insert on public.phone_conversations;
+-- drop policy if exists phone_conversations_select on public.phone_conversations;
+-- alter table public.phone_messages disable row level security;
+-- alter table public.phone_conversations disable row level security;
+-- drop trigger if exists trg_phone_conversations_updated_at on public.phone_conversations;
+-- drop index if exists public.idx_phone_messages_org_job_sent_at;
+-- drop index if exists public.idx_phone_messages_conversation_sent_at;
+-- drop index if exists public.idx_phone_conversations_contact;
+-- drop index if exists public.idx_phone_conversations_org_active;
+-- drop table if exists public.phone_messages;
+-- drop table if exists public.phone_conversations;

--- a/supabase/migration-308-smoke-test.sql
+++ b/supabase/migration-308-smoke-test.sql
@@ -1,0 +1,255 @@
+-- issue #308 (PRD #304, ADR 0003) — phone_conversations + phone_messages
+-- access-matrix smoke test.
+--
+-- Purpose:   Verify that the migration-308 RLS policies encode every cell
+--            of the ADR 0003 read-path matrix at the database. The
+--            phone-event-access TypeScript module has the same matrix in
+--            code; the two are kept in sync by this script's cases
+--            mirroring src/lib/phone/phone-event-access.test.ts's
+--            canRead suite.
+--
+--            Matrix exercised (phone_messages SELECT):
+--              - Shared untagged          → every same-org member sees
+--              - Shared Job-tagged        → every same-org member sees
+--              - Personal untagged, owner → owner sees
+--              - Personal untagged, other → hidden
+--              - Personal Job-tagged, owner → owner sees
+--              - Personal Job-tagged, other → sees (Job-visible team)
+--              - Cross-org caller         → never sees
+--
+-- Shape:     One transaction, rolled back at the end. Service-role seeds
+--            two orgs, three users, two phone_numbers (Shared + Personal),
+--            two conversations, six messages covering the matrix. Each
+--            assertion block sets the JWT claims, switches to
+--            `authenticated`, runs a SELECT, and asserts the row-count
+--            against expected.
+--
+-- Run:       Via Supabase MCP `execute_sql` against the target project.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed. Service-role bypass for orgs / users / memberships.
+--      Org 1: smoke-308-org-1
+--        User A — admin
+--        User B — crew_lead (non-owner of any Personal number)
+--        User C — crew_lead (owner of the Personal number)
+--      Org 2: smoke-308-org-2
+--        User D — admin
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('a8000000-0000-0000-0000-000000000001', 'smoke-308-org-1', 'smoke-308-org-1'),
+  ('a8000000-0000-0000-0000-000000000002', 'smoke-308-org-2', 'smoke-308-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('a8000000-0000-0000-0000-000000000010', 'smoke-308-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('a8000000-0000-0000-0000-000000000011', 'smoke-308-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('a8000000-0000-0000-0000-000000000012', 'smoke-308-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('a8000000-0000-0000-0000-000000000013', 'smoke-308-d@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('a8000000-0000-0000-0000-000000000010', 'a8000000-0000-0000-0000-000000000001', 'admin'),
+  ('a8000000-0000-0000-0000-000000000011', 'a8000000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('a8000000-0000-0000-0000-000000000012', 'a8000000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('a8000000-0000-0000-0000-000000000013', 'a8000000-0000-0000-0000-000000000002', 'admin');
+
+-- Two phone numbers in org-1: one Shared, one Personal owned by User C.
+insert into public.phone_numbers
+  (id, organization_id, twilio_sid, e164, kind, user_id)
+values
+  ('a8000000-0000-0000-0000-0000000000a1', 'a8000000-0000-0000-0000-000000000001',
+   'PN-smoke-shared', '+15125550000', 'shared', null),
+  ('a8000000-0000-0000-0000-0000000000a2', 'a8000000-0000-0000-0000-000000000001',
+   'PN-smoke-personal', '+15125550001', 'personal',
+   'a8000000-0000-0000-0000-000000000012');
+
+-- Two conversations — one on each number.
+insert into public.phone_conversations
+  (id, organization_id, phone_number_id, outside_e164)
+values
+  ('a8000000-0000-0000-0000-0000000000b1', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000a1', '+15551110001'),
+  ('a8000000-0000-0000-0000-0000000000b2', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000a2', '+15551110002');
+
+-- One Job in org-1 for the Job-tagged cases. Contact is a placeholder.
+insert into public.contacts (id, full_name)
+values ('a8000000-0000-0000-0000-0000000000c1', 'smoke-308-contact');
+
+insert into public.jobs
+  (id, organization_id, contact_id, damage_type, property_address)
+values
+  ('a8000000-0000-0000-0000-0000000000d1', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000c1', 'water', '1 smoke st');
+
+-- Six messages cover the matrix.
+--   m1: Shared, untagged
+--   m2: Shared, tagged (job d1)
+--   m3: Personal (owner C), untagged
+--   m4: Personal (owner C), tagged (job d1)
+--   m5: Personal (owner C), untagged — duplicate of m3 for the "other user"
+--       cases (kept separate so a single failure does not cascade)
+--   m6: Personal (owner C), tagged — duplicate of m4 for symmetry
+insert into public.phone_messages
+  (id, organization_id, conversation_id, direction, from_e164, to_e164, body, job_tag)
+values
+  ('a8000000-0000-0000-0000-0000000000e1', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000b1', 'in', '+15551110001', '+15125550000', 'shared-untagged', null),
+  ('a8000000-0000-0000-0000-0000000000e2', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000b1', 'in', '+15551110001', '+15125550000', 'shared-tagged',
+   'a8000000-0000-0000-0000-0000000000d1'),
+  ('a8000000-0000-0000-0000-0000000000e3', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000b2', 'in', '+15551110002', '+15125550001', 'personal-untagged', null),
+  ('a8000000-0000-0000-0000-0000000000e4', 'a8000000-0000-0000-0000-000000000001',
+   'a8000000-0000-0000-0000-0000000000b2', 'in', '+15551110002', '+15125550001', 'personal-tagged',
+   'a8000000-0000-0000-0000-0000000000d1');
+
+-- ---------------------------------------------------------------------------
+-- 1. User A (admin, org-1) — should see Shared-untagged, Shared-tagged,
+--    Personal-tagged (Job-visible), but NOT Personal-untagged (admin
+--    cannot read untagged Personal content per ADR 0003).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000010","active_organization_id":"a8000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(body, ',' order by body)
+    into v_count, v_ids
+    from public.phone_messages;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-308 smoke (case 1: admin): expected 3 visible messages, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-308 smoke (case 1: admin): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-308 smoke (case 1: admin) — admin sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. User B (crew_lead, org-1, NOT owner of any Personal number) — should
+--    see Shared-untagged, Shared-tagged, Personal-tagged (Job-visible),
+--    but NOT Personal-untagged.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000011","active_organization_id":"a8000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(body, ',' order by body)
+    into v_count, v_ids
+    from public.phone_messages;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-308 smoke (case 2: crew_lead non-owner): expected 3 visible messages, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-308 smoke (case 2: crew_lead non-owner): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-308 smoke (case 2: crew_lead non-owner) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. User C (crew_lead, org-1, OWNER of Personal +15125550001) — should
+--    see all 4 messages.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000012","active_organization_id":"a8000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_messages;
+
+  reset role;
+
+  if v_count <> 4 then
+    raise exception 'migration-308 smoke (case 3: Personal owner): expected 4 visible messages, got %', v_count;
+  end if;
+  raise notice 'migration-308 smoke (case 3: Personal owner) — sees all 4 of own + Shared rows';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. User D (admin, org-2) — cross-org. Should see 0 messages.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000013","active_organization_id":"a8000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_messages;
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-308 smoke (case 4: cross-org admin): expected 0 visible messages, got %', v_count;
+  end if;
+  raise notice 'migration-308 smoke (case 4: cross-org admin) — sees nothing';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. phone_conversations: User B (non-owner) should see only the Shared
+--    conversation, NOT the Personal one (untagged content branch). User C
+--    (owner) should see both. User D (cross-org) should see none.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_b int;
+  v_c int;
+  v_d int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000011","active_organization_id":"a8000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  select count(*) into v_b from public.phone_conversations;
+  reset role;
+
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000012","active_organization_id":"a8000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  select count(*) into v_c from public.phone_conversations;
+  reset role;
+
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a8000000-0000-0000-0000-000000000013","active_organization_id":"a8000000-0000-0000-0000-000000000002","role":"authenticated"}';
+  select count(*) into v_d from public.phone_conversations;
+  reset role;
+
+  if v_b <> 1 then
+    raise exception 'migration-308 smoke (case 5b: B): expected 1 conversation, got %', v_b;
+  end if;
+  if v_c <> 2 then
+    raise exception 'migration-308 smoke (case 5c: C owner): expected 2 conversations, got %', v_c;
+  end if;
+  if v_d <> 0 then
+    raise exception 'migration-308 smoke (case 5d: cross-org D): expected 0 conversations, got %', v_d;
+  end if;
+  raise notice 'migration-308 smoke (case 5) — phone_conversations RLS pins Shared vs Personal-owner vs cross-org';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Done.
+-- ---------------------------------------------------------------------------
+rollback;


### PR DESCRIPTION
## Summary

PRD #304, slice 4 — the entire inbound read path. A customer texts the Shared number provisioned in slice 3 and the message lands in the Phone tab as a threaded Conversation. Threading is iMessage-style (one per Contact); smart-attach auto-tags to a Job when unambiguous and prompts with chips otherwise.

Closes #308.

## What's in the slice

**Pure modules**
- `phone-format`: `findContactByPhone` — outside-E.164 → Contact via digits-equal (not substring).
- `phone-event-access`: `canRead` — full ADR 0003 matrix.
- `smart-attach`: `decideJobTag` (inbound branches — auto / prompt / untagged).
- `route-inbound`: composes the above against a Twilio payload.

**Migration**
- `migration-308-phone-conversations-messages.sql` — both tables, the `(conversation_id, sent_at)` + `(organization_id, job_tag, sent_at)` indexes, and RLS mirroring `phone-event-access.canRead`.
- `migration-308-smoke-test.sql` — every cell of the ADR 0003 matrix.

**Routes** (all `view_phone` gated unless noted)
- `POST /api/phone/webhook/sms-inbound` — Twilio signature-validated, persists conversation + message, returns TwiML.
- `GET  /api/phone/conversations` — list sorted by `last_event_at` desc.
- `GET  /api/phone/conversations/[id]/messages` — thread chronological.
- `POST /api/phone/conversations/[id]/save-as-contact` — convert raw-number thread.
- `POST /api/phone/messages/[id]/tag` — chip-banner tag/re-tag.

**UI**
- `phone-page-client.tsx` — two-pane (list + thread), Save as Contact button, tag chips above untagged inbound messages with 2+ Active jobs, realtime via `use-phone-sync`.
- `use-phone-sync.ts` — Supabase realtime hook on `phone_messages` INSERTs.

## Test plan

- [ ] Apply `migration-308-phone-conversations-messages.sql` against AAA prod (after approval). Roll-back block included.
- [ ] Run `migration-308-smoke-test.sql` (`begin … rollback`) and confirm every NOTICE line prints without an exception.
- [ ] Manual end-to-end: text the slice-3 Shared number from a real phone; verify the message appears in `/phone` without a refresh; verify the unread badge; verify Save as Contact converts the thread; verify clicking a tag chip persists `job_tag`.
- [ ] Unit/route tests already pass: `npx vitest run src/lib/phone src/lib/phone.test.ts src/app/api/phone src/app/phone` → 142 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)