### PR TITLE
feat(photo-report): before/after pair pages (slice 4 of #326)

### DIFF
--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -2,11 +2,12 @@
 
 import { Document } from "@react-pdf/renderer";
 
+import BeforeAfterPairPage from "@/components/report-pdf/before-after-pair-page";
 import CoverPage from "@/components/report-pdf/cover-page";
 import PhotoPage from "@/components/report-pdf/photo-page";
 import SectionDividerPage from "@/components/report-pdf/section-divider-page";
 import type { CoverPageData } from "@/lib/cover-page-data";
-import type { DocumentPage } from "@/lib/build-report-document";
+import type { DocumentPage, PhotoSlot } from "@/lib/build-report-document";
 
 interface ReportPhoto {
   id: string;
@@ -14,6 +15,23 @@ interface ReportPhoto {
   caption: string | null;
   before_after_role: "before" | "after" | null;
   taken_at: string | null;
+}
+
+function resolveSlot(
+  slot: PhotoSlot,
+  photos: Record<string, ReportPhoto>,
+) {
+  const photo = photos[slot.photoId];
+  if (!photo) return null;
+  return {
+    photoId: slot.photoId,
+    url: photo.url,
+    number: slot.number,
+    caption: slot.caption,
+    takenAt: slot.takenAt,
+    takenBy: slot.takenBy,
+    orientation: slot.orientation,
+  };
 }
 
 interface ReportPDFProps {
@@ -64,20 +82,24 @@ export default function ReportPDFDocument({
           );
         }
 
+        if (page.kind === "beforeAfterPair") {
+          const beforeSlot = resolveSlot(page.before, photos);
+          const afterSlot = resolveSlot(page.after, photos);
+          if (!beforeSlot || !afterSlot) return null;
+          return (
+            <BeforeAfterPairPage
+              key={`bap${idx}`}
+              before={beforeSlot}
+              after={afterSlot}
+              sectionTitle={page.sectionTitle}
+              customerName={customerName}
+              reportDate={reportDate}
+            />
+          );
+        }
+
         const photoSlots = page.slots
-          .map((slot) => {
-            const photo = photos[slot.photoId];
-            if (!photo) return null;
-            return {
-              photoId: slot.photoId,
-              url: photo.url,
-              number: slot.number,
-              caption: slot.caption,
-              takenAt: slot.takenAt,
-              takenBy: slot.takenBy,
-              orientation: slot.orientation,
-            };
-          })
+          .map((slot) => resolveSlot(slot, photos))
           .filter((s): s is NonNullable<typeof s> => s !== null);
 
         return (

--- a/src/components/report-pdf/before-after-pair-page.test.tsx
+++ b/src/components/report-pdf/before-after-pair-page.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import BeforeAfterPairPage from "./before-after-pair-page";
+import type { PhotoPageSlot } from "./photo-page";
+import { collectText, expandTree, findAll } from "./test-helpers";
+
+function makeSlot(overrides: Partial<PhotoPageSlot> = {}): PhotoPageSlot {
+  return {
+    photoId: "p1",
+    url: "https://example.com/p1.jpg",
+    number: 1,
+    caption: null,
+    takenAt: "2026-05-19T11:03:00",
+    takenBy: "Eric Daniels",
+    orientation: "portrait",
+    ...overrides,
+  };
+}
+
+describe("BeforeAfterPairPage", () => {
+  it("renders the 'Before' and 'After' labels", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({ photoId: "before", number: 7 })}
+        after={makeSlot({ photoId: "after", number: 8 })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={3}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Before");
+    expect(text).toContain("After");
+  });
+
+  it("renders both photo images at their respective URLs", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({ photoId: "p1", url: "https://x/before.jpg", number: 7 })}
+        after={makeSlot({ photoId: "p2", url: "https://x/after.jpg", number: 8 })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+      />,
+    );
+
+    const images = findAll(tree, (n) => n.type === "IMAGE");
+    const urls = images.map((i) => i.props.src as string);
+    expect(urls).toContain("https://x/before.jpg");
+    expect(urls).toContain("https://x/after.jpg");
+  });
+
+  it("renders each slot's continuous photo number as a badge", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({ photoId: "p1", number: 7 })}
+        after={makeSlot({ photoId: "p2", number: 8 })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("7");
+    expect(text).toContain("8");
+  });
+
+  it("renders the page header and footer with section, customer, and counter", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({ photoId: "p1", number: 1 })}
+        after={makeSlot({ photoId: "p2", number: 2 })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={3}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Jane Doe");
+    expect(text).toContain("Photo Report");
+    expect(text).toContain("May 19, 2026");
+    expect(text).toContain("Living Room");
+    expect(text).toContain("3 / 9");
+  });
+
+  it("renders captions and metadata for each photo when present", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({
+          photoId: "p1",
+          number: 1,
+          caption: "Wet subfloor",
+          takenAt: "2026-05-19T11:03:00",
+          takenBy: "Eric Daniels",
+        })}
+        after={makeSlot({
+          photoId: "p2",
+          number: 2,
+          caption: "Fully dried",
+          takenAt: "2026-05-21T10:00:00",
+          takenBy: "Eric Daniels",
+        })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Wet subfloor");
+    expect(text).toContain("Fully dried");
+    expect(text).toContain("May 19, 2026, 11:03 AM");
+    expect(text).toContain("May 21, 2026, 10:00 AM");
+  });
+});

--- a/src/components/report-pdf/before-after-pair-page.tsx
+++ b/src/components/report-pdf/before-after-pair-page.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { Image, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+import { format } from "date-fns";
+
+import PageFooter from "./page-footer";
+import PageHeader from "./page-header";
+import type { PhotoPageSlot } from "./photo-page";
+
+const colors = {
+  primary: "#1B2434",
+  text: "#1A1A1A",
+  muted: "#666666",
+  light: "#999999",
+  border: "#E5E7EB",
+  bg: "#F4F4F4",
+  white: "#FFFFFF",
+};
+
+const PHOTO_HEIGHT = 320;
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: "Helvetica",
+    fontSize: 10,
+    paddingTop: 56,
+    paddingBottom: 56,
+    paddingHorizontal: 40,
+    color: colors.text,
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginTop: 8,
+  },
+  column: {
+    flex: 1,
+    marginHorizontal: 4,
+  },
+  label: {
+    fontFamily: "Helvetica-Bold",
+    fontSize: 12,
+    color: colors.text,
+    textAlign: "center",
+    marginBottom: 6,
+  },
+  photoFrame: {
+    width: "100%",
+    height: PHOTO_HEIGHT,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    position: "relative",
+    overflow: "hidden",
+  },
+  photoImage: {
+    width: "100%",
+    height: "100%",
+  },
+  badge: {
+    position: "absolute",
+    top: 8,
+    left: 8,
+    backgroundColor: colors.primary,
+    color: colors.white,
+    fontFamily: "Helvetica-Bold",
+    fontSize: 9,
+    paddingVertical: 2,
+    paddingHorizontal: 7,
+    borderRadius: 10,
+  },
+  meta: {
+    paddingTop: 10,
+    paddingHorizontal: 2,
+  },
+  caption: {
+    fontSize: 11,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    marginBottom: 6,
+  },
+  metaLine: {
+    fontSize: 9,
+    color: colors.muted,
+    marginBottom: 3,
+  },
+});
+
+function formatTakenAt(takenAt: string | null): string | null {
+  if (!takenAt) return null;
+  const d = new Date(takenAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return format(d, "MMM d, yyyy, h:mm a");
+}
+
+function PairColumn({ slot, label }: { slot: PhotoPageSlot; label: string }) {
+  const objectFit = slot.orientation === "landscape" ? "contain" : "cover";
+  const dateLine = formatTakenAt(slot.takenAt);
+
+  return (
+    <View style={styles.column}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.photoFrame}>
+        <Image src={slot.url} style={[styles.photoImage, { objectFit }]} />
+        <Text style={styles.badge}>{slot.number}</Text>
+      </View>
+      <View style={styles.meta}>
+        {slot.caption ? (
+          <Text style={styles.caption}>{slot.caption}</Text>
+        ) : null}
+        {dateLine ? <Text style={styles.metaLine}>{dateLine}</Text> : null}
+        {slot.takenBy ? (
+          <Text style={styles.metaLine}>{slot.takenBy}</Text>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+interface BeforeAfterPairPageProps {
+  before: PhotoPageSlot;
+  after: PhotoPageSlot;
+  sectionTitle: string;
+  customerName: string;
+  reportDate: string;
+  pageNumber?: number;
+  totalPages?: number;
+}
+
+export default function BeforeAfterPairPage({
+  before,
+  after,
+  sectionTitle,
+  customerName,
+  reportDate,
+  pageNumber,
+  totalPages,
+}: BeforeAfterPairPageProps) {
+  return (
+    <Page size="LETTER" style={styles.page}>
+      <PageHeader customerName={customerName} reportDate={reportDate} />
+      <View style={styles.row}>
+        <PairColumn slot={before} label="Before" />
+        <PairColumn slot={after} label="After" />
+      </View>
+      <PageFooter
+        sectionTitle={sectionTitle}
+        customerName={customerName}
+        pageNumber={pageNumber}
+        totalPages={totalPages}
+      />
+    </Page>
+  );
+}

--- a/src/lib/build-report-document.test.ts
+++ b/src/lib/build-report-document.test.ts
@@ -15,6 +15,8 @@ function makePhoto(overrides: Partial<ReportPhotoInput> = {}): ReportPhotoInput 
     takenBy: null,
     width: 100,
     height: 200,
+    beforeAfterPairId: null,
+    beforeAfterRole: null,
     ...overrides,
   };
 }
@@ -249,6 +251,273 @@ describe("buildReportDocument", () => {
       takenAt: "2026-05-20T14:32:00Z",
       takenBy: "Eric Daniels",
     });
+  });
+
+  it("emits a beforeAfterPair page when two photos in a section share a before_after_pair_id", () => {
+    const pages = buildReportDocument({
+      sections: [makeSection({ title: "Living Room", photoIds: ["a", "b"] })],
+      photos: {
+        a: makePhoto({
+          id: "a",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+          caption: "Before drying",
+        }),
+        b: makePhoto({
+          id: "b",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+          caption: "After drying",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "beforeAfterPair",
+    ]);
+
+    const pair = pages[2];
+    if (pair.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(pair.sectionTitle).toBe("Living Room");
+    expect(pair.before.photoId).toBe("a");
+    expect(pair.after.photoId).toBe("b");
+    expect(pair.before.number).toBe(1);
+    expect(pair.after.number).toBe(2);
+    expect(pair.before.caption).toBe("Before drying");
+    expect(pair.after.caption).toBe("After drying");
+  });
+
+  it("skips the partner in subsequent traversal so a pair is never double-rendered", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["a", "b", "c"] }),
+      ],
+      photos: {
+        a: makePhoto({
+          id: "a",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+        }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({
+          id: "c",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "beforeAfterPair",
+      "photoPage",
+    ]);
+
+    const pair = pages[2];
+    if (pair.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(pair.before.photoId).toBe("a");
+    expect(pair.after.photoId).toBe("c");
+    expect(pair.before.number).toBe(1);
+    expect(pair.after.number).toBe(2);
+
+    const single = pages[3];
+    if (single.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(single.slots.map((s) => s.photoId)).toEqual(["b"]);
+    expect(single.slots.map((s) => s.number)).toEqual([3]);
+  });
+
+  it("falls back to regular photoPage rendering when a paired photo's partner is missing from the section", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["a", "b"] }),
+      ],
+      photos: {
+        // "a" claims a pair id, but its partner is not in the photo set.
+        a: makePhoto({
+          id: "a",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+        }),
+        b: makePhoto({ id: "b" }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+    ]);
+
+    const photoPage = pages[2];
+    if (photoPage.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(photoPage.slots.map((s) => s.photoId)).toEqual(["a", "b"]);
+    expect(photoPage.slots.map((s) => s.number)).toEqual([1, 2]);
+  });
+
+  it("when more than two photos share a before_after_pair_id, pairs the first two and renders extras as regular photos", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["a", "b", "c"] }),
+      ],
+      photos: {
+        a: makePhoto({
+          id: "a",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+        }),
+        b: makePhoto({
+          id: "b",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+        }),
+        c: makePhoto({
+          id: "c",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "beforeAfterPair",
+      "photoPage",
+    ]);
+
+    const pair = pages[2];
+    if (pair.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(pair.before.photoId).toBe("a");
+    expect(pair.after.photoId).toBe("b");
+    expect(pair.before.number).toBe(1);
+    expect(pair.after.number).toBe(2);
+
+    const single = pages[3];
+    if (single.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(single.slots.map((s) => s.photoId)).toEqual(["c"]);
+    expect(single.slots.map((s) => s.number)).toEqual([3]);
+  });
+
+  it("emits each pair on its own page regardless of photosPerPage (1, 2, or 4)", () => {
+    for (const ppp of [1, 2, 4]) {
+      const pages = buildReportDocument({
+        sections: [
+          makeSection({ title: "Living Room", photoIds: ["a", "b"] }),
+        ],
+        photos: {
+          a: makePhoto({
+            id: "a",
+            beforeAfterPairId: "pair-1",
+            beforeAfterRole: "before",
+          }),
+          b: makePhoto({
+            id: "b",
+            beforeAfterPairId: "pair-1",
+            beforeAfterRole: "after",
+          }),
+        },
+        photosPerPage: ppp,
+      });
+
+      expect(pages.map((p) => p.kind)).toEqual([
+        "cover",
+        "sectionDivider",
+        "beforeAfterPair",
+      ]);
+    }
+  });
+
+  it("emits a separate beforeAfterPair page for each pair in the same section, with continuous numbering", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({
+          title: "Living Room",
+          photoIds: ["a", "b", "c", "d"],
+        }),
+      ],
+      photos: {
+        a: makePhoto({
+          id: "a",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+        }),
+        b: makePhoto({
+          id: "b",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+        }),
+        c: makePhoto({
+          id: "c",
+          beforeAfterPairId: "pair-2",
+          beforeAfterRole: "before",
+        }),
+        d: makePhoto({
+          id: "d",
+          beforeAfterPairId: "pair-2",
+          beforeAfterRole: "after",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "beforeAfterPair",
+      "beforeAfterPair",
+    ]);
+
+    const first = pages[2];
+    if (first.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(first.before.photoId).toBe("a");
+    expect(first.after.photoId).toBe("b");
+    expect(first.before.number).toBe(1);
+    expect(first.after.number).toBe(2);
+
+    const second = pages[3];
+    if (second.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(second.before.photoId).toBe("c");
+    expect(second.after.photoId).toBe("d");
+    expect(second.before.number).toBe(3);
+    expect(second.after.number).toBe(4);
+  });
+
+  it("assigns the 'before' slot to the photo whose role is 'before' even when 'after' appears first in the section list", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["after-first", "before-second"] }),
+      ],
+      photos: {
+        "after-first": makePhoto({
+          id: "after-first",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "after",
+        }),
+        "before-second": makePhoto({
+          id: "before-second",
+          beforeAfterPairId: "pair-1",
+          beforeAfterRole: "before",
+        }),
+      },
+      photosPerPage: 2,
+    });
+
+    const pair = pages[2];
+    if (pair.kind !== "beforeAfterPair") throw new Error("expected beforeAfterPair");
+    expect(pair.before.photoId).toBe("before-second");
+    expect(pair.after.photoId).toBe("after-first");
+    // Numbering is in traversal order: after-first encountered first → 1,
+    // partner before-second → 2. The slot/role assignment is independent
+    // of the numbering.
+    expect(pair.after.number).toBe(1);
+    expect(pair.before.number).toBe(2);
   });
 
   it("treats unsupported photosPerPage values (1, 4) as 2 for this slice", () => {

--- a/src/lib/build-report-document.ts
+++ b/src/lib/build-report-document.ts
@@ -5,6 +5,8 @@ export interface ReportPhotoInput {
   takenBy: string | null;
   width: number | null;
   height: number | null;
+  beforeAfterPairId?: string | null;
+  beforeAfterRole?: "before" | "after" | null;
 }
 
 export interface ReportSectionInput {
@@ -25,7 +27,13 @@ export interface PhotoSlot {
 export type DocumentPage =
   | { kind: "cover" }
   | { kind: "sectionDivider"; title: string; description: string | null }
-  | { kind: "photoPage"; sectionTitle: string; slots: PhotoSlot[] };
+  | { kind: "photoPage"; sectionTitle: string; slots: PhotoSlot[] }
+  | {
+      kind: "beforeAfterPair";
+      sectionTitle: string;
+      before: PhotoSlot;
+      after: PhotoSlot;
+    };
 
 export interface BuildReportDocumentArgs {
   sections: ReportSectionInput[];
@@ -38,6 +46,17 @@ function orientationOf(photo: ReportPhotoInput): "portrait" | "landscape" {
     return "landscape";
   }
   return "portrait";
+}
+
+function makeSlot(photo: ReportPhotoInput, number: number): PhotoSlot {
+  return {
+    photoId: photo.id,
+    number,
+    caption: photo.caption,
+    takenAt: photo.takenAt,
+    takenBy: photo.takenBy,
+    orientation: orientationOf(photo),
+  };
 }
 
 export function buildReportDocument(
@@ -58,18 +77,107 @@ export function buildReportDocument(
       .map((id) => args.photos[id])
       .filter((p): p is ReportPhotoInput => Boolean(p));
 
-    for (let i = 0; i < sectionPhotos.length; i += bucketSize) {
-      const bucket = sectionPhotos.slice(i, i + bucketSize);
-      const slots: PhotoSlot[] = bucket.map((photo) => ({
-        photoId: photo.id,
-        number: runningNumber++,
-        caption: photo.caption,
-        takenAt: photo.takenAt,
-        takenBy: photo.takenBy,
-        orientation: orientationOf(photo),
-      }));
-      pages.push({ kind: "photoPage", sectionTitle: section.title, slots });
+    // First pass: walk in order, emit beforeAfterPair pages for the first
+    // two photos sharing any given before_after_pair_id within this section.
+    // Extras (a third+ sharing the same id) and photos whose partner is
+    // missing fall back to regular photoPage bucketing in document order.
+    const pairConsumed = new Set<string>();
+    const pairedByPhotoId = new Set<string>();
+
+    type Item =
+      | {
+          kind: "pair";
+          before: ReportPhotoInput;
+          after: ReportPhotoInput;
+          // Encounter order: the first photo of the pair encountered in the
+          // section's photoIds traversal (used for numbering). The slot
+          // (before/after) is assigned independently from `beforeAfterRole`.
+          first: ReportPhotoInput;
+          second: ReportPhotoInput;
+        }
+      | { kind: "single"; photo: ReportPhotoInput };
+    const items: Item[] = [];
+
+    for (let i = 0; i < sectionPhotos.length; i++) {
+      const photo = sectionPhotos[i];
+      if (pairedByPhotoId.has(photo.id)) continue;
+
+      const pairId = photo.beforeAfterPairId;
+      if (pairId && !pairConsumed.has(pairId)) {
+        const partnerIndex = sectionPhotos.findIndex(
+          (other, j) =>
+            j > i &&
+            other.beforeAfterPairId === pairId &&
+            !pairedByPhotoId.has(other.id),
+        );
+
+        if (partnerIndex !== -1) {
+          const partner = sectionPhotos[partnerIndex];
+          // Assign before/after by role when available; otherwise fall back
+          // to document order (the earlier-encountered photo is "before").
+          const photoIsBefore =
+            photo.beforeAfterRole === "after"
+              ? false
+              : partner.beforeAfterRole === "before"
+                ? false
+                : true;
+          const beforePhoto = photoIsBefore ? photo : partner;
+          const afterPhoto = photoIsBefore ? partner : photo;
+
+          items.push({
+            kind: "pair",
+            before: beforePhoto,
+            after: afterPhoto,
+            first: photo,
+            second: partner,
+          });
+          pairConsumed.add(pairId);
+          pairedByPhotoId.add(photo.id);
+          pairedByPhotoId.add(partner.id);
+          continue;
+        }
+      }
+
+      items.push({ kind: "single", photo });
     }
+
+    // Second pass: emit pages. Pairs flush any in-progress photo bucket and
+    // get their own page. Singles bucket two-per-page in document order.
+    let singleBuffer: ReportPhotoInput[] = [];
+
+    const flushSingles = () => {
+      if (singleBuffer.length === 0) return;
+      for (let i = 0; i < singleBuffer.length; i += bucketSize) {
+        const bucket = singleBuffer.slice(i, i + bucketSize);
+        pages.push({
+          kind: "photoPage",
+          sectionTitle: section.title,
+          slots: bucket.map((p) => makeSlot(p, runningNumber++)),
+        });
+      }
+      singleBuffer = [];
+    };
+
+    for (const item of items) {
+      if (item.kind === "single") {
+        singleBuffer.push(item.photo);
+        continue;
+      }
+      flushSingles();
+      // Number in encounter order, then map to the before/after slot.
+      const firstNumber = runningNumber++;
+      const secondNumber = runningNumber++;
+      const numberFor = (p: ReportPhotoInput) =>
+        p.id === item.first.id ? firstNumber : secondNumber;
+      pages.push({
+        kind: "beforeAfterPair",
+        sectionTitle: section.title,
+        before: makeSlot(item.before, numberFor(item.before)),
+        after: makeSlot(item.after, numberFor(item.after)),
+      });
+    }
+
+    flushSingles();
   }
 
   return pages;

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -149,7 +149,7 @@ export async function generateReportPDF(reportId: string): Promise<string> {
   const { data: photoData } = await supabase
     .from("photos")
     .select(
-      "id, storage_path, annotated_path, caption, before_after_role, taken_at, taken_by, width, height",
+      "id, storage_path, annotated_path, caption, before_after_pair_id, before_after_role, taken_at, taken_by, width, height",
     )
     .in("id", Array.from(allPhotoIds));
 
@@ -182,6 +182,8 @@ export async function generateReportPDF(reportId: string): Promise<string> {
       takenBy: p.taken_by ?? null,
       width: p.width ?? null,
       height: p.height ?? null,
+      beforeAfterPairId: p.before_after_pair_id ?? null,
+      beforeAfterRole: p.before_after_role ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary

- Extends `buildReportDocument` to detect photos sharing a `before_after_pair_id` within a section and emit a new `beforeAfterPair` page kind, with continuous photo numbering and partner-skip semantics.
- Adds `before-after-pair-page.tsx` — a react-pdf page that renders the two photos side by side with "Before" / "After" labels and a metadata column per photo.
- Pair pages always stand alone regardless of `photosPerPage` (1, 2, or 4).
- Slot assignment honors `before_after_role`; numbering follows traversal order.
- Edge cases covered (and tested): missing partner falls back to regular rendering; more-than-two-sharing-a-pair-id pairs the first two and renders extras as regular photos.
- `generate-report-pdf` selects `before_after_pair_id` and forwards both fields into the engine.

Closes #336.

## Test plan

- [x] `vitest run src/lib/build-report-document.test.ts` — 15 tests, +7 covering pair detection, partner skip, missing-partner fallback, >2 sharing a pair id, photosPerPage independence, multiple pairs in a section, role-reversed traversal order.
- [x] `vitest run src/components/report-pdf/before-after-pair-page.test.tsx` — 5 tests covering labels, both images, badges, header/footer, captions and metadata.
- [x] Full vitest suite — only pre-existing failures (`twilio` module missing, `email/accounts/route.test.ts`, `template-drag-end.test.ts`).
- [x] `tsc --noEmit` clean on all touched files (pre-existing `sync-folder-incremental.test.ts` / `twilio-client.ts` / `template-drag-end.test.ts` errors unchanged).
- [x] `eslint` clean on touched files (the lone `jsx-a11y/alt-text` warning on `<Image>` matches the existing pattern in `photo-page.tsx`).
- [ ] Browser-verify a generated PDF with a real before/after pair from the photos UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)