### PR TITLE
feat(phone): MMS attachments (inbound + outbound) (#310)

### DIFF
--- a/src/app/api/phone/attachments/route.test.ts
+++ b/src/app/api/phone/attachments/route.test.ts
@@ -1,0 +1,254 @@
+// @vitest-environment node
+// PRD #304 — Nookleus Phone. Slice 6 (#310).
+//
+// Tests for the MMS attachment upload + signed-URL route.
+//
+// POST: accepts a multipart upload, validates type+size, stores under the
+// caller's Organization prefix in the `phone-attachments` bucket, and
+// returns the storage path + media type the client then attaches to its
+// outbound message.
+//
+// GET: mints a short-lived signed URL for an already-stored attachment
+// path so the thread can render images and surface download links for
+// non-image media.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST, GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { fakeUserClient, memberTables } from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const ORG = "org-1";
+
+const routeCtx = { params: Promise.resolve({}) };
+
+function postRequest(formData: FormData): Request {
+  return new Request("http://test/api/phone/attachments", {
+    method: "POST",
+    body: formData,
+  });
+}
+
+function getRequest(path: string): Request {
+  return new Request(
+    `http://test/api/phone/attachments?path=${encodeURIComponent(path)}`,
+  );
+}
+
+function jpegFile(name = "damage.jpg", size = 1000): File {
+  // Routes do not parse the bytes — a non-empty payload of the right type
+  // is enough.
+  const bytes = new Uint8Array(size).fill(0xff);
+  return new File([bytes], name, { type: "image/jpeg" });
+}
+
+// Service-client fake with storage.upload + createSignedUrl. The route
+// authenticates through the User-client wrapper but writes through the
+// Service client; we mock only the calls the route makes.
+function makeService() {
+  const uploads: Array<{ bucket: string; path: string }> = [];
+  const signed: Array<{ bucket: string; path: string }> = [];
+  return {
+    uploads,
+    signed,
+    client: {
+      storage: {
+        from(bucket: string) {
+          return {
+            async upload(path: string) {
+              uploads.push({ bucket, path });
+              return { data: { path }, error: null };
+            },
+            async createSignedUrl(path: string) {
+              signed.push({ bucket, path });
+              return {
+                data: { signedUrl: `https://signed/${bucket}/${path}` },
+                error: null,
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+function authed(userId: string, role: "admin" | "crew_lead" | "crew_member") {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: userId },
+      tables: memberTables({
+        userId,
+        role,
+        grants: role === "crew_member" ? [] : ["view_phone"],
+      }),
+    }) as never,
+  );
+}
+
+function unauthed() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({ user: null }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue(ORG);
+});
+
+describe("POST /api/phone/attachments — auth + permission gate", () => {
+  it("401 when unauthenticated", async () => {
+    unauthed();
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const form = new FormData();
+    form.append("file", jpegFile());
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when caller lacks view_phone (crew_member)", async () => {
+    authed("u-cm", "crew_member");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const form = new FormData();
+    form.append("file", jpegFile());
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/phone/attachments — validation", () => {
+  it("400 when no file is provided", async () => {
+    authed("u-1", "crew_lead");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await POST(postRequest(new FormData()), routeCtx);
+    expect(res.status).toBe(400);
+  });
+
+  it("400 with a clear error when the file is above the per-MMS size limit", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+    const form = new FormData();
+    // 5 MB + 1 byte — past Twilio's MMS ceiling.
+    form.append("file", jpegFile("huge.jpg", 5 * 1024 * 1024 + 1));
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/too large/i);
+    expect(svc.uploads).toHaveLength(0);
+  });
+
+  it("400 with a clear error for an unsupported media type", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+    const form = new FormData();
+    form.append(
+      "file",
+      new File([new Uint8Array([1, 2])], "macro.bat", {
+        type: "application/x-bat",
+      }),
+    );
+    const res = await POST(postRequest(form), routeCtx);
+    expect(res.status).toBe(400);
+    expect(svc.uploads).toHaveLength(0);
+  });
+});
+
+describe("POST /api/phone/attachments — happy path", () => {
+  it("stores a valid image and returns an org-scoped storage path", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+
+    const form = new FormData();
+    form.append("file", jpegFile("damage.jpg", 1024));
+    const res = await POST(postRequest(form), routeCtx);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attachment).toMatchObject({
+      media_type: "image/jpeg",
+      kind: "image",
+    });
+    expect(body.attachment.storage_path).toMatch(/^org-1\/[0-9a-f-]+\.jpg$/);
+    expect(svc.uploads).toHaveLength(1);
+    expect(svc.uploads[0].bucket).toBe("phone-attachments");
+    expect(svc.uploads[0].path).toBe(body.attachment.storage_path);
+  });
+
+  it("stores a PDF as a non-image attachment with a `file` kind", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+
+    const form = new FormData();
+    form.append(
+      "file",
+      new File([new Uint8Array([1, 2])], "estimate.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    const res = await POST(postRequest(form), routeCtx);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.attachment.kind).toBe("file");
+    expect(body.attachment.media_type).toBe("application/pdf");
+    expect(body.attachment.filename).toBe("estimate.pdf");
+    expect(body.attachment.storage_path).toMatch(/^org-1\/[0-9a-f-]+\.pdf$/);
+  });
+});
+
+describe("GET /api/phone/attachments — signed URL", () => {
+  it("401 when unauthenticated", async () => {
+    unauthed();
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(getRequest("org-1/abc.jpg"), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("400 when no path is given", async () => {
+    authed("u-1", "crew_lead");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(
+      new Request("http://test/api/phone/attachments"),
+      routeCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404 for a path outside the caller's organization", async () => {
+    authed("u-1", "crew_lead");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(getRequest("org-OTHER/secret.jpg"), routeCtx);
+    expect(res.status).toBe(404);
+  });
+
+  it("returns a signed URL for an in-org path", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+    const res = await GET(getRequest("org-1/abc.jpg"), routeCtx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://signed/phone-attachments/org-1/abc.jpg");
+    expect(svc.signed).toEqual([
+      { bucket: "phone-attachments", path: "org-1/abc.jpg" },
+    ]);
+  });
+});
+

--- a/src/app/api/phone/attachments/route.ts
+++ b/src/app/api/phone/attachments/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { validateMmsAttachment } from "@/lib/phone/mms-attachments";
+import {
+  uploadPhoneAttachment,
+  signedUrlForPhoneAttachment,
+  type PhoneStorageClient,
+} from "@/lib/phone/attachments-storage";
+
+// PRD #304 — Nookleus Phone. Slice 6 (#310) — MMS attachment upload + signed URL.
+//
+// POST: a Crew Lead drags an image (or PDF / short video) into the compose
+// box. The browser uploads it here BEFORE the outbound /api/phone/messages
+// call — that way the message route can mint a signed URL and hand it to
+// Twilio as `mediaUrl[]`, and the persisted `phone_messages.media_urls`
+// entry already points at a Nookleus-owned object that survives Twilio's
+// media retention.
+//
+// GET: thread render needs a short-lived public URL for the stored object —
+// images render inline, non-images surface a download link. Cross-org
+// reads are refused at the path level (the object path is `{org}/...`).
+
+const SIGNED_URL_TTL_SECONDS = 600; // 10 minutes
+
+export const POST = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx) => {
+    if (!ctx.orgId) {
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 403 },
+      );
+    }
+
+    const formData = await request.formData();
+    const file = formData.get("file");
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    const validation = validateMmsAttachment({
+      type: file.type,
+      size: file.size,
+    });
+    if (!validation.ok) {
+      return NextResponse.json({ error: validation.error }, { status: 400 });
+    }
+
+    let stored: { storagePath: string };
+    try {
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      stored = await uploadPhoneAttachment(
+        ctx.serviceClient as unknown as PhoneStorageClient,
+        {
+          orgId: ctx.orgId,
+          mediaType: validation.mediaType,
+          bytes,
+        },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "upload failed";
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      attachment: {
+        kind: validation.kind,
+        media_type: validation.mediaType,
+        storage_path: stored.storagePath,
+        filename: file.name || undefined,
+      },
+    });
+  },
+);
+
+export const GET = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx) => {
+    if (!ctx.orgId) {
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 403 },
+      );
+    }
+    const path = new URL(request.url).searchParams.get("path");
+    if (!path) {
+      return NextResponse.json({ error: "path is required" }, { status: 400 });
+    }
+    // Org scoping — the object path begins with the org id. Refuse to mint
+    // a URL for anything outside the caller's Organization prefix.
+    if (!path.startsWith(`${ctx.orgId}/`)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    try {
+      const url = await signedUrlForPhoneAttachment(
+        ctx.serviceClient as unknown as PhoneStorageClient,
+        path,
+        SIGNED_URL_TTL_SECONDS,
+      );
+      return NextResponse.json({ url });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Not found";
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+  },
+);

--- a/src/app/api/phone/messages/route.test.ts
+++ b/src/app/api/phone/messages/route.test.ts
@@ -42,6 +42,16 @@ vi.mock("@/lib/phone/twilio-client", () => ({
   createTwilioClient: () => createTwilioClientMock(),
 }));
 
+// Slice 6 (#310) — attachments are pre-uploaded via /api/phone/attachments
+// then their storage paths are handed to this route. The route mints a
+// signed URL per path and passes them to Twilio as mediaUrl[]. Tests mock
+// the signing helper at the module boundary so they don't need a real
+// bucket.
+const signedUrlMock = vi.fn();
+vi.mock("@/lib/phone/attachments-storage", () => ({
+  signedUrlForPhoneAttachment: (...args: unknown[]) => signedUrlMock(...args),
+}));
+
 import { POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
@@ -174,6 +184,10 @@ beforeEach(() => {
   vi.mocked(getActiveOrganizationId).mockResolvedValue(ORG);
   createTwilioClientMock.mockReturnValue({});
   sendSmsMock.mockResolvedValue({ sid: "SM-out", status: "queued" });
+  signedUrlMock.mockImplementation(
+    async (_client: unknown, path: string) =>
+      `https://signed.example/phone-attachments/${path}`,
+  );
   // #309 ships behind a feature flag pending #305 (A2P 10DLC). Tests
   // exercise the route under the "flag ON" assumption; the flag-OFF
   // behaviour gets its own dedicated test block below.
@@ -487,6 +501,148 @@ describe("POST /api/phone/messages — persistence", () => {
     expect(res.status).toBe(502);
     // No phone_messages row should be written when Twilio failed —
     // an unsent message that looks sent is worse than a clean retry.
+    expect(inserts.find((i) => i.table === "phone_messages")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. MMS attachments (slice 6 / #310)
+//
+// Attachments arrive on the route as `attachments: [{ storage_path,
+// media_type, filename? }]` — already in the `phone-attachments` bucket
+// from a prior /api/phone/attachments upload. The route mints a signed
+// URL per path, passes them as Twilio mediaUrl[], and persists the
+// storage paths in `phone_messages.media_urls`.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/messages — MMS attachments", () => {
+  it("passes a signed mediaUrl[] to Twilio and persists media_urls", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "see attached",
+        attachments: [
+          {
+            storage_path: "org-1/aaa-uuid.jpg",
+            media_type: "image/jpeg",
+            filename: "damage.jpg",
+          },
+          {
+            storage_path: "org-1/bbb-uuid.pdf",
+            media_type: "application/pdf",
+            filename: "estimate.pdf",
+          },
+        ],
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    // Each path was signed once.
+    expect(signedUrlMock).toHaveBeenCalledTimes(2);
+    expect(signedUrlMock.mock.calls[0][1]).toBe("org-1/aaa-uuid.jpg");
+    expect(signedUrlMock.mock.calls[1][1]).toBe("org-1/bbb-uuid.pdf");
+
+    // Twilio received the signed URLs as mediaUrl[].
+    expect(sendSmsMock).toHaveBeenCalledOnce();
+    const sendArgs = sendSmsMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(sendArgs.mediaUrl).toEqual([
+      "https://signed.example/phone-attachments/org-1/aaa-uuid.jpg",
+      "https://signed.example/phone-attachments/org-1/bbb-uuid.pdf",
+    ]);
+
+    // Storage paths were persisted on the message row (Twilio's signed
+    // URLs expire — we keep the bucket path, not the URL).
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row).toMatchObject({
+      direction: "out",
+      body: "see attached",
+      media_urls: [
+        {
+          storage_path: "org-1/aaa-uuid.jpg",
+          media_type: "image/jpeg",
+          filename: "damage.jpg",
+        },
+        {
+          storage_path: "org-1/bbb-uuid.pdf",
+          media_type: "application/pdf",
+          filename: "estimate.pdf",
+        },
+      ],
+    });
+  });
+
+  it("accepts an empty body when at least one attachment is present (image-only MMS)", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "",
+        attachments: [
+          { storage_path: "org-1/img.jpg", media_type: "image/jpeg" },
+        ],
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(sendSmsMock).toHaveBeenCalledOnce();
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row).toMatchObject({
+      body: "",
+      media_urls: [{ storage_path: "org-1/img.jpg", media_type: "image/jpeg" }],
+    });
+  });
+
+  it("still rejects a send with no body AND no attachments", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", body: "", attachments: [] }),
+      noParams,
+    );
+
+    expect(res.status).toBe(400);
+    expect(sendSmsMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses an attachment whose storage path is outside the caller's organization", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "hi",
+        attachments: [
+          { storage_path: "org-OTHER/secret.jpg", media_type: "image/jpeg" },
+        ],
+      }),
+      noParams,
+    );
+
+    // The route must not sign or send a cross-org attachment.
+    expect(res.status).toBe(403);
+    expect(signedUrlMock).not.toHaveBeenCalled();
+    expect(sendSmsMock).not.toHaveBeenCalled();
     expect(inserts.find((i) => i.table === "phone_messages")).toBeUndefined();
   });
 });

--- a/src/app/api/phone/messages/route.ts
+++ b/src/app/api/phone/messages/route.ts
@@ -12,6 +12,10 @@ import {
   type SmartAttachSource,
 } from "@/lib/phone/smart-attach";
 import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
+import {
+  signedUrlForPhoneAttachment,
+  type PhoneStorageClient,
+} from "@/lib/phone/attachments-storage";
 
 // PRD #304 — Nookleus Phone. Slice 5 (#309) — outbound SMS send.
 //
@@ -47,9 +51,39 @@ interface Body {
   // here are 'phone-tab' and 'contact-card'. A `{ kind: 'job', jobId }`
   // shape is accepted so slice 7 is a one-line change.
   sourceContext?: unknown;
+  // Slice 6 (#310) — MMS attachments pre-uploaded via
+  // /api/phone/attachments. Each entry is the stored path + the media
+  // type the upload route validated.
+  attachments?: unknown;
+}
+
+interface PersistedAttachment {
+  storage_path: string;
+  media_type: string;
+  filename?: string;
 }
 
 const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+const SIGNED_MMS_URL_TTL_SECONDS = 600; // 10 minutes — Twilio fetches quickly.
+
+function parseAttachments(input: unknown): PersistedAttachment[] {
+  if (!Array.isArray(input)) return [];
+  const out: PersistedAttachment[] = [];
+  for (const item of input) {
+    if (!item || typeof item !== "object") continue;
+    const obj = item as Record<string, unknown>;
+    const storage_path = obj.storage_path;
+    const media_type = obj.media_type;
+    if (typeof storage_path !== "string" || typeof media_type !== "string") {
+      continue;
+    }
+    const filename =
+      typeof obj.filename === "string" ? (obj.filename as string) : undefined;
+    out.push({ storage_path, media_type, ...(filename ? { filename } : {}) });
+  }
+  return out;
+}
 
 function parseSourceContext(input: unknown): SmartAttachSource {
   if (input && typeof input === "object" && "kind" in input) {
@@ -85,13 +119,36 @@ export const POST = withRequestContext(
     }
 
     const body = (await request.json().catch(() => null)) as Body | null;
-    if (!body || typeof body.body !== "string" || body.body.length === 0) {
+    if (!body || typeof body.body !== "string") {
       return NextResponse.json(
         { error: "body is required" },
         { status: 400 },
       );
     }
+    const attachments = parseAttachments(body.attachments);
+    if (body.body.length === 0 && attachments.length === 0) {
+      // Slice 6 (#310) — an MMS may have an empty body iff at least one
+      // attachment is present. Reject when both are empty so the send
+      // button gate can rely on the route refusing if the UI is bypassed.
+      return NextResponse.json(
+        { error: "body or attachments required" },
+        { status: 400 },
+      );
+    }
     const messageBody = body.body;
+
+    // Slice 6 (#310) — cross-org safety. The /api/phone/attachments upload
+    // route always writes under `{orgId}/...`, so any path that doesn't
+    // start with the caller's org id is either a forged reference or a
+    // mis-ported one from another org and must be refused before signing.
+    for (const a of attachments) {
+      if (!a.storage_path.startsWith(`${ctx.orgId}/`)) {
+        return NextResponse.json(
+          { error: "Attachment outside caller's organization" },
+          { status: 403 },
+        );
+      }
+    }
 
     const hasConv = typeof body.conversationId === "string";
     const hasOutside = typeof body.outsideE164 === "string";
@@ -252,6 +309,29 @@ export const POST = withRequestContext(
     });
     const jobTag = smartAttach.kind === "auto" ? smartAttach.jobId : null;
 
+    // Slice 6 (#310) — mint a short-lived signed URL per attachment for
+    // Twilio to fetch from. We keep the storage path (not the URL) on
+    // the persisted row, since signed URLs expire — the bucket object
+    // is the durable record.
+    let mediaUrl: string[] | undefined;
+    if (attachments.length > 0) {
+      try {
+        mediaUrl = await Promise.all(
+          attachments.map((a) =>
+            signedUrlForPhoneAttachment(
+              ctx.serviceClient as unknown as PhoneStorageClient,
+              a.storage_path,
+              SIGNED_MMS_URL_TTL_SECONDS,
+            ),
+          ),
+        );
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "attachment sign failed";
+        return NextResponse.json({ error: message }, { status: 500 });
+      }
+    }
+
     // Dispatch via Twilio.
     const statusCallback = process.env.PHONE_STATUS_CALLBACK_URL || undefined;
     let dispatch: { sid: string; status: string };
@@ -261,6 +341,7 @@ export const POST = withRequestContext(
         to: outsideE164,
         body: messageBody,
         statusCallback,
+        ...(mediaUrl ? { mediaUrl } : {}),
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Twilio error";
@@ -281,7 +362,7 @@ export const POST = withRequestContext(
         from_e164: fromNumber.e164,
         to_e164: outsideE164,
         body: messageBody,
-        media_urls: [],
+        media_urls: attachments,
         twilio_sid: dispatch.sid,
         status: dispatch.status,
         job_tag: jobTag,

--- a/src/app/api/phone/webhook/sms-inbound/route.test.ts
+++ b/src/app/api/phone/webhook/sms-inbound/route.test.ts
@@ -29,6 +29,15 @@ vi.mock("@/lib/supabase-api", () => ({
   createServiceClient: () => createServiceClientMock(),
 }));
 
+// Slice 6 (#310) — inbound MMS copies Twilio's media to the Nookleus
+// `phone-attachments` bucket so it survives Twilio's media retention.
+// Mocked at the module boundary; the test asserts the upload was called
+// and the persisted media_urls match.
+const uploadPhoneAttachmentMock = vi.fn();
+vi.mock("@/lib/phone/attachments-storage", () => ({
+  uploadPhoneAttachment: (...args: unknown[]) => uploadPhoneAttachmentMock(...args),
+}));
+
 import { POST } from "./route";
 
 interface Row { [key: string]: unknown }
@@ -117,12 +126,19 @@ function inboundForm(opts: {
   To?: string;
   Body?: string;
   MessageSid?: string;
+  Media?: Array<{ url: string; contentType: string }>;
 }): { req: Request; bodyString: string } {
   const params = new URLSearchParams();
   params.set("From", opts.From ?? "+15551234567");
   params.set("To", opts.To ?? "+15125550000");
   params.set("Body", opts.Body ?? "hello");
   params.set("MessageSid", opts.MessageSid ?? "SM-abc");
+  const media = opts.Media ?? [];
+  params.set("NumMedia", String(media.length));
+  media.forEach((m, i) => {
+    params.set(`MediaUrl${i}`, m.url);
+    params.set(`MediaContentType${i}`, m.contentType);
+  });
   const bodyString = params.toString();
   const req = new Request("http://test/api/phone/webhook/sms-inbound", {
     method: "POST",
@@ -676,5 +692,177 @@ describe("inbound HELP — gated by #309 feature flag", () => {
     expect(res.status).toBe(200);
     expect(upserts.find((u) => u.table === "phone_opt_outs")).toBeDefined();
     expect(sendSmsModuleMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 6 (#310) — Inbound MMS attachments.
+//
+// When Twilio's webhook arrives with NumMedia > 0, the route fetches each
+// MediaUrlN, copies the bytes to the Nookleus `phone-attachments` bucket
+// (so the media survives Twilio's media retention), and persists the
+// storage paths on phone_messages.media_urls.
+// ---------------------------------------------------------------------------
+
+describe("inbound MMS — media copy to Nookleus storage", () => {
+  beforeEach(() => {
+    uploadPhoneAttachmentMock.mockReset();
+    // Default: each upload resolves with a path derived from the call index.
+    let callIdx = 0;
+    uploadPhoneAttachmentMock.mockImplementation(
+      async (_client: unknown, params: { mediaType: string }) => {
+        const ext = params.mediaType.split("/")[1] ?? "bin";
+        callIdx += 1;
+        return {
+          storagePath: `org-1/copied-${callIdx}.${ext}`,
+          mediaType: params.mediaType,
+        };
+      },
+    );
+  });
+
+  it("fetches each Twilio MediaUrl, copies it to the bucket, and persists media_urls", async () => {
+    // Stub global fetch — Twilio media URLs are publicly fetchable for
+    // a limited window; the route reads the bytes from there.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => {
+        return new Response(new Uint8Array([1, 2, 3]), { status: 200 });
+      });
+
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({
+      Body: "look at this",
+      Media: [
+        {
+          url: "https://api.twilio.com/.../Media/ME111",
+          contentType: "image/jpeg",
+        },
+        {
+          url: "https://api.twilio.com/.../Media/ME222",
+          contentType: "image/png",
+        },
+      ],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    // Two Twilio fetches.
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect((fetchSpy.mock.calls[0][0] as string).toString()).toContain("ME111");
+    expect((fetchSpy.mock.calls[1][0] as string).toString()).toContain("ME222");
+    // Two bucket uploads.
+    expect(uploadPhoneAttachmentMock).toHaveBeenCalledTimes(2);
+    // Persisted media_urls on the inbound message.
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row).toMatchObject({
+      direction: "in",
+      body: "look at this",
+      media_urls: [
+        { storage_path: "org-1/copied-1.jpeg", media_type: "image/jpeg" },
+        { storage_path: "org-1/copied-2.png", media_type: "image/png" },
+      ],
+    });
+
+    fetchSpy.mockRestore();
+  });
+
+  it("persists the message even when a Twilio media fetch fails (best-effort copy)", async () => {
+    // A single failure should not lose the inbound message — without
+    // attachments we can still surface the body and the customer's number.
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("nope", { status: 500 }));
+
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({
+      Body: "broken",
+      Media: [
+        {
+          url: "https://api.twilio.com/.../Media/MEbad",
+          contentType: "image/jpeg",
+        },
+      ],
+    });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(uploadPhoneAttachmentMock).not.toHaveBeenCalled();
+    // The message row is still inserted, with media_urls=[].
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row).toMatchObject({
+      direction: "in",
+      body: "broken",
+      media_urls: [],
+    });
+    fetchSpy.mockRestore();
+  });
+
+  it("is a no-op (no fetches, no uploads) when NumMedia is 0", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [
+        {
+          id: "pn-1",
+          organization_id: "org-1",
+          e164: "+15125550000",
+          kind: "shared",
+          user_id: null,
+          released_at: null,
+        },
+      ],
+      contacts: [],
+      jobs: [],
+      phone_conversations: [],
+      phone_messages: [],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const { req } = inboundForm({ Body: "no media" });
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(uploadPhoneAttachmentMock).not.toHaveBeenCalled();
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row).toMatchObject({
+      direction: "in",
+      media_urls: [],
+    });
+    fetchSpy.mockRestore();
   });
 });

--- a/src/app/api/phone/webhook/sms-inbound/route.ts
+++ b/src/app/api/phone/webhook/sms-inbound/route.ts
@@ -14,6 +14,14 @@ import {
 import type { ActiveJob } from "@/lib/phone/smart-attach";
 import { classifyOptOutKeyword } from "@/lib/phone/opt-out-registry";
 import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
+import {
+  uploadPhoneAttachment,
+  type PhoneStorageClient,
+} from "@/lib/phone/attachments-storage";
+import {
+  validateMmsAttachment,
+  type MmsMediaType,
+} from "@/lib/phone/mms-attachments";
 
 // PRD #304 — Nookleus Phone. Slice 4 (#308) — Inbound SMS webhook.
 //
@@ -42,6 +50,58 @@ import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
 const EMPTY_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
 
 const ACTIVE_STATUSES = ["new", "in_progress", "pending_invoice"] as const;
+
+interface PersistedMmsAttachment {
+  storage_path: string;
+  media_type: string;
+}
+
+// Fetch each MediaUrlN out of the Twilio payload, copy the bytes to the
+// `phone-attachments` bucket, and return what to persist on
+// phone_messages.media_urls. Per-attachment failures are swallowed —
+// losing the inbound message because one media fetch failed would be
+// worse than a partial copy. Twilio retains its media for ~24h; a
+// follow-up reconciliation could re-fetch the missing ones, but slice 6
+// keeps the inbound write atomic.
+async function copyTwilioMediaToBucket(
+  client: PhoneStorageClient,
+  params: Record<string, string>,
+  orgId: string,
+): Promise<PersistedMmsAttachment[]> {
+  const numMedia = Number.parseInt(params.NumMedia ?? "0", 10);
+  if (!Number.isFinite(numMedia) || numMedia <= 0) return [];
+
+  const out: PersistedMmsAttachment[] = [];
+  for (let i = 0; i < numMedia; i++) {
+    const url = params[`MediaUrl${i}`];
+    const contentType = params[`MediaContentType${i}`] ?? "";
+    if (!url) continue;
+
+    const validation = validateMmsAttachment({
+      type: contentType,
+      size: 0,
+    });
+    if (!validation.ok) continue;
+
+    try {
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const stored = await uploadPhoneAttachment(client, {
+        orgId,
+        mediaType: validation.mediaType as MmsMediaType,
+        bytes,
+      });
+      out.push({
+        storage_path: stored.storagePath,
+        media_type: stored.mediaType,
+      });
+    } catch {
+      // Best-effort: continue to the next attachment.
+    }
+  }
+  return out;
+}
 
 function twimlResponse(status = 200): Response {
   return new Response(EMPTY_TWIML, {
@@ -183,6 +243,17 @@ export async function POST(request: NextRequest | Request): Promise<Response> {
     .single<{ id: string; unread_count: number }>();
   if (!conv) return twimlResponse();
 
+  // Slice 6 (#310) — MMS copy. If Twilio's payload carries media, fetch
+  // each URL and re-upload to the Nookleus bucket so the references on
+  // disk outlive Twilio's media retention. Per-attachment failures
+  // degrade gracefully (the message itself still persists with
+  // whatever copies succeeded).
+  const mediaUrls = await copyTwilioMediaToBucket(
+    supabase as unknown as PhoneStorageClient,
+    params,
+    decision.organizationId,
+  );
+
   // 6. Insert the message.
   const jobTag =
     decision.smartAttach.kind === "auto" ? decision.smartAttach.jobId : null;
@@ -193,7 +264,7 @@ export async function POST(request: NextRequest | Request): Promise<Response> {
     from_e164: decision.outsideE164,
     to_e164: toE164,
     body: params.Body ?? null,
-    media_urls: [],
+    media_urls: mediaUrls,
     twilio_sid: params.MessageSid ?? null,
     status: params.SmsStatus ?? null,
     job_tag: jobTag,

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -720,4 +720,351 @@ describe("PhonePageClient", () => {
       screen.queryByRole("button", { name: /new conversation/i }),
     ).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Slice 6 (#310) — MMS attachments.
+  //
+  // Drag-and-drop + file-picker stage attachments inline above the compose
+  // textarea; previews carry a remove-X; the Send button is gated on
+  // (text || attachments); inline thread images render from the
+  // attachments signed URL; non-image media shows as a download chip.
+  // ---------------------------------------------------------------------------
+
+  beforeEach(() => {
+    // jsdom has no object-URL support; the compose strip uses one per preview.
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  function imageFile(name = "damage.jpg", size = 1000): File {
+    return new File([new Uint8Array(size)], name, { type: "image/jpeg" });
+  }
+
+  function attachmentRoutesFor(convId: string) {
+    return async (input: RequestInfo, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      // Thread fetch.
+      if (
+        path === `/api/phone/conversations/${convId}/messages` &&
+        (!init || init.method !== "POST")
+      ) {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      // Pre-upload — stages the attachment in the bucket and returns
+      // the storage path the client then sends to /api/phone/messages.
+      if (path === "/api/phone/attachments" && init?.method === "POST") {
+        const form = init.body as FormData;
+        const file = form.get("file") as File;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            attachment: {
+              kind: "image",
+              media_type: "image/jpeg",
+              storage_path: `org-1/${file.name}.uuid.jpg`,
+              filename: file.name,
+            },
+          }),
+        };
+      }
+      // Outbound send.
+      if (path === "/api/phone/messages" && init?.method === "POST") {
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            id: "msg-out",
+            conversationId: convId,
+            twilio_sid: "SM-mms",
+            status: "queued",
+          }),
+        };
+      }
+      // Signed-URL for thread render (slice 6).
+      if (path.startsWith("/api/phone/attachments?path=")) {
+        const stored = decodeURIComponent(path.split("path=")[1]);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ url: `https://signed.example/${stored}` }),
+        };
+      }
+      throw new Error(`unmocked fetch: ${path} ${init?.method ?? "GET"}`);
+    };
+  }
+
+  it("renders an Attach button in the compose box", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": { ok: true, body: [] },
+    });
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+    expect(screen.getByRole("button", { name: /attach/i })).toBeDefined();
+  });
+
+  it("uploads a picked file via /api/phone/attachments and shows a preview with a remove-X", async () => {
+    mockFetch.mockImplementation(attachmentRoutesFor("conv-1"));
+
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [imageFile("photo.jpg")] } });
+
+    await waitFor(() => {
+      expect(screen.getByAltText("photo.jpg")).toBeDefined();
+    });
+    expect(
+      screen.getByRole("button", { name: /remove attachment/i }),
+    ).toBeDefined();
+  });
+
+  it("stages a drag-and-dropped file the same way as the file picker", async () => {
+    mockFetch.mockImplementation(attachmentRoutesFor("conv-1"));
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+
+    const dropzone = container.querySelector('[data-dropzone="phone-compose"]')!;
+    fireEvent.drop(dropzone, {
+      dataTransfer: { files: [imageFile("dropped.jpg")] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByAltText("dropped.jpg")).toBeDefined();
+    });
+  });
+
+  it("rejects an oversize file with a clear inline error and does NOT upload it", async () => {
+    mockFetch.mockImplementation(attachmentRoutesFor("conv-1"));
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    // 5 MB + 1 — past Twilio's per-MMS ceiling.
+    fireEvent.change(fileInput, {
+      target: { files: [imageFile("huge.jpg", 5 * 1024 * 1024 + 1)] },
+    });
+
+    await screen.findByText(/too large/i);
+    // No preview, no upload POST.
+    expect(screen.queryByAltText("huge.jpg")).toBeNull();
+    const uploadPost = mockFetch.mock.calls.find(
+      ([, init]) =>
+        (init as RequestInit | undefined)?.method === "POST" &&
+        (typeof init === "object"
+          ? init?.body instanceof FormData
+          : false),
+    );
+    expect(uploadPost).toBeUndefined();
+  });
+
+  it("enables Send when only attachments are staged (image-only MMS)", async () => {
+    mockFetch.mockImplementation(attachmentRoutesFor("conv-1"));
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+
+    const send = screen.getByRole("button", {
+      name: /^send$/i,
+    }) as HTMLButtonElement;
+    expect(send.disabled).toBe(true);
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [imageFile("p.jpg")] } });
+
+    await waitFor(() => expect(send.disabled).toBe(false));
+  });
+
+  it("POSTs attachments[] to /api/phone/messages and renders the outbound row inline", async () => {
+    mockFetch.mockImplementation(attachmentRoutesFor("conv-1"));
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByPlaceholderText(/text message/i);
+
+    const fileInput = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [imageFile("p.jpg")] } });
+
+    await waitFor(() => expect(screen.getByAltText("p.jpg")).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: /^send$/i }));
+
+    await waitFor(() => {
+      const sendCall = mockFetch.mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith("/api/phone/messages") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      );
+      expect(sendCall).toBeDefined();
+      const body = JSON.parse(
+        (sendCall![1] as RequestInit).body as string,
+      ) as { attachments: Array<{ storage_path: string }> };
+      expect(body.attachments).toHaveLength(1);
+      expect(body.attachments[0].storage_path).toBe("org-1/p.jpg.uuid.jpg");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 6 (#310) — thread render of attachments.
+// ---------------------------------------------------------------------------
+
+describe("PhonePageClient — thread media render (#310)", () => {
+  beforeEach(() => {
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+  });
+
+  function setupMediaThread(media_urls: Array<Record<string, string>>) {
+    mockFetch.mockImplementation(async (input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      if (path === "/api/phone/conversations/conv-mms/messages") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              id: "m-1",
+              conversation_id: "conv-mms",
+              direction: "in",
+              body: "",
+              sent_at: "2026-05-27T10:00:00Z",
+              job_tag: null,
+              media_urls,
+            },
+          ],
+        };
+      }
+      if (path.startsWith("/api/phone/attachments?path=")) {
+        const stored = decodeURIComponent(path.split("path=")[1]);
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ url: `https://signed.example/${stored}` }),
+        };
+      }
+      throw new Error(`unmocked fetch: ${path}`);
+    });
+  }
+
+  it("renders an inline image thumbnail for image attachments", async () => {
+    setupMediaThread([
+      { storage_path: "org-1/in.jpg", media_type: "image/jpeg" },
+    ]);
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          {
+            id: "conv-mms",
+            organization_id: "org-1",
+            phone_number_id: "pn-1",
+            outside_e164: "+15551112222",
+            contact_id: "c-1",
+            contact_name: "Alice",
+            last_event_at: "2026-05-27T10:00:00Z",
+            unread_count: 0,
+            active_jobs: [],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    const thumb = (await screen.findByRole("img", {
+      name: /attachment/i,
+    })) as HTMLImageElement;
+    await waitFor(() => expect(thumb.src).toContain("signed.example"));
+    expect(thumb.src).toContain("org-1/in.jpg");
+  });
+
+  it("renders a downloadable filename link for non-image attachments", async () => {
+    setupMediaThread([
+      {
+        storage_path: "org-1/estimate.pdf",
+        media_type: "application/pdf",
+        filename: "estimate.pdf",
+      },
+    ]);
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          {
+            id: "conv-mms",
+            organization_id: "org-1",
+            phone_number_id: "pn-1",
+            outside_e164: "+15551112222",
+            contact_id: "c-1",
+            contact_name: "Alice",
+            last_event_at: "2026-05-27T10:00:00Z",
+            unread_count: 0,
+            active_jobs: [],
+          },
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    const link = (await screen.findByRole("link", {
+      name: /estimate\.pdf/i,
+    })) as HTMLAnchorElement;
+    await waitFor(() => expect(link.href).toContain("estimate.pdf"));
+  });
 });

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Phone as PhoneIcon, Plus, UserPlus, Send } from "lucide-react";
+import { Phone as PhoneIcon, Plus, UserPlus, Send, Paperclip, X } from "lucide-react";
 import { createClient } from "@/lib/supabase";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import { usePhoneSync } from "@/lib/phone/use-phone-sync";
 import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
+import {
+  validateMmsAttachment,
+  isMmsImageMediaType,
+} from "@/lib/phone/mms-attachments";
 
 // PRD #304 — Nookleus Phone. Slice 4 (#308) — two-pane Phone-tab UI.
 //
@@ -35,6 +39,12 @@ export interface PhoneConversationItem {
   active_jobs: Array<{ id: string; label: string }>;
 }
 
+interface PhoneAttachmentRef {
+  storage_path: string;
+  media_type: string;
+  filename?: string;
+}
+
 interface PhoneMessage {
   id: string;
   conversation_id: string;
@@ -42,6 +52,21 @@ interface PhoneMessage {
   body: string | null;
   sent_at: string;
   job_tag: string | null;
+  media_urls?: PhoneAttachmentRef[];
+}
+
+// Slice 6 (#310) — a staged attachment in the compose strip. Either the
+// upload is in flight (no storage_path yet) or it has completed and the
+// path is the one the outbound /api/phone/messages POST will reference.
+interface StagedAttachment {
+  id: string;
+  filename: string;
+  previewUrl: string;
+  mediaType: string;
+  kind: "image" | "file";
+  storage_path?: string;
+  uploading: boolean;
+  error?: string;
 }
 
 export interface PhonePageClientProps {
@@ -81,6 +106,14 @@ export function PhonePageClient({
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const [retagMenuFor, setRetagMenuFor] = useState<string | null>(null);
+  // Slice 6 (#310) — staged MMS attachments + the file input ref the
+  // paperclip button hands clicks to.
+  const [attachments, setAttachments] = useState<StagedAttachment[]>([]);
+  const [attachError, setAttachError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Slice 6 (#310) — lightbox state: the storage_path of the image
+  // currently being shown full-size, or null.
+  const [lightboxPath, setLightboxPath] = useState<string | null>(null);
   // #309 outbound surfaces are gated on the A2P 10DLC feature flag.
   // Computed once at mount — the flag flips by env-var redeploy, not at
   // runtime, so we never need to re-evaluate. The read path (thread,
@@ -116,8 +149,109 @@ export function PhonePageClient({
     if (!selectedId) return;
     setDraft("");
     setSendError(null);
+    setAttachments([]);
+    setAttachError(null);
     void loadMessages(selectedId);
   }, [selectedId, loadMessages]);
+
+  // Slice 6 (#310) — pre-upload one picked/dropped file. Returns the
+  // staged ID so the caller can correlate the in-flight slot.
+  const stageOneFile = useCallback(async (file: File) => {
+    const validation = validateMmsAttachment({
+      type: file.type,
+      size: file.size,
+    });
+    if (!validation.ok) {
+      setAttachError(validation.error);
+      return;
+    }
+    const id =
+      typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random()}`;
+    const previewUrl = URL.createObjectURL(file);
+    setAttachError(null);
+    setAttachments((prev) => [
+      ...prev,
+      {
+        id,
+        filename: file.name,
+        previewUrl,
+        mediaType: validation.mediaType,
+        kind: validation.kind,
+        uploading: true,
+      },
+    ]);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await fetch("/api/phone/attachments", {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        setAttachments((prev) =>
+          prev.map((a) =>
+            a.id === id
+              ? {
+                  ...a,
+                  uploading: false,
+                  error: err.error ?? `Upload failed (${res.status})`,
+                }
+              : a,
+          ),
+        );
+        return;
+      }
+      const body = (await res.json()) as {
+        attachment: {
+          storage_path: string;
+          media_type: string;
+          kind: "image" | "file";
+          filename?: string;
+        };
+      };
+      setAttachments((prev) =>
+        prev.map((a) =>
+          a.id === id
+            ? {
+                ...a,
+                uploading: false,
+                storage_path: body.attachment.storage_path,
+                mediaType: body.attachment.media_type,
+                kind: body.attachment.kind,
+              }
+            : a,
+        ),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Upload failed";
+      setAttachments((prev) =>
+        prev.map((a) =>
+          a.id === id ? { ...a, uploading: false, error: message } : a,
+        ),
+      );
+    }
+  }, []);
+
+  const onPickFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files) return;
+      for (const file of Array.from(files)) {
+        void stageOneFile(file);
+      }
+    },
+    [stageOneFile],
+  );
+
+  const onRemoveAttachment = useCallback((id: string) => {
+    setAttachments((prev) => {
+      const removed = prev.find((a) => a.id === id);
+      if (removed) URL.revokeObjectURL(removed.previewUrl);
+      return prev.filter((a) => a.id !== id);
+    });
+  }, []);
 
   const onCreateConversation = useCallback(async () => {
     if (!newConv) return;
@@ -175,11 +309,30 @@ export function PhonePageClient({
     }
   }, [newConv, organizationId]);
 
+  const readyAttachments = useMemo(
+    () =>
+      attachments.filter(
+        (a): a is StagedAttachment & { storage_path: string } =>
+          !!a.storage_path && !a.uploading && !a.error,
+      ),
+    [attachments],
+  );
+  const anyUploading = attachments.some((a) => a.uploading);
+
   const onSend = useCallback(async () => {
-    if (!selected || draft.trim().length === 0) return;
+    if (!selected) return;
+    if (anyUploading) return;
+    const hasText = draft.trim().length > 0;
+    const hasAttachments = readyAttachments.length > 0;
+    if (!hasText && !hasAttachments) return;
     setSending(true);
     setSendError(null);
     try {
+      const outAttachments = readyAttachments.map((a) => ({
+        storage_path: a.storage_path,
+        media_type: a.mediaType,
+        ...(a.filename ? { filename: a.filename } : {}),
+      }));
       const res = await fetch("/api/phone/messages", {
         method: "POST",
         headers: { "content-type": "application/json" },
@@ -187,6 +340,9 @@ export function PhonePageClient({
           conversationId: selected.id,
           body: draft,
           sourceContext: { kind: "phone-tab" },
+          ...(outAttachments.length > 0
+            ? { attachments: outAttachments }
+            : {}),
         }),
       });
       if (!res.ok) {
@@ -211,6 +367,7 @@ export function PhonePageClient({
           body: draft,
           sent_at: now,
           job_tag: null,
+          media_urls: outAttachments,
         },
       ]);
       setConversations((prev) =>
@@ -221,10 +378,13 @@ export function PhonePageClient({
         ),
       );
       setDraft("");
+      // Drop the strip; the message bubble now shows the media inline.
+      attachments.forEach((a) => URL.revokeObjectURL(a.previewUrl));
+      setAttachments([]);
     } finally {
       setSending(false);
     }
-  }, [selected, draft]);
+  }, [selected, draft, readyAttachments, anyUploading, attachments]);
 
   // Realtime: when a new inbound lands, reload the affected thread and
   // bump the conversation in the list. Slice 4's update is intentionally
@@ -415,6 +575,14 @@ export function PhonePageClient({
         </ul>
       </aside>
 
+      {/* Slice 6 (#310) — lightbox over the selected attachment, if any. */}
+      {lightboxPath ? (
+        <PhoneAttachmentLightbox
+          path={lightboxPath}
+          onClose={() => setLightboxPath(null)}
+        />
+      ) : null}
+
       {/* Right pane — selected thread */}
       <section className="flex-1 flex flex-col">
         {selected ? (
@@ -470,6 +638,21 @@ export function PhonePageClient({
                       }`}
                     >
                       {m.body}
+                      {/* Slice 6 (#310) — render inline attachments under the body.
+                          Images become thumbnails (click → lightbox);
+                          non-images become a downloadable filename chip. */}
+                      {m.media_urls && m.media_urls.length > 0 ? (
+                        <ul className="mt-2 flex flex-wrap gap-2">
+                          {m.media_urls.map((mu, idx) => (
+                            <li key={`${m.id}-att-${idx}`}>
+                              <MessageAttachment
+                                attachment={mu}
+                                onOpenLightbox={(p) => setLightboxPath(p)}
+                              />
+                            </li>
+                          ))}
+                        </ul>
+                      ) : null}
                       {/* Re-tag affordance — small button on every message. */}
                       <button
                         type="button"
@@ -530,7 +713,15 @@ export function PhonePageClient({
                 small banner explaining the wait so users aren't left
                 wondering why they can't reply. */}
             {outboundEnabled ? (
-              <div className="border-t border-border p-3 space-y-2">
+              <div
+                data-dropzone="phone-compose"
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  onPickFiles(e.dataTransfer?.files ?? null);
+                }}
+                className="border-t border-border p-3 space-y-2"
+              >
                 {sendError ? (
                   <p
                     role="alert"
@@ -539,12 +730,78 @@ export function PhonePageClient({
                     {sendError}
                   </p>
                 ) : null}
+                {attachError ? (
+                  <p
+                    role="alert"
+                    className="text-sm text-red-600 dark:text-red-400"
+                  >
+                    {attachError}
+                  </p>
+                ) : null}
                 {selected.active_jobs.length > 0 && selected.contact_id ? (
                   <p className="text-xs text-muted-foreground">
                     This message will be smart-attached when sent.
                   </p>
                 ) : null}
+                {attachments.length > 0 ? (
+                  <ul className="flex flex-wrap gap-2">
+                    {attachments.map((a) => (
+                      <li
+                        key={a.id}
+                        className="relative inline-flex items-center rounded-md border border-border bg-background p-1 text-xs"
+                      >
+                        {a.kind === "image" ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={a.previewUrl}
+                            alt={a.filename}
+                            className="h-14 w-14 rounded object-cover"
+                          />
+                        ) : (
+                          <span className="block max-w-[12rem] truncate px-2">
+                            {a.filename}
+                          </span>
+                        )}
+                        {a.uploading ? (
+                          <span className="ml-2 text-muted-foreground">
+                            Uploading…
+                          </span>
+                        ) : null}
+                        {a.error ? (
+                          <span className="ml-2 text-red-600">{a.error}</span>
+                        ) : null}
+                        <button
+                          type="button"
+                          aria-label="Remove attachment"
+                          onClick={() => onRemoveAttachment(a.id)}
+                          className="absolute -right-1 -top-1 inline-flex h-5 w-5 items-center justify-center rounded-full bg-background shadow"
+                        >
+                          <X size={12} />
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
                 <div className="flex items-end gap-2">
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    multiple
+                    className="hidden"
+                    onChange={(e) => {
+                      onPickFiles(e.target.files);
+                      // Reset so re-picking the same file fires onChange.
+                      e.target.value = "";
+                    }}
+                  />
+                  <button
+                    type="button"
+                    aria-label="Attach"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-background hover:bg-accent"
+                  >
+                    <Paperclip size={16} />
+                  </button>
                   <textarea
                     value={draft}
                     onChange={(e) => setDraft(e.target.value)}
@@ -554,8 +811,10 @@ export function PhonePageClient({
                     onKeyDown={(e) => {
                       if (
                         (e.key === "Enter" && (e.metaKey || e.ctrlKey)) &&
-                        draft.trim().length > 0 &&
-                        !sending
+                        (draft.trim().length > 0 ||
+                          readyAttachments.length > 0) &&
+                        !sending &&
+                        !anyUploading
                       ) {
                         e.preventDefault();
                         void onSend();
@@ -565,7 +824,12 @@ export function PhonePageClient({
                   <button
                     type="button"
                     onClick={() => void onSend()}
-                    disabled={sending || draft.trim().length === 0}
+                    disabled={
+                      sending ||
+                      anyUploading ||
+                      (draft.trim().length === 0 &&
+                        readyAttachments.length === 0)
+                    }
                     className="inline-flex items-center gap-1 rounded-md bg-[var(--brand-primary)] px-3 py-2 text-sm font-medium text-white disabled:opacity-50"
                   >
                     <Send size={14} /> Send
@@ -584,6 +848,112 @@ export function PhonePageClient({
           </div>
         )}
       </section>
+    </div>
+  );
+}
+
+// Slice 6 (#310) — render one stored attachment in a message bubble.
+// Images load via the signed-URL endpoint and click open the lightbox;
+// non-image media is a labelled download link (also via the signed URL).
+function MessageAttachment({
+  attachment,
+  onOpenLightbox,
+}: {
+  attachment: PhoneAttachmentRef;
+  onOpenLightbox: (path: string) => void;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/attachments?path=${encodeURIComponent(attachment.storage_path)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.storage_path]);
+
+  if (isMmsImageMediaType(attachment.media_type)) {
+    return (
+      <button
+        type="button"
+        aria-label={`Open attachment ${attachment.filename ?? ""}`.trim()}
+        onClick={() => onOpenLightbox(attachment.storage_path)}
+        className="block overflow-hidden rounded border border-border bg-background"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url ?? ""}
+          alt={`attachment ${attachment.filename ?? ""}`.trim()}
+          className="block h-32 w-32 object-cover"
+        />
+      </button>
+    );
+  }
+  const label = attachment.filename ?? "Download attachment";
+  return (
+    <a
+      href={url ?? "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground hover:underline"
+    >
+      {label}
+    </a>
+  );
+}
+
+// Slice 6 (#310) — full-size image overlay. Click outside or press Escape
+// to dismiss. Loads via the same signed-URL endpoint so a fresh URL is
+// minted; the TTL is short, but the URL is fetched at open time.
+function PhoneAttachmentLightbox({
+  path,
+  onClose,
+}: {
+  path: string;
+  onClose: () => void;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/attachments?path=${encodeURIComponent(path)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+  return (
+    <div
+      role="dialog"
+      aria-label="Attachment preview"
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url ?? ""}
+        alt="attachment full size"
+        className="max-h-[90vh] max-w-[90vw] rounded shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      />
     </div>
   );
 }

--- a/src/lib/phone/attachments-storage.test.ts
+++ b/src/lib/phone/attachments-storage.test.ts
@@ -1,0 +1,135 @@
+// PRD #304 — Nookleus Phone. Slice 6 (#310) — storage helpers.
+//
+// The bucket layer behind the MMS pipeline. Pure shape + thin I/O over
+// the Supabase Storage client. Org-scoping is enforced by the path prefix
+// (and double-checked by the read policy on the bucket).
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  PHONE_ATTACHMENTS_BUCKET,
+  phoneAttachmentPath,
+  uploadPhoneAttachment,
+  signedUrlForPhoneAttachment,
+} from "./attachments-storage";
+
+// Minimal fake of the bucket-client surface the helpers touch.
+function makeBucketFake() {
+  const uploads: Array<{
+    path: string;
+    body: unknown;
+    options: { contentType?: string; upsert?: boolean } | undefined;
+  }> = [];
+  const signed: string[] = [];
+  const bucket = {
+    upload: vi.fn(
+      async (
+        path: string,
+        body: unknown,
+        options?: { contentType?: string; upsert?: boolean },
+      ) => {
+        uploads.push({ path, body, options });
+        return { data: { path }, error: null };
+      },
+    ),
+    createSignedUrl: vi.fn(async (path: string) => {
+      signed.push(path);
+      return { data: { signedUrl: `https://signed.example/${path}` }, error: null };
+    }),
+  };
+  const client = {
+    storage: { from: vi.fn(() => bucket) },
+  } as const;
+  return { client, bucket, uploads, signed };
+}
+
+describe("phoneAttachmentPath", () => {
+  it("returns {org}/{uuid}.{ext}", () => {
+    expect(phoneAttachmentPath("org-1", "abc-uuid", "jpg")).toBe(
+      "org-1/abc-uuid.jpg",
+    );
+  });
+});
+
+describe("PHONE_ATTACHMENTS_BUCKET", () => {
+  it("is the documented bucket name", () => {
+    expect(PHONE_ATTACHMENTS_BUCKET).toBe("phone-attachments");
+  });
+});
+
+describe("uploadPhoneAttachment", () => {
+  it("uploads to the phone-attachments bucket and returns the storage path", async () => {
+    const { client, bucket, uploads } = makeBucketFake();
+
+    const result = await uploadPhoneAttachment(client, {
+      orgId: "org-1",
+      mediaType: "image/jpeg",
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(client.storage.from).toHaveBeenCalledWith("phone-attachments");
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].path).toMatch(/^org-1\/[0-9a-f-]+\.jpg$/);
+    expect(uploads[0].options).toEqual({
+      contentType: "image/jpeg",
+      upsert: false,
+    });
+    expect(result.storagePath).toEqual(uploads[0].path);
+    expect(result.mediaType).toBe("image/jpeg");
+    expect(bucket.upload).toHaveBeenCalledOnce();
+  });
+
+  it("throws when the bucket returns an error", async () => {
+    const client = {
+      storage: {
+        from: () => ({
+          upload: async () => ({
+            data: null,
+            error: { message: "bucket boom" },
+          }),
+        }),
+      },
+    } as const;
+
+    await expect(
+      uploadPhoneAttachment(client as never, {
+        orgId: "org-1",
+        mediaType: "image/png",
+        bytes: new Uint8Array([1]),
+      }),
+    ).rejects.toThrow(/bucket boom/);
+  });
+});
+
+describe("signedUrlForPhoneAttachment", () => {
+  it("mints a signed URL for the path on the phone-attachments bucket", async () => {
+    const { client, signed } = makeBucketFake();
+
+    const url = await signedUrlForPhoneAttachment(
+      client,
+      "org-1/abc.jpg",
+      60,
+    );
+
+    expect(client.storage.from).toHaveBeenCalledWith("phone-attachments");
+    expect(signed).toEqual(["org-1/abc.jpg"]);
+    expect(url).toBe("https://signed.example/org-1/abc.jpg");
+  });
+
+  it("throws when the signing call fails", async () => {
+    const client = {
+      storage: {
+        from: () => ({
+          createSignedUrl: async () => ({
+            data: null,
+            error: { message: "not found" },
+          }),
+        }),
+      },
+    } as const;
+
+    await expect(
+      signedUrlForPhoneAttachment(client as never, "org-x/missing.jpg", 60),
+    ).rejects.toThrow(/not found/);
+  });
+});

--- a/src/lib/phone/attachments-storage.ts
+++ b/src/lib/phone/attachments-storage.ts
@@ -1,0 +1,82 @@
+// PRD #304 — Nookleus Phone. Slice 6 (#310) — MMS attachments bucket I/O.
+//
+// Owns the `phone-attachments` bucket: path shape + upload + signed-URL
+// minting. Org-scoping is enforced at the path level — every object lives
+// under `{organization_id}/` — and double-enforced by the Storage read
+// policy installed alongside the bucket.
+
+import { mmsExtensionForMediaType, type MmsMediaType } from "./mms-attachments";
+
+export const PHONE_ATTACHMENTS_BUCKET = "phone-attachments";
+
+// Structural slice of the Supabase Storage client — only the calls these
+// helpers make.
+interface StorageError {
+  message: string;
+}
+interface BucketClient {
+  upload(
+    path: string,
+    body: Buffer | Uint8Array | ArrayBuffer,
+    options?: { contentType?: string; upsert?: boolean },
+  ): Promise<{ data: unknown; error: StorageError | null }>;
+  createSignedUrl(
+    path: string,
+    expiresIn: number,
+  ): Promise<{ data: { signedUrl: string } | null; error: StorageError | null }>;
+}
+export interface PhoneStorageClient {
+  storage: { from(bucket: string): BucketClient };
+}
+
+// {organization_id}/{uuid}.{ext} — Phone has no conversation-prefix sweep
+// (phone conversations aren't user-deletable), so the path stays flat
+// under the org id.
+export function phoneAttachmentPath(
+  orgId: string,
+  uuid: string,
+  ext: string,
+): string {
+  return `${orgId}/${uuid}.${ext}`;
+}
+
+export interface UploadParams {
+  orgId: string;
+  mediaType: MmsMediaType;
+  bytes: Buffer | Uint8Array;
+}
+
+export async function uploadPhoneAttachment(
+  client: PhoneStorageClient,
+  params: UploadParams,
+): Promise<{ storagePath: string; mediaType: MmsMediaType }> {
+  const uuid = crypto.randomUUID();
+  const ext = mmsExtensionForMediaType(params.mediaType);
+  const storagePath = phoneAttachmentPath(params.orgId, uuid, ext);
+  const { error } = await client.storage
+    .from(PHONE_ATTACHMENTS_BUCKET)
+    .upload(storagePath, params.bytes, {
+      contentType: params.mediaType,
+      upsert: false,
+    });
+  if (error) {
+    throw new Error(`Failed to upload phone attachment: ${error.message}`);
+  }
+  return { storagePath, mediaType: params.mediaType };
+}
+
+export async function signedUrlForPhoneAttachment(
+  client: PhoneStorageClient,
+  storagePath: string,
+  expiresInSeconds: number,
+): Promise<string> {
+  const { data, error } = await client.storage
+    .from(PHONE_ATTACHMENTS_BUCKET)
+    .createSignedUrl(storagePath, expiresInSeconds);
+  if (error || !data) {
+    throw new Error(
+      `Failed to sign phone attachment URL: ${error?.message ?? "no url"}`,
+    );
+  }
+  return data.signedUrl;
+}

--- a/src/lib/phone/mms-attachments.test.ts
+++ b/src/lib/phone/mms-attachments.test.ts
@@ -1,0 +1,124 @@
+// PRD #304 — Nookleus Phone. Slice 6 (#310) — MMS attachments.
+//
+// Pure-logic gate between a user-picked attachment and the rest of the
+// MMS pipeline. AC bullet:
+//
+//   "Per-message size enforcement: client-side rejects attachments above
+//    Twilio's per-MMS size limit with a clear error before the user
+//    clicks send."
+//
+// Twilio's hard ceiling is 5 MB total per MMS in the US/CA. We treat that
+// as the per-attachment limit too (a single oversized file is rejected
+// before anything else is added).
+
+import { describe, it, expect } from "vitest";
+
+import {
+  MAX_MMS_ATTACHMENT_BYTES,
+  validateMmsAttachment,
+  mmsExtensionForMediaType,
+  isMmsImageMediaType,
+} from "./mms-attachments";
+
+describe("validateMmsAttachment", () => {
+  it("accepts a small JPEG", () => {
+    const result = validateMmsAttachment({
+      type: "image/jpeg",
+      size: 100_000,
+    });
+    expect(result).toEqual({ ok: true, mediaType: "image/jpeg", kind: "image" });
+  });
+
+  it("accepts PNG / GIF / WEBP images", () => {
+    for (const t of ["image/png", "image/gif", "image/webp"] as const) {
+      expect(validateMmsAttachment({ type: t, size: 100 })).toEqual({
+        ok: true,
+        mediaType: t,
+        kind: "image",
+      });
+    }
+  });
+
+  it("accepts a PDF as a non-image attachment", () => {
+    const result = validateMmsAttachment({
+      type: "application/pdf",
+      size: 100_000,
+    });
+    expect(result).toEqual({
+      ok: true,
+      mediaType: "application/pdf",
+      kind: "file",
+    });
+  });
+
+  it("accepts a short video clip", () => {
+    const result = validateMmsAttachment({
+      type: "video/mp4",
+      size: 100_000,
+    });
+    expect(result).toEqual({
+      ok: true,
+      mediaType: "video/mp4",
+      kind: "file",
+    });
+  });
+
+  it("rejects an attachment above Twilio's per-MMS size limit", () => {
+    const result = validateMmsAttachment({
+      type: "image/jpeg",
+      size: MAX_MMS_ATTACHMENT_BYTES + 1,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/too large/i);
+      expect(result.error).toMatch(/5\s*MB/i);
+    }
+  });
+
+  it("rejects an unsupported media type", () => {
+    const result = validateMmsAttachment({
+      type: "application/x-msdownload",
+      size: 100,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/not.*supported|isn't.*supported/i);
+    }
+  });
+
+  it("rejects when type is empty", () => {
+    const result = validateMmsAttachment({ type: "", size: 100 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("isMmsImageMediaType", () => {
+  it("returns true for supported image types", () => {
+    expect(isMmsImageMediaType("image/jpeg")).toBe(true);
+    expect(isMmsImageMediaType("image/png")).toBe(true);
+    expect(isMmsImageMediaType("image/gif")).toBe(true);
+    expect(isMmsImageMediaType("image/webp")).toBe(true);
+  });
+
+  it("returns false for non-image types", () => {
+    expect(isMmsImageMediaType("application/pdf")).toBe(false);
+    expect(isMmsImageMediaType("video/mp4")).toBe(false);
+    expect(isMmsImageMediaType("")).toBe(false);
+  });
+});
+
+describe("mmsExtensionForMediaType", () => {
+  it("maps known image and document types to file extensions", () => {
+    expect(mmsExtensionForMediaType("image/jpeg")).toBe("jpg");
+    expect(mmsExtensionForMediaType("image/png")).toBe("png");
+    expect(mmsExtensionForMediaType("image/gif")).toBe("gif");
+    expect(mmsExtensionForMediaType("image/webp")).toBe("webp");
+    expect(mmsExtensionForMediaType("application/pdf")).toBe("pdf");
+    expect(mmsExtensionForMediaType("video/mp4")).toBe("mp4");
+  });
+
+  it("falls back to `bin` for an unrecognised type", () => {
+    expect(mmsExtensionForMediaType("application/x-unknown")).toBe("bin");
+    expect(mmsExtensionForMediaType("")).toBe("bin");
+  });
+});

--- a/src/lib/phone/mms-attachments.ts
+++ b/src/lib/phone/mms-attachments.ts
@@ -1,0 +1,84 @@
+// PRD #304 — Nookleus Phone. Slice 6 (#310) — MMS attachments.
+//
+// Pure-logic helpers for the MMS attachment pipeline: size + content-type
+// gating, plus the media-type → file-extension map used by both the
+// outbound storage path and the inbound copy-to-storage step.
+//
+// Kept narrow on purpose — every other module in the slice composes over
+// these helpers. The size ceiling is Twilio's hard 5 MB MMS limit; the
+// supported list is the intersection of "Twilio will deliver" and "the
+// inline thread render or a download chip can handle". Anything outside
+// that list is rejected at the client *and* the server.
+
+export const MAX_MMS_ATTACHMENT_BYTES = 5 * 1024 * 1024; // 5 MB
+
+export const MMS_IMAGE_MEDIA_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export type MmsImageMediaType = (typeof MMS_IMAGE_MEDIA_TYPES)[number];
+
+const MMS_FILE_MEDIA_TYPES = [
+  "application/pdf",
+  "video/mp4",
+  "video/quicktime",
+  "video/3gpp",
+] as const;
+
+export type MmsFileMediaType = (typeof MMS_FILE_MEDIA_TYPES)[number];
+
+export type MmsMediaType = MmsImageMediaType | MmsFileMediaType;
+
+export type MmsValidationResult =
+  | { ok: true; kind: "image"; mediaType: MmsImageMediaType }
+  | { ok: true; kind: "file"; mediaType: MmsFileMediaType }
+  | { ok: false; error: string };
+
+export function isMmsImageMediaType(type: string): type is MmsImageMediaType {
+  return (MMS_IMAGE_MEDIA_TYPES as readonly string[]).includes(type);
+}
+
+function isMmsFileMediaType(type: string): type is MmsFileMediaType {
+  return (MMS_FILE_MEDIA_TYPES as readonly string[]).includes(type);
+}
+
+export function validateMmsAttachment(file: {
+  type: string;
+  size: number;
+}): MmsValidationResult {
+  if (file.size > MAX_MMS_ATTACHMENT_BYTES) {
+    const mb = Math.round(MAX_MMS_ATTACHMENT_BYTES / (1024 * 1024));
+    return {
+      ok: false,
+      error: `That file is too large — keep attachments under ${mb} MB.`,
+    };
+  }
+  if (isMmsImageMediaType(file.type)) {
+    return { ok: true, kind: "image", mediaType: file.type };
+  }
+  if (isMmsFileMediaType(file.type)) {
+    return { ok: true, kind: "file", mediaType: file.type };
+  }
+  return {
+    ok: false,
+    error: `${file.type || "That file"} isn't a supported attachment.`,
+  };
+}
+
+const EXTENSION_BY_MEDIA_TYPE: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "application/pdf": "pdf",
+  "video/mp4": "mp4",
+  "video/quicktime": "mov",
+  "video/3gpp": "3gp",
+};
+
+export function mmsExtensionForMediaType(mediaType: string): string {
+  return EXTENSION_BY_MEDIA_TYPE[mediaType] ?? "bin";
+}

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -243,4 +243,69 @@ describe("sendSms", () => {
       sendSms(client, { from: "+15125550000", to: "+15551234567", body: "hi" }),
     ).rejects.toThrow(/21610/);
   });
+
+  // Slice 6 (#310) — MMS attachments.
+  it("includes the mediaUrl array in the SDK call when given", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMmms", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "see attached",
+      mediaUrl: [
+        "https://signed/phone-attachments/org-1/a.jpg",
+        "https://signed/phone-attachments/org-1/b.png",
+      ],
+    });
+    const payload = (messageCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      mediaUrl: [
+        "https://signed/phone-attachments/org-1/a.jpg",
+        "https://signed/phone-attachments/org-1/b.png",
+      ],
+    });
+  });
+
+  it("omits mediaUrl from the SDK call when none is provided", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMa", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "hi",
+    });
+    const payload = (messageCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).not.toHaveProperty("mediaUrl");
+  });
+
+  it("accepts an empty body when mediaUrl is non-empty (image-only MMS)", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMmms", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    const result = await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "",
+      mediaUrl: ["https://signed/phone-attachments/org-1/photo.jpg"],
+    });
+    expect(result).toEqual({ sid: "SMmms", status: "queued" });
+    expect(messageCreateSpy).toHaveBeenCalledOnce();
+  });
+
+  it("still rejects when both body AND mediaUrl are empty", async () => {
+    const client = fakeClient({});
+    await expect(
+      sendSms(client, {
+        from: "+15125550000",
+        to: "+15551234567",
+        body: "",
+        mediaUrl: [],
+      }),
+    ).rejects.toThrow(/body|media/i);
+  });
 });

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -59,6 +59,7 @@ export interface TwilioClientLike {
       to: string;
       body: string;
       statusCallback?: string;
+      mediaUrl?: string[];
     }): Promise<{ sid: string; status: string }>;
   };
 }
@@ -137,6 +138,10 @@ export interface SendSmsParams {
   to: string;
   body: string;
   statusCallback?: string;
+  // Slice 6 (#310) — MMS attachments. Each entry is a publicly-fetchable
+  // URL Twilio downloads from; pass an empty/undefined array for plain SMS.
+  // An MMS may carry an empty body provided at least one mediaUrl is set.
+  mediaUrl?: string[];
 }
 
 export interface SendSmsResult {
@@ -167,20 +172,25 @@ export async function sendSms(
       `twilio-client: sendSms to "${params.to}" must be E.164 (e.g. +15125551234)`,
     );
   }
-  if (params.body.length === 0) {
-    throw new Error("twilio-client: sendSms body must not be empty");
+  const hasMedia = (params.mediaUrl?.length ?? 0) > 0;
+  if (params.body.length === 0 && !hasMedia) {
+    throw new Error(
+      "twilio-client: sendSms requires a non-empty body OR at least one mediaUrl",
+    );
   }
   const payload: {
     from: string;
     to: string;
     body: string;
     statusCallback?: string;
+    mediaUrl?: string[];
   } = {
     from: params.from,
     to: params.to,
     body: params.body,
   };
   if (params.statusCallback) payload.statusCallback = params.statusCallback;
+  if (hasMedia) payload.mediaUrl = params.mediaUrl;
   const created = await client.messages.create(payload);
   return { sid: created.sid, status: created.status };
 }

--- a/supabase/migration-310-phone-attachments-bucket.sql
+++ b/supabase/migration-310-phone-attachments-bucket.sql
@@ -1,0 +1,33 @@
+-- Issue #310 — Phone slice 6 — MMS attachments (inbound + outbound).
+--
+-- Adds the private `phone-attachments` Storage bucket. Both outbound MMS
+-- (a Crew Lead drops a photo into the compose box → upload → Twilio
+-- fetches the signed URL) and inbound MMS (Twilio's webhook carries
+-- MediaUrlN → fetch → re-upload into our own bucket) share this one
+-- bucket. The attachment references are kept inline in
+-- `phone_messages.media_urls` JSONB (no separate `phone_attachments`
+-- table — slice 4 of PRD #304 reserved `media_urls` for exactly this).
+--
+-- Object paths: {organization_id}/{uuid}.{ext}
+--
+-- All I/O — upload, signed-URL generation, and conversation-prefix delete
+-- — runs through the /api/phone/attachments and /api/phone/messages
+-- routes on the Service client, which bypasses RLS. The read policy
+-- below is Organization-scoped defense-in-depth: even a direct client
+-- read can only see objects under the caller's Active Organization
+-- prefix. Mirrors the `jarvis-attachments` bucket (migration-198).
+
+-- 1. Storage bucket (private; signed URLs only).
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('phone-attachments', 'phone-attachments', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- 2. Organization-scoped read policy. The first path segment is the
+-- organization id; a member may read only objects under their own
+-- Active Organization prefix.
+CREATE POLICY "phone_attachments_org_members_read"
+  ON storage.objects FOR SELECT
+  USING (
+    bucket_id = 'phone-attachments'
+    AND (storage.foldername(name))[1] = nookleus.active_organization_id()::text
+  );


### PR DESCRIPTION
## Summary

Slice 6 of PRD #304 — Nookleus Phone. A Crew Lead drags a damage photo into the compose box and the customer receives it as MMS; a customer's photo reply renders inline in the thread.

Refs #310. (Issue intentionally left open for review after merge.)

## What landed

**Pure modules**
- `src/lib/phone/mms-attachments.ts` — 5 MB Twilio MMS ceiling, supported media-type gate (JPEG/PNG/GIF/WebP/PDF/video), ext map. The client-side rejection AC bullet.
- `src/lib/phone/attachments-storage.ts` — `phone-attachments` bucket name, `{org}/{uuid}.{ext}` path shape, upload + signed-URL helpers.

**Routes**
- `POST /api/phone/attachments` — multipart upload, view_phone gate, org-scoped write, returns `{ storage_path, media_type, kind, filename? }`.
- `GET /api/phone/attachments?path=` — short-lived signed URL, refuses cross-org paths.
- `POST /api/phone/messages` extended: accepts `attachments: [{ storage_path, media_type, filename? }]`, mints signed URLs, passes them to Twilio as `mediaUrl[]`, persists storage paths on `phone_messages.media_urls`. Empty body accepted iff ≥1 attachment; cross-org paths refused.
- Inbound webhook (`/api/phone/webhook/sms-inbound`) copies each `MediaUrlN` to the bucket so the reference survives Twilio's media retention. Per-attachment fetch failures degrade gracefully so the inbound message still persists.
- `sendSms` in `twilio-client` gained `mediaUrl?: string[]` and accepts an empty body when at least one mediaUrl is set.

**Schema**
- `supabase/migration-310-phone-attachments-bucket.sql` — adds the private bucket + org-scoped Storage read policy. Mirrors `jarvis-attachments` (#198). **NOT yet applied to prod** — apply via `apply_migration` after this PR lands.

**UI**
- Compose box: paperclip button + hidden multi-file input + drag-and-drop zone + thumbnail strip with remove-X + oversize inline error. Send gated on (text OR ≥1 ready attachment) AND no uploads in flight.
- Thread render: image attachments load via the signed-URL endpoint and become thumbnails that open a lightbox; non-image media renders as a downloadable filename link.

## Test plan

- [x] 38 new Vitest tests (13 red→green cycles); 319/319 phone-related tests pass
- [x] `tsc --noEmit` clean on all new + modified files (2 pre-existing unrelated errors unchanged)
- [x] ESLint clean on all new + modified files
- [x] Same 6 pre-existing Vitest failures as `main` (estimate-drag-end, email/accounts, sync-folder-incremental); 0 new regressions
- [ ] Apply `migration-310-phone-attachments-bucket.sql` to AAA prod after merge
- [ ] After `NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED=true` (post-#305 A2P 10DLC clearance): send a JPG MMS from a Crew Lead account to a real cell phone and confirm delivery
- [ ] Reply with a photo from the cell; confirm the image renders inline in the Phone-tab thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)