### PR TITLE
feat(photo-report): layout engine driving page-by-page rendering (#333)

### DIFF
--- a/docs/adr/0003-single-photo-report-layout.md
+++ b/docs/adr/0003-single-photo-report-layout.md
@@ -1,0 +1,26 @@
+# Single hardcoded photo report layout
+
+Photo reports previously supported per-template cover pages and configurable
+layouts via the `photo_report_templates` table. With the May 2026 rework
+(see issue #326), photo reports converge on **one** hardcoded layout — fixed
+cover page, fixed header/footer, fixed section divider page, fixed before/after
+pair behavior. The only remaining knob is `report_photos_per_page` (1/2/4).
+
+We picked one layout over a template system because every photo report this
+business produces serves the same audience (insurance adjusters and property
+owners) and benefits from looking the same every time. The template machinery
+was being maintained for flexibility nobody used, and dragging that flexibility
+forward into the rework would have doubled the surface area of the cover-page
+and footer code for no current need.
+
+## Consequences
+
+- `photo_report_templates` table and `PhotoReportTemplate.cover_page` JSON
+  become dead code. They are not dropped yet — existing rows are harmless and
+  removing the table is a separate migration.
+- `photo_report_defaults` loses `default_report_template`, `report_preparer_name`,
+  and `report_footer_text`. Only `report_photos_per_page` survives.
+- Reintroducing template choice later means rebuilding the template system,
+  not toggling it back on.
+- Existing PDFs in the `reports` bucket are not regenerated — they keep the
+  old layout as a historical record.

--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -11,6 +11,7 @@ import {
 
 import CoverPage from "@/components/report-pdf/cover-page";
 import type { CoverPageData } from "@/lib/cover-page-data";
+import type { DocumentPage } from "@/lib/build-report-document";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -22,18 +23,12 @@ interface ReportPhoto {
   taken_at: string | null;
 }
 
-interface ReportSection {
-  title: string;
-  description: string;
-  photo_ids: string[];
-}
-
 interface ReportPDFProps {
   title: string;
   coverPageData: CoverPageData;
   coverPhotoUrl: string | null;
   logoUrl: string | null;
-  sections: ReportSection[];
+  pages: DocumentPage[];
   photos: Record<string, ReportPhoto>;
   photosPerPage: number;
 }
@@ -255,57 +250,65 @@ export default function ReportPDFDocument({
   coverPageData,
   coverPhotoUrl,
   logoUrl,
-  sections,
+  pages,
   photos,
   photosPerPage,
 }: ReportPDFProps) {
   const photoHeight = getPhotoHeight(photosPerPage);
   const gridCols = getGridCols(photosPerPage);
 
+  const sectionOrdinals = new Map<string, number>();
+  for (const page of pages) {
+    if (page.kind === "photoPage" && !sectionOrdinals.has(page.sectionTitle)) {
+      sectionOrdinals.set(page.sectionTitle, sectionOrdinals.size + 1);
+    }
+  }
+
+  let prevSectionTitle: string | null = null;
+
   return (
     <Document title={title} author="AAA Disaster Recovery">
-      <CoverPage
-        data={coverPageData}
-        title={title}
-        coverPhotoUrl={coverPhotoUrl}
-        logoUrl={logoUrl}
-      />
+      {pages.map((page, idx) => {
+        if (page.kind === "cover") {
+          return (
+            <CoverPage
+              key={`cover-${idx}`}
+              data={coverPageData}
+              title={title}
+              coverPhotoUrl={coverPhotoUrl}
+              logoUrl={logoUrl}
+            />
+          );
+        }
 
-      {sections.map((section, si) => {
-        const sectionPhotos = section.photo_ids
-          .map((id) => photos[id])
-          .filter(Boolean);
+        const isFirstOfSection = prevSectionTitle !== page.sectionTitle;
+        prevSectionTitle = page.sectionTitle;
+        const ordinal = sectionOrdinals.get(page.sectionTitle) ?? 0;
+        const rows = chunkArray(page.slots, gridCols);
 
-        if (sectionPhotos.length === 0) return null;
-
-        const rows = chunkArray(sectionPhotos, gridCols);
-        const rowsPerPage = getRowsPerPage(photosPerPage);
-        const pages = chunkArray(rows, rowsPerPage);
-
-        return pages.map((pageRows, pi) => (
-          <Page key={`s${si}-p${pi}`} size="LETTER" style={styles.page}>
-            {pi === 0 && (
+        return (
+          <Page key={`p${idx}`} size="LETTER" style={styles.page}>
+            {isFirstOfSection && (
               <View style={styles.sectionHeader}>
                 <Text style={styles.sectionTitle}>
-                  {si + 1}. {section.title}
+                  {ordinal}. {page.sectionTitle}
                 </Text>
-                {section.description && (
-                  <Text style={styles.sectionDescription}>
-                    {section.description}
-                  </Text>
-                )}
               </View>
             )}
 
-            {pageRows.map((row, ri) => (
+            {rows.map((row, ri) => (
               <View key={ri} style={styles.photoRow}>
-                {row.map((photo) => (
-                  <PhotoCard
-                    key={photo.id}
-                    photo={photo}
-                    height={photoHeight}
-                  />
-                ))}
+                {row.map((slot) => {
+                  const photo = photos[slot.photoId];
+                  if (!photo) return null;
+                  return (
+                    <PhotoCard
+                      key={slot.photoId}
+                      photo={photo}
+                      height={photoHeight}
+                    />
+                  );
+                })}
                 {row.length < gridCols &&
                   Array.from({ length: gridCols - row.length }).map((_, i) => (
                     <View key={`empty-${i}`} style={{ flex: 1 }} />
@@ -315,7 +318,7 @@ export default function ReportPDFDocument({
 
             <PageFooter title={title} />
           </Page>
-        ));
+        );
       })}
     </Document>
   );

--- a/src/lib/build-report-document.test.ts
+++ b/src/lib/build-report-document.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildReportDocument,
+  type DocumentPage,
+  type ReportPhotoInput,
+  type ReportSectionInput,
+} from "./build-report-document";
+
+function makePhoto(overrides: Partial<ReportPhotoInput> = {}): ReportPhotoInput {
+  return {
+    id: "p-1",
+    caption: null,
+    takenAt: null,
+    takenBy: null,
+    width: 100,
+    height: 200,
+    ...overrides,
+  };
+}
+
+function makeSection(
+  overrides: Partial<ReportSectionInput> = {},
+): ReportSectionInput {
+  return {
+    title: "Section",
+    photoIds: [],
+    ...overrides,
+  };
+}
+
+describe("buildReportDocument", () => {
+  it("emits a single cover page when there are no sections", () => {
+    const pages = buildReportDocument({
+      sections: [],
+      photos: {},
+      photosPerPage: 2,
+    });
+
+    expect(pages).toEqual([{ kind: "cover" }]);
+  });
+
+  it("buckets 3 photos in one section into two photoPages (2 + 1) with continuous numbering", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["a", "b", "c"] }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).toEqual({ kind: "cover" });
+
+    const firstPhotoPage = pages[1];
+    if (firstPhotoPage.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(firstPhotoPage.sectionTitle).toBe("Living Room");
+    expect(firstPhotoPage.slots.map((s) => s.photoId)).toEqual(["a", "b"]);
+    expect(firstPhotoPage.slots.map((s) => s.number)).toEqual([1, 2]);
+
+    const secondPhotoPage = pages[2];
+    if (secondPhotoPage.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(secondPhotoPage.sectionTitle).toBe("Living Room");
+    expect(secondPhotoPage.slots.map((s) => s.photoId)).toEqual(["c"]);
+    expect(secondPhotoPage.slots.map((s) => s.number)).toEqual([3]);
+  });
+
+  it("continues photo numbering across sections and tags each page with its section title", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Exterior", photoIds: ["a", "b"] }),
+        makeSection({ title: "Interior", photoIds: ["c", "d", "e"] }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+        d: makePhoto({ id: "d" }),
+        e: makePhoto({ id: "e" }),
+      },
+      photosPerPage: 2,
+    });
+
+    const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+      DocumentPage,
+      { kind: "photoPage" }
+    >[];
+
+    expect(photoPages.map((p) => p.sectionTitle)).toEqual([
+      "Exterior",
+      "Interior",
+      "Interior",
+    ]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.number))).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.photoId))).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+    ]);
+  });
+
+  it("emits no photoPages for an empty section, and continues numbering across the gap", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Exterior", photoIds: ["a"] }),
+        makeSection({ title: "Empty", photoIds: [] }),
+        makeSection({ title: "Interior", photoIds: ["b"] }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+      },
+      photosPerPage: 2,
+    });
+
+    const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+      DocumentPage,
+      { kind: "photoPage" }
+    >[];
+
+    expect(photoPages.map((p) => p.sectionTitle)).toEqual([
+      "Exterior",
+      "Interior",
+    ]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.number))).toEqual([
+      1, 2,
+    ]);
+  });
+
+  it("derives portrait orientation when height >= width, landscape when width > height", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "S", photoIds: ["tall", "wide", "square", "unknown"] }),
+      ],
+      photos: {
+        tall: makePhoto({ id: "tall", width: 100, height: 200 }),
+        wide: makePhoto({ id: "wide", width: 300, height: 200 }),
+        square: makePhoto({ id: "square", width: 200, height: 200 }),
+        unknown: makePhoto({ id: "unknown", width: null, height: null }),
+      },
+      photosPerPage: 2,
+    });
+
+    const slots = pages
+      .filter((p) => p.kind === "photoPage")
+      .flatMap(
+        (p) => (p as Extract<DocumentPage, { kind: "photoPage" }>).slots,
+      );
+
+    const orientationsById = Object.fromEntries(
+      slots.map((s) => [s.photoId, s.orientation]),
+    );
+
+    expect(orientationsById).toEqual({
+      tall: "portrait",
+      wide: "landscape",
+      square: "portrait",
+      unknown: "portrait",
+    });
+  });
+
+  it("passes caption, takenAt, and takenBy through to each slot verbatim", () => {
+    const pages = buildReportDocument({
+      sections: [makeSection({ title: "S", photoIds: ["a"] })],
+      photos: {
+        a: makePhoto({
+          id: "a",
+          caption: "Buckled subfloor",
+          takenAt: "2026-05-20T14:32:00Z",
+          takenBy: "Eric Daniels",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    const photoPage = pages[1];
+    if (photoPage.kind !== "photoPage") throw new Error("expected photoPage");
+
+    expect(photoPage.slots[0]).toMatchObject({
+      photoId: "a",
+      number: 1,
+      caption: "Buckled subfloor",
+      takenAt: "2026-05-20T14:32:00Z",
+      takenBy: "Eric Daniels",
+    });
+  });
+
+  it("treats unsupported photosPerPage values (1, 4) as 2 for this slice", () => {
+    const photoIds = ["a", "b", "c"];
+    const photos: Record<string, ReportPhotoInput> = {
+      a: makePhoto({ id: "a" }),
+      b: makePhoto({ id: "b" }),
+      c: makePhoto({ id: "c" }),
+    };
+
+    for (const ppp of [1, 4]) {
+      const pages = buildReportDocument({
+        sections: [makeSection({ title: "S", photoIds })],
+        photos,
+        photosPerPage: ppp,
+      });
+
+      const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+        DocumentPage,
+        { kind: "photoPage" }
+      >[];
+
+      expect(photoPages.map((p) => p.slots.length)).toEqual([2, 1]);
+    }
+  });
+});

--- a/src/lib/build-report-document.ts
+++ b/src/lib/build-report-document.ts
@@ -1,0 +1,68 @@
+export interface ReportPhotoInput {
+  id: string;
+  caption: string | null;
+  takenAt: string | null;
+  takenBy: string | null;
+  width: number | null;
+  height: number | null;
+}
+
+export interface ReportSectionInput {
+  title: string;
+  photoIds: string[];
+}
+
+export interface PhotoSlot {
+  photoId: string;
+  number: number;
+  caption: string | null;
+  takenAt: string | null;
+  takenBy: string | null;
+  orientation: "portrait" | "landscape";
+}
+
+export type DocumentPage =
+  | { kind: "cover" }
+  | { kind: "photoPage"; sectionTitle: string; slots: PhotoSlot[] };
+
+export interface BuildReportDocumentArgs {
+  sections: ReportSectionInput[];
+  photos: Record<string, ReportPhotoInput>;
+  photosPerPage: number;
+}
+
+function orientationOf(photo: ReportPhotoInput): "portrait" | "landscape" {
+  if (photo.width != null && photo.height != null && photo.width > photo.height) {
+    return "landscape";
+  }
+  return "portrait";
+}
+
+export function buildReportDocument(
+  args: BuildReportDocumentArgs,
+): DocumentPage[] {
+  const pages: DocumentPage[] = [{ kind: "cover" }];
+  const bucketSize = 2;
+  let runningNumber = 1;
+
+  for (const section of args.sections) {
+    const sectionPhotos = section.photoIds
+      .map((id) => args.photos[id])
+      .filter((p): p is ReportPhotoInput => Boolean(p));
+
+    for (let i = 0; i < sectionPhotos.length; i += bucketSize) {
+      const bucket = sectionPhotos.slice(i, i + bucketSize);
+      const slots: PhotoSlot[] = bucket.map((photo) => ({
+        photoId: photo.id,
+        number: runningNumber++,
+        caption: photo.caption,
+        takenAt: photo.takenAt,
+        takenBy: photo.takenBy,
+        orientation: orientationOf(photo),
+      }));
+      pages.push({ kind: "photoPage", sectionTitle: section.title, slots });
+    }
+  }
+
+  return pages;
+}

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -3,6 +3,10 @@
 import { pdf } from "@react-pdf/renderer";
 import { createClient } from "@/lib/supabase";
 import ReportPDFDocument from "@/components/report-pdf-document";
+import {
+  buildReportDocument,
+  type ReportPhotoInput,
+} from "@/lib/build-report-document";
 import { resolveCoverPageData } from "@/lib/cover-page-data";
 import type { CompanySettings } from "@/lib/types";
 
@@ -144,7 +148,9 @@ export async function generateReportPDF(reportId: string): Promise<string> {
 
   const { data: photoData } = await supabase
     .from("photos")
-    .select("id, storage_path, annotated_path, caption, before_after_role, taken_at")
+    .select(
+      "id, storage_path, annotated_path, caption, before_after_role, taken_at, taken_by, width, height",
+    )
     .in("id", Array.from(allPhotoIds));
 
   const photos: Record<
@@ -158,6 +164,8 @@ export async function generateReportPDF(reportId: string): Promise<string> {
     }
   > = {};
 
+  const engineInputPhotos: Record<string, ReportPhotoInput> = {};
+
   for (const p of photoData || []) {
     const path = p.annotated_path || p.storage_path;
     photos[p.id] = {
@@ -167,16 +175,31 @@ export async function generateReportPDF(reportId: string): Promise<string> {
       before_after_role: p.before_after_role,
       taken_at: p.taken_at,
     };
+    engineInputPhotos[p.id] = {
+      id: p.id,
+      caption: p.caption,
+      takenAt: p.taken_at,
+      takenBy: p.taken_by ?? null,
+      width: p.width ?? null,
+      height: p.height ?? null,
+    };
   }
 
-  // 7. Render PDF
+  // 7. Build the document page list from the engine
+  const documentPages = buildReportDocument({
+    sections: sections.map((s) => ({ title: s.title, photoIds: s.photo_ids })),
+    photos: engineInputPhotos,
+    photosPerPage,
+  });
+
+  // 8. Render PDF
   const blob = await pdf(
     <ReportPDFDocument
       title={report.title}
       coverPageData={coverPageData}
       coverPhotoUrl={coverPhotoUrl}
       logoUrl={logoUrl}
-      sections={sections}
+      pages={documentPages}
       photos={photos}
       photosPerPage={photosPerPage}
     />,


### PR DESCRIPTION
## Summary

Closes #333 — Photo Report Rework Slice 2a.

- New pure module `src/lib/build-report-document.ts` — no Supabase, no react-pdf imports. Turns sections + photos + photos-per-page into an ordered `DocumentPage[]` of `cover` and `photoPage` entries with continuous numbering across sections.
- `src/components/report-pdf-document.tsx` and `src/lib/generate-report-pdf.tsx` rewired so the engine output drives body rendering.
- Visual treatment of body pages is intentionally unchanged — placeholder rendering uses the existing photo-grid styles. The new visual layout lands in the follow-up slice (along with section divider pages, which reintroduce per-section descriptions).
- No before/after pair special-casing, no section divider pages, no `photosPerPage = 1/4` support (treated as 2) — all per the issue's scope.

## Test plan

- [x] Unit tests for `buildReportDocument` cover: empty input → cover only, 2-per-page bucketing with odd final photo, continuous numbering across sections, empty section emits no pages, orientation marker from width/height (null → portrait), slot passes through caption/takenAt/takenBy, unsupported `photosPerPage` defaults to 2.
- [x] Existing photo-report-related vitests (`cover-page-data`, `photo-report-defaults-tab`) still pass.
- [x] Full `npm test` — 1590 passing; 2 pre-existing unrelated failures (`twilio` module not installed; email-accounts route test).
- [ ] Manual QA: generate a photo report against a real job — body should look visually similar to today, with section header on the first page of each section run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)