### PR TITLE
feat(photo-reports): source photos-per-page from Company Settings (#361)

### DIFF
--- a/docs/adr/0003-single-photo-report-layout.md
+++ b/docs/adr/0003-single-photo-report-layout.md
@@ -24,3 +24,26 @@ and footer code for no current need.
   not toggling it back on.
 - Existing PDFs in the `reports` bucket are not regenerated — they keep the
   old layout as a historical record.
+
+## Amended (May 2026, #361 — slice 1 of #360)
+
+The original rework left `report_photos_per_page` as "the only remaining knob"
+but never wired it through: the generator silently read the **per-template**
+`photo_report_templates.photos_per_page` column for the body layout, so the
+Settings → Report Defaults control did nothing. This is now corrected.
+
+- **Photos-per-page is global**, sourced from
+  `company_settings.report_photos_per_page` (a key/value row, stored as the
+  string `"1" | "2" | "4"`, default `"2"`). The new pure module
+  `resolvePhotosPerPage()` (`src/lib/resolve-photos-per-page.ts`) is the single
+  place that parses and validates that string into a `1 | 2 | 4`, falling back
+  to `2` for missing/empty/invalid values.
+- The per-template **`photo_report_templates.photos_per_page` column is now dead
+  at render time**, exactly like `cover_page` JSON already is. The generator no
+  longer reads it.
+- A report's **`template_id` is preset provenance only** — it no longer
+  influences rendering. Reports created under the old template-bound flow
+  generate correctly under the global value.
+- The `photo_report_templates` table and its `photos_per_page` column are not
+  dropped (still dead data, a separate migration). No schema change or migration
+  accompanies this amendment.

--- a/src/lib/generate-report-pdf.test.tsx
+++ b/src/lib/generate-report-pdf.test.tsx
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Integration-flavored test for the report generator's photos-per-page wiring
+ * (issue #361). Supabase is mocked at the client boundary (@/lib/supabase), the
+ * react-pdf renderer and the document component are stubbed so no real PDF is
+ * produced, and the pure layout engine is spied so we can read the
+ * photos-per-page it was handed.
+ *
+ * The seeded report carries a template_id and the seeded template advertises a
+ * DIFFERENT photos_per_page (1) than Company Settings (4) — so any test that
+ * expects the settings value proves the template no longer drives layout.
+ */
+const h = vi.hoisted(() => {
+  const REPORT_ID = "report-1";
+  const JOB_NUMBER = "JOB-123";
+  const TEMPLATE_PHOTOS_PER_PAGE = 1;
+
+  const state = {
+    // value of the report_photos_per_page company_settings row; undefined = row absent
+    companySettingsValue: "4" as string | undefined,
+    fromTables: [] as string[],
+    companySettingsKeys: [] as string[],
+    uploads: [] as Array<{ bucket: string; path: string }>,
+    templateQueried: false,
+  };
+
+  const reportRow = {
+    id: REPORT_ID,
+    title: "Roof Inspection",
+    report_date: "2026-05-29",
+    template_id: "tmpl-1",
+    sections: [{ title: "Exterior", description: "", photo_ids: ["photo-1"] }],
+    job: {
+      id: "job-1",
+      job_number: JOB_NUMBER,
+      property_address: "123 Main St",
+      claim_number: "CLM-9",
+      insurance_company: "Acme Mutual",
+      cover_photo_id: null,
+      contact: { full_name: "Jane Doe" },
+      cover_photo: null,
+    },
+  };
+
+  const photoRows = [
+    {
+      id: "photo-1",
+      storage_path: "p/photo-1.jpg",
+      annotated_path: null,
+      caption: null,
+      before_after_pair_id: null,
+      before_after_role: null,
+      taken_at: null,
+      taken_by: null,
+      width: 100,
+      height: 100,
+    },
+  ];
+
+  function companyRows() {
+    const rows: Array<{ key: string; value: string }> = [
+      { key: "company_name", value: "Acme Restoration" },
+      { key: "phone", value: "555-1212" },
+      { key: "email", value: "ops@acme.test" },
+      { key: "logo_path", value: "" },
+    ];
+    if (state.companySettingsValue !== undefined) {
+      rows.push({
+        key: "report_photos_per_page",
+        value: state.companySettingsValue,
+      });
+    }
+    return rows;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function makeQuery(table: string): any {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const q: any = {
+      select: () => q,
+      update: () => q,
+      eq: () => q,
+      in: (col: string, vals: string[]) => {
+        if (table === "company_settings" && col === "key") {
+          state.companySettingsKeys = vals;
+        }
+        return q;
+      },
+      single: () => {
+        if (table === "photo_report_templates") {
+          state.templateQueried = true;
+          return Promise.resolve({
+            data: { photos_per_page: TEMPLATE_PHOTOS_PER_PAGE },
+            error: null,
+          });
+        }
+        if (table === "photo_reports") {
+          return Promise.resolve({ data: reportRow, error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      then: (onFulfilled: any, onRejected: any) => {
+        let result: { data: unknown; error: null };
+        if (table === "company_settings") {
+          result = { data: companyRows(), error: null };
+        } else if (table === "photos") {
+          result = { data: photoRows, error: null };
+        } else {
+          result = { data: null, error: null };
+        }
+        return Promise.resolve(result).then(onFulfilled, onRejected);
+      },
+    };
+    return q;
+  }
+
+  function makeClient() {
+    return {
+      from: (table: string) => {
+        state.fromTables.push(table);
+        return makeQuery(table);
+      },
+      storage: {
+        from: (bucket: string) => ({
+          upload: (path: string) => {
+            state.uploads.push({ bucket, path });
+            return Promise.resolve({ data: { path }, error: null });
+          },
+        }),
+      },
+    };
+  }
+
+  return { REPORT_ID, JOB_NUMBER, TEMPLATE_PHOTOS_PER_PAGE, state, makeClient };
+});
+
+vi.mock("@/lib/supabase", () => ({ createClient: () => h.makeClient() }));
+vi.mock("@react-pdf/renderer", () => ({
+  pdf: () => ({
+    toBlob: async () => new Blob(["%PDF"], { type: "application/pdf" }),
+  }),
+}));
+vi.mock("@/components/report-pdf-document", () => ({ default: () => null }));
+vi.mock("@/lib/build-report-document", () => ({
+  buildReportDocument: vi.fn(() => []),
+}));
+
+import { generateReportPDF } from "./generate-report-pdf";
+import { buildReportDocument } from "@/lib/build-report-document";
+
+describe("generateReportPDF — photos-per-page wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.state.companySettingsValue = "4";
+    h.state.fromTables = [];
+    h.state.companySettingsKeys = [];
+    h.state.uploads = [];
+    h.state.templateQueried = false;
+    vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
+  });
+
+  afterEach(() => {
+    // Hermetic: don't leak the env stub into other files sharing this worker.
+    vi.unstubAllEnvs();
+  });
+
+  it("hands buildReportDocument the photos-per-page from Company Settings, not the template", async () => {
+    await generateReportPDF(h.REPORT_ID);
+
+    expect(buildReportDocument).toHaveBeenCalledTimes(1);
+    const arg = vi.mocked(buildReportDocument).mock.calls[0][0];
+    // Settings say 4; the seeded template says 1. The resolved value must be 4.
+    expect(arg.photosPerPage).toBe(4);
+  });
+
+  it("loads report_photos_per_page among the Company Settings keys", async () => {
+    await generateReportPDF(h.REPORT_ID);
+
+    expect(h.state.companySettingsKeys).toContain("report_photos_per_page");
+  });
+
+  it("never queries photo_report_templates for layout", async () => {
+    await generateReportPDF(h.REPORT_ID);
+
+    expect(h.state.fromTables).not.toContain("photo_report_templates");
+    expect(h.state.templateQueried).toBe(false);
+  });
+
+  it("defaults to 2 photos per page when the setting has never been set", async () => {
+    h.state.companySettingsValue = undefined; // no report_photos_per_page row
+
+    await generateReportPDF(h.REPORT_ID);
+
+    const arg = vi.mocked(buildReportDocument).mock.calls[0][0];
+    expect(arg.photosPerPage).toBe(2);
+  });
+
+  it("still generates a report carrying a template_id, using the global value", async () => {
+    h.state.companySettingsValue = "1"; // company-wide setting
+
+    const pdfPath = await generateReportPDF(h.REPORT_ID);
+
+    // reportRow.template_id is "tmpl-1" (old template-bound flow), but layout
+    // now comes from the global setting (1), not the template (1 here too, so
+    // also assert the template was never consulted).
+    expect(h.state.templateQueried).toBe(false);
+    const arg = vi.mocked(buildReportDocument).mock.calls[0][0];
+    expect(arg.photosPerPage).toBe(1);
+    expect(pdfPath).toBe(`${h.JOB_NUMBER}/${h.REPORT_ID}.pdf`);
+  });
+
+  it("uploads the PDF to {job_number}/{reportId}.pdf in the reports bucket", async () => {
+    await generateReportPDF(h.REPORT_ID);
+
+    expect(h.state.uploads).toEqual([
+      { bucket: "reports", path: `${h.JOB_NUMBER}/${h.REPORT_ID}.pdf` },
+    ]);
+  });
+});

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -8,6 +8,7 @@ import {
   type ReportPhotoInput,
 } from "@/lib/build-report-document";
 import { resolveCoverPageData } from "@/lib/cover-page-data";
+import { resolvePhotosPerPage } from "@/lib/resolve-photos-per-page";
 import type { CompanySettings } from "@/lib/types";
 
 interface ReportSection {
@@ -41,6 +42,7 @@ const COMPANY_SETTINGS_KEYS = [
   "phone",
   "email",
   "logo_path",
+  "report_photos_per_page",
 ] as const;
 
 async function loadCompanySettings(
@@ -99,23 +101,13 @@ export async function generateReportPDF(reportId: string): Promise<string> {
   const job = report.job as JoinedJob;
   const sections = report.sections as ReportSection[];
 
-  // 2. photos_per_page is still template-driven for the body (slice 1: cover
-  //    only). Template's cover_page JSON is no longer read.
-  let photosPerPage = 2;
-  if (report.template_id) {
-    const { data: template } = await supabase
-      .from("photo_report_templates")
-      .select("photos_per_page")
-      .eq("id", report.template_id)
-      .single();
-
-    if (template) {
-      photosPerPage = template.photos_per_page;
-    }
-  }
-
-  // 3. Company settings for cover page + branding
+  // 2. Company settings for cover page + branding + body layout
   const companySettings = await loadCompanySettings(supabase);
+
+  // 3. Photos-per-page is company-wide (ADR 0003, amended): resolved from
+  //    Company Settings, not the report's template. A report's template_id is
+  //    preset provenance only and no longer influences layout.
+  const photosPerPage = resolvePhotosPerPage(companySettings);
 
   // 4. Resolve cover page model (pure)
   const coverPageData = resolveCoverPageData(

--- a/src/lib/resolve-photos-per-page.test.ts
+++ b/src/lib/resolve-photos-per-page.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolvePhotosPerPage,
+  type PhotosPerPage,
+} from "./resolve-photos-per-page";
+
+describe("resolvePhotosPerPage", () => {
+  it('returns 2 when the stored setting is "2"', () => {
+    expect(resolvePhotosPerPage({ report_photos_per_page: "2" })).toBe(2);
+  });
+
+  it("passes the valid stored strings through to their numbers", () => {
+    const cases: Array<[string, PhotosPerPage]> = [
+      ["1", 1],
+      ["2", 2],
+      ["4", 4],
+    ];
+    for (const [stored, expected] of cases) {
+      expect(resolvePhotosPerPage({ report_photos_per_page: stored })).toBe(
+        expected,
+      );
+    }
+  });
+
+  it("falls back to 2 when the key is missing", () => {
+    expect(resolvePhotosPerPage({})).toBe(2);
+  });
+
+  it("falls back to 2 when the settings object is null or undefined", () => {
+    expect(resolvePhotosPerPage(null)).toBe(2);
+    expect(resolvePhotosPerPage(undefined)).toBe(2);
+  });
+
+  it("falls back to 2 for an empty string", () => {
+    expect(resolvePhotosPerPage({ report_photos_per_page: "" })).toBe(2);
+  });
+
+  it("falls back to 2 for out-of-range or non-numeric strings", () => {
+    for (const invalid of ["3", "0", "abc", "-1", "2.5"]) {
+      expect(resolvePhotosPerPage({ report_photos_per_page: invalid })).toBe(2);
+    }
+  });
+
+  it("tolerates a numeric value as well as a string", () => {
+    expect(resolvePhotosPerPage({ report_photos_per_page: 1 })).toBe(1);
+    expect(resolvePhotosPerPage({ report_photos_per_page: 4 })).toBe(4);
+    expect(resolvePhotosPerPage({ report_photos_per_page: 3 })).toBe(2);
+  });
+});

--- a/src/lib/resolve-photos-per-page.ts
+++ b/src/lib/resolve-photos-per-page.ts
@@ -1,0 +1,30 @@
+/** The validated set of photos-per-page layout values a report body can use. */
+export type PhotosPerPage = 1 | 2 | 4;
+
+const DEFAULT_PHOTOS_PER_PAGE: PhotosPerPage = 2;
+
+/**
+ * The slice of Company Settings that carries the company-wide photos-per-page
+ * value. Company Settings are key/value rows, so the value arrives as a string
+ * ("1" | "2" | "4"); it is typed loosely here to tolerate a numeric value too.
+ */
+export interface PhotosPerPageSettings {
+  report_photos_per_page?: string | number | null;
+}
+
+/**
+ * Resolve the company-wide photos-per-page layout value from Company Settings.
+ *
+ * This is the single place the stored `report_photos_per_page` value is parsed
+ * and validated, containing the string-to-number boundary in one tested
+ * function. Missing, empty, or out-of-range values fall back to 2.
+ */
+export function resolvePhotosPerPage(
+  settings: PhotosPerPageSettings | null | undefined,
+): PhotosPerPage {
+  const parsed = Number(settings?.report_photos_per_page);
+  if (parsed === 1 || parsed === 2 || parsed === 4) {
+    return parsed;
+  }
+  return DEFAULT_PHOTOS_PER_PAGE;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -506,6 +506,8 @@ export interface CompanySettings {
   email?: string;
   website?: string;
   license_number?: string;
+  /** Company-wide photos-per-page for generated photo reports ("1" | "2" | "4"). */
+  report_photos_per_page?: string;
 }
 
 export type VendorType =


### PR DESCRIPTION
## Summary

Slice 1 of #360. Makes Settings → Report Defaults **Photos Per Page** the single, company-wide source of truth for how many photos render per body page of a generated photo report. Previously the generator silently read the per-template `photos_per_page`, so the knob was decorative.

## Changes
- **New** `src/lib/resolve-photos-per-page.ts` — pure `resolvePhotosPerPage()`: parses/validates the stored `report_photos_per_page` string into `1 | 2 | 4`, falling back to `2` for missing/empty/invalid values. The string↔number boundary now lives in exactly one tested function.
- **Rewire** `src/lib/generate-report-pdf.tsx` — load `report_photos_per_page` alongside the other Company Settings keys, derive `photosPerPage` via `resolvePhotosPerPage`, and **delete** the `photo_report_templates.photos_per_page` fetch. A report's `template_id` is now preset provenance only.
- `CompanySettings` gains `report_photos_per_page?: string` (keeps the `as CompanySettings` cast honest).
- **ADR 0003** amended: photos-per-page is global via `company_settings.report_photos_per_page`; the per-template column is dead at render time (like `cover_page` JSON).
- No schema change, no migration.

## Tests (TDD, red→green per behavior)
- `resolve-photos-per-page.test.ts` (7): `"1"/"2"/"4"` → 1/2/4, missing → 2, empty → 2, `"3"/"0"/"abc"` → 2, numeric tolerance.
- `generate-report-pdf.test.tsx` (6, Supabase mocked at the `@/lib/supabase` client boundary): the resolved value reaches `buildReportDocument`; `report_photos_per_page` is loaded; `photo_report_templates` is **never** queried; default 2 when unset; a report carrying a `template_id` still generates under the global value; upload targets `{job_number}/{reportId}.pdf`.

All 13 pass in isolation.

> ℹ️ The full `npm test` suite is flaky **independent of this change** — verified by stashing these edits and re-running: the clean tree is also red, with a different victim set each run (none of which are these files). Worth a separate task.

Closes #361.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
