### PR TITLE
feat(photo-report): new photo body rendering at 2-per-page (#334)

### DIFF
--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -1,19 +1,11 @@
 "use client";
 
-import {
-  Document,
-  Image,
-  Page,
-  StyleSheet,
-  Text,
-  View,
-} from "@react-pdf/renderer";
+import { Document } from "@react-pdf/renderer";
 
 import CoverPage from "@/components/report-pdf/cover-page";
+import PhotoPage from "@/components/report-pdf/photo-page";
 import type { CoverPageData } from "@/lib/cover-page-data";
 import type { DocumentPage } from "@/lib/build-report-document";
-
-// ─── Types ───────────────────────────────────────────────────────────────────
 
 interface ReportPhoto {
   id: string;
@@ -28,243 +20,21 @@ interface ReportPDFProps {
   coverPageData: CoverPageData;
   coverPhotoUrl: string | null;
   logoUrl: string | null;
+  reportDate: string;
   pages: DocumentPage[];
   photos: Record<string, ReportPhoto>;
-  photosPerPage: number;
 }
-
-// ─── Styles (body only — cover lives in CoverPage) ───────────────────────────
-
-const colors = {
-  primary: "#1B2434",
-  text: "#1A1A1A",
-  muted: "#666666",
-  light: "#999999",
-  border: "#E5E7EB",
-  bg: "#F9FAFB",
-  white: "#FFFFFF",
-};
-
-const styles = StyleSheet.create({
-  page: {
-    fontFamily: "Helvetica",
-    fontSize: 10,
-    paddingTop: 40,
-    paddingBottom: 60,
-    paddingHorizontal: 40,
-    color: colors.text,
-  },
-  sectionHeader: {
-    backgroundColor: colors.primary,
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    marginBottom: 16,
-    borderRadius: 4,
-  },
-  sectionTitle: {
-    fontSize: 14,
-    fontFamily: "Helvetica-Bold",
-    color: colors.white,
-  },
-  sectionDescription: {
-    fontSize: 9,
-    color: "#CBD5E1",
-    marginTop: 3,
-  },
-  photoRow: {
-    flexDirection: "row",
-    gap: 12,
-    marginBottom: 12,
-  },
-  photoContainer: {
-    flex: 1,
-    borderWidth: 1,
-    borderColor: colors.border,
-    borderRadius: 4,
-    overflow: "hidden",
-  },
-  photoImage: {
-    width: "100%",
-    objectFit: "cover",
-  },
-  photoCaption: {
-    padding: 6,
-    backgroundColor: colors.bg,
-  },
-  photoCaptionText: {
-    fontSize: 8,
-    color: colors.text,
-  },
-  photoBadge: {
-    fontSize: 7,
-    fontFamily: "Helvetica-Bold",
-    paddingVertical: 1,
-    paddingHorizontal: 4,
-    borderRadius: 2,
-    marginTop: 3,
-    alignSelf: "flex-start",
-  },
-  beforeBadge: {
-    backgroundColor: "#FCEBEB",
-    color: "#791F1F",
-  },
-  afterBadge: {
-    backgroundColor: "#E1F5EE",
-    color: "#085041",
-  },
-  footer: {
-    position: "absolute",
-    bottom: 24,
-    left: 40,
-    right: 40,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    borderTopWidth: 1,
-    borderTopColor: colors.border,
-    paddingTop: 8,
-  },
-  footerText: {
-    fontSize: 7,
-    color: colors.light,
-  },
-  footerPage: {
-    fontSize: 7,
-    color: colors.muted,
-    fontFamily: "Helvetica-Bold",
-  },
-});
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-function chunkArray<T>(arr: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    chunks.push(arr.slice(i, i + size));
-  }
-  return chunks;
-}
-
-function getPhotoHeight(photosPerPage: number): number {
-  switch (photosPerPage) {
-    case 1:
-      return 480;
-    case 2:
-      return 230;
-    case 4:
-      return 210;
-    case 6:
-      return 140;
-    default:
-      return 230;
-  }
-}
-
-function getGridCols(photosPerPage: number): number {
-  switch (photosPerPage) {
-    case 1:
-      return 1;
-    case 2:
-      return 1;
-    case 4:
-      return 2;
-    case 6:
-      return 2;
-    default:
-      return 1;
-  }
-}
-
-function getRowsPerPage(photosPerPage: number): number {
-  switch (photosPerPage) {
-    case 1:
-      return 1;
-    case 2:
-      return 2;
-    case 4:
-      return 2;
-    case 6:
-      return 3;
-    default:
-      return 2;
-  }
-}
-
-// ─── Components ──────────────────────────────────────────────────────────────
-
-function PageFooter({ title }: { title: string }) {
-  return (
-    <View style={styles.footer} fixed>
-      <Text style={styles.footerText}>
-        AAA Disaster Recovery — {title}
-      </Text>
-      <Text
-        style={styles.footerPage}
-        render={({ pageNumber, totalPages }) =>
-          `Page ${pageNumber} of ${totalPages}`
-        }
-      />
-    </View>
-  );
-}
-
-function PhotoCard({
-  photo,
-  height,
-}: {
-  photo: ReportPhoto;
-  height: number;
-}) {
-  return (
-    <View style={styles.photoContainer}>
-      <Image src={photo.url} style={[styles.photoImage, { height }]} />
-      <View style={styles.photoCaption}>
-        {photo.caption && (
-          <Text style={styles.photoCaptionText}>{photo.caption}</Text>
-        )}
-        {photo.before_after_role && (
-          <Text
-            style={[
-              styles.photoBadge,
-              photo.before_after_role === "before"
-                ? styles.beforeBadge
-                : styles.afterBadge,
-            ]}
-          >
-            {photo.before_after_role === "before" ? "BEFORE" : "AFTER"}
-          </Text>
-        )}
-        {!photo.caption && !photo.before_after_role && (
-          <Text style={[styles.photoCaptionText, { color: colors.light }]}>
-            No caption
-          </Text>
-        )}
-      </View>
-    </View>
-  );
-}
-
-// ─── Main Document ───────────────────────────────────────────────────────────
 
 export default function ReportPDFDocument({
   title,
   coverPageData,
   coverPhotoUrl,
   logoUrl,
+  reportDate,
   pages,
   photos,
-  photosPerPage,
 }: ReportPDFProps) {
-  const photoHeight = getPhotoHeight(photosPerPage);
-  const gridCols = getGridCols(photosPerPage);
-
-  const sectionOrdinals = new Map<string, number>();
-  for (const page of pages) {
-    if (page.kind === "photoPage" && !sectionOrdinals.has(page.sectionTitle)) {
-      sectionOrdinals.set(page.sectionTitle, sectionOrdinals.size + 1);
-    }
-  }
-
-  let prevSectionTitle: string | null = null;
+  const customerName = coverPageData.customerName;
 
   return (
     <Document title={title} author="AAA Disaster Recovery">
@@ -281,43 +51,30 @@ export default function ReportPDFDocument({
           );
         }
 
-        const isFirstOfSection = prevSectionTitle !== page.sectionTitle;
-        prevSectionTitle = page.sectionTitle;
-        const ordinal = sectionOrdinals.get(page.sectionTitle) ?? 0;
-        const rows = chunkArray(page.slots, gridCols);
+        const photoSlots = page.slots
+          .map((slot) => {
+            const photo = photos[slot.photoId];
+            if (!photo) return null;
+            return {
+              photoId: slot.photoId,
+              url: photo.url,
+              number: slot.number,
+              caption: slot.caption,
+              takenAt: slot.takenAt,
+              takenBy: slot.takenBy,
+              orientation: slot.orientation,
+            };
+          })
+          .filter((s): s is NonNullable<typeof s> => s !== null);
 
         return (
-          <Page key={`p${idx}`} size="LETTER" style={styles.page}>
-            {isFirstOfSection && (
-              <View style={styles.sectionHeader}>
-                <Text style={styles.sectionTitle}>
-                  {ordinal}. {page.sectionTitle}
-                </Text>
-              </View>
-            )}
-
-            {rows.map((row, ri) => (
-              <View key={ri} style={styles.photoRow}>
-                {row.map((slot) => {
-                  const photo = photos[slot.photoId];
-                  if (!photo) return null;
-                  return (
-                    <PhotoCard
-                      key={slot.photoId}
-                      photo={photo}
-                      height={photoHeight}
-                    />
-                  );
-                })}
-                {row.length < gridCols &&
-                  Array.from({ length: gridCols - row.length }).map((_, i) => (
-                    <View key={`empty-${i}`} style={{ flex: 1 }} />
-                  ))}
-              </View>
-            ))}
-
-            <PageFooter title={title} />
-          </Page>
+          <PhotoPage
+            key={`p${idx}`}
+            slots={photoSlots}
+            sectionTitle={page.sectionTitle}
+            customerName={customerName}
+            reportDate={reportDate}
+          />
         );
       })}
     </Document>

--- a/src/components/report-pdf/page-footer.test.tsx
+++ b/src/components/report-pdf/page-footer.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import PageFooter from "./page-footer";
+import { collectText, expandTree, findAll } from "./test-helpers";
+
+describe("PageFooter", () => {
+  it("renders the section name on the left, customer on the right", () => {
+    const tree = expandTree(
+      <PageFooter
+        sectionTitle="Exterior"
+        customerName="Jane Doe"
+        pageNumber={2}
+        totalPages={7}
+      />,
+    );
+    const text = collectText(tree);
+    expect(text).toContain("Exterior");
+    expect(text).toContain("Jane Doe");
+  });
+
+  it("renders 'X / Y' page counter using the supplied static numbers", () => {
+    const tree = expandTree(
+      <PageFooter
+        sectionTitle="Exterior"
+        customerName="Jane Doe"
+        pageNumber={2}
+        totalPages={7}
+      />,
+    );
+    expect(collectText(tree)).toContain("2 / 7");
+  });
+
+  it("uses react-pdf's dynamic page render fn when pageNumber is omitted", () => {
+    const tree = expandTree(
+      <PageFooter sectionTitle="Exterior" customerName="Jane Doe" />,
+    );
+    // Look for a TEXT node carrying a `render` function (react-pdf dynamic
+    // text). That is how the live PDF resolves {pageNumber}/{totalPages}.
+    const dynamicTexts = findAll(
+      tree,
+      (n) => n.type === "TEXT" && typeof n.props.render === "function",
+    );
+    expect(dynamicTexts.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/report-pdf/page-footer.tsx
+++ b/src/components/report-pdf/page-footer.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { StyleSheet, Text, View } from "@react-pdf/renderer";
+
+const colors = {
+  muted: "#666666",
+  light: "#999999",
+  border: "#E5E7EB",
+};
+
+const styles = StyleSheet.create({
+  footer: {
+    position: "absolute",
+    bottom: 24,
+    left: 40,
+    right: 40,
+    flexDirection: "row",
+    alignItems: "center",
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: 8,
+  },
+  side: {
+    flex: 1,
+    fontSize: 8,
+    color: colors.light,
+  },
+  right: {
+    flex: 1,
+    fontSize: 8,
+    color: colors.light,
+    textAlign: "right",
+  },
+  pageCounter: {
+    fontSize: 8,
+    fontFamily: "Helvetica-Bold",
+    color: colors.muted,
+    textAlign: "center",
+    flex: 1,
+  },
+});
+
+interface PageFooterProps {
+  sectionTitle: string;
+  customerName: string;
+  pageNumber?: number;
+  totalPages?: number;
+}
+
+export default function PageFooter({
+  sectionTitle,
+  customerName,
+  pageNumber,
+  totalPages,
+}: PageFooterProps) {
+  const hasStaticCounter =
+    pageNumber !== undefined && totalPages !== undefined;
+
+  return (
+    <View style={styles.footer} fixed>
+      <Text style={styles.side}>{sectionTitle}</Text>
+      {hasStaticCounter ? (
+        <Text style={styles.pageCounter}>
+          {pageNumber} / {totalPages}
+        </Text>
+      ) : (
+        <Text
+          style={styles.pageCounter}
+          render={({ pageNumber: pn, totalPages: tp }) => `${pn} / ${tp}`}
+        />
+      )}
+      <Text style={styles.right}>{customerName}</Text>
+    </View>
+  );
+}

--- a/src/components/report-pdf/page-header.test.tsx
+++ b/src/components/report-pdf/page-header.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import PageHeader from "./page-header";
+import { collectText, expandTree } from "./test-helpers";
+
+describe("PageHeader", () => {
+  it("renders customer name and 'Photo Report' label on the left", () => {
+    const tree = expandTree(
+      <PageHeader customerName="Jane Doe" reportDate="2026-05-19" />,
+    );
+    expect(collectText(tree)).toContain("Jane Doe");
+    expect(collectText(tree)).toContain("Photo Report");
+  });
+
+  it("renders the report date formatted as 'MMM d, yyyy'", () => {
+    const tree = expandTree(
+      <PageHeader customerName="Jane Doe" reportDate="2026-05-19" />,
+    );
+    expect(collectText(tree)).toContain("May 19, 2026");
+  });
+
+  it("omits the customer chunk when the name is empty, still shows 'Photo Report'", () => {
+    const tree = expandTree(
+      <PageHeader customerName="" reportDate="2026-05-19" />,
+    );
+    const text = collectText(tree);
+    expect(text).toContain("Photo Report");
+    expect(text).not.toContain("—  —");
+  });
+});

--- a/src/components/report-pdf/page-header.tsx
+++ b/src/components/report-pdf/page-header.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { StyleSheet, Text, View } from "@react-pdf/renderer";
+import { format } from "date-fns";
+
+const colors = {
+  text: "#1A1A1A",
+  muted: "#666666",
+  border: "#E5E7EB",
+};
+
+const styles = StyleSheet.create({
+  header: {
+    position: "absolute",
+    top: 24,
+    left: 40,
+    right: 40,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    paddingBottom: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+  },
+  left: {
+    flexDirection: "row",
+    flexShrink: 1,
+  },
+  customer: {
+    fontSize: 9,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+  },
+  label: {
+    fontSize: 9,
+    color: colors.muted,
+  },
+  date: {
+    fontSize: 9,
+    color: colors.muted,
+  },
+});
+
+interface PageHeaderProps {
+  customerName: string;
+  reportDate: string;
+}
+
+function formatReportDate(reportDate: string): string {
+  // report_date is a Postgres `date` (YYYY-MM-DD). Parse as a local
+  // calendar date so it does not shift across timezones.
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(reportDate);
+  const d = m
+    ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+    : new Date(reportDate);
+  if (Number.isNaN(d.getTime())) return reportDate;
+  return format(d, "MMM d, yyyy");
+}
+
+export default function PageHeader({
+  customerName,
+  reportDate,
+}: PageHeaderProps) {
+  return (
+    <View style={styles.header} fixed>
+      <View style={styles.left}>
+        {customerName ? (
+          <Text style={styles.customer}>{customerName} </Text>
+        ) : null}
+        <Text style={styles.label}>— Photo Report</Text>
+      </View>
+      <Text style={styles.date}>{formatReportDate(reportDate)}</Text>
+    </View>
+  );
+}

--- a/src/components/report-pdf/photo-page.test.tsx
+++ b/src/components/report-pdf/photo-page.test.tsx
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import PhotoPage, { type PhotoPageSlot } from "./photo-page";
+import { collectText, expandTree, findAll } from "./test-helpers";
+
+function makeSlot(overrides: Partial<PhotoPageSlot> = {}): PhotoPageSlot {
+  return {
+    photoId: "p1",
+    url: "https://example.com/p1.jpg",
+    number: 1,
+    caption: null,
+    takenAt: "2026-05-19T11:03:00",
+    takenBy: "Eric Daniels",
+    orientation: "portrait",
+    ...overrides,
+  };
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, s) => ({ ...acc, ...flattenStyle(s) }),
+      {},
+    );
+  }
+  if (style && typeof style === "object") return style as Record<string, unknown>;
+  return {};
+}
+
+describe("PhotoPage (2-per-page)", () => {
+  it("renders the caption (bold) when a slot has one, and omits caption text when null", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({ photoId: "p1", number: 1, caption: "Buckled subfloor" }),
+          makeSlot({ photoId: "p2", number: 2, caption: null }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={3}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Buckled subfloor");
+
+    // Find the TEXT node carrying the caption and verify it is bold.
+    const captionTexts = findAll(
+      tree,
+      (n) =>
+        n.type === "TEXT" &&
+        typeof n.props.children === "string" &&
+        (n.props.children as string).includes("Buckled subfloor"),
+    );
+    expect(captionTexts.length).toBe(1);
+    const style = flattenStyle(captionTexts[0].props.style);
+    expect(style.fontFamily).toBe("Helvetica-Bold");
+  });
+
+  it("renders the formatted date taken and the creator for each photo", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({
+            photoId: "p1",
+            number: 1,
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric Daniels",
+          }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={1}
+        totalPages={1}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("May 19, 2026, 11:03 AM");
+    expect(text).toContain("Eric Daniels");
+  });
+
+  it("renders a numbered badge for each photo with its slot number", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({ photoId: "p1", number: 5 }),
+          makeSlot({ photoId: "p2", number: 6 }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={3}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("5");
+    expect(text).toContain("6");
+  });
+
+  it("uses objectFit:'contain' (letterbox) for a landscape photo, 'cover' for portrait", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({
+            photoId: "wide",
+            number: 1,
+            orientation: "landscape",
+            url: "https://x/wide.jpg",
+          }),
+          makeSlot({
+            photoId: "tall",
+            number: 2,
+            orientation: "portrait",
+            url: "https://x/tall.jpg",
+          }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={1}
+        totalPages={1}
+      />,
+    );
+
+    const images = findAll(tree, (n) => n.type === "IMAGE");
+    expect(images.length).toBe(2);
+
+    const styleByUrl = new Map(
+      images.map((img) => {
+        const src = img.props.src as string | undefined;
+        return [src, flattenStyle(img.props.style)];
+      }),
+    );
+
+    expect(styleByUrl.get("https://x/wide.jpg")?.objectFit).toBe("contain");
+    expect(styleByUrl.get("https://x/tall.jpg")?.objectFit).toBe("cover");
+  });
+
+  it("renders the page header (customer + 'Photo Report' + report_date) and footer (section + counter + customer)", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[makeSlot()]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={5}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Jane Doe");
+    expect(text).toContain("Photo Report");
+    expect(text).toContain("May 19, 2026");
+    expect(text).toContain("Living Room");
+    expect(text).toContain("2 / 5");
+  });
+});

--- a/src/components/report-pdf/photo-page.tsx
+++ b/src/components/report-pdf/photo-page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Image, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+import { format } from "date-fns";
+
+import PageFooter from "./page-footer";
+import PageHeader from "./page-header";
+
+const colors = {
+  primary: "#1B2434",
+  text: "#1A1A1A",
+  muted: "#666666",
+  light: "#999999",
+  border: "#E5E7EB",
+  bg: "#F4F4F4",
+  white: "#FFFFFF",
+};
+
+// Slot geometry: each of the two photo rows takes roughly half of the
+// printable area between header and footer. The photo itself is a
+// portrait-shaped frame (~3:4) with the metadata column to the right.
+const PHOTO_HEIGHT = 295;
+const PHOTO_WIDTH = 220;
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: "Helvetica",
+    fontSize: 10,
+    paddingTop: 56,
+    paddingBottom: 56,
+    paddingHorizontal: 40,
+    color: colors.text,
+  },
+  slot: {
+    flexDirection: "row",
+    marginBottom: 16,
+    alignItems: "stretch",
+  },
+  photoFrame: {
+    width: PHOTO_WIDTH,
+    height: PHOTO_HEIGHT,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    position: "relative",
+    overflow: "hidden",
+  },
+  photoImage: {
+    width: "100%",
+    height: "100%",
+  },
+  badge: {
+    position: "absolute",
+    top: 8,
+    left: 8,
+    backgroundColor: colors.primary,
+    color: colors.white,
+    fontFamily: "Helvetica-Bold",
+    fontSize: 9,
+    paddingVertical: 2,
+    paddingHorizontal: 7,
+    borderRadius: 10,
+  },
+  meta: {
+    flex: 1,
+    paddingLeft: 14,
+    paddingVertical: 4,
+    justifyContent: "flex-start",
+  },
+  caption: {
+    fontSize: 11,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    marginBottom: 8,
+  },
+  metaLine: {
+    fontSize: 9,
+    color: colors.muted,
+    marginBottom: 3,
+  },
+  metaLabel: {
+    color: colors.light,
+  },
+});
+
+export interface PhotoPageSlot {
+  photoId: string;
+  url: string;
+  number: number;
+  caption: string | null;
+  takenAt: string | null;
+  takenBy: string | null;
+  orientation: "portrait" | "landscape";
+}
+
+interface PhotoPageProps {
+  slots: PhotoPageSlot[];
+  sectionTitle: string;
+  customerName: string;
+  reportDate: string;
+  pageNumber?: number;
+  totalPages?: number;
+}
+
+function formatTakenAt(takenAt: string | null): string | null {
+  if (!takenAt) return null;
+  const d = new Date(takenAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return format(d, "MMM d, yyyy, h:mm a");
+}
+
+function PhotoSlotView({ slot }: { slot: PhotoPageSlot }) {
+  const objectFit = slot.orientation === "landscape" ? "contain" : "cover";
+  const dateLine = formatTakenAt(slot.takenAt);
+
+  return (
+    <View style={styles.slot}>
+      <View style={styles.photoFrame}>
+        <Image src={slot.url} style={[styles.photoImage, { objectFit }]} />
+        <Text style={styles.badge}>{slot.number}</Text>
+      </View>
+      <View style={styles.meta}>
+        {slot.caption ? (
+          <Text style={styles.caption}>{slot.caption}</Text>
+        ) : null}
+        {dateLine ? <Text style={styles.metaLine}>{dateLine}</Text> : null}
+        {slot.takenBy ? (
+          <Text style={styles.metaLine}>{slot.takenBy}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+export default function PhotoPage({
+  slots,
+  sectionTitle,
+  customerName,
+  reportDate,
+  pageNumber,
+  totalPages,
+}: PhotoPageProps) {
+  return (
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader customerName={customerName} reportDate={reportDate} />
+      {slots.map((slot) => (
+        <PhotoSlotView key={slot.photoId} slot={slot} />
+      ))}
+      <PageFooter
+        sectionTitle={sectionTitle}
+        customerName={customerName}
+        pageNumber={pageNumber}
+        totalPages={totalPages}
+      />
+    </Page>
+  );
+}

--- a/src/components/report-pdf/test-helpers.ts
+++ b/src/components/report-pdf/test-helpers.ts
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+type Expanded =
+  | string
+  | number
+  | null
+  | Expanded[]
+  | { type: string; props: { [k: string]: unknown; children: Expanded } };
+
+/**
+ * Recursively invoke function components and return a tree whose only
+ * element `type`s are the @react-pdf/primitives string tags ('VIEW',
+ * 'TEXT', 'PAGE', 'IMAGE', etc.). Lets render-shape tests assert on
+ * structure and text without involving the PDF reconciler.
+ */
+export function expandTree(node: ReactNode | unknown): Expanded {
+  if (node == null || typeof node === "boolean") return null;
+  if (typeof node === "string" || typeof node === "number") return node;
+  if (Array.isArray(node)) return node.map(expandTree) as Expanded[];
+  if (typeof node === "object" && node !== null && "type" in node) {
+    const el = node as { type: unknown; props: { children?: unknown } };
+    const { type, props } = el;
+    if (typeof type === "function") {
+      const rendered = (type as (p: unknown) => ReactNode)(props ?? {});
+      return expandTree(rendered);
+    }
+    if (typeof type === "string") {
+      return {
+        type,
+        props: {
+          ...(props as Record<string, unknown>),
+          children: expandTree((props as { children?: unknown })?.children),
+        },
+      };
+    }
+  }
+  return null;
+}
+
+export function collectText(node: Expanded): string {
+  if (node == null) return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(collectText).join("");
+  return collectText(node.props.children);
+}
+
+/**
+ * Walks the expanded tree and returns every node whose `type` matches.
+ */
+export function findAll(
+  node: Expanded,
+  match: (n: Exclude<Expanded, string | number | null | unknown[]>) => boolean,
+): Array<Exclude<Expanded, string | number | null | unknown[]>> {
+  const out: Array<Exclude<Expanded, string | number | null | unknown[]>> = [];
+  function visit(n: Expanded) {
+    if (n == null || typeof n === "string" || typeof n === "number") return;
+    if (Array.isArray(n)) {
+      n.forEach(visit);
+      return;
+    }
+    if (match(n)) out.push(n);
+    visit(n.props.children);
+  }
+  visit(node);
+  return out;
+}

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -199,9 +199,9 @@ export async function generateReportPDF(reportId: string): Promise<string> {
       coverPageData={coverPageData}
       coverPhotoUrl={coverPhotoUrl}
       logoUrl={logoUrl}
+      reportDate={report.report_date}
       pages={documentPages}
       photos={photos}
-      photosPerPage={photosPerPage}
     />,
   ).toBlob();
 


### PR DESCRIPTION
## Summary

Slice 2b of the photo report rework (parent: #326). Replaces the Slice 2a placeholder body rendering with the structured layout described in the parent PRD, for `photosPerPage = 2`.

- New components in `src/components/report-pdf/`:
  - `page-header.tsx` — customer + "— Photo Report" left, formatted `report_date` right (fixed)
  - `page-footer.tsx` — section left, "X / Y" centered, customer right (fixed); accepts either static page numbers or uses react-pdf's live render fn
  - `photo-page.tsx` — two portrait-shaped slots stacked vertically; numbered badge top-left of each photo; metadata column to the right with bold caption (omitted when null), formatted date taken, and creator name; landscape photos letterbox via `objectFit: 'contain'`
- `report-pdf-document.tsx` maps each engine `photoPage` entry to `<PhotoPage>` and threads `customerName` + `reportDate`. Old inline body styles removed.
- `generate-report-pdf.tsx` passes `report.report_date` through.

## Acceptance criteria (from #334)

- [x] 2-per-page renders two photos with metadata block to the right
- [x] Each photo shows caption (bold, omitted when null), date taken, creator
- [x] Numbered badge top-left, continuous 1…N (engine-supplied)
- [x] Landscape in portrait slot letterboxes (no crop) via `objectFit: 'contain'`
- [x] Header (customer + "— Photo Report" left, report date right) and footer (section left, X/Y center, customer right) on every photo page
- [x] No section divider pages (deferred)
- [x] No before/after pair special-casing (deferred)
- [x] `photosPerPage` 1/4 not yet supported (engine still treats them as 2)

## Tests

11 new render-shape tests over the new components, using a small `expandTree`/`collectText`/`findAll` helper that walks the React element tree without invoking the PDF reconciler. All 30 photo-report related tests pass; the 2 pre-existing unrelated failures (twilio-client, email-accounts, referral-partners) touch none of the modified files.

## Test plan

- [ ] Generate a photo report on a real job and verify the body matches the parent PRD's visual treatment at 2-per-page
- [ ] Spot-check a landscape photo lands with letterbox bars rather than a crop
- [ ] Confirm header date matches the report's `report_date`
- [ ] Confirm footer's "X / Y" page counter reflects the actual page count

Closes #334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)