### PR TITLE
feat(reports): collapse photo-report-defaults tab to one knob (#332)

### DIFF
--- a/src/app/settings/templates/photo-report-defaults-tab.test.tsx
+++ b/src/app/settings/templates/photo-report-defaults-tab.test.tsx
@@ -1,0 +1,124 @@
+// PRD #326 — Photo Report Rework, Slice 6 (#332).
+//
+// The photo-report-defaults settings tab used to expose four knobs
+// (default template, preparer name, photos-per-page, footer text). Slice 6
+// collapses it to a single knob: photos-per-page (1 / 2 / 4, default 2).
+//
+// AC pinned here:
+//   - "The photo-report-defaults settings tab renders only one control:
+//      photos-per-page (1, 2, or 4 — default 2)."
+//   - "Changing the photos-per-page setting persists to
+//      photo_report_defaults.report_photos_per_page and is read back on
+//      page reload." — settings live in `company_settings` (key/value),
+//      so the PUT body carries only `report_photos_per_page`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    from: () => ({
+      select: () => ({
+        order: () => Promise.resolve({ data: [], error: null }),
+      }),
+    }),
+  }),
+}));
+
+import { PhotoReportDefaultsTab } from "./photo-report-defaults-tab";
+
+function stubFetch(opts: {
+  settings?: Record<string, string>;
+  putResult?: { ok: boolean };
+}) {
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  const spy = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url === "/api/settings/company") {
+      if (init?.method === "PUT") {
+        return json({ success: true }, opts.putResult?.ok === false ? 500 : 200);
+      }
+      return json(opts.settings ?? {});
+    }
+    return json({});
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("PhotoReportDefaultsTab", () => {
+  it("renders only the photos-per-page knob — no template / preparer / footer fields", async () => {
+    stubFetch({ settings: {} });
+
+    render(<PhotoReportDefaultsTab />);
+
+    // Photos-per-page buttons must be present.
+    expect(
+      await screen.findByRole("button", { name: /1 per page/i }),
+    ).toBeDefined();
+    expect(screen.getByRole("button", { name: /2 per page/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /4 per page/i })).toBeDefined();
+
+    // The three retired controls must be gone. Labels in this file aren't
+    // associated via htmlFor, so we check by visible text instead.
+    expect(screen.queryByText(/default template/i)).toBeNull();
+    expect(screen.queryByText(/preparer/i)).toBeNull();
+    expect(screen.queryByText(/footer/i)).toBeNull();
+  });
+
+  it("defaults to 2-per-page on a fresh load (no saved value)", async () => {
+    stubFetch({ settings: {} });
+
+    render(<PhotoReportDefaultsTab />);
+
+    const twoBtn = await screen.findByRole("button", { name: /2 per page/i });
+    // The selected button gets the gradient class; the simpler check is that
+    // it carries the `text-white` class (only the selected one does in the
+    // current visual style).
+    await waitFor(() => {
+      expect(twoBtn.className).toMatch(/text-white/);
+    });
+  });
+
+  it("reads back the saved photos-per-page from /api/settings/company", async () => {
+    stubFetch({ settings: { report_photos_per_page: "4" } });
+
+    render(<PhotoReportDefaultsTab />);
+
+    const fourBtn = await screen.findByRole("button", { name: /4 per page/i });
+    await waitFor(() => {
+      expect(fourBtn.className).toMatch(/text-white/);
+    });
+  });
+
+  it("saves only report_photos_per_page (none of the dropped keys)", async () => {
+    const fetchSpy = stubFetch({ settings: { report_photos_per_page: "2" } });
+
+    render(<PhotoReportDefaultsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /1 per page/i }));
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      const putCall = fetchSpy.mock.calls.find(
+        (c) =>
+          String(c[0]) === "/api/settings/company" &&
+          (c[1] as RequestInit | undefined)?.method === "PUT",
+      );
+      expect(putCall).toBeDefined();
+      const body = JSON.parse(String((putCall![1] as RequestInit).body));
+      expect(body).toEqual({ report_photos_per_page: "1" });
+    });
+  });
+});

--- a/src/app/settings/templates/photo-report-defaults-tab.tsx
+++ b/src/app/settings/templates/photo-report-defaults-tab.tsx
@@ -1,41 +1,24 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
-import { createClient } from "@/lib/supabase";
-import type { PhotoReportTemplate } from "@/lib/types";
 
+// PRD #326 — Photo Report Rework, Slice 6 (#332). The tab used to expose
+// four knobs; it now exposes only photos-per-page (1 / 2 / 4, default 2).
+// The dropped values (default template, preparer name, footer text) live
+// in `company_settings` as key/value rows and are deleted by migration.
 export function PhotoReportDefaultsTab() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [templates, setTemplates] = useState<PhotoReportTemplate[]>([]);
-
-  const [defaultTemplateId, setDefaultTemplateId] = useState("");
-  const [preparerName, setPreparerName] = useState("");
   const [photosPerPage, setPhotosPerPage] = useState("2");
-  const [footerText, setFooterText] = useState("");
 
   const fetchData = useCallback(async () => {
-    const [settingsRes, templatesRes] = await Promise.all([
-      fetch("/api/settings/company"),
-      createClient().from("photo_report_templates").select("*").order("name"),
-    ]);
-
-    if (settingsRes.ok) {
-      const data = await settingsRes.json();
-      setDefaultTemplateId(data.default_report_template || "");
-      setPreparerName(data.report_preparer_name || "");
+    const res = await fetch("/api/settings/company");
+    if (res.ok) {
+      const data = await res.json();
       setPhotosPerPage(data.report_photos_per_page || "2");
-      setFooterText(data.report_footer_text || "");
     }
-
-    if (templatesRes.data) {
-      setTemplates(templatesRes.data as PhotoReportTemplate[]);
-    }
-
     setLoading(false);
   }, []);
 
@@ -49,10 +32,7 @@ export function PhotoReportDefaultsTab() {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        default_report_template: defaultTemplateId,
-        report_preparer_name: preparerName,
         report_photos_per_page: photosPerPage,
-        report_footer_text: footerText,
       }),
     });
 
@@ -80,35 +60,7 @@ export function PhotoReportDefaultsTab() {
       <div className="bg-card rounded-xl border border-border p-6 space-y-4">
         <div>
           <label className="block text-xs font-medium text-muted-foreground mb-1">
-            Default Template
-          </label>
-          <select
-            value={defaultTemplateId}
-            onChange={(e) => setDefaultTemplateId(e.target.value)}
-            className="w-full rounded-lg border border-border bg-card px-3 py-2.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-[var(--brand-primary)]/20"
-          >
-            <option value="">None (start blank)</option>
-            {templates.map((t) => (
-              <option key={t.id} value={t.id}>{t.name}</option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">
-            Default Preparer Name
-          </label>
-          <Input
-            value={preparerName}
-            onChange={(e) => setPreparerName(e.target.value)}
-            placeholder="Eric Daniels"
-          />
-          <p className="text-[10px] text-muted-foreground mt-1">Auto-fills on new reports</p>
-        </div>
-
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">
-            Default Photos Per Page
+            Photos Per Page
           </label>
           <div className="flex gap-2">
             {["1", "2", "4"].map((n) => (
@@ -126,18 +78,6 @@ export function PhotoReportDefaultsTab() {
               </button>
             ))}
           </div>
-        </div>
-
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">
-            Footer Text
-          </label>
-          <Textarea
-            value={footerText}
-            onChange={(e) => setFooterText(e.target.value)}
-            placeholder="Custom footer text shown on all report pages..."
-            rows={2}
-          />
         </div>
       </div>
 

--- a/supabase/migration-332-drop-photo-report-defaults-keys.sql
+++ b/supabase/migration-332-drop-photo-report-defaults-keys.sql
@@ -1,0 +1,31 @@
+-- migration-332-drop-photo-report-defaults-keys.sql
+--
+-- PRD #326 — Photo Report Rework, Slice 6 (#332).
+--
+-- The photo-report-defaults settings tab is collapsed to a single knob
+-- (photos-per-page). The other three values are dropped from the schema.
+--
+-- The PRD's slice description says "drop columns from photo_report_defaults",
+-- but there is no such table in this codebase — the four settings are stored
+-- as key/value rows in `company_settings` (id, organization_id, key, value).
+-- The schema-correct equivalent of "drop the columns" is therefore to DELETE
+-- the rows holding the retired keys.
+--
+-- The retired keys:
+--   - default_report_template   (template picker the rework abandons)
+--   - report_preparer_name      (preparer auto-fill on new reports)
+--   - report_footer_text        (custom footer textarea)
+--
+-- `photo_report_templates` (a separate table) is intentionally NOT touched —
+-- ADR 0003 keeps it as dead data in the schema for now.
+--
+-- Idempotent: a DELETE of rows that don't exist is a no-op. As of writing
+-- no Organization had saved values under these keys, so the migration is
+-- defensive cleanup that keeps the slice's intent provable in SQL.
+
+delete from public.company_settings
+ where key in (
+   'default_report_template',
+   'report_preparer_name',
+   'report_footer_text'
+ );


### PR DESCRIPTION
## Summary

- Slice 6 of #326 (Photo Report Rework). The `/settings/templates` → **Photo Report Defaults** tab is collapsed to a single control: photos-per-page (1 / 2 / 4, default 2). The template picker, preparer-name field, and footer textarea are gone.
- Save body to `PUT /api/settings/company` now carries only `report_photos_per_page` — the three retired keys are no longer written from the client.
- Migration `migration-332-drop-photo-report-defaults-keys.sql` deletes any rows in `company_settings` keyed `default_report_template`, `report_preparer_name`, or `report_footer_text`. Already applied to AAA prod.

The slice text mentioned a `photo_report_defaults` table; that table does not exist in this codebase — the four settings live as key/value rows in `company_settings`. The "drop the columns" intent is honored by deleting the rows. `photo_report_templates` (a different table) is intentionally left in place per ADR 0003.

## Test plan

- [x] New file `photo-report-defaults-tab.test.tsx` — 4 RTL tests, watched RED before GREEN
  - renders only the photos-per-page knob (no template / preparer / footer copy)
  - defaults to 2-per-page on empty settings
  - reads back saved `report_photos_per_page`
  - save body carries only `report_photos_per_page`, no dropped keys
- [x] `npx vitest run src/app/settings/templates/` — 5 tests, all green (4 new + the existing shell smoke test)
- [x] `npx tsc --noEmit` — clean for changed files (two pre-existing errors elsewhere are unrelated)
- [x] Prod verification: `SELECT … WHERE key IN (…three keys…)` returns 0 rows after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)