### PR TITLE
feat(estimate-templates): snapshot line items end-to-end (#351)

### DIFF
--- a/src/lib/estimate-templates.test.ts
+++ b/src/lib/estimate-templates.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeStructureFromBuilder, synthItemFromTemplate } from "./estimate-templates";
+import type { TemplateStructureItem, TemplateWithContents } from "@/lib/types";
+
+// Minimal builder-shape factory — only the fields the serializer reads matter.
+function makeBuilderState(
+  items: TemplateWithContents["sections"][number]["items"],
+): TemplateWithContents {
+  return {
+    id: "tmpl-1",
+    organization_id: "org-1",
+    name: "T",
+    description: null,
+    damage_type_tags: [],
+    opening_statement: null,
+    closing_statement: null,
+    structure: { sections: [] },
+    is_active: true,
+    created_by: null,
+    created_at: "",
+    updated_at: "",
+    sections: [
+      {
+        id: "sec-1",
+        title: "Demo",
+        sort_order: 0,
+        parent_section_id: null,
+        items,
+        subsections: [],
+      },
+    ],
+  };
+}
+
+describe("serializeStructureFromBuilder (snapshot shape, #351)", () => {
+  it("writes flat snapshot fields for a library-backed item", () => {
+    const state = makeBuilderState([
+      {
+        id: "li-1",
+        library_item_id: "lib-abc",
+        name: "Asbestos Testing",
+        description: "Lab analysis of sample",
+        code: "ABT-01",
+        quantity: 2,
+        unit: "ea",
+        unit_price: 125.5,
+        sort_order: 0,
+      },
+    ]);
+
+    const out = serializeStructureFromBuilder(state);
+    const item = out.sections[0].items![0];
+
+    expect(item).toMatchObject({
+      library_item_id: "lib-abc",
+      name: "Asbestos Testing",
+      description: "Lab analysis of sample",
+      code: "ABT-01",
+      unit: "ea",
+      quantity: 2,
+      unit_price: 125.5,
+      sort_order: 0,
+    });
+  });
+
+  it("does NOT write legacy *_override fields", () => {
+    const state = makeBuilderState([
+      {
+        id: "li-1",
+        library_item_id: "lib-abc",
+        name: "X",
+        description: "d",
+        code: null,
+        quantity: 1,
+        unit: null,
+        unit_price: 0,
+        sort_order: 0,
+      },
+    ]);
+
+    const item = serializeStructureFromBuilder(state).sections[0].items![0];
+
+    expect(item).not.toHaveProperty("description_override");
+    expect(item).not.toHaveProperty("quantity_override");
+    expect(item).not.toHaveProperty("unit_price_override");
+  });
+
+  it("writes flat snapshot fields for a custom item (null library_item_id)", () => {
+    const state = makeBuilderState([
+      {
+        id: "li-1",
+        library_item_id: null,
+        name: "Custom one-off",
+        description: "Hand-written line",
+        code: "CUST-1",
+        quantity: 3,
+        unit: "hr",
+        unit_price: 75,
+        sort_order: 0,
+      },
+    ]);
+
+    const item = serializeStructureFromBuilder(state).sections[0].items![0];
+
+    expect(item).toMatchObject({
+      library_item_id: null,
+      name: "Custom one-off",
+      description: "Hand-written line",
+      code: "CUST-1",
+      unit: "hr",
+      quantity: 3,
+      unit_price: 75,
+    });
+  });
+
+  it("also writes the snapshot fields for subsection items", () => {
+    const state: TemplateWithContents = {
+      ...makeBuilderState([]),
+      sections: [
+        {
+          id: "sec-1",
+          title: "Demo",
+          sort_order: 0,
+          parent_section_id: null,
+          items: [],
+          subsections: [
+            {
+              id: "sub-1",
+              title: "Sub",
+              sort_order: 0,
+              items: [
+                {
+                  id: "li-sub-1",
+                  library_item_id: null,
+                  name: "Sub Custom",
+                  description: "Sub desc",
+                  code: "SUB-1",
+                  quantity: 5,
+                  unit: "sqft",
+                  unit_price: 12.25,
+                  sort_order: 0,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const subItem = serializeStructureFromBuilder(state).sections[0].subsections![0].items![0];
+    expect(subItem).toMatchObject({
+      name: "Sub Custom",
+      description: "Sub desc",
+      code: "SUB-1",
+      unit: "sqft",
+      quantity: 5,
+      unit_price: 12.25,
+    });
+  });
+});
+
+describe("synthItemFromTemplate (snapshot read + legacy fallback, #351)", () => {
+  it("reads flat snapshot fields when present (new shape)", () => {
+    const stored: TemplateStructureItem = {
+      library_item_id: "lib-abc",
+      name: "Asbestos Testing",
+      description: "Lab analysis",
+      code: "ABT-01",
+      unit: "ea",
+      quantity: 2,
+      unit_price: 125.5,
+      sort_order: 0,
+    };
+
+    const out = synthItemFromTemplate("sec-1", 0, stored);
+
+    expect(out).toMatchObject({
+      library_item_id: "lib-abc",
+      name: "Asbestos Testing",
+      description: "Lab analysis",
+      code: "ABT-01",
+      unit: "ea",
+      quantity: 2,
+      unit_price: 125.5,
+      sort_order: 0,
+    });
+  });
+
+  it("falls back to *_override fields on un-migrated rows (old shape)", () => {
+    const legacy: TemplateStructureItem = {
+      library_item_id: "lib-abc",
+      description_override: "Legacy description",
+      quantity_override: 7,
+      unit_price_override: 42,
+      sort_order: 0,
+    };
+
+    const out = synthItemFromTemplate("sec-1", 0, legacy);
+
+    expect(out).toMatchObject({
+      library_item_id: "lib-abc",
+      description: "Legacy description",
+      quantity: 7,
+      unit_price: 42,
+    });
+    // name/code/unit on the legacy shape are unknown at the template layer
+    // (they used to be resolved from the library at apply-time); the projection
+    // surfaces null so the builder can render them blank rather than guess.
+    expect(out.name).toBeNull();
+    expect(out.code).toBeNull();
+    expect(out.unit).toBeNull();
+  });
+
+  it("prefers flat fields over override fields when both are present", () => {
+    const mixed: TemplateStructureItem = {
+      library_item_id: null,
+      name: "Flat name",
+      description: "Flat desc",
+      code: "FLAT",
+      unit: "ea",
+      quantity: 3,
+      unit_price: 9,
+      // Legacy values that must be ignored.
+      description_override: "OLD desc",
+      quantity_override: 99,
+      unit_price_override: 99,
+      sort_order: 0,
+    };
+
+    const out = synthItemFromTemplate("sec-1", 0, mixed);
+
+    expect(out).toMatchObject({
+      name: "Flat name",
+      description: "Flat desc",
+      code: "FLAT",
+      unit: "ea",
+      quantity: 3,
+      unit_price: 9,
+    });
+  });
+});

--- a/src/lib/estimate-templates.ts
+++ b/src/lib/estimate-templates.ts
@@ -86,15 +86,19 @@ export async function getTemplateWithContents(
   return { ...tmpl, sections } as TemplateWithContents;
 }
 
-function synthItemFromTemplate(synthSectionId: string, idx: number, item: TemplateStructureItem) {
+/** Project one stored template item into the builder-shape item the editor renders.
+ *  Reads the new flat snapshot fields (#351). Falls back to the legacy `*_override`
+ *  fields on un-migrated rows so existing templates open without losing data. */
+export function synthItemFromTemplate(synthSectionId: string, idx: number, item: TemplateStructureItem) {
   return {
     id: `synth-item-${synthSectionId}-${idx}`,
     library_item_id: item.library_item_id,
-    description: item.description_override ?? "",
-    code: null,
-    quantity: item.quantity_override ?? 1,
-    unit: null,
-    unit_price: item.unit_price_override ?? 0,
+    name: item.name ?? null,
+    description: item.description ?? item.description_override ?? "",
+    code: item.code ?? null,
+    quantity: item.quantity ?? item.quantity_override ?? 1,
+    unit: item.unit ?? null,
+    unit_price: item.unit_price ?? item.unit_price_override ?? 0,
     sort_order: item.sort_order,
   };
 }
@@ -104,27 +108,25 @@ function synthItemFromTemplate(synthSectionId: string, idx: number, item: Templa
  *  template auto-save collapses to rootPut-only and rootPut writes both metadata
  *  AND structure). */
 export function serializeStructureFromBuilder(state: TemplateWithContents): TemplateStructure {
+  const snapshot = (it: TemplateWithContents["sections"][number]["items"][number]): TemplateStructureItem => ({
+    library_item_id: it.library_item_id,
+    name: it.name ?? null,
+    description: it.description || null,
+    code: it.code ?? null,
+    unit: it.unit ?? null,
+    quantity: it.quantity ?? null,
+    unit_price: it.unit_price ?? null,
+    sort_order: it.sort_order,
+  });
   return {
     sections: state.sections.map((s) => ({
       title: s.title,
       sort_order: s.sort_order,
-      items: s.items.map((it) => ({
-        library_item_id: it.library_item_id,
-        description_override: it.description || null,
-        quantity_override: it.quantity ?? null,
-        unit_price_override: it.unit_price ?? null,
-        sort_order: it.sort_order,
-      })),
+      items: s.items.map(snapshot),
       subsections: s.subsections.map((sub) => ({
         title: sub.title,
         sort_order: sub.sort_order,
-        items: sub.items.map((it) => ({
-          library_item_id: it.library_item_id,
-          description_override: it.description || null,
-          quantity_override: it.quantity ?? null,
-          unit_price_override: it.unit_price ?? null,
-          sort_order: it.sort_order,
-        })),
+        items: sub.items.map(snapshot),
       })),
     })),
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -798,11 +798,23 @@ export interface TemplateStructure {
   }>;
 }
 
+/** Snapshot shape per ADR 0004. A template item stores its own name, code, unit,
+ *  description, quantity, and unit_price; `library_item_id` is a soft breadcrumb.
+ *  The legacy `*_override` fields stay on the type for backwards-compat reads of
+ *  un-migrated rows — new code does not write them. */
 export interface TemplateStructureItem {
   library_item_id: string | null;
-  description_override: string | null;
-  quantity_override: number | null;
-  unit_price_override: number | null;
+  // Snapshot fields (new shape — written by all post-#351 code).
+  name?: string | null;
+  description?: string | null;
+  code?: string | null;
+  unit?: string | null;
+  quantity?: number | null;
+  unit_price?: number | null;
+  // Legacy override fields (old shape — read-only for backwards compat).
+  description_override?: string | null;
+  quantity_override?: number | null;
+  unit_price_override?: number | null;
   sort_order: number;
 }
 

--- a/supabase/migration-351-template-line-items-snapshot.sql
+++ b/supabase/migration-351-template-line-items-snapshot.sql
@@ -1,0 +1,295 @@
+-- Issue #351 — Template line items: switch to snapshot shape end-to-end.
+-- See docs/adr/0004-template-line-items-snapshot.md for the rationale.
+--
+-- Updates `apply_template_to_estimate` so that instead of resolving
+-- name/code/unit from `item_library` at apply time, it copies the values
+-- straight out of the template `structure` JSONB. Per-item fields use a
+-- COALESCE(new_flat, old_override, library_value) ladder so:
+--   - newly-authored templates (#351 onward) write only the flat snapshot
+--     fields and the RPC reads them directly,
+--   - pre-#351 templates that still carry `description_override` etc. keep
+--     applying with the same observable result as before,
+--   - and library-only pre-#351 items still resolve through the library.
+--
+-- The `library_item_id` column on `estimate_line_items` stays populated with
+-- the soft breadcrumb (when present in the template), so existing line-item
+-- → library navigation continues to work. The `broken_refs` return value is
+-- preserved for callers, but only fires for items that genuinely have a
+-- library_item_id whose library row could not be loaded — exactly as before.
+--
+-- This migration is purely a function body swap. No schema changes. No data
+-- changes. The companion backfill (rewriting old `*_override` rows into
+-- flat snapshot rows) is scoped as issue #352; the cleanup that drops the
+-- dual-shape fallback once the backfill is done is issue #353.
+
+CREATE OR REPLACE FUNCTION public.apply_template_to_estimate(
+  p_estimate_id uuid,
+  p_template_id uuid
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_estimate    estimates%ROWTYPE;
+  v_template    estimate_templates%ROWTYPE;
+  v_existing_section_count integer;
+  v_struct      jsonb;
+  v_section     jsonb;
+  v_subsection  jsonb;
+  v_item        jsonb;
+  v_section_idx integer := 0;
+  v_subsection_idx integer := 0;
+  v_item_idx    integer;
+  v_new_section_id uuid;
+  v_new_subsection_id uuid;
+  v_lib_id      uuid;
+  v_lib         item_library%ROWTYPE;
+  v_name        text;
+  v_desc        text;
+  v_qty         numeric(10,2);
+  v_unit_price  numeric(10,2);
+  v_unit        text;
+  v_code        text;
+  v_total       numeric(10,2);
+  v_broken_refs jsonb := '[]'::jsonb;
+  v_section_count_out integer := 0;
+  v_line_item_count_out integer := 0;
+  v_placeholder bool;
+  v_ref_obj     jsonb;
+  v_subtotal     numeric(10,2) := 0;
+  v_markup_amt   numeric(10,2) := 0;
+  v_discount_amt numeric(10,2) := 0;
+  v_adjusted     numeric(10,2) := 0;
+  v_tax_amt      numeric(10,2) := 0;
+  v_total_out    numeric(10,2) := 0;
+BEGIN
+  SELECT * INTO v_estimate FROM estimates WHERE id = p_estimate_id FOR UPDATE;
+  IF v_estimate.id IS NULL THEN
+    RAISE EXCEPTION 'estimate_not_found' USING ERRCODE = 'P0002';
+  END IF;
+  IF v_estimate.status <> 'draft' THEN
+    RAISE EXCEPTION 'estimate_not_draft' USING ERRCODE = 'P0001';
+  END IF;
+  SELECT COUNT(*) INTO v_existing_section_count
+    FROM estimate_sections WHERE estimate_id = p_estimate_id;
+  IF v_existing_section_count > 0 THEN
+    RAISE EXCEPTION 'estimate_not_empty' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT * INTO v_template FROM estimate_templates WHERE id = p_template_id;
+  IF v_template.id IS NULL OR v_template.is_active = false
+     OR v_template.organization_id <> v_estimate.organization_id THEN
+    RAISE EXCEPTION 'template_not_found_or_inactive' USING ERRCODE = 'P0002';
+  END IF;
+
+  v_struct := v_template.structure;
+
+  FOR v_section IN SELECT * FROM jsonb_array_elements(COALESCE(v_struct->'sections', '[]'::jsonb))
+  LOOP
+    INSERT INTO estimate_sections (organization_id, estimate_id, parent_section_id, title, sort_order)
+    VALUES (
+      v_estimate.organization_id, p_estimate_id, NULL,
+      v_section->>'title',
+      COALESCE((v_section->>'sort_order')::integer, v_section_idx)
+    )
+    RETURNING id INTO v_new_section_id;
+    v_section_count_out := v_section_count_out + 1;
+
+    v_item_idx := 0;
+    FOR v_item IN SELECT * FROM jsonb_array_elements(COALESCE(v_section->'items', '[]'::jsonb))
+    LOOP
+      v_lib_id := NULLIF(v_item->>'library_item_id', '')::uuid;
+      v_placeholder := false;
+      IF v_lib_id IS NOT NULL THEN
+        SELECT * INTO v_lib FROM item_library
+         WHERE id = v_lib_id AND is_active = true
+           AND organization_id = v_estimate.organization_id;
+      ELSE
+        v_lib := NULL;
+      END IF;
+
+      -- #351 snapshot ladder: prefer the flat snapshot field, then the legacy
+      -- `_override` field for un-migrated rows, then the library value.
+      v_name       := COALESCE(NULLIF(v_item->>'name', ''),               v_lib.name);
+      v_desc       := COALESCE(NULLIF(v_item->>'description', ''),
+                               NULLIF(v_item->>'description_override', ''),
+                               v_lib.description,
+                               '[unknown item]');
+      v_code       := COALESCE(NULLIF(v_item->>'code', ''),               v_lib.code);
+      v_unit       := COALESCE(NULLIF(v_item->>'unit', ''),               v_lib.default_unit);
+      v_qty        := COALESCE(NULLIF(v_item->>'quantity', '')::numeric,
+                               NULLIF(v_item->>'quantity_override', '')::numeric,
+                               v_lib.default_quantity,
+                               1);
+      v_unit_price := COALESCE(NULLIF(v_item->>'unit_price', '')::numeric,
+                               NULLIF(v_item->>'unit_price_override', '')::numeric,
+                               v_lib.unit_price,
+                               0);
+      v_total      := round((v_qty * v_unit_price)::numeric, 2);
+
+      -- A broken_ref is only reported when the template carried a
+      -- `library_item_id` whose library row could not be loaded AND the
+      -- template itself has no snapshot/override values to fall back on
+      -- (i.e. the legacy lib-only shape that we used to call "placeholder").
+      IF v_lib_id IS NOT NULL AND v_lib.id IS NULL THEN
+        v_placeholder := (
+             (v_item->>'name')                IS NULL
+          AND (v_item->>'description')        IS NULL
+          AND (v_item->>'code')               IS NULL
+          AND (v_item->>'unit')               IS NULL
+          AND (v_item->>'quantity')           IS NULL
+          AND (v_item->>'unit_price')         IS NULL
+          AND (v_item->>'description_override') IS NULL
+          AND (v_item->>'quantity_override')   IS NULL
+          AND (v_item->>'unit_price_override') IS NULL
+        );
+        v_ref_obj := jsonb_build_object(
+          'section_idx', v_section_idx,
+          'item_idx',    v_item_idx,
+          'library_item_id', v_lib_id,
+          'placeholder', v_placeholder
+        );
+        v_broken_refs := v_broken_refs || jsonb_build_array(v_ref_obj);
+      END IF;
+
+      INSERT INTO estimate_line_items (
+        organization_id, estimate_id, section_id, library_item_id,
+        name, description, code, quantity, unit, unit_price, total, sort_order
+      ) VALUES (
+        v_estimate.organization_id, p_estimate_id, v_new_section_id,
+        v_lib_id, -- keep the breadcrumb even if the lib row is gone
+        v_name, v_desc, v_code, v_qty, v_unit, v_unit_price, v_total,
+        COALESCE((v_item->>'sort_order')::integer, v_item_idx)
+      );
+      v_subtotal := v_subtotal + v_total;
+      v_line_item_count_out := v_line_item_count_out + 1;
+      v_item_idx := v_item_idx + 1;
+    END LOOP;
+
+    v_subsection_idx := 0;
+    FOR v_subsection IN SELECT * FROM jsonb_array_elements(COALESCE(v_section->'subsections', '[]'::jsonb))
+    LOOP
+      INSERT INTO estimate_sections (organization_id, estimate_id, parent_section_id, title, sort_order)
+      VALUES (
+        v_estimate.organization_id, p_estimate_id, v_new_section_id,
+        v_subsection->>'title',
+        COALESCE((v_subsection->>'sort_order')::integer, v_subsection_idx)
+      )
+      RETURNING id INTO v_new_subsection_id;
+      v_section_count_out := v_section_count_out + 1;
+
+      v_item_idx := 0;
+      FOR v_item IN SELECT * FROM jsonb_array_elements(COALESCE(v_subsection->'items', '[]'::jsonb))
+      LOOP
+        v_lib_id := NULLIF(v_item->>'library_item_id', '')::uuid;
+        v_placeholder := false;
+        IF v_lib_id IS NOT NULL THEN
+          SELECT * INTO v_lib FROM item_library
+           WHERE id = v_lib_id AND is_active = true
+             AND organization_id = v_estimate.organization_id;
+        ELSE
+          v_lib := NULL;
+        END IF;
+
+        v_name       := COALESCE(NULLIF(v_item->>'name', ''),               v_lib.name);
+        v_desc       := COALESCE(NULLIF(v_item->>'description', ''),
+                                 NULLIF(v_item->>'description_override', ''),
+                                 v_lib.description,
+                                 '[unknown item]');
+        v_code       := COALESCE(NULLIF(v_item->>'code', ''),               v_lib.code);
+        v_unit       := COALESCE(NULLIF(v_item->>'unit', ''),               v_lib.default_unit);
+        v_qty        := COALESCE(NULLIF(v_item->>'quantity', '')::numeric,
+                                 NULLIF(v_item->>'quantity_override', '')::numeric,
+                                 v_lib.default_quantity,
+                                 1);
+        v_unit_price := COALESCE(NULLIF(v_item->>'unit_price', '')::numeric,
+                                 NULLIF(v_item->>'unit_price_override', '')::numeric,
+                                 v_lib.unit_price,
+                                 0);
+        v_total      := round((v_qty * v_unit_price)::numeric, 2);
+
+        IF v_lib_id IS NOT NULL AND v_lib.id IS NULL THEN
+          v_placeholder := (
+               (v_item->>'name')                IS NULL
+            AND (v_item->>'description')        IS NULL
+            AND (v_item->>'code')               IS NULL
+            AND (v_item->>'unit')               IS NULL
+            AND (v_item->>'quantity')           IS NULL
+            AND (v_item->>'unit_price')         IS NULL
+            AND (v_item->>'description_override') IS NULL
+            AND (v_item->>'quantity_override')   IS NULL
+            AND (v_item->>'unit_price_override') IS NULL
+          );
+          v_ref_obj := jsonb_build_object(
+            'section_idx', v_section_idx,
+            'item_idx',    v_item_idx,
+            'library_item_id', v_lib_id,
+            'placeholder', v_placeholder,
+            'in_subsection', true,
+            'subsection_idx', v_subsection_idx
+          );
+          v_broken_refs := v_broken_refs || jsonb_build_array(v_ref_obj);
+        END IF;
+
+        INSERT INTO estimate_line_items (
+          organization_id, estimate_id, section_id, library_item_id,
+          name, description, code, quantity, unit, unit_price, total, sort_order
+        ) VALUES (
+          v_estimate.organization_id, p_estimate_id, v_new_subsection_id,
+          v_lib_id,
+          v_name, v_desc, v_code, v_qty, v_unit, v_unit_price, v_total,
+          COALESCE((v_item->>'sort_order')::integer, v_item_idx)
+        );
+        v_subtotal := v_subtotal + v_total;
+        v_line_item_count_out := v_line_item_count_out + 1;
+        v_item_idx := v_item_idx + 1;
+      END LOOP;
+      v_subsection_idx := v_subsection_idx + 1;
+    END LOOP;
+
+    v_section_idx := v_section_idx + 1;
+  END LOOP;
+
+  IF v_template.opening_statement IS NOT NULL AND v_template.opening_statement <> '' THEN
+    UPDATE estimates SET opening_statement = v_template.opening_statement
+     WHERE id = p_estimate_id;
+  END IF;
+  IF v_template.closing_statement IS NOT NULL AND v_template.closing_statement <> '' THEN
+    UPDATE estimates SET closing_statement = v_template.closing_statement
+     WHERE id = p_estimate_id;
+  END IF;
+
+  v_subtotal := round(v_subtotal::numeric, 2);
+  v_markup_amt := CASE v_estimate.markup_type
+    WHEN 'percent' THEN round((v_subtotal * v_estimate.markup_value / 100)::numeric, 2)
+    WHEN 'amount'  THEN round(v_estimate.markup_value::numeric, 2)
+    ELSE 0
+  END;
+  v_discount_amt := CASE v_estimate.discount_type
+    WHEN 'percent' THEN round((v_subtotal * v_estimate.discount_value / 100)::numeric, 2)
+    WHEN 'amount'  THEN round(v_estimate.discount_value::numeric, 2)
+    ELSE 0
+  END;
+  v_adjusted := round((v_subtotal + v_markup_amt - v_discount_amt)::numeric, 2);
+  v_tax_amt  := round((v_adjusted * v_estimate.tax_rate / 100)::numeric, 2);
+  v_total_out := round((v_adjusted + v_tax_amt)::numeric, 2);
+
+  UPDATE estimates SET
+    subtotal = v_subtotal,
+    markup_amount = v_markup_amt,
+    discount_amount = v_discount_amt,
+    adjusted_subtotal = v_adjusted,
+    tax_amount = v_tax_amt,
+    total = v_total_out,
+    updated_at = now()
+  WHERE id = p_estimate_id;
+
+  RETURN jsonb_build_object(
+    'section_count', v_section_count_out,
+    'line_item_count', v_line_item_count_out,
+    'broken_refs', v_broken_refs
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.apply_template_to_estimate(uuid, uuid) TO authenticated;


### PR DESCRIPTION
## Summary

Shifts `TemplateStructureItem` from the "library-only + overrides" model to the snapshot model spelled out in [ADR 0004](docs/adr/0004-template-line-items-snapshot.md). Every template item now stores its own `name`, `description`, `code`, `unit`, `quantity`, and `unit_price`; `library_item_id` stays as a nullable soft breadcrumb. Legacy `*_override` fields stay on the type and in the RPC for backwards-compat reads of un-migrated rows.

- `serializeStructureFromBuilder` writes the flat snapshot fields, not `*_override`.
- `synthItemFromTemplate` (now exported) reads the flat fields, falls back to `*_override` on un-migrated rows, and surfaces `name` / `code` / `unit` so the builder renders them.
- `apply_template_to_estimate` copies values straight out of the template structure via `COALESCE(flat, override, library)` so pre-#351 templates keep applying correctly. `broken_refs` semantics preserved.
- AddItemDialog Custom tab in template mode already builds a full local item — no UI change needed for it to round-trip.

Companion follow-ups already scoped: #352 backfills existing templates from the library; #353 drops the dual-shape fallback once the backfill is done.

## Test plan

- [x] `vitest run src/lib/estimate-templates.test.ts` — 7/7 pass (library round-trip, custom round-trip, subsections, no `*_override` writes, flat-read, legacy fallback, flat-wins-over-legacy).
- [x] Full `vitest run` — 1643/1645 pass; 2 failures (`twilio-client.test.ts`, `email/accounts/route.test.ts`) are pre-existing on `main` and unmodified here.
- [x] `tsc --noEmit` adds no new errors on touched files (3 pre-existing errors in unmodified files remain).
- [x] `eslint` clean on all touched files.
- [ ] Apply `supabase/migration-351-template-line-items-snapshot.sql` to AAA prod (requires explicit approval — not run yet).
- [ ] Browser-verify the AC bullets on the Vercel preview: create a template with library + custom items, save and reopen in a new tab (titles/codes/units/qtys/prices intact); apply a freshly-created template to a draft estimate; apply a pre-existing template (dual-shape fallback path).

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)