### PR TITLE
test(estimate-templates): cover apply_template_to_estimate RPC end-to-end (#351)

### DIFF
--- a/docs/adr/0004-template-line-items-snapshot.md
+++ b/docs/adr/0004-template-line-items-snapshot.md
@@ -1,0 +1,53 @@
+# Estimate template line items are snapshots, not library references
+
+When a Library item is added to an Estimate template, the template stores a
+**full copy** of the item's fields (name, description, code, unit, quantity,
+unit_price) plus a soft `library_item_id` pointer that records where the copy
+came from. Subsequent edits to the underlying Library item do **not**
+propagate into existing templates. Custom items (no library reference) are
+allowed and store the same fields directly.
+
+This replaces the build 67b/67e "library-only" pattern, in which the template
+structure stored only `library_item_id` plus a few overrides
+(`description_override`, `quantity_override`, `unit_price_override`) and
+`apply_template_to_estimate` resolved `name`, `code`, and `unit` from the
+Library at apply time.
+
+We picked snapshot semantics over live-from-library because:
+
+- **Templates are user-authored documents, not derived views.** A contractor
+  who saved a template last month expects it to look the same next month.
+  Library edits silently rewriting templates is spooky-action-at-a-distance.
+- **The builder UI already lets users edit name/code/unit per row.** Before
+  this change, those edits were accepted in the UI and silently dropped on
+  save (issue #350). Snapshot semantics let those edits do what they
+  obviously look like they should do.
+- **Custom items need somewhere to live anyway.** Once we accept that a
+  template item must be able to store its own name (for the Custom case),
+  the schema asymmetry between Library-backed and Custom items is gone, and
+  the cleanest model is "every template item just stores its own state."
+- **Library deletes stop silently corrupting templates.** Under the old
+  model, deleting a Library item left dangling references that
+  `apply_template_to_estimate` would turn into `[unknown item]` placeholders.
+  Snapshots are immune.
+
+## Consequences
+
+- `TemplateStructureItem` shape changes: `description_override`,
+  `quantity_override`, `unit_price_override` are replaced by plain
+  `name`, `description`, `code`, `unit`, `quantity`, `unit_price`.
+  `library_item_id` stays as a nullable soft pointer.
+- One-time migration walks every existing template, looks up each
+  `library_item_id` in `item_library`, and writes the snapshot. Items whose
+  Library item has been deleted, and items already created via the Custom
+  tab (which silently lost name/code/unit before this change), need manual
+  cleanup — they get whatever stub data the old structure preserved.
+- `apply_template_to_estimate` no longer reads from `item_library`. It
+  copies values straight out of the template structure into the new
+  estimate's line items. The `broken_refs` return value becomes vestigial
+  (kept only for items the migration couldn't backfill).
+- Library renames are intentional one-way: editing a Library item updates
+  only future template items, not existing ones. If a user wants the new
+  name in an existing template, they delete the row and re-add it.
+- The Custom tab in `AddItemDialog` (template mode) becomes fully
+  functional rather than silently lossy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "@types/mailparser": "^3.4.6",
         "@types/node": "^20",
         "@types/nodemailer": "^8.0.0",
+        "@types/pg": "^8.20.0",
         "@types/pngjs": "^6.0.5",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -86,9 +87,11 @@
         "@types/uuid": "^10.0.0",
         "@vitest/ui": "^4.1.5",
         "dotenv-cli": "^11.0.0",
+        "embedded-postgres": "^18.3.0-beta.17",
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
         "jsdom": "^29.1.1",
+        "pg": "^8.21.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.5"
@@ -1279,6 +1282,150 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-arm64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-arm64/-/darwin-arm64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-Pvrej3Xz5flfyVc9mchVfekrKoTJyvPtM3U0vjuXamZkRKmi+inP2zRmnmzYecIVbr7Zhu82xbsCENMXrwMp9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/darwin-x64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/darwin-x64/-/darwin-x64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-MVWe+C47pPoMD9LlIWGQkvZ5Xsu3IBo54CYqnIps/Z1byMIUBNc7y/dZ3mfqEwiCbVDVqirG0CU462xnrSEfKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm/-/linux-arm-18.3.0-beta.17.tgz",
+      "integrity": "sha512-Y2vw7p80PO/Ko7CDm8CCpStnNfMe+oc11e0WZtqAVRjxO6H0oic/ehULhUsWU3mZm5jq7wQAv37VMzf4JN+SFQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-arm64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-arm64/-/linux-arm64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-hXp7yHJHYWkdjkgF6As8whEHbdYxhBdmXeLpLTw0aiac0O6+0Cbqk3cOR9U+e49oyIpElHVwZUo6OewquSRhSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ia32": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ia32/-/linux-ia32-18.3.0-beta.17.tgz",
+      "integrity": "sha512-hVUOM+7QxkzAIdN3gewfVwL1EpJIx+0qUiNTD8cMqRtaZyU87e4AFIvBS0UiDJ9xzMTVWr/X24wePtbvIbkopg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-ppc64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-ppc64/-/linux-ppc64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-p3/u4YUqSdE2CKUBlC84JGZCi6RnE1fyeLPIIVy2DJUiKtExR5rE3OpDJcVoN40uecYGL+nR4qFocGzDwG1TBw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/linux-x64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/linux-x64/-/linux-x64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-8orSD6NNopSLtjqir4dWQBrj+g8j1eJjWd9mB60A3xbWMzIBIPQpzT7XzbacW9YFSl/DejOLnRXfff+Wr13Tgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@embedded-postgres/windows-x64": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@embedded-postgres/windows-x64/-/windows-x64-18.3.0-beta.17.tgz",
+      "integrity": "sha512-kDC5aBsmhWDjeQjj2V4g+Bk+pMeDU27b7l0rBbaKgtt2gsNmCB34ULg/5cqs2kqUKSk/tiGMHKCNE+zQZ+s4rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emnapi/core": {
@@ -5203,6 +5350,18 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@types/pngjs": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
@@ -6448,6 +6607,16 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -8182,6 +8351,30 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/embedded-postgres": {
+      "version": "18.3.0-beta.17",
+      "resolved": "https://registry.npmjs.org/embedded-postgres/-/embedded-postgres-18.3.0-beta.17.tgz",
+      "integrity": "sha512-1biFWyuPVtAV5S9RBgcr4PGuAdNL9WhnNZVQ5Arp3gsB24Ci9X9s/8Z7RFYFSc6tJWcj9kzF55YcDAcr3jLUbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "pg": "^8.7.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@embedded-postgres/darwin-arm64": "^18.3.0-beta.17",
+        "@embedded-postgres/darwin-x64": "^18.3.0-beta.17",
+        "@embedded-postgres/linux-arm": "^18.3.0-beta.17",
+        "@embedded-postgres/linux-arm64": "^18.3.0-beta.17",
+        "@embedded-postgres/linux-ia32": "^18.3.0-beta.17",
+        "@embedded-postgres/linux-ppc64": "^18.3.0-beta.17",
+        "@embedded-postgres/linux-x64": "^18.3.0-beta.17",
+        "@embedded-postgres/windows-x64": "^18.3.0-beta.17"
       }
     },
     "node_modules/emoji-regex": {
@@ -14013,6 +14206,103 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14163,6 +14453,49 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/potpack": {
       "version": "1.0.2",
@@ -18160,6 +18493,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --config vitest.integration.config.ts"
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:pg": "vitest run --config vitest.pg.config.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.86.1",
@@ -83,6 +84,7 @@
     "@types/mailparser": "^3.4.6",
     "@types/node": "^20",
     "@types/nodemailer": "^8.0.0",
+    "@types/pg": "^8.20.0",
     "@types/pngjs": "^6.0.5",
     "@types/react": "^19",
     "@types/react-dom": "^19",
@@ -90,9 +92,11 @@
     "@types/uuid": "^10.0.0",
     "@vitest/ui": "^4.1.5",
     "dotenv-cli": "^11.0.0",
+    "embedded-postgres": "^18.3.0-beta.17",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "jsdom": "^29.1.1",
+    "pg": "^8.21.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/tests/integration/apply-template-schema.sql
+++ b/tests/integration/apply-template-schema.sql
@@ -1,0 +1,105 @@
+-- Self-contained schema for the embedded-postgres apply_template_to_estimate
+-- harness (#351). Loaded by apply-template.pg.test.ts into a throwaway cluster.
+--
+-- This is NOT the Supabase stack: there is no PostgREST, no RLS, and none of
+-- the anon/authenticated/service_role grants the shared schema.sql carries.
+-- It is the smallest schema that lets the LIVE migration-351 function run:
+-- the five tables it reads/writes, with only the columns it actually touches,
+-- typed to match the prod shape (migration-build67a).
+--
+-- Deliberate divergences from prod, both safe because the RPC never depends on
+-- them:
+--   * estimates drops the NOT NULL job_id FK — so a fixture is just an
+--     estimate + a template, no contact/job chain.
+--   * estimate_line_items.library_item_id is FK-LESS — the RPC keeps the
+--     breadcrumb even when the library row is gone (the broken_refs path), so
+--     a FK here would reject exactly the dangling-reference case we test.
+
+-- gen_random_uuid() is core since PG 13; keep pgcrypto too for older binaries.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Library: read for the legacy "resolve from library" fallback rung.
+CREATE TABLE item_library (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid,
+  name text NOT NULL,
+  description text NOT NULL,
+  code text,
+  category text NOT NULL DEFAULT 'services'
+    CHECK (category IN ('labor', 'equipment', 'materials', 'services', 'other')),
+  default_quantity numeric(10,2) NOT NULL DEFAULT 1,
+  default_unit text,
+  unit_price numeric(10,2) NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Templates: the RPC reads `structure` (the sections/items JSONB tree),
+-- is_active, organization_id, and the opening/closing statements.
+CREATE TABLE estimate_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid,
+  name text NOT NULL,
+  description text,
+  opening_statement text,
+  closing_statement text,
+  structure jsonb NOT NULL DEFAULT '{"sections":[]}'::jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Estimates: the RPC locks it, guards on status/emptiness, reads the
+-- markup/discount/tax settings, and writes back the resolved totals + the
+-- statements. Defaults mirror prod so an untouched estimate has total = subtotal.
+CREATE TABLE estimates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid,
+  status text NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('draft', 'sent', 'approved', 'rejected', 'converted', 'voided')),
+  opening_statement text,
+  closing_statement text,
+  subtotal numeric(10,2) NOT NULL DEFAULT 0,
+  markup_type text NOT NULL DEFAULT 'none' CHECK (markup_type IN ('percent', 'amount', 'none')),
+  markup_value numeric(10,2) NOT NULL DEFAULT 0,
+  markup_amount numeric(10,2) NOT NULL DEFAULT 0,
+  discount_type text NOT NULL DEFAULT 'none' CHECK (discount_type IN ('percent', 'amount', 'none')),
+  discount_value numeric(10,2) NOT NULL DEFAULT 0,
+  discount_amount numeric(10,2) NOT NULL DEFAULT 0,
+  adjusted_subtotal numeric(10,2) NOT NULL DEFAULT 0,
+  tax_rate numeric(5,2) NOT NULL DEFAULT 0,
+  tax_amount numeric(10,2) NOT NULL DEFAULT 0,
+  total numeric(10,2) NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Sections: one row per template section AND per subsection (subsections
+-- carry a non-null parent_section_id back to their parent).
+CREATE TABLE estimate_sections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid,
+  estimate_id uuid NOT NULL REFERENCES estimates(id) ON DELETE CASCADE,
+  parent_section_id uuid REFERENCES estimate_sections(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Line items: the resolved snapshot for every template item. See the header
+-- note on why library_item_id has no FK.
+CREATE TABLE estimate_line_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid,
+  estimate_id uuid NOT NULL REFERENCES estimates(id) ON DELETE CASCADE,
+  section_id uuid NOT NULL REFERENCES estimate_sections(id) ON DELETE CASCADE,
+  library_item_id uuid,
+  name text,
+  description text NOT NULL,
+  code text,
+  quantity numeric(10,2) NOT NULL DEFAULT 1,
+  unit text,
+  unit_price numeric(10,2) NOT NULL DEFAULT 0,
+  total numeric(10,2) NOT NULL DEFAULT 0,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/tests/integration/apply-template.pg.test.ts
+++ b/tests/integration/apply-template.pg.test.ts
@@ -1,0 +1,572 @@
+// Integration coverage for `apply_template_to_estimate` — the PL/pgSQL RPC
+// redefined by #351 (docs/adr/0004-template-line-items-snapshot.md).
+//
+// Gap this fills. The unit suite (src/lib/estimate-templates.test.ts) covers
+// the TS serialize/synth round-trip (AC #1/#2/#5), but the apply RPC — the
+// COALESCE(flat, _override, library) ladder that actually builds the estimate
+// — had no automated test. AC #3 (apply a fresh snapshot template) and AC #4
+// (apply a legacy *_override template via the fallback) live here.
+//
+// Harness. The repo's blessed integration harness (tests/integration/
+// global-setup.ts) boots Supabase via `supabase start`, which needs Docker +
+// hardware virtualization — unavailable on this machine. Since the thing under
+// test is a database function, we instead boot a throwaway embedded-postgres
+// cluster, load a focused schema + the LIVE migration-351 SQL verbatim (no
+// copy-paste drift), and drive it through a raw `pg` client at the SQL layer.
+// Nothing here touches the network, Docker, or the local PG service. Run with
+// `npm run test:pg`.
+//
+// node-postgres returns `numeric` columns as strings to preserve precision, so
+// every numeric assertion coerces with Number().
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import { randomUUID } from "node:crypto";
+
+import EmbeddedPostgres from "embedded-postgres";
+import type { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SCHEMA_SQL = readFileSync(join(process.cwd(), "tests", "integration", "apply-template-schema.sql"), "utf8");
+const MIGRATION_SQL = readFileSync(
+  join(process.cwd(), "supabase", "migration-351-template-line-items-snapshot.sql"),
+  "utf8",
+);
+
+/** Grab a free ephemeral port so the cluster never collides with the local
+ *  PostgreSQL 17/18 services already listening on 5432. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+let pgServer: EmbeddedPostgres;
+let dataDir: string;
+let client: Client;
+
+const TEST_DB = "apply_template_test";
+
+beforeAll(async () => {
+  // Data dir under the OS temp root, NOT under the OneDrive-synced project
+  // tree (OneDrive interferes with initdb's file locking).
+  dataDir = mkdtempSync(join(tmpdir(), "nookleus-pg-"));
+  pgServer = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    port: await freePort(),
+    user: "postgres",
+    password: "postgres",
+    persistent: false, // stop() wipes the data dir
+    // Match prod: a UTF8 cluster. Without this, initdb inherits the Windows
+    // WIN1252 locale and chokes on the UTF-8 arrows/box-drawing in the real
+    // migration's comments. `--locale=C` keeps UTF8 valid on Windows (the
+    // default 1252-based locale would otherwise force WIN1252 encoding).
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+
+  await pgServer.initialise();
+  await pgServer.start();
+  await pgServer.createDatabase(TEST_DB);
+
+  client = pgServer.getPgClient(TEST_DB);
+  await client.connect();
+
+  // The shipped migration ends with `GRANT EXECUTE ... TO authenticated`, a
+  // role Supabase provides but a bare cluster doesn't. Create it so the real
+  // SQL loads verbatim.
+  await client.query(
+    "DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated; END IF; END $$;",
+  );
+  await client.query(SCHEMA_SQL); // tables first (the function's %ROWTYPE needs them)
+  await client.query(MIGRATION_SQL); // then the live function + its grant
+}, 120_000);
+
+afterAll(async () => {
+  if (client) await client.end().catch(() => {});
+  if (pgServer) await pgServer.stop().catch(() => {});
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+});
+
+/** Insert a fresh draft (empty) estimate under `orgId`; returns its id. */
+async function seedDraftEstimate(orgId: string): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    "INSERT INTO estimates (organization_id, status) VALUES ($1, 'draft') RETURNING id",
+    [orgId],
+  );
+  return rows[0].id;
+}
+
+interface ApplyResult {
+  section_count: number;
+  line_item_count: number;
+  broken_refs: unknown[];
+}
+
+interface LineItemRow {
+  library_item_id: string | null;
+  name: string | null;
+  description: string;
+  code: string | null;
+  unit: string | null;
+  quantity: string; // numeric -> string from pg
+  unit_price: string;
+  total: string;
+}
+
+describe("apply_template_to_estimate (snapshot shape, #351)", () => {
+  // ── AC #3 (tracer): a freshly-authored snapshot template applies its own
+  //    flat name/code/unit/description/qty/price straight onto the estimate. ──
+  it("copies a snapshot item's flat fields onto the new line item", async () => {
+    const orgId = randomUUID();
+    const estimateId = await seedDraftEstimate(orgId);
+
+    const structure = {
+      sections: [
+        {
+          title: "Demolition",
+          sort_order: 0,
+          subsections: [],
+          items: [
+            {
+              library_item_id: null,
+              name: "Asbestos Testing",
+              description: "Lab analysis of sample",
+              code: "ABT-01",
+              unit: "ea",
+              quantity: 2,
+              unit_price: 125.5,
+              sort_order: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, $2, $3) RETURNING id",
+      [orgId, "Asbestos Abatement", JSON.stringify(structure)],
+    );
+    const templateId = tmplRows[0].id;
+
+    const { rows: resultRows } = await client.query<{ result: ApplyResult }>(
+      "SELECT apply_template_to_estimate($1, $2) AS result",
+      [estimateId, templateId],
+    );
+    expect(resultRows[0].result).toMatchObject({
+      section_count: 1,
+      line_item_count: 1,
+      broken_refs: [],
+    });
+
+    const { rows: items } = await client.query<LineItemRow>(
+      "SELECT * FROM estimate_line_items WHERE estimate_id = $1",
+      [estimateId],
+    );
+    expect(items).toHaveLength(1);
+
+    const item = items[0];
+    expect(item.name).toBe("Asbestos Testing");
+    expect(item.description).toBe("Lab analysis of sample");
+    expect(item.code).toBe("ABT-01");
+    expect(item.unit).toBe("ea");
+    expect(item.library_item_id).toBeNull();
+    expect(Number(item.quantity)).toBe(2);
+    expect(Number(item.unit_price)).toBe(125.5);
+    expect(Number(item.total)).toBe(251); // 2 × 125.50
+  });
+
+  // ── AC #4: a pre-#351 template carries no flat fields — only a
+  //    library_item_id plus *_override values. name/code/unit must resolve
+  //    from the library; description/qty/price from the overrides. ──────────
+  it("resolves library name/code/unit + override desc/qty/price for a legacy item", async () => {
+    const orgId = randomUUID();
+    const estimateId = await seedDraftEstimate(orgId);
+
+    const { rows: libRows } = await client.query<{ id: string }>(
+      `INSERT INTO item_library
+         (organization_id, name, description, code, default_unit, default_quantity, unit_price)
+       VALUES ($1, 'Drywall Repair', 'Library description', 'DRY-10', 'sqft', 5, 3.25)
+       RETURNING id`,
+      [orgId],
+    );
+    const libId = libRows[0].id;
+
+    const structure = {
+      sections: [
+        {
+          title: "Repairs",
+          sort_order: 0,
+          subsections: [],
+          items: [
+            {
+              library_item_id: libId,
+              // legacy shape: no name/code/unit/description/quantity/unit_price
+              description_override: "Legacy patch note",
+              quantity_override: 7,
+              unit_price_override: 4.5,
+              sort_order: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, 'Legacy', $2) RETURNING id",
+      [orgId, JSON.stringify(structure)],
+    );
+
+    const { rows: resultRows } = await client.query<{ result: ApplyResult }>(
+      "SELECT apply_template_to_estimate($1, $2) AS result",
+      [estimateId, tmplRows[0].id],
+    );
+    expect(resultRows[0].result).toMatchObject({
+      section_count: 1,
+      line_item_count: 1,
+      broken_refs: [],
+    });
+
+    const { rows: items } = await client.query<LineItemRow>(
+      "SELECT * FROM estimate_line_items WHERE estimate_id = $1",
+      [estimateId],
+    );
+    expect(items).toHaveLength(1);
+
+    const item = items[0];
+    // name/code/unit fall back to the library (the legacy item carried none)…
+    expect(item.name).toBe("Drywall Repair");
+    expect(item.code).toBe("DRY-10");
+    expect(item.unit).toBe("sqft");
+    // …description/quantity/unit_price come from the *_override fields.
+    expect(item.description).toBe("Legacy patch note");
+    expect(Number(item.quantity)).toBe(7);
+    expect(Number(item.unit_price)).toBe(4.5);
+    expect(Number(item.total)).toBe(31.5); // 7 × 4.50
+    expect(item.library_item_id).toBe(libId); // breadcrumb preserved
+  });
+
+  // ── Precedence: when an item carries flat fields AND legacy overrides AND
+  //    points at a library row, the flat snapshot wins every field. ─────────
+  it("prefers flat snapshot fields over both *_override and library values", async () => {
+    const orgId = randomUUID();
+    const estimateId = await seedDraftEstimate(orgId);
+
+    const { rows: libRows } = await client.query<{ id: string }>(
+      `INSERT INTO item_library
+         (organization_id, name, description, code, default_unit, default_quantity, unit_price)
+       VALUES ($1, 'Lib Name', 'Lib desc', 'LIB', 'lf', 50, 1)
+       RETURNING id`,
+      [orgId],
+    );
+    const libId = libRows[0].id;
+
+    const structure = {
+      sections: [
+        {
+          title: "Mixed",
+          sort_order: 0,
+          subsections: [],
+          items: [
+            {
+              library_item_id: libId,
+              // flat snapshot — should win…
+              name: "Flat Name",
+              description: "Flat desc",
+              code: "FLAT",
+              unit: "ea",
+              quantity: 3,
+              unit_price: 9,
+              // …over these legacy overrides…
+              description_override: "OLD desc",
+              quantity_override: 99,
+              unit_price_override: 99,
+              sort_order: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, 'Mixed', $2) RETURNING id",
+      [orgId, JSON.stringify(structure)],
+    );
+
+    await client.query("SELECT apply_template_to_estimate($1, $2)", [estimateId, tmplRows[0].id]);
+
+    const { rows: items } = await client.query<LineItemRow>(
+      "SELECT * FROM estimate_line_items WHERE estimate_id = $1",
+      [estimateId],
+    );
+    expect(items).toHaveLength(1);
+
+    const item = items[0];
+    expect(item.name).toBe("Flat Name");
+    expect(item.description).toBe("Flat desc");
+    expect(item.code).toBe("FLAT");
+    expect(item.unit).toBe("ea");
+    expect(Number(item.quantity)).toBe(3);
+    expect(Number(item.unit_price)).toBe(9);
+    expect(Number(item.total)).toBe(27); // 3 × 9, NOT 99×99 and NOT the library's 50×1
+  });
+
+  // ── Subsections: a subsection becomes a child estimate_section
+  //    (parent_section_id → its parent), and its items attach to it. ─────────
+  it("nests subsection items under a child section pointing at its parent", async () => {
+    const orgId = randomUUID();
+    const estimateId = await seedDraftEstimate(orgId);
+
+    const structure = {
+      sections: [
+        {
+          title: "Parent",
+          sort_order: 0,
+          items: [
+            {
+              library_item_id: null,
+              name: "Parent Item",
+              description: "top-level",
+              code: "P-1",
+              unit: "ea",
+              quantity: 1,
+              unit_price: 10,
+              sort_order: 0,
+            },
+          ],
+          subsections: [
+            {
+              title: "Child",
+              sort_order: 0,
+              items: [
+                {
+                  library_item_id: null,
+                  name: "Sub Item",
+                  description: "nested",
+                  code: "S-1",
+                  unit: "sqft",
+                  quantity: 4,
+                  unit_price: 2.5,
+                  sort_order: 0,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, 'Nested', $2) RETURNING id",
+      [orgId, JSON.stringify(structure)],
+    );
+
+    const { rows: resultRows } = await client.query<{ result: ApplyResult }>(
+      "SELECT apply_template_to_estimate($1, $2) AS result",
+      [estimateId, tmplRows[0].id],
+    );
+    // Parent section + subsection both count toward section_count.
+    expect(resultRows[0].result).toMatchObject({ section_count: 2, line_item_count: 2, broken_refs: [] });
+
+    const { rows: sections } = await client.query<{ id: string; title: string; parent_section_id: string | null }>(
+      "SELECT id, title, parent_section_id FROM estimate_sections WHERE estimate_id = $1",
+      [estimateId],
+    );
+    expect(sections).toHaveLength(2);
+    const parent = sections.find((s) => s.parent_section_id === null)!;
+    const child = sections.find((s) => s.parent_section_id !== null)!;
+    expect(parent.title).toBe("Parent");
+    expect(child.title).toBe("Child");
+    expect(child.parent_section_id).toBe(parent.id);
+
+    const { rows: items } = await client.query<{ name: string | null; section_id: string }>(
+      "SELECT name, section_id FROM estimate_line_items WHERE estimate_id = $1",
+      [estimateId],
+    );
+    const parentItem = items.find((i) => i.name === "Parent Item")!;
+    const subItem = items.find((i) => i.name === "Sub Item")!;
+    expect(parentItem.section_id).toBe(parent.id);
+    expect(subItem.section_id).toBe(child.id);
+  });
+
+  // ── Broken ref: a library_item_id with no resolvable row and no snapshot/
+  //    override data still inserts a line item ([unknown item], breadcrumb
+  //    kept) and reports a broken_ref with placeholder: true. ────────────────
+  it("reports a placeholder broken_ref for a dangling library_item_id", async () => {
+    const orgId = randomUUID();
+    const estimateId = await seedDraftEstimate(orgId);
+
+    const danglingLibId = randomUUID(); // no item_library row exists for this id
+
+    const structure = {
+      sections: [
+        {
+          title: "Orphans",
+          sort_order: 0,
+          subsections: [],
+          items: [
+            // lib-only legacy shape: nothing but a (now-dangling) breadcrumb.
+            { library_item_id: danglingLibId, sort_order: 0 },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, 'Orphan', $2) RETURNING id",
+      [orgId, JSON.stringify(structure)],
+    );
+
+    const { rows: resultRows } = await client.query<{ result: ApplyResult }>(
+      "SELECT apply_template_to_estimate($1, $2) AS result",
+      [estimateId, tmplRows[0].id],
+    );
+    const result = resultRows[0].result;
+    expect(result).toMatchObject({ section_count: 1, line_item_count: 1 });
+    expect(result.broken_refs).toHaveLength(1);
+    expect(result.broken_refs[0]).toMatchObject({
+      section_idx: 0,
+      item_idx: 0,
+      library_item_id: danglingLibId,
+      placeholder: true,
+    });
+
+    const { rows: items } = await client.query<LineItemRow>(
+      "SELECT * FROM estimate_line_items WHERE estimate_id = $1",
+      [estimateId],
+    );
+    expect(items).toHaveLength(1);
+    const item = items[0];
+    expect(item.description).toBe("[unknown item]"); // final COALESCE fallback
+    expect(item.name).toBeNull();
+    expect(item.code).toBeNull();
+    expect(item.unit).toBeNull();
+    expect(Number(item.quantity)).toBe(1); // default
+    expect(Number(item.unit_price)).toBe(0); // default
+    expect(item.library_item_id).toBe(danglingLibId); // breadcrumb kept despite the dangling ref
+  });
+
+  // ── Totals: after inserting items, the RPC recomputes the estimate's money
+  //    columns from its own markup/discount/tax settings. ────────────────────
+  it("recomputes estimate totals from markup/discount/tax settings", async () => {
+    const orgId = randomUUID();
+    const { rows: estRows } = await client.query<{ id: string }>(
+      `INSERT INTO estimates
+         (organization_id, status, markup_type, markup_value, discount_type, discount_value, tax_rate)
+       VALUES ($1, 'draft', 'percent', 10, 'amount', 5, 8.25)
+       RETURNING id`,
+      [orgId],
+    );
+    const estimateId = estRows[0].id;
+
+    const structure = {
+      sections: [
+        {
+          title: "Line",
+          sort_order: 0,
+          subsections: [],
+          items: [
+            {
+              library_item_id: null,
+              name: "Item",
+              description: "d",
+              code: null,
+              unit: "ea",
+              quantity: 2,
+              unit_price: 100,
+              sort_order: 0,
+            },
+          ],
+        },
+      ],
+    };
+    const { rows: tmplRows } = await client.query<{ id: string }>(
+      "INSERT INTO estimate_templates (organization_id, name, structure) VALUES ($1, 'Totals', $2) RETURNING id",
+      [orgId, JSON.stringify(structure)],
+    );
+
+    await client.query("SELECT apply_template_to_estimate($1, $2)", [estimateId, tmplRows[0].id]);
+
+    const { rows } = await client.query<{
+      subtotal: string;
+      markup_amount: string;
+      discount_amount: string;
+      adjusted_subtotal: string;
+      tax_amount: string;
+      total: string;
+    }>(
+      `SELECT subtotal, markup_amount, discount_amount, adjusted_subtotal, tax_amount, total
+       FROM estimates WHERE id = $1`,
+      [estimateId],
+    );
+    const e = rows[0];
+    expect(Number(e.subtotal)).toBe(200); // 2 × 100
+    expect(Number(e.markup_amount)).toBe(20); // 10% of 200
+    expect(Number(e.discount_amount)).toBe(5); // flat amount
+    expect(Number(e.adjusted_subtotal)).toBe(215); // 200 + 20 − 5
+    expect(Number(e.tax_amount)).toBe(17.74); // round(215 × 8.25%, 2)
+    expect(Number(e.total)).toBe(232.74); // 215 + 17.74
+  });
+
+  // ── Guards: each precondition raises a distinct error code, surfaced by the
+  //    `pg` client as a rejected query. ──────────────────────────────────────
+  describe("guards", () => {
+    it("rejects when the estimate does not exist (estimate_not_found)", async () => {
+      const orgId = randomUUID();
+      const { rows: tmpl } = await client.query<{ id: string }>(
+        "INSERT INTO estimate_templates (organization_id, name) VALUES ($1, 'G') RETURNING id",
+        [orgId],
+      );
+      await expect(
+        client.query("SELECT apply_template_to_estimate($1, $2)", [randomUUID(), tmpl[0].id]),
+      ).rejects.toThrow(/estimate_not_found/);
+    });
+
+    it("rejects when the estimate is not a draft (estimate_not_draft)", async () => {
+      const orgId = randomUUID();
+      const { rows: est } = await client.query<{ id: string }>(
+        "INSERT INTO estimates (organization_id, status) VALUES ($1, 'sent') RETURNING id",
+        [orgId],
+      );
+      const { rows: tmpl } = await client.query<{ id: string }>(
+        "INSERT INTO estimate_templates (organization_id, name) VALUES ($1, 'G') RETURNING id",
+        [orgId],
+      );
+      await expect(
+        client.query("SELECT apply_template_to_estimate($1, $2)", [est[0].id, tmpl[0].id]),
+      ).rejects.toThrow(/estimate_not_draft/);
+    });
+
+    it("rejects when the estimate already has sections (estimate_not_empty)", async () => {
+      const orgId = randomUUID();
+      const estimateId = await seedDraftEstimate(orgId);
+      await client.query(
+        "INSERT INTO estimate_sections (organization_id, estimate_id, title) VALUES ($1, $2, 'Pre-existing')",
+        [orgId, estimateId],
+      );
+      const { rows: tmpl } = await client.query<{ id: string }>(
+        "INSERT INTO estimate_templates (organization_id, name) VALUES ($1, 'G') RETURNING id",
+        [orgId],
+      );
+      await expect(
+        client.query("SELECT apply_template_to_estimate($1, $2)", [estimateId, tmpl[0].id]),
+      ).rejects.toThrow(/estimate_not_empty/);
+    });
+
+    it("rejects when the template is inactive (template_not_found_or_inactive)", async () => {
+      const orgId = randomUUID();
+      const estimateId = await seedDraftEstimate(orgId);
+      const { rows: tmpl } = await client.query<{ id: string }>(
+        "INSERT INTO estimate_templates (organization_id, name, is_active) VALUES ($1, 'G', false) RETURNING id",
+        [orgId],
+      );
+      await expect(
+        client.query("SELECT apply_template_to_estimate($1, $2)", [estimateId, tmpl[0].id]),
+      ).rejects.toThrow(/template_not_found_or_inactive/);
+    });
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -22,7 +22,10 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["tests/integration/**/*.test.ts"],
-    exclude: ["node_modules", ".next", "out", "ios"],
+    // `*.pg.test.ts` files run against embedded-postgres (no Docker) via
+    // vitest.pg.config.ts / `npm run test:pg`; keep them out of this Dockerized
+    // Supabase suite so they aren't double-run against a stack they don't use.
+    exclude: ["node_modules", ".next", "out", "ios", "tests/integration/**/*.pg.test.ts"],
     globalSetup: ["tests/integration/global-setup.ts"],
     // Booting supabase + applying schema + seeding fixture can run long
     // on a cold Docker boot; give the suite room without holding the

--- a/vitest.pg.config.ts
+++ b/vitest.pg.config.ts
@@ -1,0 +1,23 @@
+// Vitest config for the embedded-postgres integration suite (`*.pg.test.ts`).
+//
+// Distinct from vitest.integration.config.ts: those tests boot a Dockerized
+// Supabase stack via global-setup and talk to it through PostgREST. These boot
+// a throwaway embedded-postgres cluster INSIDE each test file's beforeAll and
+// drive it through a raw `pg` client — so there is NO globalSetup here, and no
+// Docker/virtualization requirement. Run with `npm run test:pg`.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["tests/integration/**/*.pg.test.ts"],
+    exclude: ["node_modules", ".next", "out", "ios"],
+    // initdb + cluster boot happens in beforeAll; give it room. The cluster
+    // binary ships extracted with @embedded-postgres/windows-x64, so there's
+    // no download — but a cold initdb on Windows can still take ~10-20s.
+    testTimeout: 30_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## What

Adds integration coverage for the `apply_template_to_estimate` PL/pgSQL RPC redefined by #351, which shipped (PR #357) with **no automated test** — the unit suite only covers the TS serialize/synth round-trip (AC #1/#2/#5).

**10 tests** exercise the real `migration-351` SQL verbatim:

- **AC #3** — a fresh snapshot template applies its own flat name/code/unit/description/qty/price onto the estimate
- **AC #4** — a legacy `*_override` template resolves name/code/unit from the library and description/qty/price from the override fields (dual-shape fallback)
- the flat snapshot wins over both `*_override` and library values (precedence)
- subsection items nest under a child section pointing at its parent
- a dangling `library_item_id` → `[unknown item]` line item + `broken_ref{placeholder:true}`, breadcrumb kept
- totals recompute from the estimate's markup/discount/tax settings
- the four guards reject (`not_found` / `not_draft` / `not_empty` / `template_inactive`)

## Harness

The repo's Docker/supabase integration harness can't run on this machine (no Docker; virtualization disabled in BIOS), so this suite boots a throwaway **embedded-postgres** cluster and drives the function through a raw `pg` client at the SQL layer — no Docker, no PostgREST.

- `tests/integration/apply-template.pg.test.ts`
- `tests/integration/apply-template-schema.sql` — focused 5-table schema (estimates has no `job_id` FK; `line_items.library_item_id` is FK-less for the broken-ref case)
- `vitest.pg.config.ts` + `npm run test:pg`; `*.pg.test.ts` is excluded from the Docker integration config so it isn't double-run
- devDeps: `embedded-postgres`, `pg`, `@types/pg`

Also commits `docs/adr/0004-template-line-items-snapshot.md`, which PR #357 referenced but never committed.

## Test plan

- `npm run test:pg` → **10/10 pass**
- ESLint clean; `tsc --noEmit` introduces no new errors (2 pre-existing, unrelated: `template-drag-end.test.tsx`, `sync-folder-incremental.test.ts`)
- The shared `tests/integration/schema.sql` was reverted to pristine — **no impact on the existing #282 test**

Re #351.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
