### PR TITLE
feat(dashboard): style action hub to match the app design system (#246)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default function DashboardPage() {
   const firstName = getFirstName(profile?.full_name);
 
   return (
-    <div className="max-w-6xl animate-fade-slide-up">
+    <div className="max-w-3xl animate-fade-slide-up">
       <div className="mb-8">
         <h1 className="text-3xl font-extrabold text-foreground">
           <span className="gradient-text">Dashboard</span>
@@ -38,14 +38,16 @@ export default function DashboardPage() {
         canViewEmail={canViewEmail}
       />
 
-      {canViewJobs && <NewJobsSection jobs={newJobs} total={newJobsCount} />}
+      <div className="space-y-6">
+        {canViewJobs && <NewJobsSection jobs={newJobs} total={newJobsCount} />}
 
-      {canViewEmail && (
-        <UnreadResponsesSection
-          threads={unreadResponseThreads}
-          total={unreadResponsesCount}
-        />
-      )}
+        {canViewEmail && (
+          <UnreadResponsesSection
+            threads={unreadResponseThreads}
+            total={unreadResponsesCount}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/new-jobs-section.tsx
+++ b/src/components/dashboard/new-jobs-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { Briefcase, ChevronRight } from "lucide-react";
 import type { Job } from "@/lib/types";
 
 interface NewJobsSectionProps {
@@ -11,31 +12,82 @@ interface NewJobsSectionProps {
 const PREVIEW_CAP = 3;
 
 export function NewJobsSection({ jobs, total }: NewJobsSectionProps) {
-  if (total === 0) {
-    return <p>No new jobs.</p>;
-  }
-
   const preview = jobs.slice(0, PREVIEW_CAP);
   const overflow = total - PREVIEW_CAP;
 
   return (
-    <section>
-      <header>
-        <h2>New jobs</h2>
-        <span data-testid="new-jobs-count">{total}</span>
-        <Link href="/jobs">View all jobs →</Link>
+    <section className="overflow-hidden rounded-xl border border-border bg-card">
+      <header className="flex items-center justify-between gap-4 border-b border-border px-5 py-4">
+        <div className="flex items-center gap-2.5">
+          <h2 className="text-base font-semibold text-foreground">New jobs</h2>
+          <span
+            data-testid="new-jobs-count"
+            className="inline-flex h-[22px] min-w-[22px] items-center justify-center rounded-full bg-primary/10 px-1.5 text-xs font-semibold text-primary"
+          >
+            {total}
+          </span>
+        </div>
+        <Link
+          href="/jobs"
+          className="shrink-0 text-sm font-medium text-primary hover:underline"
+        >
+          View all jobs →
+        </Link>
       </header>
-      <ul>
-        {preview.map((job) => (
-          <li key={job.id}>
-            <Link href={`/jobs/${job.id}`}>
-              <p>{job.job_number}</p>
-            </Link>
-          </li>
-        ))}
-      </ul>
-      {overflow > 0 && (
-        <Link href="/jobs">+ {overflow} more</Link>
+
+      {total === 0 ? (
+        <p className="px-5 py-8 text-center text-sm text-muted-foreground/70">
+          No new jobs.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {preview.map((job) => {
+            const contactName = job.contact?.full_name;
+            return (
+              <li key={job.id}>
+                <Link
+                  href={`/jobs/${job.id}`}
+                  className="group flex items-center gap-3 px-5 py-3 transition-colors hover:bg-primary/5"
+                >
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Briefcase size={16} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      {contactName && (
+                        <p className="min-w-0 truncate text-sm font-medium text-foreground">
+                          {contactName}
+                        </p>
+                      )}
+                      <p className="shrink-0 font-mono text-xs text-muted-foreground">
+                        {job.job_number}
+                      </p>
+                    </div>
+                    {job.property_address && (
+                      <p className="mt-0.5 truncate text-xs text-muted-foreground/70">
+                        {job.property_address}
+                      </p>
+                    )}
+                  </div>
+                  <ChevronRight
+                    size={16}
+                    className="shrink-0 text-muted-foreground/40 transition-transform group-hover:translate-x-0.5"
+                  />
+                </Link>
+              </li>
+            );
+          })}
+          {overflow > 0 && (
+            <li>
+              <Link
+                href="/jobs"
+                className="block px-5 py-2.5 text-center text-sm font-medium text-primary transition-colors hover:bg-primary/5"
+              >
+                + {overflow} more
+              </Link>
+            </li>
+          )}
+        </ul>
       )}
     </section>
   );

--- a/src/components/dashboard/stat-strip.tsx
+++ b/src/components/dashboard/stat-strip.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Briefcase, Mail } from "lucide-react";
+
 interface StatStripProps {
   newJobsCount: number;
   canViewJobs: boolean;
@@ -7,6 +9,10 @@ interface StatStripProps {
   canViewEmail: boolean;
 }
 
+// Compact one-row strip: "<N> new jobs · <N> unread responses". Each column
+// hides when the viewer lacks the gating permission, so the `·` divider only
+// renders when both columns are present. Counts stay in a single text node so
+// the stat-strip tests can match the "<N> new jobs" copy.
 export function StatStrip({
   newJobsCount,
   canViewJobs,
@@ -14,13 +20,31 @@ export function StatStrip({
   canViewEmail,
 }: StatStripProps) {
   return (
-    <div role="presentation">
+    <div
+      role="presentation"
+      className="mb-8 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm"
+    >
       {canViewJobs && (
-        <span data-testid="stat-strip-new-jobs">{newJobsCount} new jobs</span>
+        <span
+          data-testid="stat-strip-new-jobs"
+          className="inline-flex items-center gap-1.5 font-medium text-foreground"
+        >
+          <Briefcase size={15} className="text-primary" />
+          {`${newJobsCount} new jobs`}
+        </span>
+      )}
+      {canViewJobs && canViewEmail && (
+        <span aria-hidden className="text-muted-foreground/40">
+          ·
+        </span>
       )}
       {canViewEmail && (
-        <span data-testid="stat-strip-unread-responses">
-          {unreadResponsesCount} unread responses
+        <span
+          data-testid="stat-strip-unread-responses"
+          className="inline-flex items-center gap-1.5 font-medium text-foreground"
+        >
+          <Mail size={15} className="text-primary" />
+          {`${unreadResponsesCount} unread responses`}
         </span>
       )}
     </div>

--- a/src/components/dashboard/unread-responses-section.tsx
+++ b/src/components/dashboard/unread-responses-section.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Link from "next/link";
+import { format } from "date-fns";
+import { Mail, Clock } from "lucide-react";
 import type { UnreadResponseThread } from "@/lib/dashboard/use-dashboard-data";
 
 export type { UnreadResponseThread };
@@ -12,37 +14,91 @@ interface UnreadResponsesSectionProps {
 
 const PREVIEW_CAP = 3;
 
-export function UnreadResponsesSection({ threads, total }: UnreadResponsesSectionProps) {
-  if (total === 0) {
-    return <p>No unread responses on shared inboxes.</p>;
-  }
-
+export function UnreadResponsesSection({
+  threads,
+  total,
+}: UnreadResponsesSectionProps) {
   const preview = threads.slice(0, PREVIEW_CAP);
   const overflow = total - PREVIEW_CAP;
 
   return (
-    <section>
-      <header>
-        <h2>People to respond to</h2>
-        <span data-testid="unread-responses-count">{total}</span>
-        <Link href="/email">Open inbox →</Link>
+    <section className="overflow-hidden rounded-xl border border-border bg-card">
+      <header className="flex items-center justify-between gap-4 border-b border-border px-5 py-4">
+        <div className="flex items-center gap-2.5">
+          <h2 className="text-base font-semibold text-foreground">
+            People to respond to
+          </h2>
+          <span
+            data-testid="unread-responses-count"
+            className="inline-flex h-[22px] min-w-[22px] items-center justify-center rounded-full bg-primary/10 px-1.5 text-xs font-semibold text-primary"
+          >
+            {total}
+          </span>
+        </div>
+        <Link
+          href="/email"
+          className="shrink-0 text-sm font-medium text-primary hover:underline"
+        >
+          Open inbox →
+        </Link>
       </header>
-      <ul>
-        {preview.map((thread) => (
-          <li key={thread.thread_id}>
-            <Link href={`/email?id=${thread.latest_email_id}`}>
-              <p>{thread.latest_from_name ?? thread.latest_from_address}</p>
-              <p>{thread.latest_subject}</p>
-              {thread.latest_snippet && <p>{thread.latest_snippet}</p>}
-              {thread.unread_count > 1 && (
-                <span>{thread.unread_count} unread</span>
-              )}
-            </Link>
-          </li>
-        ))}
-      </ul>
-      {overflow > 0 && (
-        <Link href="/email">+ {overflow} more</Link>
+
+      {total === 0 ? (
+        <p className="px-5 py-8 text-center text-sm text-muted-foreground/70">
+          No unread responses on shared inboxes.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {preview.map((thread) => {
+            const sender = thread.latest_from_name ?? thread.latest_from_address;
+            return (
+              <li key={thread.thread_id}>
+                <Link
+                  href={`/email?id=${thread.latest_email_id}`}
+                  className="group flex items-start gap-3 px-5 py-3 transition-colors hover:bg-primary/5"
+                >
+                  <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Mail size={16} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="min-w-0 flex-1 truncate text-sm font-semibold text-foreground">
+                        {sender}
+                      </p>
+                      {thread.unread_count > 1 && (
+                        <span className="shrink-0 rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                          {`${thread.unread_count} unread`}
+                        </span>
+                      )}
+                      <span className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground/60">
+                        <Clock size={11} />
+                        {format(new Date(thread.latest_received_at), "MMM d")}
+                      </span>
+                    </div>
+                    <p className="mt-0.5 truncate text-sm text-foreground/80">
+                      {thread.latest_subject}
+                    </p>
+                    {thread.latest_snippet && (
+                      <p className="mt-0.5 truncate text-xs text-muted-foreground/60">
+                        {thread.latest_snippet}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+          {overflow > 0 && (
+            <li>
+              <Link
+                href="/email"
+                className="block px-5 py-2.5 text-center text-sm font-medium text-primary transition-colors hover:bg-primary/5"
+              >
+                + {overflow} more
+              </Link>
+            </li>
+          )}
+        </ul>
       )}
     </section>
   );


### PR DESCRIPTION
## What

The #246 dashboard rebuild (#292/#293/#294) shipped **behavior-complete but visually unstyled** — the three components were raw semantic HTML with no CSS, so the page rendered as bare stacked text (`0 new jobs1 unread responses`, an orphaned `No new jobs.` line, etc.). The data layer, filters, polling, gating, and greeting were all working; only the styling layer was missing.

This PR dresses the components in the app's existing design language (`job-card` / `email-inbox` rows / settings panels) — no new aesthetic invented, just consistency.

## Changes

- **StatStrip** → compact inline strip with icons + a `·` divider, per the PRD's `<N> new jobs · <N> unread responses` spec. Counts kept in a single text node so the matchers still work.
- **NewJobsSection / UnreadResponsesSection** → `bg-card rounded-xl border` panels with styled headers (title + `bg-primary/10` count pill + `text-primary` 'view all' link), divided hover rows mirroring the email/job-list rows (icon tile, bold sender/contact, muted subject/snippet, truncation), an `N unread` pill, a timestamp, and a styled `+ N more` tail.
- **Empty state (PRD story #12)** → the section header now stays stable when a queue is empty, instead of collapsing to an orphaned bare line (the floating `No new jobs.` in the original screenshot).
- **Page** → `space-y-6` between sections and a focused `max-w-3xl` column.

## Verification

- ✅ **27/27** dashboard + page tests pass — every contract preserved (testids, exact copy, link targets, permission gating, DOM order, the count+label single-text-node rule).
- ✅ Lint clean on all changed files.
- ✅ Types clean for changed files (3 pre-existing `tsc` errors in unrelated files: estimate-builder, email sync-folder, twilio-client).
- ⚠️ Visual not author-confirmed locally (dashboard is behind `AuthProvider`/`AppShell` + Supabase) — please eyeball the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)