### PR TITLE
feat(photo-report): photos-per-page 1 and 4 variants (slice 5 of #326)

### DIFF
--- a/src/components/report-pdf-document.tsx
+++ b/src/components/report-pdf-document.tsx
@@ -109,6 +109,7 @@ export default function ReportPDFDocument({
             sectionTitle={page.sectionTitle}
             customerName={customerName}
             reportDate={reportDate}
+            photosPerPage={page.photosPerPage}
           />
         );
       })}

--- a/src/components/report-pdf/photo-page.test.tsx
+++ b/src/components/report-pdf/photo-page.test.tsx
@@ -142,6 +142,28 @@ describe("PhotoPage (2-per-page)", () => {
     expect(styleByUrl.get("https://x/tall.jpg")?.objectFit).toBe("cover");
   });
 
+  it("places the metadata column to the side of the photo (row layout) when photosPerPage is 2", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[makeSlot({ photoId: "p1", number: 1, caption: "Side meta" })]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={2}
+      />,
+    );
+
+    const slotWrappers = findAll(tree, (n) => {
+      if (n.type !== "VIEW") return false;
+      const s = flattenStyle(n.props.style);
+      return (
+        s.flexDirection === "row" &&
+        Array.isArray(n.props.children) === true
+      );
+    });
+    expect(slotWrappers.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("renders the page header (customer + 'Photo Report' + report_date) and footer (section + counter + customer)", () => {
     const tree = expandTree(
       <PhotoPage
@@ -160,5 +182,279 @@ describe("PhotoPage (2-per-page)", () => {
     expect(text).toContain("May 19, 2026");
     expect(text).toContain("Living Room");
     expect(text).toContain("2 / 5");
+  });
+});
+
+describe("PhotoPage (1-per-page)", () => {
+  it("renders the single photo with its caption, date, creator, and numbered badge", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({
+            photoId: "p1",
+            number: 7,
+            caption: "Buckled subfloor",
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric Daniels",
+          }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={1}
+        totalPages={5}
+        photosPerPage={1}
+      />,
+    );
+
+    const images = findAll(tree, (n) => n.type === "IMAGE");
+    expect(images.length).toBe(1);
+
+    const text = collectText(tree);
+    expect(text).toContain("Buckled subfloor");
+    expect(text).toContain("May 19, 2026, 11:03 AM");
+    expect(text).toContain("Eric Daniels");
+    expect(text).toContain("7");
+  });
+
+  it("stacks metadata beneath the photo (column layout) at photosPerPage=1", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[makeSlot({ photoId: "p1", number: 1, caption: "below" })]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={1}
+      />,
+    );
+
+    // No slot wrapper should be using row layout — meta is below, not beside.
+    const rowSlotWrappers = findAll(tree, (n) => {
+      if (n.type !== "VIEW") return false;
+      const s = flattenStyle(n.props.style);
+      // A "slot row" wrapper is a row-flex view that contains an image
+      // somewhere in its subtree.
+      if (s.flexDirection !== "row") return false;
+      const imgs = findAll(n, (m) => m.type === "IMAGE");
+      return imgs.length > 0;
+    });
+    expect(rowSlotWrappers.length).toBe(0);
+  });
+
+  it("renders the page header and footer at photosPerPage=1", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[makeSlot({ photoId: "p1", number: 1 })]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={3}
+        totalPages={9}
+        photosPerPage={1}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Jane Doe");
+    expect(text).toContain("Photo Report");
+    expect(text).toContain("May 19, 2026");
+    expect(text).toContain("Living Room");
+    expect(text).toContain("3 / 9");
+  });
+});
+
+describe("PhotoPage (4-per-page)", () => {
+  it("renders all four photos with their numbered badges, captions, dates, and creators", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({
+            photoId: "p1",
+            number: 10,
+            caption: "one",
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric",
+          }),
+          makeSlot({
+            photoId: "p2",
+            number: 11,
+            caption: "two",
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric",
+          }),
+          makeSlot({
+            photoId: "p3",
+            number: 12,
+            caption: "three",
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric",
+          }),
+          makeSlot({
+            photoId: "p4",
+            number: 13,
+            caption: "four",
+            takenAt: "2026-05-19T11:03:00",
+            takenBy: "Eric",
+          }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={4}
+      />,
+    );
+
+    const images = findAll(tree, (n) => n.type === "IMAGE");
+    expect(images.length).toBe(4);
+
+    const text = collectText(tree);
+    for (const word of ["one", "two", "three", "four"]) {
+      expect(text).toContain(word);
+    }
+    for (const num of ["10", "11", "12", "13"]) {
+      expect(text).toContain(num);
+    }
+  });
+
+  it("arranges the four tiles in a 2x2 grid (row-flex wrapper with flexWrap='wrap')", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({ photoId: "p1", number: 1 }),
+          makeSlot({ photoId: "p2", number: 2 }),
+          makeSlot({ photoId: "p3", number: 3 }),
+          makeSlot({ photoId: "p4", number: 4 }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={4}
+      />,
+    );
+
+    const gridWrappers = findAll(tree, (n) => {
+      if (n.type !== "VIEW") return false;
+      const s = flattenStyle(n.props.style);
+      if (s.flexDirection !== "row" || s.flexWrap !== "wrap") return false;
+      const imgs = findAll(n, (m) => m.type === "IMAGE");
+      return imgs.length === 4;
+    });
+    expect(gridWrappers.length).toBe(1);
+  });
+
+  it("stacks metadata beneath each tile (no row-layout slot wrapper around an image) at photosPerPage=4", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({ photoId: "p1", number: 1, caption: "a" }),
+          makeSlot({ photoId: "p2", number: 2, caption: "b" }),
+          makeSlot({ photoId: "p3", number: 3, caption: "c" }),
+          makeSlot({ photoId: "p4", number: 4, caption: "d" }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={4}
+      />,
+    );
+
+    // A "tile" is a column-flex wrapper that contains exactly one image.
+    const tiles = findAll(tree, (n) => {
+      if (n.type !== "VIEW") return false;
+      const imgs = findAll(n, (m) => m.type === "IMAGE");
+      if (imgs.length !== 1) return false;
+      const s = flattenStyle(n.props.style);
+      // Either explicit column or no flexDirection (default is column in
+      // react-pdf). Importantly NOT row — that would put meta to the side.
+      return s.flexDirection !== "row";
+    });
+    expect(tiles.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("handles a partial final page of 1, 2, or 3 tiles without breaking the 2x2 grid wrapper", () => {
+    for (const count of [1, 2, 3]) {
+      const slots = Array.from({ length: count }, (_, i) =>
+        makeSlot({ photoId: `p${i + 1}`, number: i + 1, caption: `c${i}` }),
+      );
+      const tree = expandTree(
+        <PhotoPage
+          slots={slots}
+          sectionTitle="Living Room"
+          customerName="Jane Doe"
+          reportDate="2026-05-19"
+          photosPerPage={4}
+        />,
+      );
+
+      const images = findAll(tree, (n) => n.type === "IMAGE");
+      expect(images.length).toBe(count);
+
+      // Grid wrapper still present even when partially filled.
+      const gridWrappers = findAll(tree, (n) => {
+        if (n.type !== "VIEW") return false;
+        const s = flattenStyle(n.props.style);
+        return s.flexDirection === "row" && s.flexWrap === "wrap";
+      });
+      expect(gridWrappers.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("renders the page header and footer at photosPerPage=4", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({ photoId: "p1", number: 1 }),
+          makeSlot({ photoId: "p2", number: 2 }),
+        ]}
+        sectionTitle="Kitchen"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={4}
+        totalPages={7}
+        photosPerPage={4}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Jane Doe");
+    expect(text).toContain("Photo Report");
+    expect(text).toContain("May 19, 2026");
+    expect(text).toContain("Kitchen");
+    expect(text).toContain("4 / 7");
+  });
+
+  it("uses objectFit 'contain' (letterbox) for landscape photos at photosPerPage=4", () => {
+    const tree = expandTree(
+      <PhotoPage
+        slots={[
+          makeSlot({
+            photoId: "wide",
+            number: 1,
+            orientation: "landscape",
+            url: "https://x/wide.jpg",
+          }),
+          makeSlot({
+            photoId: "tall",
+            number: 2,
+            orientation: "portrait",
+            url: "https://x/tall.jpg",
+          }),
+        ]}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        photosPerPage={4}
+      />,
+    );
+
+    const images = findAll(tree, (n) => n.type === "IMAGE");
+    const styleByUrl = new Map(
+      images.map((img) => [
+        img.props.src as string | undefined,
+        flattenStyle(img.props.style),
+      ]),
+    );
+    expect(styleByUrl.get("https://x/wide.jpg")?.objectFit).toBe("contain");
+    expect(styleByUrl.get("https://x/tall.jpg")?.objectFit).toBe("cover");
   });
 });

--- a/src/components/report-pdf/photo-page.tsx
+++ b/src/components/report-pdf/photo-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Image, Page, StyleSheet, Text, View } from "@react-pdf/renderer";
+import type { Style } from "@react-pdf/types";
 import { format } from "date-fns";
 
 import PageFooter from "./page-footer";
@@ -16,11 +17,20 @@ const colors = {
   white: "#FFFFFF",
 };
 
-// Slot geometry: each of the two photo rows takes roughly half of the
-// printable area between header and footer. The photo itself is a
+// 2-per-page slot geometry: each of the two photo rows takes roughly half
+// of the printable area between header and footer. The photo itself is a
 // portrait-shaped frame (~3:4) with the metadata column to the right.
-const PHOTO_HEIGHT = 295;
-const PHOTO_WIDTH = 220;
+const TWO_PHOTO_HEIGHT = 295;
+const TWO_PHOTO_WIDTH = 220;
+
+// 1-per-page slot geometry: one large portrait-shaped photo dominating the
+// page, metadata beneath.
+const ONE_PHOTO_HEIGHT = 540;
+const ONE_PHOTO_WIDTH = 405;
+
+// 4-per-page tile geometry: 2x2 grid; each tile ~half the usable width.
+const FOUR_TILE_WIDTH = 240;
+const FOUR_PHOTO_HEIGHT = 245;
 
 const styles = StyleSheet.create({
   page: {
@@ -31,14 +41,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
     color: colors.text,
   },
-  slot: {
+
+  // 2-per-page layout — photo + side metadata.
+  twoSlot: {
     flexDirection: "row",
     marginBottom: 16,
     alignItems: "stretch",
   },
-  photoFrame: {
-    width: PHOTO_WIDTH,
-    height: PHOTO_HEIGHT,
+  twoPhotoFrame: {
+    width: TWO_PHOTO_WIDTH,
+    height: TWO_PHOTO_HEIGHT,
     backgroundColor: colors.bg,
     borderWidth: 1,
     borderColor: colors.border,
@@ -46,6 +58,58 @@ const styles = StyleSheet.create({
     position: "relative",
     overflow: "hidden",
   },
+  twoMeta: {
+    flex: 1,
+    paddingLeft: 14,
+    paddingVertical: 4,
+    justifyContent: "flex-start",
+  },
+
+  // 1-per-page layout — large photo + metadata stacked beneath.
+  oneTile: {
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  onePhotoFrame: {
+    width: ONE_PHOTO_WIDTH,
+    height: ONE_PHOTO_HEIGHT,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    position: "relative",
+    overflow: "hidden",
+  },
+  oneMeta: {
+    width: ONE_PHOTO_WIDTH,
+    paddingTop: 10,
+  },
+
+  // 4-per-page layout — 2x2 grid; each tile has photo + metadata beneath.
+  fourGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+  },
+  fourTile: {
+    width: FOUR_TILE_WIDTH,
+    marginBottom: 14,
+  },
+  fourPhotoFrame: {
+    width: FOUR_TILE_WIDTH,
+    height: FOUR_PHOTO_HEIGHT,
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 4,
+    position: "relative",
+    overflow: "hidden",
+  },
+  fourMeta: {
+    paddingTop: 6,
+  },
+
+  // Shared.
   photoImage: {
     width: "100%",
     height: "100%",
@@ -62,25 +126,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 7,
     borderRadius: 10,
   },
-  meta: {
-    flex: 1,
-    paddingLeft: 14,
-    paddingVertical: 4,
-    justifyContent: "flex-start",
-  },
   caption: {
     fontSize: 11,
     fontFamily: "Helvetica-Bold",
     color: colors.text,
     marginBottom: 8,
   },
+  captionSmall: {
+    fontSize: 10,
+    fontFamily: "Helvetica-Bold",
+    color: colors.text,
+    marginBottom: 4,
+  },
   metaLine: {
     fontSize: 9,
     color: colors.muted,
     marginBottom: 3,
   },
-  metaLabel: {
-    color: colors.light,
+  metaLineSmall: {
+    fontSize: 8,
+    color: colors.muted,
+    marginBottom: 2,
   },
 });
 
@@ -101,6 +167,7 @@ interface PhotoPageProps {
   reportDate: string;
   pageNumber?: number;
   totalPages?: number;
+  photosPerPage?: 1 | 2 | 4;
 }
 
 function formatTakenAt(takenAt: string | null): string | null {
@@ -110,24 +177,81 @@ function formatTakenAt(takenAt: string | null): string | null {
   return format(d, "MMM d, yyyy, h:mm a");
 }
 
-function PhotoSlotView({ slot }: { slot: PhotoPageSlot }) {
-  const objectFit = slot.orientation === "landscape" ? "contain" : "cover";
-  const dateLine = formatTakenAt(slot.takenAt);
+function objectFitFor(orientation: PhotoPageSlot["orientation"]) {
+  return orientation === "landscape" ? "contain" : "cover";
+}
 
+function renderMetaLines(
+  slot: PhotoPageSlot,
+  captionStyle: Style,
+  lineStyle: Style,
+) {
+  const dateLine = formatTakenAt(slot.takenAt);
+  return [
+    slot.caption ? (
+      <Text key="caption" style={captionStyle}>
+        {slot.caption}
+      </Text>
+    ) : null,
+    dateLine ? (
+      <Text key="date" style={lineStyle}>
+        {dateLine}
+      </Text>
+    ) : null,
+    slot.takenBy ? (
+      <Text key="creator" style={lineStyle}>
+        {slot.takenBy}
+      </Text>
+    ) : null,
+  ];
+}
+
+function TwoPerPageSlot({ slot }: { slot: PhotoPageSlot }) {
   return (
-    <View style={styles.slot}>
-      <View style={styles.photoFrame}>
-        <Image src={slot.url} style={[styles.photoImage, { objectFit }]} />
+    <View style={styles.twoSlot}>
+      <View style={styles.twoPhotoFrame}>
+        <Image
+          src={slot.url}
+          style={[styles.photoImage, { objectFit: objectFitFor(slot.orientation) }]}
+        />
         <Text style={styles.badge}>{slot.number}</Text>
       </View>
-      <View style={styles.meta}>
-        {slot.caption ? (
-          <Text style={styles.caption}>{slot.caption}</Text>
-        ) : null}
-        {dateLine ? <Text style={styles.metaLine}>{dateLine}</Text> : null}
-        {slot.takenBy ? (
-          <Text style={styles.metaLine}>{slot.takenBy}</Text>
-        ) : null}
+      <View style={styles.twoMeta}>
+        {renderMetaLines(slot, styles.caption, styles.metaLine)}
+      </View>
+    </View>
+  );
+}
+
+function OnePerPageTile({ slot }: { slot: PhotoPageSlot }) {
+  return (
+    <View style={styles.oneTile}>
+      <View style={styles.onePhotoFrame}>
+        <Image
+          src={slot.url}
+          style={[styles.photoImage, { objectFit: objectFitFor(slot.orientation) }]}
+        />
+        <Text style={styles.badge}>{slot.number}</Text>
+      </View>
+      <View style={styles.oneMeta}>
+        {renderMetaLines(slot, styles.caption, styles.metaLine)}
+      </View>
+    </View>
+  );
+}
+
+function FourPerPageTile({ slot }: { slot: PhotoPageSlot }) {
+  return (
+    <View style={styles.fourTile}>
+      <View style={styles.fourPhotoFrame}>
+        <Image
+          src={slot.url}
+          style={[styles.photoImage, { objectFit: objectFitFor(slot.orientation) }]}
+        />
+        <Text style={styles.badge}>{slot.number}</Text>
+      </View>
+      <View style={styles.fourMeta}>
+        {renderMetaLines(slot, styles.captionSmall, styles.metaLineSmall)}
       </View>
     </View>
   );
@@ -140,13 +264,22 @@ export default function PhotoPage({
   reportDate,
   pageNumber,
   totalPages,
+  photosPerPage = 2,
 }: PhotoPageProps) {
   return (
     <Page size="LETTER" style={styles.page}>
       <PageHeader customerName={customerName} reportDate={reportDate} />
-      {slots.map((slot) => (
-        <PhotoSlotView key={slot.photoId} slot={slot} />
-      ))}
+      {photosPerPage === 1 ? (
+        slots.map((slot) => <OnePerPageTile key={slot.photoId} slot={slot} />)
+      ) : photosPerPage === 4 ? (
+        <View style={styles.fourGrid}>
+          {slots.map((slot) => (
+            <FourPerPageTile key={slot.photoId} slot={slot} />
+          ))}
+        </View>
+      ) : (
+        slots.map((slot) => <TwoPerPageSlot key={slot.photoId} slot={slot} />)
+      )}
       <PageFooter
         sectionTitle={sectionTitle}
         customerName={customerName}

--- a/src/lib/build-report-document.test.ts
+++ b/src/lib/build-report-document.test.ts
@@ -520,27 +520,121 @@ describe("buildReportDocument", () => {
     expect(pair.before.number).toBe(2);
   });
 
-  it("treats unsupported photosPerPage values (1, 4) as 2 for this slice", () => {
-    const photoIds = ["a", "b", "c"];
-    const photos: Record<string, ReportPhotoInput> = {
-      a: makePhoto({ id: "a" }),
-      b: makePhoto({ id: "b" }),
-      c: makePhoto({ id: "c" }),
-    };
+  it("at photosPerPage=1 emits one photoPage per non-paired photo with one slot each, numbered continuously", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({ title: "Living Room", photoIds: ["a", "b", "c"] }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+      },
+      photosPerPage: 1,
+    });
 
-    for (const ppp of [1, 4]) {
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+      "photoPage",
+      "photoPage",
+    ]);
+
+    const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+      DocumentPage,
+      { kind: "photoPage" }
+    >[];
+    expect(photoPages.map((p) => p.slots.length)).toEqual([1, 1, 1]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.photoId))).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.number))).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it("at photosPerPage=4 buckets four photos into one photoPage with four slots", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({
+          title: "Living Room",
+          photoIds: ["a", "b", "c", "d"],
+        }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+        d: makePhoto({ id: "d" }),
+      },
+      photosPerPage: 4,
+    });
+
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+    ]);
+
+    const photoPage = pages[2];
+    if (photoPage.kind !== "photoPage") throw new Error("expected photoPage");
+    expect(photoPage.slots.map((s) => s.photoId)).toEqual(["a", "b", "c", "d"]);
+    expect(photoPage.slots.map((s) => s.number)).toEqual([1, 2, 3, 4]);
+  });
+
+  it("tags each photoPage with the photosPerPage value the engine bucketed at", () => {
+    for (const ppp of [1, 2, 4] as const) {
       const pages = buildReportDocument({
-        sections: [makeSection({ title: "S", photoIds })],
-        photos,
+        sections: [makeSection({ title: "S", photoIds: ["a"] })],
+        photos: { a: makePhoto({ id: "a" }) },
         photosPerPage: ppp,
       });
-
-      const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+      const photoPage = pages.find((p) => p.kind === "photoPage") as Extract<
         DocumentPage,
         { kind: "photoPage" }
-      >[];
-
-      expect(photoPages.map((p) => p.slots.length)).toEqual([2, 1]);
+      >;
+      expect(photoPage.photosPerPage).toBe(ppp);
     }
+  });
+
+  it("at photosPerPage=4 with a partial final page, the trailing photos render on their own page with fewer slots", () => {
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({
+          title: "Living Room",
+          photoIds: ["a", "b", "c", "d", "e", "f"],
+        }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+        d: makePhoto({ id: "d" }),
+        e: makePhoto({ id: "e" }),
+        f: makePhoto({ id: "f" }),
+      },
+      photosPerPage: 4,
+    });
+
+    const photoPages = pages.filter((p) => p.kind === "photoPage") as Extract<
+      DocumentPage,
+      { kind: "photoPage" }
+    >[];
+
+    expect(photoPages.map((p) => p.slots.length)).toEqual([4, 2]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.photoId))).toEqual([
+      "a",
+      "b",
+      "c",
+      "d",
+      "e",
+      "f",
+    ]);
+    expect(photoPages.flatMap((p) => p.slots.map((s) => s.number))).toEqual([
+      1, 2, 3, 4, 5, 6,
+    ]);
   });
 });

--- a/src/lib/build-report-document.ts
+++ b/src/lib/build-report-document.ts
@@ -27,7 +27,12 @@ export interface PhotoSlot {
 export type DocumentPage =
   | { kind: "cover" }
   | { kind: "sectionDivider"; title: string; description: string | null }
-  | { kind: "photoPage"; sectionTitle: string; slots: PhotoSlot[] }
+  | {
+      kind: "photoPage";
+      sectionTitle: string;
+      slots: PhotoSlot[];
+      photosPerPage: 1 | 2 | 4;
+    }
   | {
       kind: "beforeAfterPair";
       sectionTitle: string;
@@ -63,7 +68,8 @@ export function buildReportDocument(
   args: BuildReportDocumentArgs,
 ): DocumentPage[] {
   const pages: DocumentPage[] = [{ kind: "cover" }];
-  const bucketSize = 2;
+  const bucketSize: 1 | 2 | 4 =
+    args.photosPerPage === 1 || args.photosPerPage === 4 ? args.photosPerPage : 2;
   let runningNumber = 1;
 
   for (const section of args.sections) {
@@ -153,6 +159,7 @@ export function buildReportDocument(
           kind: "photoPage",
           sectionTitle: section.title,
           slots: bucket.map((p) => makeSlot(p, runningNumber++)),
+          photosPerPage: bucketSize,
         });
       }
       singleBuffer = [];


### PR DESCRIPTION
## Summary

- Engine: `buildReportDocument` now buckets by `photosPerPage` (1, 2, or 4) instead of a hard-coded 2, and tags each `photoPage` with its variant so the renderer can pick the right layout even on a partial final page.
- `photo-page.tsx`: new 1-per-page (single dominating photo, metadata stacked beneath) and 4-per-page (2x2 grid of tiles, metadata beneath each tile) variants. 2-per-page layout (metadata to the side) is unchanged. Letterbox, numbered badges, header, and footer behavior preserved across all three variants.
- Orchestrator: `report-pdf-document.tsx` passes `page.photosPerPage` through to `PhotoPage`.

Closes #337.

## Test plan

- [x] `npx vitest run src/lib/build-report-document.test.ts src/components/report-pdf` — 48/48 pass
- [x] `npx tsc --noEmit` — no new errors on touched files
- [ ] Manual QA: generate a real report at `photosPerPage = 1` and confirm one photo per page with metadata beneath.
- [ ] Manual QA: generate a real report at `photosPerPage = 4` and confirm the 2x2 grid with metadata beneath each tile.
- [ ] Manual QA: at `photosPerPage = 4`, confirm a 1/2/3-photo partial final page renders without breaking layout.
- [ ] Manual QA: confirm Before/After pair pages and section divider pages still appear at `photosPerPage = 1` and `= 4`.

Two pre-existing test suites fail on baseline `main` (`twilio-client.test.ts` missing the `twilio` package locally, and `email/accounts/route.test.ts`) — unrelated to this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)