### PR TITLE
fix(camera): drop bg-black from outer mount in overlay mode (#345)

### DIFF
--- a/src/components/mobile/camera-view.test.tsx
+++ b/src/components/mobile/camera-view.test.tsx
@@ -128,11 +128,12 @@ describe("CameraView overlay branch (iPad landscape)", () => {
     });
   });
 
-  it("preview rect is transparent so the native camera feed shows through the WebView", () => {
+  it("preview rect AND outer container are transparent so the native camera feed shows through the WebView", () => {
     // Regression guard: the @capacitor-community/camera-preview plugin paints
-    // the camera feed *behind* the WebView at the preview rect. If the
-    // wrapping div has an opaque background, the camera is hidden by a black
-    // square at exactly the rect coordinates.
+    // the camera feed *behind* the WebView at the preview rect (toBack:true).
+    // useCameraLifecycle sets html+body transparent so the camera shows
+    // through. Any opaque background on the outer container or the preview
+    // rect wrapper paints over the camera at exactly that region.
     render(
       <CameraView
         jobId="job-1"
@@ -142,8 +143,49 @@ describe("CameraView overlay branch (iPad landscape)", () => {
       />,
     );
 
+    const outer = screen.getByTestId("camera-root");
+    expect(outer.className).not.toMatch(/\bbg-/);
+
     const rect = screen.getByTestId("camera-preview-rect");
     expect(rect.className).not.toMatch(/\bbg-/);
+  });
+
+  it("renders black bezel strips around the centered preview rect (non-4:3 iPads)", () => {
+    // 1180x820 is the common modern iPad landscape size; ~44pt margins remain
+    // on each side of the 4:3 preview rect. Without bezels those areas would
+    // show whatever sits behind the transparent WebView.
+    viewportMock.mockReturnValue({
+      width: 1180,
+      height: 820,
+      orientation: "landscape",
+    });
+
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    expect(screen.getByTestId("camera-left-bezel")).toBeDefined();
+    expect(screen.getByTestId("camera-right-bezel")).toBeDefined();
+  });
+
+  it("skips bezel strips when the preview rect is edge-to-edge (4:3 viewports)", () => {
+    // 1024x768 is exact 4:3 — previewRect.x === 0, no margins to cover.
+    render(
+      <CameraView
+        jobId="job-1"
+        sessionId="sess-1"
+        onDone={() => undefined}
+        onAbort={() => undefined}
+      />,
+    );
+
+    expect(screen.queryByTestId("camera-left-bezel")).toBeNull();
+    expect(screen.queryByTestId("camera-right-bezel")).toBeNull();
   });
 
   it("top-right cluster holds exactly mode-toggle, flip, flash, settings in DOM order", () => {

--- a/src/components/mobile/camera-view.tsx
+++ b/src/components/mobile/camera-view.tsx
@@ -414,10 +414,12 @@ export default function CameraView({
       id="camera-preview-mount"
       className={cn(
         "fixed inset-0 z-[1000] text-white",
-        // Overlay needs bg-black on the outer container so non-4:3 iPads get
-        // black side margins around the centered 4:3 preview rect. Stacked
-        // keeps the original behaviour (controls panel supplies the black).
-        stacked ? "flex flex-col" : "block bg-black",
+        // No background on this outer container. The native camera lives
+        // BEHIND the WebView (toBack:true) and shows through any transparent
+        // WebView pixel — useCameraLifecycle sets html+body transparent for
+        // this exact reason. An opaque bg here paints over the entire camera.
+        // Non-4:3 iPads get black side margins from the bezel strips below.
+        stacked ? "flex flex-col" : "block",
       )}
       data-testid="camera-root"
     >
@@ -474,12 +476,28 @@ export default function CameraView({
         </>
       ) : (
         <>
-          {/* Overlay: 4:3 preview centered horizontally; chrome floats on top.
-              No background on this wrapper — @capacitor-community/camera-preview
-              renders the native camera feed *behind* the WebView at exactly
-              these rect coordinates, so any opaque background here paints a
-              black square over the camera. The outer #camera-preview-mount
-              supplies bg-black for the side margins on non-4:3 iPads. */}
+          {/* Black bezel strips covering only the side margins outside the
+              centered 4:3 preview rect. Kept narrow & local so the camera
+              area of the WebView stays transparent. Skipped when previewRect
+              is edge-to-edge (4:3 viewports like 12.9" iPad landscape). */}
+          {layout.previewRect.x > 0 && (
+            <>
+              <div
+                data-testid="camera-left-bezel"
+                className="absolute bottom-0 left-0 top-0 bg-black"
+                style={{ width: layout.previewRect.x }}
+              />
+              <div
+                data-testid="camera-right-bezel"
+                className="absolute bottom-0 right-0 top-0 bg-black"
+                style={{ width: layout.previewRect.x }}
+              />
+            </>
+          )}
+
+          {/* Overlay preview rect: must stay transparent — the native camera
+              renders BEHIND the WebView at these coords (toBack:true) and any
+              opaque background here paints a black square over the feed. */}
           <div
             data-testid="camera-preview-rect"
             className="absolute"


### PR DESCRIPTION
## Summary

Hotfix on top of #355. Build 225 still showed the black overlay on physical iPad despite the preview wrapper being transparent. See the screenshot Eric attached to #344 — only a thin strip of camera shows at the top, the rest is solid black with the chrome correctly overlaid.

Reading \`useCameraLifecycle\`: the plugin runs with \`toBack: true\` and the hook explicitly sets \`html\` + \`body\` \`backgroundColor\` to transparent so the camera (rendered BEHIND the WebView) shows through. The previous hotfix moved \`bg-black\` from the preview wrapper to the outer \`#camera-preview-mount\` — but the outer is \`fixed inset-0\`, so that's a full-viewport opaque rectangle painting over the entire camera. The thin strip of camera visible at the top of the screenshot is just the safe-area padding above the WebView (line 65 of the hook: \`height: r.height + safeTop\`).

Real fix:
- Outer container stays transparent in overlay mode.
- Two narrow \`bg-black\` bezel strips cover only the left/right margins outside the 4:3 preview rect on non-4:3 iPads.
- Skipped entirely when \`previewRect.x === 0\` (edge-to-edge 4:3 viewports like 12.9\" iPad).

## Test plan

- [x] Regression test now asserts BOTH the outer container and the preview rect have no \`bg-*\` class.
- [x] New test: non-4:3 viewport (1180×820) renders \`camera-left-bezel\` + \`camera-right-bezel\`.
- [x] New test: 4:3 viewport (1024×768) does NOT render the bezels.
- [x] \`npx vitest run src/lib/mobile/ src/components/mobile/\` — 73/73 mobile suite pass.
- [ ] **Re-verify on physical iPad** — kick another Xcode Cloud build off the new \`main\` and confirm the camera feed fills the rect with black bezels on the sides (non-4:3 iPads).

## Honesty about the test gap

jsdom has no concept of \"is the native camera surface occluded by an opaque DOM element.\" The regression tests are necessary but not sufficient — they guard against the two specific opaque-pixel patterns we've hit, but a third one could slip past them. Physical-device verify remains the only gate that catches this class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)