### PR TITLE
fix(camera): drop opaque bg from overlay preview rect (#345)

### DIFF
--- a/src/components/mobile/camera-view.test.tsx
+++ b/src/components/mobile/camera-view.test.tsx
@@ -128,6 +128,24 @@ describe("CameraView overlay branch (iPad landscape)", () => {
     });
   });
 
+  it("preview rect is transparent so the native camera feed shows through the WebView", () => {
+    // Regression guard: the @capacitor-community/camera-preview plugin paints
+    // the camera feed *behind* the WebView at the preview rect. If the
+    // wrapping div has an opaque background, the camera is hidden by a black
+    // square at exactly the rect coordinates.
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    const rect = screen.getByTestId("camera-preview-rect");
+    expect(rect.className).not.toMatch(/\bbg-/);
+  });
+
   it("top-right cluster holds exactly mode-toggle, flip, flash, settings in DOM order", () => {
     render(
       <CameraView

--- a/src/components/mobile/camera-view.tsx
+++ b/src/components/mobile/camera-view.tsx
@@ -414,7 +414,10 @@ export default function CameraView({
       id="camera-preview-mount"
       className={cn(
         "fixed inset-0 z-[1000] text-white",
-        stacked ? "flex flex-col" : "block",
+        // Overlay needs bg-black on the outer container so non-4:3 iPads get
+        // black side margins around the centered 4:3 preview rect. Stacked
+        // keeps the original behaviour (controls panel supplies the black).
+        stacked ? "flex flex-col" : "block bg-black",
       )}
       data-testid="camera-root"
     >
@@ -471,9 +474,15 @@ export default function CameraView({
         </>
       ) : (
         <>
-          {/* Overlay: 4:3 preview centered horizontally; chrome floats on top. */}
+          {/* Overlay: 4:3 preview centered horizontally; chrome floats on top.
+              No background on this wrapper — @capacitor-community/camera-preview
+              renders the native camera feed *behind* the WebView at exactly
+              these rect coordinates, so any opaque background here paints a
+              black square over the camera. The outer #camera-preview-mount
+              supplies bg-black for the side margins on non-4:3 iPads. */}
           <div
-            className="absolute bg-black"
+            data-testid="camera-preview-rect"
+            className="absolute"
             style={{
               left: layout.previewRect.x,
               top: layout.previewRect.y,


### PR DESCRIPTION
## Summary

Hotfix on top of #354. On physical iPad, the landscape overlay rendered a black square exactly over the camera preview rect — the live camera feed was hidden.

Root cause: the overlay branch wrapped `#camera-preview-window` in a div with `bg-black`. The Capacitor camera-preview plugin paints the native camera feed *behind* the WebView at the rect coords; any opaque background on the wrapper at those coords blocks the camera.

Fix: drop `bg-black` from the preview-rect wrapper; move `bg-black` to the outer `#camera-preview-mount` so non-4:3 iPads still get black side margins around the centered 4:3 preview. Comment added at the wrapper explaining why no background may go there.

## Test plan

- [x] Regression test on the wrapper's transparency contract — `\`camera-preview-rect\`` has no `bg-*` class. jsdom can't tell whether the native camera surface is occluded, but it can guard against this exact class of regression.
- [x] `npx vitest run src/lib/mobile/ src/components/mobile/` — 71/71 mobile suite pass.
- [ ] Re-verify on physical iPad (Xcode Cloud → TestFlight build, then walk the same AC checklist from #354).

🤖 Generated with [Claude Code](https://claude.com/claude-code)