### PR TITLE
feat(photo-report): section divider pages (slice 3 of #326)

### DIFF
--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -4,6 +4,7 @@ import { Document } from "@react-pdf/renderer";
 
 import CoverPage from "@/components/report-pdf/cover-page";
 import PhotoPage from "@/components/report-pdf/photo-page";
+import SectionDividerPage from "@/components/report-pdf/section-divider-page";
 import type { CoverPageData } from "@/lib/cover-page-data";
 import type { DocumentPage } from "@/lib/build-report-document";
 
@@ -47,6 +48,18 @@ export default function ReportPDFDocument({
               title={title}
               coverPhotoUrl={coverPhotoUrl}
               logoUrl={logoUrl}
+            />
+          );
+        }
+
+        if (page.kind === "sectionDivider") {
+          return (
+            <SectionDividerPage
+              key={`d${idx}`}
+              title={page.title}
+              description={page.description}
+              customerName={customerName}
+              reportDate={reportDate}
             />
           );
         }

--- a/src/components/report-pdf/section-divider-page.test.tsx
+++ b/src/components/report-pdf/section-divider-page.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import SectionDividerPage from "./section-divider-page";
+import { collectText, expandTree, findAll } from "./test-helpers";
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, s) => ({ ...acc, ...flattenStyle(s) }),
+      {},
+    );
+  }
+  if (style && typeof style === "object") return style as Record<string, unknown>;
+  return {};
+}
+
+describe("SectionDividerPage", () => {
+  it("renders the section title large and centered", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Living Room"
+        description={null}
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Living Room");
+
+    const titleNodes = findAll(
+      tree,
+      (n) =>
+        n.type === "TEXT" &&
+        typeof n.props.children === "string" &&
+        (n.props.children as string) === "Living Room",
+    );
+    // The title TEXT and the footer's section label both render the string.
+    // The title is the one whose font size is large.
+    const big = titleNodes
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => Number(s.fontSize) >= 28);
+    expect(big).toBeDefined();
+    expect(big!.textAlign).toBe("center");
+  });
+
+  it("renders the description beneath the title when present", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Living Room"
+        description="Buckled flooring after water loss."
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("Buckled flooring after water loss.");
+  });
+
+  it("omits the description block when description is null or empty", () => {
+    for (const description of [null, ""]) {
+      const tree = expandTree(
+        <SectionDividerPage
+          title="Living Room"
+          description={description}
+          customerName="Jane Doe"
+          reportDate="2026-05-19"
+          pageNumber={2}
+          totalPages={9}
+        />,
+      );
+
+      const text = collectText(tree);
+      // No stray bullet/dash characters where the description would go.
+      expect(text).toContain("Living Room");
+      expect(text).not.toContain("undefined");
+      expect(text).not.toContain("null");
+    }
+  });
+
+  it("renders the page header and footer (section name in footer-left, page counter, customer)", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Living Room"
+        description={null}
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={5}
+      />,
+    );
+
+    const text = collectText(tree);
+    // Header
+    expect(text).toContain("Jane Doe");
+    expect(text).toContain("Photo Report");
+    expect(text).toContain("May 19, 2026");
+    // Footer: section identifier left, page counter center, customer right
+    expect(text).toContain("Living Room");
+    expect(text).toContain("2 / 5");
+  });
+});

--- a/src/components/report-pdf/section-divider-page.tsx
+++ b/src/components/report-pdf/section-divider-page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+
+import PageFooter from "./page-footer";
+import PageHeader from "./page-header";
+
+const colors = {
+  text: "#1A1A1A",
+  muted: "#666666",
+};
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: "Helvetica",
+    fontSize: 10,
+    paddingTop: 56,
+    paddingBottom: 56,
+    paddingHorizontal: 40,
+    color: colors.text,
+  },
+  body: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  title: {
+    fontSize: 36,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    textAlign: "center",
+  },
+  description: {
+    marginTop: 24,
+    fontSize: 14,
+    color: colors.muted,
+    textAlign: "center",
+    lineHeight: 1.4,
+  },
+});
+
+interface SectionDividerPageProps {
+  title: string;
+  description: string | null;
+  customerName: string;
+  reportDate: string;
+  pageNumber?: number;
+  totalPages?: number;
+}
+
+export default function SectionDividerPage({
+  title,
+  description,
+  customerName,
+  reportDate,
+  pageNumber,
+  totalPages,
+}: SectionDividerPageProps) {
+  const hasDescription = description != null && description.length > 0;
+
+  return (
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader customerName={customerName} reportDate={reportDate} />
+      <View style={styles.body}>
+        <Text style={styles.title}>{title}</Text>
+        {hasDescription ? (
+          <Text style={styles.description}>{description}</Text>
+        ) : null}
+      </View>
+      <PageFooter
+        sectionTitle={title}
+        customerName={customerName}
+        pageNumber={pageNumber}
+        totalPages={totalPages}
+      />
+    </Page>
+  );
+}

--- a/src/lib/build-report-document.test.ts
+++ b/src/lib/build-report-document.test.ts
@@ -24,6 +24,7 @@ function makeSection(
 ): ReportSectionInput {
   return {
     title: "Section",
+    description: null,
     photoIds: [],
     ...overrides,
   };
@@ -40,6 +41,31 @@ describe("buildReportDocument", () => {
     expect(pages).toEqual([{ kind: "cover" }]);
   });
 
+  it("inserts a sectionDivider page before the first photoPage of a non-empty section, carrying its title and description", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({
+          title: "Living Room",
+          description: "Buckled flooring after water loss.",
+          photoIds: ["a"],
+        }),
+      ],
+      photos: { a: makePhoto({ id: "a" }) },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+    ]);
+
+    const divider = pages[1];
+    if (divider.kind !== "sectionDivider") throw new Error("expected sectionDivider");
+    expect(divider.title).toBe("Living Room");
+    expect(divider.description).toBe("Buckled flooring after water loss.");
+  });
+
   it("buckets 3 photos in one section into two photoPages (2 + 1) with continuous numbering", () => {
     const pages = buildReportDocument({
       sections: [
@@ -53,16 +79,20 @@ describe("buildReportDocument", () => {
       photosPerPage: 2,
     });
 
-    expect(pages).toHaveLength(3);
-    expect(pages[0]).toEqual({ kind: "cover" });
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+      "photoPage",
+    ]);
 
-    const firstPhotoPage = pages[1];
+    const firstPhotoPage = pages[2];
     if (firstPhotoPage.kind !== "photoPage") throw new Error("expected photoPage");
     expect(firstPhotoPage.sectionTitle).toBe("Living Room");
     expect(firstPhotoPage.slots.map((s) => s.photoId)).toEqual(["a", "b"]);
     expect(firstPhotoPage.slots.map((s) => s.number)).toEqual([1, 2]);
 
-    const secondPhotoPage = pages[2];
+    const secondPhotoPage = pages[3];
     if (secondPhotoPage.kind !== "photoPage") throw new Error("expected photoPage");
     expect(secondPhotoPage.sectionTitle).toBe("Living Room");
     expect(secondPhotoPage.slots.map((s) => s.photoId)).toEqual(["c"]);
@@ -105,13 +135,23 @@ describe("buildReportDocument", () => {
       "d",
       "e",
     ]);
+
+    // Each section's divider precedes its first photoPage in document order.
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+      "sectionDivider",
+      "photoPage",
+      "photoPage",
+    ]);
   });
 
-  it("emits no photoPages for an empty section, and continues numbering across the gap", () => {
+  it("emits a sectionDivider for an empty section but no photoPages, and continues numbering across the gap", () => {
     const pages = buildReportDocument({
       sections: [
         makeSection({ title: "Exterior", photoIds: ["a"] }),
-        makeSection({ title: "Empty", photoIds: [] }),
+        makeSection({ title: "Empty", description: "nothing here", photoIds: [] }),
         makeSection({ title: "Interior", photoIds: ["b"] }),
       ],
       photos: {
@@ -121,11 +161,29 @@ describe("buildReportDocument", () => {
       photosPerPage: 2,
     });
 
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+      "sectionDivider",
+      "sectionDivider",
+      "photoPage",
+    ]);
+
+    const dividers = pages.filter((p) => p.kind === "sectionDivider") as Extract<
+      DocumentPage,
+      { kind: "sectionDivider" }
+    >[];
+    expect(dividers.map((d) => d.title)).toEqual([
+      "Exterior",
+      "Empty",
+      "Interior",
+    ]);
+
     const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
       DocumentPage,
       { kind: "photoPage" }
     >[];
-
     expect(photoPages.map((p) => p.sectionTitle)).toEqual([
       "Exterior",
       "Interior",
@@ -181,7 +239,7 @@ describe("buildReportDocument", () => {
       photosPerPage: 2,
     });
 
-    const photoPage = pages[1];
+    const photoPage = pages[2];
     if (photoPage.kind !== "photoPage") throw new Error("expected photoPage");
 
     expect(photoPage.slots[0]).toMatchObject({

--- a/src/lib/build-report-document.ts
+++ b/src/lib/build-report-document.ts
@@ -9,6 +9,7 @@ export interface ReportPhotoInput {
 
 export interface ReportSectionInput {
   title: string;
+  description: string | null;
   photoIds: string[];
 }
 
@@ -23,6 +24,7 @@ export interface PhotoSlot {
 
 export type DocumentPage =
   | { kind: "cover" }
+  | { kind: "sectionDivider"; title: string; description: string | null }
   | { kind: "photoPage"; sectionTitle: string; slots: PhotoSlot[] };
 
 export interface BuildReportDocumentArgs {
@@ -46,6 +48,12 @@ export function buildReportDocument(
   let runningNumber = 1;
 
   for (const section of args.sections) {
+    pages.push({
+      kind: "sectionDivider",
+      title: section.title,
+      description: section.description,
+    });
+
     const sectionPhotos = section.photoIds
       .map((id) => args.photos[id])
       .filter((p): p is ReportPhotoInput => Boolean(p));

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -187,7 +187,11 @@ export async function generateReportPDF(reportId: string): Promise<string> {
 
   // 7. Build the document page list from the engine
   const documentPages = buildReportDocument({
-    sections: sections.map((s) => ({ title: s.title, photoIds: s.photo_ids })),
+    sections: sections.map((s) => ({
+      title: s.title,
+      description: s.description ?? null,
+      photoIds: s.photo_ids,
+    })),
     photos: engineInputPhotos,
     photosPerPage,
   });


### PR DESCRIPTION
## Summary
- Engine emits a new `sectionDivider` page before the first photo page of every section (including empty sections), carrying the section's `title` and optional `description`.
- New react-pdf component `section-divider-page.tsx`: title large and centered, optional description beneath, reuses `PageHeader`/`PageFooter` (section name appears in footer-left).
- Orchestrator (`report-pdf-document.tsx`) maps `sectionDivider` entries to the new component; `generate-report-pdf.tsx` threads each section's `description` through to the engine.

Closes #335.

## Test plan
- [x] `vitest run src/lib/build-report-document.test.ts` (8 tests) — covers divider-before-first-photoPage, empty-section divider with no photo pages, multi-section ordinal ordering.
- [x] `vitest run src/components/report-pdf/` (component + orchestrator tests) — covers title style, description rendering, description-omission for null/empty, header + footer composition.
- [ ] Generate a photo report with multiple sections (one with a description, one empty) and confirm divider pages appear in the PDF with correct page numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)