### PR TITLE
feat(photo-report): new structured cover page (slice 1 of #326) (#331)

### DIFF
--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -2,12 +2,15 @@
 
 import {
   Document,
+  Image,
   Page,
+  StyleSheet,
   Text,
   View,
-  Image,
-  StyleSheet,
 } from "@react-pdf/renderer";
+
+import CoverPage from "@/components/report-pdf/cover-page";
+import type { CoverPageData } from "@/lib/cover-page-data";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -25,32 +28,20 @@ interface ReportSection {
   photo_ids: string[];
 }
 
-interface CoverPageConfig {
-  show_logo: boolean;
-  show_company: boolean;
-  show_date: boolean;
-  show_photo_count: boolean;
-}
-
 interface ReportPDFProps {
   title: string;
-  jobNumber: string;
-  propertyAddress: string;
-  claimNumber: string | null;
-  insuranceCompany: string | null;
-  reportDate: string;
+  coverPageData: CoverPageData;
+  coverPhotoUrl: string | null;
+  logoUrl: string | null;
   sections: ReportSection[];
   photos: Record<string, ReportPhoto>;
   photosPerPage: number;
-  coverPage: CoverPageConfig;
 }
 
-// ─── Styles ──────────────────────────────────────────────────────────────────
+// ─── Styles (body only — cover lives in CoverPage) ───────────────────────────
 
 const colors = {
   primary: "#1B2434",
-  accent: "#C41E2A",
-  blue: "#2B5EA7",
   text: "#1A1A1A",
   muted: "#666666",
   light: "#999999",
@@ -68,59 +59,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
     color: colors.text,
   },
-  // Cover page
-  coverPage: {
-    fontFamily: "Helvetica",
-    display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "center",
-    padding: 60,
-    color: colors.text,
-  },
-  coverCompany: {
-    fontSize: 28,
-    fontFamily: "Helvetica-Bold",
-    color: colors.primary,
-    marginBottom: 6,
-  },
-  coverSubtitle: {
-    fontSize: 12,
-    color: colors.accent,
-    fontFamily: "Helvetica-Bold",
-    letterSpacing: 2,
-    marginBottom: 40,
-  },
-  coverDivider: {
-    width: 80,
-    height: 3,
-    backgroundColor: colors.accent,
-    marginBottom: 40,
-  },
-  coverTitle: {
-    fontSize: 22,
-    fontFamily: "Helvetica-Bold",
-    color: colors.text,
-    textAlign: "center",
-    marginBottom: 30,
-  },
-  coverInfoBlock: {
-    marginBottom: 8,
-    alignItems: "center",
-  },
-  coverLabel: {
-    fontSize: 9,
-    color: colors.light,
-    textTransform: "uppercase",
-    letterSpacing: 1,
-    marginBottom: 2,
-  },
-  coverValue: {
-    fontSize: 13,
-    color: colors.text,
-    fontFamily: "Helvetica-Bold",
-  },
-  // Section header
   sectionHeader: {
     backgroundColor: colors.primary,
     paddingVertical: 10,
@@ -138,7 +76,6 @@ const styles = StyleSheet.create({
     color: "#CBD5E1",
     marginTop: 3,
   },
-  // Photo grids
   photoRow: {
     flexDirection: "row",
     gap: 12,
@@ -180,7 +117,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#E1F5EE",
     color: "#085041",
   },
-  // Footer
   footer: {
     position: "absolute",
     bottom: 24,
@@ -258,18 +194,6 @@ function getRowsPerPage(photosPerPage: number): number {
   }
 }
 
-function formatDate(dateStr: string): string {
-  try {
-    return new Date(dateStr).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "long",
-      day: "numeric",
-    });
-  } catch {
-    return dateStr;
-  }
-}
-
 // ─── Components ──────────────────────────────────────────────────────────────
 
 function PageFooter({ title }: { title: string }) {
@@ -328,80 +252,25 @@ function PhotoCard({
 
 export default function ReportPDFDocument({
   title,
-  jobNumber,
-  propertyAddress,
-  claimNumber,
-  insuranceCompany,
-  reportDate,
+  coverPageData,
+  coverPhotoUrl,
+  logoUrl,
   sections,
   photos,
   photosPerPage,
-  coverPage,
 }: ReportPDFProps) {
-  const totalPhotos = sections.reduce(
-    (sum, s) => sum + s.photo_ids.length,
-    0
-  );
   const photoHeight = getPhotoHeight(photosPerPage);
   const gridCols = getGridCols(photosPerPage);
 
   return (
     <Document title={title} author="AAA Disaster Recovery">
-      {/* ═══ COVER PAGE ═══ */}
-      <Page size="LETTER" style={styles.coverPage}>
-        {coverPage.show_company && (
-          <>
-            <Text style={styles.coverCompany}>AAA Disaster Recovery</Text>
-            <Text style={styles.coverSubtitle}>PHOTO REPORT</Text>
-          </>
-        )}
+      <CoverPage
+        data={coverPageData}
+        title={title}
+        coverPhotoUrl={coverPhotoUrl}
+        logoUrl={logoUrl}
+      />
 
-        <View style={styles.coverDivider} />
-
-        <Text style={styles.coverTitle}>{title}</Text>
-
-        <View style={styles.coverInfoBlock}>
-          <Text style={styles.coverLabel}>Job Number</Text>
-          <Text style={styles.coverValue}>{jobNumber}</Text>
-        </View>
-
-        <View style={styles.coverInfoBlock}>
-          <Text style={styles.coverLabel}>Property Address</Text>
-          <Text style={styles.coverValue}>{propertyAddress}</Text>
-        </View>
-
-        {claimNumber && (
-          <View style={styles.coverInfoBlock}>
-            <Text style={styles.coverLabel}>Claim Number</Text>
-            <Text style={styles.coverValue}>{claimNumber}</Text>
-          </View>
-        )}
-
-        {insuranceCompany && (
-          <View style={styles.coverInfoBlock}>
-            <Text style={styles.coverLabel}>Insurance Company</Text>
-            <Text style={styles.coverValue}>{insuranceCompany}</Text>
-          </View>
-        )}
-
-        {coverPage.show_date && (
-          <View style={[styles.coverInfoBlock, { marginTop: 20 }]}>
-            <Text style={styles.coverLabel}>Report Date</Text>
-            <Text style={styles.coverValue}>{formatDate(reportDate)}</Text>
-          </View>
-        )}
-
-        {coverPage.show_photo_count && (
-          <View style={styles.coverInfoBlock}>
-            <Text style={styles.coverLabel}>Total Photos</Text>
-            <Text style={styles.coverValue}>{totalPhotos}</Text>
-          </View>
-        )}
-
-        <PageFooter title={title} />
-      </Page>
-
-      {/* ═══ SECTION PAGES ═══ */}
       {sections.map((section, si) => {
         const sectionPhotos = section.photo_ids
           .map((id) => photos[id])
@@ -409,14 +278,12 @@ export default function ReportPDFDocument({
 
         if (sectionPhotos.length === 0) return null;
 
-        // Chunk photos into rows, then rows into pages
         const rows = chunkArray(sectionPhotos, gridCols);
         const rowsPerPage = getRowsPerPage(photosPerPage);
         const pages = chunkArray(rows, rowsPerPage);
 
         return pages.map((pageRows, pi) => (
           <Page key={`s${si}-p${pi}`} size="LETTER" style={styles.page}>
-            {/* Show section header on first page of each section */}
             {pi === 0 && (
               <View style={styles.sectionHeader}>
                 <Text style={styles.sectionTitle}>
@@ -430,7 +297,6 @@ export default function ReportPDFDocument({
               </View>
             )}
 
-            {/* Photo rows */}
             {pageRows.map((row, ri) => (
               <View key={ri} style={styles.photoRow}>
                 {row.map((photo) => (
@@ -440,7 +306,6 @@ export default function ReportPDFDocument({
                     height={photoHeight}
                   />
                 ))}
-                {/* Fill empty cells to maintain layout */}
                 {row.length < gridCols &&
                   Array.from({ length: gridCols - row.length }).map((_, i) => (
                     <View key={`empty-${i}`} style={{ flex: 1 }} />

--- a/src/components/report-pdf/cover-page.tsx
+++ b/src/components/report-pdf/cover-page.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Image, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+
+import type { CoverPageData } from "@/lib/cover-page-data";
+
+const colors = {
+  primary: "#1B2434",
+  accent: "#C41E2A",
+  text: "#1A1A1A",
+  muted: "#666666",
+  light: "#999999",
+  border: "#E5E7EB",
+  bg: "#F9FAFB",
+};
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: "Helvetica",
+    fontSize: 10,
+    paddingTop: 48,
+    paddingBottom: 48,
+    paddingHorizontal: 48,
+    color: colors.text,
+  },
+  logoRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  logoImage: {
+    height: 48,
+    maxWidth: 200,
+    objectFit: "contain",
+  },
+  logoText: {
+    fontSize: 22,
+    fontFamily: "Helvetica-Bold",
+    color: colors.primary,
+  },
+  title: {
+    fontSize: 26,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    marginBottom: 18,
+  },
+  coverPhoto: {
+    width: "100%",
+    height: 340,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    objectFit: "cover",
+  },
+  coverPhotoPlaceholder: {
+    width: "100%",
+    height: 340,
+    marginBottom: 24,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    backgroundColor: colors.bg,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  placeholderText: {
+    fontSize: 10,
+    color: colors.light,
+  },
+  twoColumn: {
+    flexDirection: "row",
+    gap: 24,
+    marginBottom: 18,
+  },
+  column: {
+    flex: 1,
+  },
+  blockLabel: {
+    fontSize: 8,
+    color: colors.light,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 4,
+  },
+  blockValue: {
+    fontSize: 12,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    marginBottom: 2,
+  },
+  blockLine: {
+    fontSize: 11,
+    color: colors.text,
+    marginBottom: 2,
+  },
+  insuranceBlock: {
+    marginTop: 8,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+  },
+  insuranceLine: {
+    fontSize: 11,
+    color: colors.text,
+    marginBottom: 2,
+  },
+});
+
+interface CoverPageProps {
+  data: CoverPageData;
+  title: string;
+  coverPhotoUrl: string | null;
+  logoUrl: string | null;
+}
+
+export default function CoverPage({
+  data,
+  title,
+  coverPhotoUrl,
+  logoUrl,
+}: CoverPageProps) {
+  const { logo, customerName, propertyAddress, pointOfContact, insurance } =
+    data;
+
+  return (
+    <Page size="LETTER" style={styles.page}>
+      <View style={styles.logoRow}>
+        {logo.kind === "image" && logoUrl ? (
+          <Image src={logoUrl} style={styles.logoImage} />
+        ) : (
+          <Text style={styles.logoText}>
+            {logo.kind === "text" ? logo.name : ""}
+          </Text>
+        )}
+      </View>
+
+      <Text style={styles.title}>{title}</Text>
+
+      {coverPhotoUrl ? (
+        <Image src={coverPhotoUrl} style={styles.coverPhoto} />
+      ) : (
+        <View style={styles.coverPhotoPlaceholder}>
+          <Text style={styles.placeholderText}>No cover photo selected</Text>
+        </View>
+      )}
+
+      <View style={styles.twoColumn}>
+        <View style={styles.column}>
+          <Text style={styles.blockLabel}>Customer</Text>
+          <Text style={styles.blockValue}>{customerName || "—"}</Text>
+          <Text style={styles.blockLabel}>Property</Text>
+          <Text style={styles.blockLine}>{propertyAddress || "—"}</Text>
+        </View>
+
+        <View style={styles.column}>
+          <Text style={styles.blockLabel}>Point of contact</Text>
+          <Text style={styles.blockValue}>
+            {pointOfContact.companyName || ""}
+          </Text>
+          {pointOfContact.phone !== null && (
+            <Text style={styles.blockLine}>{pointOfContact.phone}</Text>
+          )}
+          {pointOfContact.email !== null && (
+            <Text style={styles.blockLine}>{pointOfContact.email}</Text>
+          )}
+        </View>
+      </View>
+
+      {insurance.visible && (
+        <View style={styles.insuranceBlock}>
+          <Text style={styles.insuranceLine}>
+            Insurance Carrier: {insurance.carrier || "—"}
+          </Text>
+          <Text style={styles.insuranceLine}>
+            Claim Number: {insurance.claimNumber || "—"}
+          </Text>
+        </View>
+      )}
+    </Page>
+  );
+}

--- a/src/lib/cover-page-data.test.ts
+++ b/src/lib/cover-page-data.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveCoverPageData } from "./cover-page-data";
+import type { CompanySettings, Contact, Job } from "./types";
+
+function makeJob(overrides: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "J-0001",
+    contact_id: "c-1",
+    status: "active",
+    urgency: "scheduled",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "123 Main St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    insurance_contact_id: null,
+    referral_partner_id: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeContact(overrides: Partial<Contact> = {}): Contact {
+  return {
+    id: "c-1",
+    full_name: "Jane Customer",
+    phone: null,
+    email: null,
+    role: "homeowner",
+    company: null,
+    title: null,
+    notes: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeCompanySettings(overrides: Partial<CompanySettings> = {}): CompanySettings {
+  return {
+    company_name: "AAA Disaster Recovery",
+    logo_path: "logos/aaa.png",
+    phone: "555-111-2222",
+    email: "ops@aaa.example",
+    ...overrides,
+  };
+}
+
+describe("resolveCoverPageData", () => {
+  describe("point of contact", () => {
+    it("assembles companyName, phone, and email from CompanySettings when all are present", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({
+          company_name: "AAA Disaster Recovery",
+          phone: "555-111-2222",
+          email: "ops@aaa.example",
+        }),
+      );
+
+      expect(data.pointOfContact).toEqual({
+        companyName: "AAA Disaster Recovery",
+        phone: "555-111-2222",
+        email: "ops@aaa.example",
+      });
+    });
+
+    it("omits the phone line (null) when CompanySettings.phone is empty", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({ phone: "", email: "ops@aaa.example" }),
+      );
+
+      expect(data.pointOfContact.phone).toBeNull();
+      expect(data.pointOfContact.email).toBe("ops@aaa.example");
+    });
+
+    it("omits the email line (null) when CompanySettings.email is undefined", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({ phone: "555-111-2222", email: undefined }),
+      );
+
+      expect(data.pointOfContact.phone).toBe("555-111-2222");
+      expect(data.pointOfContact.email).toBeNull();
+    });
+  });
+
+  describe("logo", () => {
+    it("returns an image variant when logo_path is set", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({ logo_path: "logos/aaa.png" }),
+      );
+
+      expect(data.logo).toEqual({ kind: "image", path: "logos/aaa.png" });
+    });
+
+    it("falls back to a styled-text variant using company_name when logo_path is empty", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({
+          logo_path: "",
+          company_name: "AAA Disaster Recovery",
+        }),
+      );
+
+      expect(data.logo).toEqual({
+        kind: "text",
+        name: "AAA Disaster Recovery",
+      });
+    });
+
+    it("falls back to a styled-text variant when logo_path is undefined", () => {
+      const data = resolveCoverPageData(
+        makeJob(),
+        makeCompanySettings({ logo_path: undefined, company_name: "Bob's Roofing" }),
+      );
+
+      expect(data.logo).toEqual({ kind: "text", name: "Bob's Roofing" });
+    });
+  });
+
+  describe("customer + address", () => {
+    it("pulls customer name from job.contact.full_name and property_address from the job", () => {
+      const data = resolveCoverPageData(
+        makeJob({
+          property_address: "742 Evergreen Terrace",
+          contact: makeContact({ full_name: "Marge Simpson" }),
+        }),
+        makeCompanySettings(),
+      );
+
+      expect(data.customerName).toBe("Marge Simpson");
+      expect(data.propertyAddress).toBe("742 Evergreen Terrace");
+    });
+
+    it("returns an empty customer name when job.contact is missing", () => {
+      const data = resolveCoverPageData(
+        makeJob({ contact: undefined, property_address: "1 Lonely Rd" }),
+        makeCompanySettings(),
+      );
+
+      expect(data.customerName).toBe("");
+      expect(data.propertyAddress).toBe("1 Lonely Rd");
+    });
+  });
+
+  describe("insurance block", () => {
+    it("hides the block when both insurance_company and claim_number are null", () => {
+      const data = resolveCoverPageData(
+        makeJob({ insurance_company: null, claim_number: null }),
+        makeCompanySettings(),
+      );
+
+      expect(data.insurance.visible).toBe(false);
+    });
+
+    it("hides the block when both fields are empty strings", () => {
+      const data = resolveCoverPageData(
+        makeJob({ insurance_company: "", claim_number: "" }),
+        makeCompanySettings(),
+      );
+
+      expect(data.insurance.visible).toBe(false);
+    });
+
+    it("shows the block with the carrier when only insurance_company is present", () => {
+      const data = resolveCoverPageData(
+        makeJob({ insurance_company: "Acme Mutual", claim_number: null }),
+        makeCompanySettings(),
+      );
+
+      expect(data.insurance).toEqual({
+        visible: true,
+        carrier: "Acme Mutual",
+        claimNumber: "",
+      });
+    });
+
+    it("shows the block with the claim number when only claim_number is present", () => {
+      const data = resolveCoverPageData(
+        makeJob({ insurance_company: null, claim_number: "CL-42" }),
+        makeCompanySettings(),
+      );
+
+      expect(data.insurance).toEqual({
+        visible: true,
+        carrier: "",
+        claimNumber: "CL-42",
+      });
+    });
+  });
+});

--- a/src/lib/cover-page-data.ts
+++ b/src/lib/cover-page-data.ts
@@ -1,0 +1,67 @@
+import type { CompanySettings, Contact, Job } from "./types";
+
+export type LogoVariant =
+  | { kind: "image"; path: string }
+  | { kind: "text"; name: string };
+
+export interface PointOfContact {
+  companyName: string;
+  phone: string | null;
+  email: string | null;
+}
+
+export interface InsuranceBlock {
+  visible: boolean;
+  carrier: string;
+  claimNumber: string;
+}
+
+export interface CoverPageData {
+  logo: LogoVariant;
+  customerName: string;
+  propertyAddress: string;
+  pointOfContact: PointOfContact;
+  insurance: InsuranceBlock;
+}
+
+// Structural subset — accepts a full Job or a partial Supabase-joined row.
+export type CoverPageJob = {
+  property_address: Job["property_address"];
+  insurance_company: Job["insurance_company"];
+  claim_number: Job["claim_number"];
+  contact?: Pick<Contact, "full_name"> | null;
+};
+
+export function resolveCoverPageData(
+  job: CoverPageJob,
+  companySettings: CompanySettings,
+): CoverPageData {
+  const carrier = job.insurance_company?.trim() ?? "";
+  const claimNumber = job.claim_number?.trim() ?? "";
+  const insuranceVisible = carrier !== "" || claimNumber !== "";
+
+  const logoPath = companySettings.logo_path?.trim() ?? "";
+  const logo: LogoVariant =
+    logoPath !== ""
+      ? { kind: "image", path: logoPath }
+      : { kind: "text", name: companySettings.company_name ?? "" };
+
+  const phone = companySettings.phone?.trim() ?? "";
+  const email = companySettings.email?.trim() ?? "";
+
+  return {
+    logo,
+    customerName: job.contact?.full_name ?? "",
+    propertyAddress: job.property_address ?? "",
+    pointOfContact: {
+      companyName: companySettings.company_name ?? "",
+      phone: phone !== "" ? phone : null,
+      email: email !== "" ? email : null,
+    },
+    insurance: {
+      visible: insuranceVisible,
+      carrier,
+      claimNumber,
+    },
+  };
+}

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -3,7 +3,8 @@
 import { pdf } from "@react-pdf/renderer";
 import { createClient } from "@/lib/supabase";
 import ReportPDFDocument from "@/components/report-pdf-document";
-import { PhotoReport, Photo, Job } from "@/lib/types";
+import { resolveCoverPageData } from "@/lib/cover-page-data";
+import type { CompanySettings } from "@/lib/types";
 
 interface ReportSection {
   title: string;
@@ -11,11 +12,51 @@ interface ReportSection {
   photo_ids: string[];
 }
 
-interface CoverPageConfig {
-  show_logo: boolean;
-  show_company: boolean;
-  show_date: boolean;
-  show_photo_count: boolean;
+interface JoinedContact {
+  full_name: string | null;
+}
+
+interface JoinedCoverPhoto {
+  storage_path: string | null;
+  annotated_path: string | null;
+}
+
+interface JoinedJob {
+  id: string;
+  job_number: string;
+  property_address: string;
+  claim_number: string | null;
+  insurance_company: string | null;
+  cover_photo_id: string | null;
+  contact: JoinedContact | null;
+  cover_photo: JoinedCoverPhoto | null;
+}
+
+const COMPANY_SETTINGS_KEYS = [
+  "company_name",
+  "phone",
+  "email",
+  "logo_path",
+] as const;
+
+async function loadCompanySettings(
+  supabase: ReturnType<typeof createClient>,
+): Promise<CompanySettings> {
+  const { data, error } = await supabase
+    .from("company_settings")
+    .select("key, value")
+    .in("key", COMPANY_SETTINGS_KEYS as unknown as string[]);
+
+  if (error) {
+    // Soft-fail: render with empty settings rather than block PDF generation.
+    return {};
+  }
+
+  const settings: Record<string, string> = {};
+  for (const row of data ?? []) {
+    if (row.value != null) settings[row.key] = row.value;
+  }
+  return settings as CompanySettings;
 }
 
 /**
@@ -26,10 +67,24 @@ export async function generateReportPDF(reportId: string): Promise<string> {
   const supabase = createClient();
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 
-  // 1. Fetch the report with its job
+  // 1. Fetch the report + joined job, contact, and cover photo
   const { data: report, error: reportErr } = await supabase
     .from("photo_reports")
-    .select("*, job:jobs!job_id(id, job_number, property_address, claim_number, insurance_company)")
+    .select(
+      `
+        *,
+        job:jobs!job_id(
+          id,
+          job_number,
+          property_address,
+          claim_number,
+          insurance_company,
+          cover_photo_id,
+          contact:contacts!contact_id(full_name),
+          cover_photo:photos!cover_photo_id(storage_path, annotated_path)
+        )
+      `,
+    )
     .eq("id", reportId)
     .single();
 
@@ -37,42 +92,61 @@ export async function generateReportPDF(reportId: string): Promise<string> {
     throw new Error("Failed to fetch report");
   }
 
-  const job = report.job as Pick<Job, "id" | "job_number" | "property_address" | "claim_number" | "insurance_company">;
+  const job = report.job as JoinedJob;
   const sections = report.sections as ReportSection[];
 
-  // 2. Fetch the template (for cover page config and photos_per_page)
-  let coverPage: CoverPageConfig = {
-    show_logo: true,
-    show_company: true,
-    show_date: true,
-    show_photo_count: true,
-  };
+  // 2. photos_per_page is still template-driven for the body (slice 1: cover
+  //    only). Template's cover_page JSON is no longer read.
   let photosPerPage = 2;
-
   if (report.template_id) {
     const { data: template } = await supabase
       .from("photo_report_templates")
-      .select("cover_page, photos_per_page")
+      .select("photos_per_page")
       .eq("id", report.template_id)
       .single();
 
     if (template) {
-      coverPage = template.cover_page as unknown as CoverPageConfig;
       photosPerPage = template.photos_per_page;
     }
   }
 
-  // 3. Collect all photo IDs from sections
+  // 3. Company settings for cover page + branding
+  const companySettings = await loadCompanySettings(supabase);
+
+  // 4. Resolve cover page model (pure)
+  const coverPageData = resolveCoverPageData(
+    {
+      property_address: job.property_address,
+      insurance_company: job.insurance_company,
+      claim_number: job.claim_number,
+      contact: job.contact
+        ? { full_name: job.contact.full_name ?? "" }
+        : null,
+    },
+    companySettings,
+  );
+
+  // 5. Resolve image URLs (both buckets are public)
+  const logoUrl =
+    coverPageData.logo.kind === "image"
+      ? `${supabaseUrl}/storage/v1/object/public/company-assets/${coverPageData.logo.path}`
+      : null;
+
+  const coverPhotoPath =
+    job.cover_photo?.annotated_path || job.cover_photo?.storage_path || null;
+  const coverPhotoUrl = coverPhotoPath
+    ? `${supabaseUrl}/storage/v1/object/public/photos/${coverPhotoPath}`
+    : null;
+
+  // 6. Collect body photos (body unchanged in slice 1)
   const allPhotoIds = new Set<string>();
   sections.forEach((s) => s.photo_ids.forEach((id) => allPhotoIds.add(id)));
 
-  // 4. Fetch the actual photos
   const { data: photoData } = await supabase
     .from("photos")
     .select("id, storage_path, annotated_path, caption, before_after_role, taken_at")
     .in("id", Array.from(allPhotoIds));
 
-  // Build photo lookup with full URLs
   const photos: Record<
     string,
     {
@@ -95,23 +169,20 @@ export async function generateReportPDF(reportId: string): Promise<string> {
     };
   }
 
-  // 5. Render PDF to blob
+  // 7. Render PDF
   const blob = await pdf(
     <ReportPDFDocument
       title={report.title}
-      jobNumber={job.job_number}
-      propertyAddress={job.property_address}
-      claimNumber={job.claim_number}
-      insuranceCompany={job.insurance_company}
-      reportDate={report.report_date}
+      coverPageData={coverPageData}
+      coverPhotoUrl={coverPhotoUrl}
+      logoUrl={logoUrl}
       sections={sections}
       photos={photos}
       photosPerPage={photosPerPage}
-      coverPage={coverPage}
-    />
+    />,
   ).toBlob();
 
-  // 6. Upload PDF to Supabase Storage
+  // 8. Upload PDF to Supabase Storage
   const pdfPath = `${job.job_number}/${reportId}.pdf`;
   const { error: uploadErr } = await supabase.storage
     .from("reports")
@@ -124,7 +195,7 @@ export async function generateReportPDF(reportId: string): Promise<string> {
     throw new Error(`Failed to upload PDF: ${uploadErr.message}`);
   }
 
-  // 7. Update report record
+  // 9. Update report record
   const { error: updateErr } = await supabase
     .from("photo_reports")
     .update({


### PR DESCRIPTION
## Summary

Slice 1 of [#326](https://github.com/ericdaniels22/Nookleus/issues/326) — replaces the photo report PDF cover page with the structured layout from the parent PRD. Body of the report (photo pages) is unchanged.

Closes #331.

## What the new cover renders

- Logo from `CompanySettings.logo_path`, or styled company-name text when the logo slot is empty.
- Editable title (defaults to "Photo Report", respects `PhotoReport.title`).
- Job's selected cover photo (`Job.cover_photo_id`), or a placeholder slot when none is selected — never blocks generation.
- Customer name (`Job.contact.full_name`) + property address.
- Point-of-contact block: company name / phone / email, with empty lines omitted.
- Insurance block (carrier + claim) visible only when at least one of `insurance_company` / `claim_number` is present.

## Implementation

- **Pure module** — `src/lib/cover-page-data.ts` exports `resolveCoverPageData(job, companySettings)` returning a typed model. Imports no react-pdf, no Supabase.
- **react-pdf component** — `src/components/report-pdf/cover-page.tsx` takes the resolved model + title + logo/cover-photo URLs. No business logic.
- **Orchestrator** — `src/lib/generate-report-pdf.tsx` extends the `photo_reports` select to join `contact` and `cover_photo`, loads the `company_settings` KV → `CompanySettings`, calls `resolveCoverPageData`, resolves public-bucket URLs (`company-assets/`, `photos/`), and renders. `photos_per_page` still drives the body grid; the dead `cover_page` template-config read is gone.

## Test plan

- [x] `vitest run src/lib/cover-page-data.test.ts` — 12 passing tests cover insurance visibility (both empty → hidden; either present → visible), logo fallback (image vs. styled text), POC empty phone/email handling, and missing `Job.contact`.
- [x] `tsc --noEmit` — no new type errors on touched files.
- [x] `eslint` on touched files — no new errors (3 `jsx-a11y/alt-text` warnings on react-pdf `<Image>` match the existing `PhotoCard` pattern).
- [ ] Manual QA: generate a photo report against a real job and confirm AC scenarios visually:
  - [ ] Job with cover photo + customer + address + insurance + claim → all visible, POC block shows.
  - [ ] Cash job (no insurance fields) → insurance block hidden.
  - [ ] No cover photo selected → placeholder slot, no error.
  - [ ] Empty `logo_path` → company name renders as styled text.
  - [ ] Empty `CompanySettings.phone` or `email` → that line omitted from POC.
  - [ ] Existing PDFs in the `reports` bucket are not regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)