### PR TITLE
feat(camera): iPad landscape overlay layout (#345)

### DIFF
--- a/docs/vault/builds/build-65b.2.md
+++ b/docs/vault/builds/build-65b.2.md
@@ -83,6 +83,7 @@ Driven by Vanessa's request after the 65c smoke tests: "I want the UI to look mo
 
 ## Future builds filed during grill
 
+- **iPad landscape camera redesign** — **closed by [[build-65b.3]]** (2026-05-28). Replaced the original split (preview-left / controls-right) layout with an overlay layout: 4:3 preview centered horizontally, controls float on top, X cancel dropped in favour of Done as the sole exit. Zoom selector / photo library / SCAN-WALKTHROUGH-PHOTO mode wheel remain deferred per the items below.
 - **LiDAR mode** (Scan/Measure) using ARKit + RoomPlan — native Swift Capacitor plugin work. **Sizing:** 1-2 weeks for point-to-point distance measurement; 3-4 weeks for full room scanning. LiDAR-only iPhone Pro models (12 Pro+). Adds a 3rd mode to the toggle (Tag/Rapid/LiDAR) when ready.
 - **Tag-after flow redesign** — bottom-sheet vs full-screen preview, tag picker UX, caption affordance, gesture handling. Separate grilling session.
 - **Additional capture modes** (Video, Scan, Walkthrough) — only when underlying features exist. Don't ship empty buttons.

--- a/docs/vault/builds/build-65b.3.md
+++ b/docs/vault/builds/build-65b.3.md
@@ -1,0 +1,112 @@
+---
+build_id: 65b.3
+title: iPad camera landscape overlay redesign
+status: in-progress
+phase: mobile
+started: 2026-05-28
+shipped: null
+guide_doc: null
+plan_file: null
+pr: null
+handoff: null
+related: ["[[build-65b.2]]", "[[build-65c]]"]
+---
+
+#status/in-progress #area/mobile #build/65b.3
+
+## Scope
+
+Landscape-only repaint of the camera (`src/components/mobile/camera-view.tsx`). Replaces the existing "split" layout (4:3 preview on the left + flat black controls panel on the right) with an **overlay** layout: a 4:3 preview centered horizontally, sized to viewport height, with controls floating directly on the preview pixels.
+
+Portrait (iPhone + iPad portrait) is untouched — the Build 65b.2 letterboxed brand-green chrome stays. No changes to the native plugin contract, the capture/upload pipeline, or `useCameraLifecycle`.
+
+Driven by the parent PRD #344 (issue #345 ships the entire PRD as a single slice). Decisions locked in a `/grill-with-docs` session on 2026-05-28.
+
+## Decisions locked (from 2026-05-28 grill)
+
+### Layout
+
+- **Mode enum:** `compute-camera-layout` exports `"stacked" | "overlay"` (was `"stacked" | "split"`). Naming change reflects the paradigm shift — controls now float on top of the preview, not in a sibling panel.
+- **Landscape rule (single):** `width = round(viewportHeight * 4 / 3)`; `height = viewportHeight`; `x = round((viewportWidth - width) / 2)`; `y = 0`. No `controlsMinSize` consultation in the landscape branch. `controlsMinSize` becomes optional on the input type so portrait callsites stay unchanged.
+- **Defensive narrow-landscape fallback removed.** iPad Split View slots are portrait-shaped in practice and never hit the previous fallback. Square/exotic Stage Manager sizes degrade gracefully (preview clips against viewport edges).
+- **Worked examples:**
+  - 1024×768 (4:3 iPad landscape): preview is edge-to-edge, `{ x: 0, y: 0, width: 1024, height: 768 }`.
+  - 1180×820 (modern non-4:3 iPad landscape): preview centered with ~44pt black margins on either side, `{ x: 44, y: 0, width: 1093, height: 820 }`.
+  - 800×800 (square / `>=` rule): `mode === "overlay"`.
+
+### Top-right cluster (overlay only)
+
+- Absolutely positioned, anchored to `env(safe-area-inset-top)` + `env(safe-area-inset-right)`.
+- Four icons in DOM order: **mode toggle (Tag↔Rapid) → flip → flash → settings**.
+- Bare white icons (no chip backgrounds), with a 1–2px CSS `drop-shadow` filter for legibility against bright preview content.
+- **No X cancel.** Done is the sole exit affordance in landscape.
+
+### Right rail (overlay only)
+
+- Absolutely positioned at the right edge, vertically centered with a `translateY(-50%)` transform. Respects `env(safe-area-inset-right)`.
+- Top-to-bottom: **Done pill → capture count → shutter → queue button**.
+- Capture count hidden when `count === 0`; rendered as bold white tabular-nums with a text-shadow when `count > 0`.
+- Done pill: brand-green gradient (current `doneButton` styling preserved verbatim).
+- Shutter: solid white, brand-green inner ring, ~80pt (current `shutterButton` styling preserved verbatim).
+- Queue button: brand-green gradient circle with the existing status-dot rules (red pulsing on failure, amber on uploading/pending, none on idle).
+
+### Sheets (overlay only)
+
+- Settings sheet and tag-after sheet keep their right-edge slide-in pattern, with **~40% viewport width** (`w-[40vw]`) instead of the previous `w-80 max-w-[60%]`.
+- `data-mode="overlay"` on the sheet root for testability.
+- Opaque dark backdrop sits behind the sheet column only (the sheet itself is the column); preview remains visible on the left ~60%.
+
+### Leave-confirm
+
+- Mounted only when `layout.mode === "stacked"`. In overlay mode there is no X cancel, so the leave-confirm cannot be opened. Captures persist on write, so the warning is redundant in landscape.
+
+### Visual treatment (first cut)
+
+- Top-cluster icon shadow filter: `drop-shadow(0 1px 2px rgb(0 0 0 / 0.6)) drop-shadow(0 0 1px rgb(0 0 0 / 0.4))`.
+- Capture-count text shadow: `0 1px 2px rgb(0 0 0 / 0.7)`.
+- **No right-edge scrim.** If real-device verification on the Mac/Xcode loop shows icon-legibility problems against bright preview content, file a follow-up issue for a soft right-edge scrim — do not bake it into this slice.
+
+## Implementation notes
+
+- `src/lib/mobile/compute-camera-layout.ts`: enum renamed; landscape branch collapsed to a four-line rule; `controlsMinSize` made optional with default `0`.
+- `src/components/mobile/camera-view.tsx`: split `topRow` into `stackedTopRow` (still includes X cancel) and `overlayTopCluster` (four floating icons). Overlay branch uses absolute positioning rather than the previous `flex flex-row` sibling-panel layout. Leave-confirm rendered only when `stacked`.
+- `useCameraLifecycle`: untouched. The rect it receives in landscape is now `viewportHeight * 4/3 × viewportHeight` centered, but the hook is rect-agnostic.
+- `Info.plist`: untouched.
+
+## Tests
+
+- `src/lib/mobile/compute-camera-layout.test.ts`: rewritten landscape cases (1024×768 edge-to-edge, 1180×820 centered with margins, 800×800 square → overlay). Previous "landscape narrow → stacked" assertion removed. Portrait cases unchanged.
+- `src/components/mobile/camera-view.test.tsx`: new overlay-branch group covers top-cluster DOM order, right-rail DOM order with/without count, sheet `data-mode="overlay"` + right-edge geometry, leave-confirm absent in overlay. Stacked-mode visual regression tests retained verbatim.
+
+## Real-device verification
+
+Pending on the Mac/Xcode loop against a physical iPad:
+
+- [ ] Preview fills as expected on whichever iPad model is available.
+- [ ] Right-rail icons remain legible against varied scene brightness.
+- [ ] Home indicator does not collide with the right-rail bottom edge.
+- [ ] Rotating portrait↔landscape mid-session preserves the session count and does not freeze the preview.
+- [ ] If icon-legibility fails, file a follow-up issue for a soft right-edge scrim (do not add one in this slice).
+
+## Out of scope
+
+Deferred from 65b.2 and still deferred here:
+
+- Zoom selector (.5x / 1x / 3x) — requires patching `@capacitor-community/camera-preview`; breaks the Vercel-preview iteration mode.
+- Photo library button — Nookleus has no in-app photo roll.
+- SCAN / WALKTHROUGH / PHOTO mode wheel — none of those modes exist; do not ship empty buttons.
+- Tag-after flow redesign (caption affordance, tag picker layout, gesture handling) — separate future build.
+- Haptics on capture / upload failure.
+- iPhone landscape — `Info.plist` keeps iPhone portrait-locked.
+
+Not warranted by this build:
+
+- `CONTEXT.md` updates — "overlay" / "stacked" / "right rail" are implementation shorthand, not durable domain terms.
+- ADR — design is scoped and reversible (CSS + layout math); rationale lives in this card.
+
+## Source
+
+- PRD: GitHub issue [#344](https://github.com/ericdaniels22/Nookleus/issues/344)
+- Implementation issue: GitHub issue [#345](https://github.com/ericdaniels22/Nookleus/issues/345)
+- Predecessor: [[build-65b.2]] — letterboxed brand-green portrait chrome (the sibling design this overlay slots next to)
+- Grilling session: 2026-05-28 `/grill-with-docs` (decisions captured in #344)

--- a/src/components/mobile/camera-view.test.tsx
+++ b/src/components/mobile/camera-view.test.tsx
@@ -41,8 +41,18 @@ vi.mock("@/lib/mobile/use-viewport-orientation", () => ({
 
 import CameraView from "./camera-view";
 
-const ALL_CONTROL_LABELS = [
+const STACKED_LABELS = [
   /Cancel capture/i,
+  /Flip camera/i,
+  /Flash/i,
+  /Mode:/i,
+  /Camera settings/i,
+  /Open upload queue/i,
+  /Capture photo/i,
+  /Finish capture session/i,
+];
+
+const OVERLAY_LABELS = [
   /Flip camera/i,
   /Flash/i,
   /Mode:/i,
@@ -57,7 +67,7 @@ describe("CameraView adaptive layout", () => {
     viewportMock.mockReset();
   });
 
-  it("renders every control in stacked (portrait) mode", () => {
+  it("renders every control including X cancel in stacked (portrait) mode", () => {
     viewportMock.mockReturnValue({
       width: 390,
       height: 844,
@@ -73,7 +83,7 @@ describe("CameraView adaptive layout", () => {
       />,
     );
 
-    for (const label of ALL_CONTROL_LABELS) {
+    for (const label of STACKED_LABELS) {
       expect(screen.getByLabelText(label)).toBeDefined();
     }
 
@@ -82,7 +92,7 @@ describe("CameraView adaptive layout", () => {
     );
   });
 
-  it("renders every control in split (landscape) mode", () => {
+  it("renders overlay controls but no X cancel in landscape mode", () => {
     viewportMock.mockReturnValue({
       width: 1024,
       height: 768,
@@ -98,177 +108,235 @@ describe("CameraView adaptive layout", () => {
       />,
     );
 
-    for (const label of ALL_CONTROL_LABELS) {
+    for (const label of OVERLAY_LABELS) {
       expect(screen.getByLabelText(label)).toBeDefined();
     }
-
-    expect(screen.getByTestId("camera-layout-mode").textContent).toBe("split");
-    // In split mode the shutter lives on the right side, inside the controls
-    // panel — assert by data attribute.
-    const shutter = screen.getByLabelText(/Capture photo/i);
-    const panel = screen.getByTestId("camera-controls-panel");
-    expect(panel.contains(shutter)).toBe(true);
+    expect(screen.queryByLabelText(/Cancel capture/i)).toBeNull();
+    expect(screen.getByTestId("camera-layout-mode").textContent).toBe(
+      "overlay",
+    );
   });
 });
 
-describe("CameraView in-camera surfaces (issue #272)", () => {
+describe("CameraView overlay branch (iPad landscape)", () => {
   beforeEach(() => {
     viewportMock.mockReset();
-  });
-
-  describe("split mode (iPad landscape)", () => {
-    beforeEach(() => {
-      viewportMock.mockReturnValue({
-        width: 1024,
-        height: 768,
-        orientation: "landscape",
-      });
-    });
-
-    it("settings sheet anchors to the right and is dismissible", () => {
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={() => undefined}
-        />,
-      );
-
-      fireEvent.click(screen.getByLabelText(/Camera settings/i));
-
-      const sheet = screen.getByTestId("settings-sheet");
-      expect(sheet.getAttribute("data-mode")).toBe("split");
-      expect(sheet.className).toMatch(/right-0/);
-      expect(sheet.className).not.toMatch(/bottom-0/);
-
-      fireEvent.click(within(sheet).getByText(/Close/i));
-      expect(screen.queryByTestId("settings-sheet")).toBeNull();
-    });
-
-    it("tag-after sheet anchors to the right and is dismissible", async () => {
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={() => undefined}
-        />,
-      );
-
-      fireEvent.click(screen.getByLabelText(/Capture photo/i));
-
-      const sheet = await screen.findByTestId("tag-sheet");
-      expect(sheet.getAttribute("data-mode")).toBe("split");
-      expect(sheet.className).toMatch(/right-0/);
-      expect(sheet.className).not.toMatch(/bottom-0/);
-
-      fireEvent.click(within(sheet).getByText(/Continue/i));
-      await waitFor(() => {
-        expect(screen.queryByTestId("tag-sheet")).toBeNull();
-      });
-    });
-
-    it("leave-confirm dialog anchors to the right and Stay dismisses it", async () => {
-      const onAbort = vi.fn();
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={onAbort}
-        />,
-      );
-
-      // Capture one photo so the leave guard triggers.
-      fireEvent.click(screen.getByLabelText(/Capture photo/i));
-      const tagSheet = await screen.findByTestId("tag-sheet");
-      fireEvent.click(within(tagSheet).getByText(/Continue/i));
-      await waitFor(() => {
-        expect(screen.queryByTestId("tag-sheet")).toBeNull();
-      });
-
-      fireEvent.click(screen.getByLabelText(/Cancel capture/i));
-
-      const dialog = screen.getByTestId("leave-confirm");
-      expect(dialog.getAttribute("data-mode")).toBe("split");
-      expect(dialog.className).toMatch(/right-0/);
-      expect(dialog.className).not.toMatch(/inset-0/);
-
-      fireEvent.click(within(dialog).getByText(/^Stay$/));
-      expect(screen.queryByTestId("leave-confirm")).toBeNull();
-      expect(onAbort).not.toHaveBeenCalled();
+    viewportMock.mockReturnValue({
+      width: 1024,
+      height: 768,
+      orientation: "landscape",
     });
   });
 
-  describe("stacked mode (iPhone + iPad portrait) — visual regression", () => {
-    beforeEach(() => {
-      viewportMock.mockReturnValue({
-        width: 390,
-        height: 844,
-        orientation: "portrait",
-      });
+  it("top-right cluster holds exactly mode-toggle, flip, flash, settings in DOM order", () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    const cluster = screen.getByTestId("camera-top-cluster");
+    const buttons = within(cluster).getAllByRole("button");
+    expect(buttons).toHaveLength(4);
+    expect(buttons[0].getAttribute("aria-label")).toMatch(/^Mode:/);
+    expect(buttons[1].getAttribute("aria-label")).toBe("Flip camera");
+    expect(buttons[2].getAttribute("aria-label")).toMatch(/^Flash /);
+    expect(buttons[3].getAttribute("aria-label")).toBe("Camera settings");
+  });
+
+  it("right rail renders Done → shutter → queue when count = 0 (no count node)", () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    const rail = screen.getByTestId("camera-right-rail");
+    expect(within(rail).queryByTestId("camera-capture-count")).toBeNull();
+
+    const children = Array.from(rail.children);
+    const labels = children.map(
+      (el) => el.getAttribute("aria-label") ?? el.getAttribute("data-testid"),
+    );
+    expect(labels).toEqual([
+      "Finish capture session",
+      "Capture photo",
+      "Open upload queue",
+    ]);
+  });
+
+  it("right rail renders Done → count → shutter → queue when count > 0", async () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Capture photo/i));
+    const tagSheet = await screen.findByTestId("tag-sheet");
+    fireEvent.click(within(tagSheet).getByText(/Continue/i));
+    await waitFor(() => {
+      expect(screen.queryByTestId("tag-sheet")).toBeNull();
     });
 
-    it("settings sheet slides up from the bottom", () => {
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={() => undefined}
-        />,
-      );
+    const rail = screen.getByTestId("camera-right-rail");
+    const count = within(rail).getByTestId("camera-capture-count");
+    expect(count.textContent).toBe("1");
 
-      fireEvent.click(screen.getByLabelText(/Camera settings/i));
+    const children = Array.from(rail.children);
+    const labels = children.map(
+      (el) => el.getAttribute("aria-label") ?? el.getAttribute("data-testid"),
+    );
+    expect(labels).toEqual([
+      "Finish capture session",
+      "camera-capture-count",
+      "Capture photo",
+      "Open upload queue",
+    ]);
+  });
 
-      const sheet = screen.getByTestId("settings-sheet");
-      expect(sheet.getAttribute("data-mode")).toBe("stacked");
-      expect(sheet.className).toMatch(/bottom-0/);
-      expect(sheet.className).not.toMatch(/right-0/);
+  it("settings sheet renders with data-mode=overlay and right-edge ~40vw geometry", () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Camera settings/i));
+
+    const sheet = screen.getByTestId("settings-sheet");
+    expect(sheet.getAttribute("data-mode")).toBe("overlay");
+    expect(sheet.className).toMatch(/right-0/);
+    expect(sheet.className).toMatch(/w-\[40vw\]/);
+    expect(sheet.className).not.toMatch(/bottom-0/);
+    expect(sheet.className).not.toMatch(/inset-0/);
+  });
+
+  it("tag-after sheet renders with data-mode=overlay and right-edge ~40vw geometry", async () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Capture photo/i));
+
+    const sheet = await screen.findByTestId("tag-sheet");
+    expect(sheet.getAttribute("data-mode")).toBe("overlay");
+    expect(sheet.className).toMatch(/right-0/);
+    expect(sheet.className).toMatch(/w-\[40vw\]/);
+    expect(sheet.className).not.toMatch(/bottom-0/);
+    expect(sheet.className).not.toMatch(/inset-0/);
+  });
+
+  it("leave-confirm modal cannot be opened in overlay mode (no X cancel exists)", async () => {
+    const onAbort = vi.fn();
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={onAbort}
+      />,
+    );
+
+    // Capture one photo to seed the leave guard.
+    fireEvent.click(screen.getByLabelText(/Capture photo/i));
+    const tagSheet = await screen.findByTestId("tag-sheet");
+    fireEvent.click(within(tagSheet).getByText(/Continue/i));
+    await waitFor(() => {
+      expect(screen.queryByTestId("tag-sheet")).toBeNull();
     });
 
-    it("tag-after sheet slides up from the bottom", async () => {
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={() => undefined}
-        />,
-      );
+    // No X cancel button exists in overlay mode, so leave-confirm cannot open.
+    expect(screen.queryByLabelText(/Cancel capture/i)).toBeNull();
+    expect(screen.queryByTestId("leave-confirm")).toBeNull();
+  });
+});
 
-      fireEvent.click(screen.getByLabelText(/Capture photo/i));
+describe("CameraView stacked mode (iPhone + iPad portrait) — visual regression", () => {
+  beforeEach(() => {
+    viewportMock.mockReset();
+    viewportMock.mockReturnValue({
+      width: 390,
+      height: 844,
+      orientation: "portrait",
+    });
+  });
 
-      const sheet = await screen.findByTestId("tag-sheet");
-      expect(sheet.getAttribute("data-mode")).toBe("stacked");
-      expect(sheet.className).toMatch(/bottom-0/);
-      expect(sheet.className).not.toMatch(/right-0/);
+  it("settings sheet slides up from the bottom", () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Camera settings/i));
+
+    const sheet = screen.getByTestId("settings-sheet");
+    expect(sheet.getAttribute("data-mode")).toBe("stacked");
+    expect(sheet.className).toMatch(/bottom-0/);
+    expect(sheet.className).not.toMatch(/right-0/);
+  });
+
+  it("tag-after sheet slides up from the bottom", async () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Capture photo/i));
+
+    const sheet = await screen.findByTestId("tag-sheet");
+    expect(sheet.getAttribute("data-mode")).toBe("stacked");
+    expect(sheet.className).toMatch(/bottom-0/);
+    expect(sheet.className).not.toMatch(/right-0/);
+  });
+
+  it("leave-confirm dialog covers the full screen", async () => {
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText(/Capture photo/i));
+    const tagSheet = await screen.findByTestId("tag-sheet");
+    fireEvent.click(within(tagSheet).getByText(/Continue/i));
+    await waitFor(() => {
+      expect(screen.queryByTestId("tag-sheet")).toBeNull();
     });
 
-    it("leave-confirm dialog covers the full screen", async () => {
-      render(
-        <CameraView
-          jobId="job-1"
-          sessionId="sess-1"
-          onDone={() => undefined}
-          onAbort={() => undefined}
-        />,
-      );
+    fireEvent.click(screen.getByLabelText(/Cancel capture/i));
 
-      fireEvent.click(screen.getByLabelText(/Capture photo/i));
-      const tagSheet = await screen.findByTestId("tag-sheet");
-      fireEvent.click(within(tagSheet).getByText(/Continue/i));
-      await waitFor(() => {
-        expect(screen.queryByTestId("tag-sheet")).toBeNull();
-      });
-
-      fireEvent.click(screen.getByLabelText(/Cancel capture/i));
-
-      const dialog = screen.getByTestId("leave-confirm");
-      expect(dialog.getAttribute("data-mode")).toBe("stacked");
-      expect(dialog.className).toMatch(/inset-0/);
-      expect(dialog.className).not.toMatch(/right-0/);
-    });
+    const dialog = screen.getByTestId("leave-confirm");
+    expect(dialog.getAttribute("data-mode")).toBe("stacked");
+    expect(dialog.className).toMatch(/inset-0/);
+    expect(dialog.className).not.toMatch(/right-0/);
   });
 });

--- a/src/components/mobile/camera-view.tsx
+++ b/src/components/mobile/camera-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   Camera,
   Flashlight,
@@ -45,12 +45,16 @@ const FLASH_NEXT: Record<FlashMode, FlashMode> = {
   torch: "off",
 };
 
-// Minimum space reserved for the controls cluster. In stacked layout this is
-// the bottom strip's min height; in split layout it's the right panel's min
-// width. Sized to comfortably fit Queue, Shutter, and Done with breathing
-// room on either side; iPad at 768pt portrait scales the 3:4 preview down so
-// this fits.
+// Minimum space reserved for the controls strip in stacked (portrait) layout.
+// Sized to comfortably fit Queue, Shutter, and Done with breathing room; iPad
+// at 768pt portrait scales the 3:4 preview down so this fits. Not consulted in
+// overlay (landscape) mode — controls float on top of the preview there.
 const CONTROLS_MIN_SIZE = 200;
+
+// Drop-shadow filter applied to bare white icons floating over the preview
+// in overlay mode, so they remain legible against bright scene content.
+const OVERLAY_ICON_SHADOW =
+  "drop-shadow(0 1px 2px rgb(0 0 0 / 0.6)) drop-shadow(0 0 1px rgb(0 0 0 / 0.4))";
 
 function generateUuid(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -249,7 +253,11 @@ export default function CameraView({
     );
   }
 
-  const topRow = (
+  const stacked = layout.mode === "stacked";
+
+  // Stacked-only top strip: X cancel + four icons. In overlay mode the X
+  // disappears and the four icons move into the floating top-right cluster.
+  const stackedTopRow = (
     <div className="flex items-center justify-between">
       <button
         type="button"
@@ -296,6 +304,59 @@ export default function CameraView({
         aria-label="Camera settings"
       >
         <Settings className="h-5 w-5" />
+      </button>
+    </div>
+  );
+
+  // Overlay top-right cluster: mode → flip → flash → settings. Bare white
+  // icons with a drop-shadow for legibility; no chip backgrounds.
+  const overlayTopCluster = (
+    <div
+      data-testid="camera-top-cluster"
+      className="pointer-events-auto absolute z-[1015] flex items-center gap-3"
+      style={{
+        top: "calc(env(safe-area-inset-top, 0px) + 12px)",
+        right: "calc(env(safe-area-inset-right, 0px) + 16px)",
+        filter: OVERLAY_ICON_SHADOW,
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setMode(mode === "tag-after" ? "rapid" : "tag-after")}
+        className="rounded-full p-2 text-white active:bg-white/10"
+        aria-label={`Mode: ${mode === "tag-after" ? "Tag after" : "Rapid"} — tap to switch`}
+      >
+        {mode === "tag-after" ? (
+          <Tag className="h-6 w-6" />
+        ) : (
+          <Gauge className="h-6 w-6" />
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={handleFlip}
+        className="rounded-full p-2 text-white active:bg-white/10"
+        aria-label="Flip camera"
+      >
+        <RotateCw className="h-6 w-6" />
+      </button>
+      <button
+        type="button"
+        onClick={cycleFlash}
+        className="rounded-full p-2 text-white active:bg-white/10"
+        aria-label={`Flash ${flash}`}
+      >
+        {flash === "off" && <ZapOff className="h-6 w-6" />}
+        {flash === "on" && <Zap className="h-6 w-6 text-yellow-300" />}
+        {flash === "torch" && <Flashlight className="h-6 w-6 text-yellow-300" />}
+      </button>
+      <button
+        type="button"
+        onClick={() => setSettingsOpen(true)}
+        className="rounded-full p-2 text-white active:bg-white/10"
+        aria-label="Camera settings"
+      >
+        <Settings className="h-6 w-6" />
       </button>
     </div>
   );
@@ -348,14 +409,12 @@ export default function CameraView({
     </button>
   );
 
-  const stacked = layout.mode === "stacked";
-
   return (
     <div
       id="camera-preview-mount"
       className={cn(
         "fixed inset-0 z-[1000] text-white",
-        stacked ? "flex flex-col" : "flex flex-row",
+        stacked ? "flex flex-col" : "block",
       )}
       data-testid="camera-root"
     >
@@ -394,7 +453,7 @@ export default function CameraView({
             className="flex flex-1 flex-col justify-between bg-black px-6 pb-[max(env(safe-area-inset-bottom),24px)] pt-3"
             data-testid="camera-controls-panel"
           >
-            {topRow}
+            {stackedTopRow}
 
             <div>
               {count > 0 && (
@@ -412,10 +471,12 @@ export default function CameraView({
         </>
       ) : (
         <>
-          {/* Split: preview on the left, controls panel on the right. */}
+          {/* Overlay: 4:3 preview centered horizontally; chrome floats on top. */}
           <div
-            className="relative shrink-0 self-center"
+            className="absolute bg-black"
             style={{
+              left: layout.previewRect.x,
+              top: layout.previewRect.y,
               width: layout.previewRect.width,
               height: layout.previewRect.height,
             }}
@@ -423,36 +484,38 @@ export default function CameraView({
             <div className="absolute inset-0" id="camera-preview-window" />
           </div>
 
-          <div
-            className="flex flex-1 flex-col justify-between bg-black px-4 pb-[max(env(safe-area-inset-bottom),20px)] pr-[max(env(safe-area-inset-right),16px)] pt-3"
-            data-testid="camera-controls-panel"
-          >
-            {topRow}
+          {overlayTopCluster}
 
-            <div className="flex flex-col items-center gap-4">
-              {count > 0 && (
-                <div className="text-lg font-semibold text-white tabular-nums">
-                  {count}
-                </div>
-              )}
-              {queueButton}
-              {shutterButton}
-              {doneButton}
-            </div>
+          <div
+            data-testid="camera-right-rail"
+            className="pointer-events-auto absolute z-[1015] flex flex-col items-center gap-4"
+            style={{
+              top: "50%",
+              right: "calc(env(safe-area-inset-right, 0px) + 16px)",
+              transform: "translateY(-50%)",
+            }}
+          >
+            {doneButton}
+            {count > 0 && (
+              <div
+                data-testid="camera-capture-count"
+                className="text-2xl font-bold text-white tabular-nums"
+                style={{ textShadow: "0 1px 2px rgb(0 0 0 / 0.7)" }}
+              >
+                {count}
+              </div>
+            )}
+            {shutterButton}
+            {queueButton}
           </div>
         </>
       )}
 
-      {showLeaveConfirm && (
+      {showLeaveConfirm && stacked && (
         <div
           data-testid="leave-confirm"
           data-mode={layout.mode}
-          className={cn(
-            "absolute z-[1030] flex items-center justify-center bg-black/70",
-            stacked
-              ? "inset-0 px-6"
-              : "inset-y-0 right-0 w-80 max-w-[60%] px-4",
-          )}
+          className="absolute inset-0 z-[1030] flex items-center justify-center bg-black/70 px-6"
         >
           <div className="w-full max-w-sm rounded-2xl bg-black p-6 text-white">
             <h3 className="mb-3 text-lg font-semibold">Leave camera?</h3>
@@ -487,7 +550,7 @@ export default function CameraView({
             "absolute z-[1020] bg-black/95 px-5 backdrop-blur",
             stacked
               ? "inset-x-0 bottom-0 rounded-t-2xl pb-[max(env(safe-area-inset-bottom),20px)] pt-5"
-              : "inset-y-0 right-0 w-80 max-w-[60%] rounded-l-2xl py-5 pb-[max(env(safe-area-inset-bottom),20px)]",
+              : "inset-y-0 right-0 w-[40vw] rounded-l-2xl py-5 pb-[max(env(safe-area-inset-bottom),20px)]",
           )}
         >
           <h3 className="mb-3 text-base font-semibold">Camera settings</h3>
@@ -514,7 +577,7 @@ export default function CameraView({
             "absolute z-[1010] bg-black/95 px-5 backdrop-blur",
             stacked
               ? "inset-x-0 bottom-0 rounded-t-2xl pb-[max(env(safe-area-inset-bottom),20px)] pt-5"
-              : "inset-y-0 right-0 w-96 max-w-[60%] rounded-l-2xl py-5 pb-[max(env(safe-area-inset-bottom),20px)]",
+              : "inset-y-0 right-0 w-[40vw] rounded-l-2xl py-5 pb-[max(env(safe-area-inset-bottom),20px)]",
           )}
         >
           <h3 className="mb-3 text-sm font-medium">Tag this photo</h3>

--- a/src/lib/mobile/compute-camera-layout.test.ts
+++ b/src/lib/mobile/compute-camera-layout.test.ts
@@ -29,22 +29,6 @@ describe("computeCameraLayout", () => {
     expect(layout.previewRect.x).toBe(Math.round((768 - 543) / 2));
   });
 
-  it("iPad landscape uses split layout with 4:3 preview on the left", () => {
-    // 1024x768, 300pt controls reserved on the right.
-    // Preview width = 1024-300 = 724. Height = 724 * 3/4 = 543. Centered vertically.
-    const layout = computeCameraLayout({
-      viewportWidth: 1024,
-      viewportHeight: 768,
-      controlsMinSize: 300,
-    });
-
-    expect(layout.mode).toBe("split");
-    expect(layout.previewRect.x).toBe(0);
-    expect(layout.previewRect.width).toBe(724);
-    expect(layout.previewRect.height).toBe(543);
-    expect(layout.previewRect.y).toBe(Math.round((768 - 543) / 2));
-  });
-
   it("iPad portrait at 820x1180 also scales to fit controls", () => {
     const layout = computeCameraLayout({
       viewportWidth: 820,
@@ -57,20 +41,8 @@ describe("computeCameraLayout", () => {
     expect(layout.previewRect.width).toBe(660);
   });
 
-  it("iPad landscape at 1180x820 keeps split layout with shutter region", () => {
-    const layout = computeCameraLayout({
-      viewportWidth: 1180,
-      viewportHeight: 820,
-      controlsMinSize: 300,
-    });
-
-    expect(layout.mode).toBe("split");
-    expect(layout.previewRect.width).toBe(880);
-    expect(layout.previewRect.height).toBe(660);
-  });
-
-  it("split-screen narrow portrait window falls back to stacked", () => {
-    // Half-screen iPad multitasking: ~507x1180 or so. Tall + narrow => stacked.
+  it("split-screen narrow portrait window stays stacked", () => {
+    // Half-screen iPad multitasking: ~500x1180 or so. Tall + narrow => stacked.
     const layout = computeCameraLayout({
       viewportWidth: 500,
       viewportHeight: 1180,
@@ -80,27 +52,47 @@ describe("computeCameraLayout", () => {
     expect(layout.mode).toBe("stacked");
   });
 
-  it("square viewport (width === height) chooses split per >= rule", () => {
+  it("iPad landscape at 1024x768 (4:3) uses overlay with edge-to-edge preview", () => {
+    // width = round(768 * 4/3) = 1024. x = round((1024 - 1024)/2) = 0.
+    const layout = computeCameraLayout({
+      viewportWidth: 1024,
+      viewportHeight: 768,
+      controlsMinSize: 300,
+    });
+
+    expect(layout.mode).toBe("overlay");
+    expect(layout.previewRect).toEqual({
+      x: 0,
+      y: 0,
+      width: 1024,
+      height: 768,
+    });
+  });
+
+  it("iPad landscape at 1180x820 (non-4:3) centers the overlay preview horizontally", () => {
+    // width = round(820 * 4/3) = 1093. x = round((1180 - 1093)/2) = 44.
+    const layout = computeCameraLayout({
+      viewportWidth: 1180,
+      viewportHeight: 820,
+      controlsMinSize: 300,
+    });
+
+    expect(layout.mode).toBe("overlay");
+    expect(layout.previewRect).toEqual({
+      x: 44,
+      y: 0,
+      width: 1093,
+      height: 820,
+    });
+  });
+
+  it("square viewport (width === height) chooses overlay per >= rule", () => {
     const layout = computeCameraLayout({
       viewportWidth: 800,
       viewportHeight: 800,
       controlsMinSize: 300,
     });
 
-    expect(layout.mode).toBe("split");
-  });
-
-  it("landscape with residual width less than controlsMinSize falls back to stacked", () => {
-    // Pathological landscape where the controls cluster cannot fit:
-    // viewportWidth (250) is less than controlsMinSize (300), so we
-    // cannot carve out the controls strip without producing a degenerate
-    // preview. Per spec: fall back to stacked.
-    const layout = computeCameraLayout({
-      viewportWidth: 250,
-      viewportHeight: 200,
-      controlsMinSize: 300,
-    });
-
-    expect(layout.mode).toBe("stacked");
+    expect(layout.mode).toBe("overlay");
   });
 });

--- a/src/lib/mobile/compute-camera-layout.ts
+++ b/src/lib/mobile/compute-camera-layout.ts
@@ -1,4 +1,4 @@
-export type CameraLayoutMode = "stacked" | "split";
+export type CameraLayoutMode = "stacked" | "overlay";
 
 export interface PreviewRect {
   x: number;
@@ -15,38 +15,23 @@ export interface CameraLayout {
 export interface ComputeCameraLayoutInput {
   viewportWidth: number;
   viewportHeight: number;
-  controlsMinSize: number;
+  controlsMinSize?: number;
 }
 
 export function computeCameraLayout(
   input: ComputeCameraLayoutInput,
 ): CameraLayout {
-  const { viewportWidth, viewportHeight, controlsMinSize } = input;
+  const { viewportWidth, viewportHeight, controlsMinSize = 0 } = input;
 
   if (viewportWidth >= viewportHeight) {
-    // Split: 4:3 landscape preview on the left, controls panel on the right.
-    const naturalWidth = (viewportHeight * 4) / 3;
-    const maxWidth = viewportWidth - controlsMinSize;
-
-    if (maxWidth > 0) {
-      if (naturalWidth <= maxWidth) {
-        const width = Math.round(naturalWidth);
-        return {
-          mode: "split",
-          previewRect: { x: 0, y: 0, width, height: viewportHeight },
-        };
-      }
-
-      const width = Math.round(maxWidth);
-      const height = Math.round((width * 3) / 4);
-      const y = Math.round((viewportHeight - height) / 2);
-      return {
-        mode: "split",
-        previewRect: { x: 0, y, width, height },
-      };
-    }
-    // Fall through to stacked when the controls cluster cannot fit
-    // alongside the preview — pathological narrow landscape windows.
+    // Overlay: 4:3 preview centered horizontally, full viewport height.
+    // Controls float over the preview pixels; controlsMinSize is not consulted.
+    const width = Math.round((viewportHeight * 4) / 3);
+    const x = Math.round((viewportWidth - width) / 2);
+    return {
+      mode: "overlay",
+      previewRect: { x, y: 0, width, height: viewportHeight },
+    };
   }
 
   // Stacked: 3:4 portrait preview, controls strip below.


### PR DESCRIPTION
## Summary

Closes #345. Ships the entire PRD in #344.

Replaces the iPad-landscape camera "split" UI (preview-left / controls-right) with an **overlay** layout: 4:3 preview centered horizontally at viewport height, chrome floating on top of the preview pixels.

- `compute-camera-layout` enum changes `"split"` → `"overlay"`. Landscape branch collapses to a single rule: `width = round(H * 4/3)`, centered horizontally, full viewport height. `controlsMinSize` is no longer consulted in landscape (kept as optional input so portrait callsites are unchanged). Defensive "narrow landscape → stacked" fallback removed — iPad Split View slots are portrait-shaped in practice.
- `camera-view.tsx` overlay branch: no X cancel; top-right cluster of four bare-white icons (mode → flip → flash → settings) with a CSS drop-shadow filter; right rail (Done → capture-count? → shutter → queue) vertically centered, respecting `env(safe-area-inset-right)`; settings + tag-after sheets render with `data-mode=\"overlay\"` and `w-[40vw]` right-edge geometry; leave-confirm modal mounted only when stacked.
- Portrait (iPhone + iPad portrait) unchanged — 65b.2 letterboxed brand-green chrome stays exactly as-is.
- No changes to `useCameraLifecycle`, `Info.plist`, or the capture-storage / upload-queue pipeline.

## Test plan

Automated (already passing locally):

- [x] `npx vitest run src/lib/mobile/compute-camera-layout.test.ts` — 7/7 pass (iPhone portrait, iPad portrait 768×1024 + 820×1180, narrow split-view portrait, iPad landscape 1024×768 edge-to-edge, 1180×820 centered with margins, 800×800 square → overlay)
- [x] `npx vitest run src/components/mobile/camera-view.test.tsx` — 11/11 pass (overlay branch: top-cluster DOM order, right-rail order with/without count, sheet `data-mode=overlay` + right-edge geometry, leave-confirm absent in overlay; stacked-mode visual regression preserved)
- [x] `npx vitest run src/lib/mobile/ src/components/mobile/` — 70/70 mobile suite pass
- [x] `npx tsc --noEmit` clean on touched files

Manual verify (pending on Mac/Xcode → physical iPad — blocks merge):

- [ ] Preview fills as expected on whichever iPad model is available
- [ ] Right-rail icons remain legible against varied scene brightness
- [ ] Home indicator does not collide with the right-rail bottom edge
- [ ] Rotating portrait↔landscape mid-session preserves the session count and does not freeze the preview
- [ ] If icon-legibility fails, file a follow-up issue for a soft right-edge scrim (do not add one in this slice)

## Docs

- Build card: `docs/vault/builds/build-65b.3.md` (follows the 65b.2 template)
- Cross-link from 65b.2 "Future builds filed during grill" → 65b.3 as the closer of the iPad landscape gap (zoom / library / SCAN-WALKTHROUGH-PHOTO mode wheel remain deferred per 65b.2 originally filed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)