### PR TITLE
feat(photo-reports): optional section presets + manual section editor (#362)

### DIFF
--- a/src/app/reports/new/page.test.tsx
+++ b/src/app/reports/new/page.test.tsx
@@ -1,0 +1,467 @@
+// Issue #362 — Photo Report Rework, Slice 2.
+//
+// Behavior pinned here (from the issue's acceptance criteria):
+//   - The report title field is visible without selecting a preset and
+//     defaults to "Photo Report"; it remains editable.
+//   - The preset picker is optional and labeled a "section preset"; selecting
+//     one pre-fills section titles/descriptions and does NOT set photos-per-page.
+//   - A user can add, rename, edit the description of, and remove a section.
+//   - A report can be created and saved with manually-added sections and no
+//     preset selected; save still requires at least one section.
+//
+// Supabase is mocked at the client boundary. The mock builder is both
+// chainable (.select/.order/.eq/.insert) and awaitable (thenable), mirroring
+// the real supabase-js query builder, and resolves per-table from `state`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const state = vi.hoisted(() => ({
+  jobs: [] as Array<Record<string, unknown>>,
+  templates: [] as Array<Record<string, unknown>>,
+  photos: [] as Array<Record<string, unknown>>,
+  tags: [] as Array<Record<string, unknown>>,
+  assignments: [] as Array<Record<string, unknown>>,
+  inserted: [] as Array<{ table: string; payload: Record<string, unknown> }>,
+}));
+
+vi.mock("@/lib/supabase", () => {
+  function createClient() {
+    function from(table: string) {
+      const resultFor = () => {
+        switch (table) {
+          case "jobs":
+            return { data: state.jobs, error: null };
+          case "photo_report_templates":
+            return { data: state.templates, error: null };
+          case "photo_tags":
+            return { data: state.tags, error: null };
+          case "photos":
+            return { data: state.photos, error: null };
+          case "photo_tag_assignments":
+            return { data: state.assignments, error: null };
+          case "photo_reports":
+            return { data: { id: "new-report-id" }, error: null };
+          default:
+            return { data: [], error: null };
+        }
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: () => chain,
+        order: () => chain,
+        eq: () => chain,
+        insert: (payload: Record<string, unknown>) => {
+          state.inserted.push({ table, payload });
+          return chain;
+        },
+        single: () => Promise.resolve(resultFor()),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        then: (resolve: any, reject: any) =>
+          Promise.resolve(resultFor()).then(resolve, reject),
+      };
+      return chain;
+    }
+    return { from };
+  }
+  return { createClient };
+});
+
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: () => Promise.resolve("org-1"),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import NewReportPage from "./page";
+
+function seedDefaults() {
+  state.jobs = [
+    {
+      id: "job-1",
+      job_number: "JOB-001",
+      property_address: "123 Main St",
+      claim_number: "CLM-1",
+      insurance_company: "Acme",
+    },
+  ];
+  state.templates = [];
+  state.photos = [];
+  state.tags = [];
+  state.assignments = [];
+  state.inserted = [];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: any confirm() prompt is accepted. Tests that exercise a decline
+  // override this. jsdom's native confirm() returns false and warns, so we
+  // replace it outright rather than spy (avoids spy nesting across tests).
+  window.confirm = vi.fn(() => true);
+  seedDefaults();
+});
+
+describe("NewReportPage — report title", () => {
+  it("shows the title field without a preset, defaulting to 'Photo Report'", async () => {
+    render(<NewReportPage />);
+
+    // No preset is selected and none even exist; the title field must still be
+    // present and pre-filled with the default.
+    expect(await screen.findByDisplayValue("Photo Report")).toBeDefined();
+  });
+});
+
+describe("NewReportPage — section preset picker", () => {
+  it("labels the picker a 'section preset' and marks it optional", async () => {
+    render(<NewReportPage />);
+
+    expect(await screen.findByText(/section preset/i)).toBeDefined();
+    expect(screen.getByText(/optional/i)).toBeDefined();
+    // The old mandatory "Choose Template" framing is gone.
+    expect(screen.queryByText(/choose template/i)).toBeNull();
+  });
+});
+
+describe("NewReportPage — manual section editor", () => {
+  it("lets the user add a manual section", async () => {
+    render(<NewReportPage />);
+
+    const addBtn = await screen.findByRole("button", { name: /add section/i });
+    // No sections to start (no preset selected).
+    expect(screen.queryByPlaceholderText(/section title/i)).toBeNull();
+
+    fireEvent.click(addBtn);
+
+    expect(screen.getByPlaceholderText(/section title/i)).toBeDefined();
+  });
+
+  it("supports the full add / rename / edit-description / remove lifecycle", async () => {
+    render(<NewReportPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /add section/i }));
+
+    // Rename.
+    fireEvent.change(screen.getByPlaceholderText(/section title/i), {
+      target: { value: "Roof Damage" },
+    });
+    expect(
+      (screen.getByPlaceholderText(/section title/i) as HTMLInputElement).value,
+    ).toBe("Roof Damage");
+
+    // Edit description.
+    fireEvent.change(screen.getByPlaceholderText(/description/i), {
+      target: { value: "Shingles missing after the storm" },
+    });
+    expect(
+      (screen.getByPlaceholderText(/description/i) as HTMLInputElement).value,
+    ).toBe("Shingles missing after the storm");
+
+    // Remove.
+    fireEvent.click(screen.getByRole("button", { name: /remove section/i }));
+    expect(screen.queryByPlaceholderText(/section title/i)).toBeNull();
+  });
+});
+
+function seedPreset() {
+  state.templates = [
+    {
+      id: "preset-1",
+      name: "Adjuster Report",
+      audience: "adjuster",
+      sections: [
+        { title: "Exterior", description: "Roof and siding" },
+        { title: "Interior", description: "Water damage" },
+      ],
+      cover_page: {},
+      photos_per_page: 4,
+      created_by: "tester",
+      created_at: "2026-05-29T00:00:00Z",
+      updated_at: "2026-05-29T00:00:00Z",
+    },
+  ];
+}
+
+describe("NewReportPage — choosing a section preset", () => {
+  it("pre-fills the section editor with the preset's titles and descriptions", async () => {
+    seedPreset();
+    render(<NewReportPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /adjuster report/i }));
+
+    const titles = screen
+      .getAllByPlaceholderText(/section title/i)
+      .map((el) => (el as HTMLInputElement).value);
+    expect(titles).toEqual(["Exterior", "Interior"]);
+
+    const descriptions = screen
+      .getAllByPlaceholderText(/description/i)
+      .map((el) => (el as HTMLInputElement).value);
+    expect(descriptions).toEqual(["Roof and siding", "Water damage"]);
+  });
+
+  it("does not let the preset drive the report title", async () => {
+    seedPreset();
+    render(<NewReportPage />);
+
+    // Pick a job, then a preset — neither should rewrite the default title.
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /adjuster report/i }));
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Photo Report")).toBeDefined();
+    });
+  });
+
+  it("does not re-seed (wiping edits) when the active preset is clicked again", async () => {
+    seedPreset();
+    render(<NewReportPage />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /adjuster report/i }));
+    // Rename a seeded section, then click the SAME preset again.
+    fireEvent.change(screen.getAllByPlaceholderText(/section title/i)[0], {
+      target: { value: "Custom Exterior" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /adjuster report/i }));
+
+    // The edit survives — re-clicking the active preset is a no-op.
+    expect(
+      (screen.getAllByPlaceholderText(/section title/i)[0] as HTMLInputElement)
+        .value,
+    ).toBe("Custom Exterior");
+  });
+
+  it("prompts before a different preset overwrites existing sections, and respects a decline", async () => {
+    state.templates = [
+      {
+        id: "preset-1",
+        name: "Adjuster Report",
+        audience: "adjuster",
+        sections: [
+          { title: "Exterior", description: "Roof and siding" },
+          { title: "Interior", description: "Water damage" },
+        ],
+        cover_page: {},
+        photos_per_page: 4,
+        created_by: "tester",
+        created_at: "2026-05-29T00:00:00Z",
+        updated_at: "2026-05-29T00:00:00Z",
+      },
+      {
+        id: "preset-2",
+        name: "Customer Summary",
+        audience: "customer",
+        sections: [{ title: "Summary", description: "Overview" }],
+        cover_page: {},
+        photos_per_page: 2,
+        created_by: "tester",
+        created_at: "2026-05-29T00:00:00Z",
+        updated_at: "2026-05-29T00:00:00Z",
+      },
+    ];
+    window.confirm = vi.fn(() => false);
+    render(<NewReportPage />);
+
+    // First pick seeds with no prompt (there were no sections to lose).
+    fireEvent.click(await screen.findByRole("button", { name: /adjuster report/i }));
+    expect(window.confirm).not.toHaveBeenCalled();
+
+    // Switching to a different preset would discard the current sections — prompt.
+    fireEvent.click(screen.getByRole("button", { name: /customer summary/i }));
+    expect(window.confirm).toHaveBeenCalled();
+
+    // Declined → the original sections are untouched.
+    const titles = screen
+      .getAllByPlaceholderText(/section title/i)
+      .map((el) => (el as HTMLInputElement).value);
+    expect(titles).toEqual(["Exterior", "Interior"]);
+  });
+});
+
+// The step indicator and the bottom call-to-action share a label (e.g. both
+// read "Select Photos"). Clicking the last match targets the bottom CTA, which
+// is a no-op while disabled — so a failed gate keeps the wizard on its step.
+function clickPrimary(name: RegExp) {
+  const buttons = screen.getAllByRole("button", { name });
+  fireEvent.click(buttons[buttons.length - 1]);
+}
+
+describe("NewReportPage — step gating", () => {
+  it("advances past setup with a job and a manual section, no preset", async () => {
+    render(<NewReportPage />);
+
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add section/i }));
+    fireEvent.change(screen.getByPlaceholderText(/section title/i), {
+      target: { value: "Roof" },
+    });
+
+    // No preset was ever selected.
+    clickPrimary(/select photos/i);
+
+    // Step 2 ("Select Photos") is now showing — its caption filter is present.
+    expect(
+      await screen.findByPlaceholderText(/filter by caption/i),
+    ).toBeDefined();
+  });
+
+  it("blocks advancing past setup when no section exists", async () => {
+    render(<NewReportPage />);
+
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+
+    // Job selected but zero sections — the gate must hold.
+    clickPrimary(/select photos/i);
+
+    expect(screen.queryByPlaceholderText(/filter by caption/i)).toBeNull();
+  });
+});
+
+describe("NewReportPage — saving", () => {
+  it("creates and saves a report with manual sections and no preset", async () => {
+    state.photos = [
+      {
+        id: "photo-1",
+        job_id: "job-1",
+        media_type: "photo",
+        caption: "Front door",
+        before_after_role: null,
+        storage_path: "p1.jpg",
+        annotated_path: null,
+      },
+    ];
+    render(<NewReportPage />);
+
+    // Step 1 — job + a manual section, no preset.
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add section/i }));
+    fireEvent.change(screen.getByPlaceholderText(/section title/i), {
+      target: { value: "Roof" },
+    });
+    clickPrimary(/select photos/i);
+
+    // Step 2 — pick the photo so we can reach the assignment step.
+    fireEvent.click(await screen.findByRole("button", { name: /front door/i }));
+    clickPrimary(/assign to sections/i);
+
+    // Step 3 — save the draft.
+    clickPrimary(/save draft report/i);
+
+    await waitFor(() => {
+      expect(
+        state.inserted.find((i) => i.table === "photo_reports"),
+      ).toBeDefined();
+    });
+
+    const payload = state.inserted.find(
+      (i) => i.table === "photo_reports",
+    )!.payload;
+    expect(payload.template_id).toBeNull();
+    expect(payload.title).toBe("Photo Report");
+    expect(payload.status).toBe("draft");
+    expect(payload.sections).toEqual([
+      { title: "Roof", description: "", photo_ids: [] },
+    ]);
+    expect(payload).not.toHaveProperty("photos_per_page");
+  });
+
+  it("saves a preset-seeded report with the preset id but no photos-per-page", async () => {
+    seedPreset();
+    state.photos = [
+      {
+        id: "photo-1",
+        job_id: "job-1",
+        media_type: "photo",
+        caption: "Front door",
+        before_after_role: null,
+        storage_path: "p1.jpg",
+        annotated_path: null,
+      },
+    ];
+    render(<NewReportPage />);
+
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /adjuster report/i }));
+    clickPrimary(/select photos/i);
+
+    fireEvent.click(await screen.findByRole("button", { name: /front door/i }));
+    clickPrimary(/assign to sections/i);
+    clickPrimary(/save draft report/i);
+
+    await waitFor(() => {
+      expect(
+        state.inserted.find((i) => i.table === "photo_reports"),
+      ).toBeDefined();
+    });
+
+    const payload = state.inserted.find(
+      (i) => i.table === "photo_reports",
+    )!.payload;
+    // Preset provenance is recorded...
+    expect(payload.template_id).toBe("preset-1");
+    // ...sections came from the preset...
+    expect(payload.sections).toEqual([
+      { title: "Exterior", description: "Roof and siding", photo_ids: [] },
+      { title: "Interior", description: "Water damage", photo_ids: [] },
+    ]);
+    // ...but the preset set neither a title nor a photos-per-page on the report.
+    expect(payload.title).toBe("Photo Report");
+    expect(payload).not.toHaveProperty("photos_per_page");
+  });
+
+  it("cannot create a report once every section has been removed", async () => {
+    // AC5's "save still requires at least one section" — exercised end-to-end.
+    // After deleting the only section, the setup gate closes again, the save
+    // step is unreachable, and no photo_reports row is ever inserted.
+    state.photos = [
+      {
+        id: "photo-1",
+        job_id: "job-1",
+        media_type: "photo",
+        caption: "Front door",
+        before_after_role: null,
+        storage_path: "p1.jpg",
+        annotated_path: null,
+      },
+    ];
+    render(<NewReportPage />);
+
+    fireEvent.change(await screen.findByRole("combobox"), {
+      target: { value: "job-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add section/i }));
+    fireEvent.change(screen.getByPlaceholderText(/section title/i), {
+      target: { value: "Roof" },
+    });
+    clickPrimary(/select photos/i);
+    fireEvent.click(await screen.findByRole("button", { name: /front door/i }));
+    clickPrimary(/assign to sections/i);
+
+    // Back to setup and delete the only section.
+    fireEvent.click(screen.getByRole("button", { name: /setup/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /remove section/i }));
+
+    // The gate now refuses to advance, so save is unreachable...
+    clickPrimary(/select photos/i);
+    expect(screen.queryByPlaceholderText(/filter by caption/i)).toBeNull();
+    // ...and nothing was ever written.
+    expect(
+      state.inserted.find((i) => i.table === "photo_reports"),
+    ).toBeUndefined();
+  });
+});

--- a/src/app/reports/new/page.tsx
+++ b/src/app/reports/new/page.tsx
@@ -26,14 +26,12 @@ import {
   Filter,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  buildInitialSections,
+  type ReportSection,
+} from "@/lib/build-initial-sections";
 import { toast } from "sonner";
 import Link from "next/link";
-
-interface ReportSection {
-  title: string;
-  description: string;
-  photo_ids: string[];
-}
 
 type Step = 1 | 2 | 3;
 
@@ -61,10 +59,9 @@ function NewReportPageInner() {
   const [step, setStep] = useState<Step>(1);
   const [selectedJobId, setSelectedJobId] = useState<string>(jobIdParam ?? "");
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
-  const [reportTitle, setReportTitle] = useState("");
+  const [reportTitle, setReportTitle] = useState("Photo Report");
   const [selectedPhotoIds, setSelectedPhotoIds] = useState<Set<string>>(new Set());
   const [sections, setSections] = useState<ReportSection[]>([]);
-  const [photosPerPage, setPhotosPerPage] = useState(2);
   const [saving, setSaving] = useState(false);
 
   // Filters for photo selection
@@ -133,39 +130,28 @@ function NewReportPageInner() {
     fetchPhotos();
   }, [fetchPhotos]);
 
-  // When template changes, populate sections
+  // Choosing a preset pre-fills the section editor from it. A preset only seeds
+  // section titles/descriptions — it no longer drives the report title or
+  // photos-per-page (photos-per-page is a global setting now; see #361).
   function applyTemplate(templateId: string) {
+    // Re-clicking the already-selected preset is a no-op — it would otherwise
+    // wipe any edits the user made to the seeded sections.
+    if (templateId === selectedTemplateId) return;
+    // Picking a preset replaces the current sections wholesale. When the user
+    // already has sections (hand-added or seeded from another preset), confirm
+    // before discarding that work.
+    if (
+      sections.length > 0 &&
+      !window.confirm(
+        "Replace the current sections with this preset? Sections you added or edited will be lost.",
+      )
+    ) {
+      return;
+    }
     setSelectedTemplateId(templateId);
     const tmpl = templates.find((t) => t.id === templateId);
-    if (tmpl) {
-      const tmplSections = tmpl.sections as { title: string; description: string }[];
-      setSections(
-        tmplSections.map((s) => ({
-          title: s.title,
-          description: s.description || "",
-          photo_ids: [],
-        }))
-      );
-      setPhotosPerPage(tmpl.photos_per_page);
-
-      // Auto-generate title
-      const job = jobs.find((j) => j.id === selectedJobId);
-      if (job) {
-        setReportTitle(`${tmpl.name} — ${job.job_number}`);
-      }
-    }
+    setSections(buildInitialSections(tmpl));
   }
-
-  // When job changes and template already selected, update title
-  useEffect(() => {
-    if (selectedJobId && selectedTemplateId) {
-      const tmpl = templates.find((t) => t.id === selectedTemplateId);
-      const job = jobs.find((j) => j.id === selectedJobId);
-      if (tmpl && job) {
-        setReportTitle(`${tmpl.name} — ${job.job_number}`);
-      }
-    }
-  }, [selectedJobId, selectedTemplateId, templates, jobs]);
 
   // Photo filtering
   const filteredPhotos = photos.filter((p) => {
@@ -227,6 +213,26 @@ function NewReportPageInner() {
     });
   }
 
+  // Manual section editing — add, rename, edit description, remove. These let a
+  // report be built entirely by hand, with no preset selected.
+  function addSection() {
+    setSections((prev) => [...prev, { title: "", description: "", photo_ids: [] }]);
+  }
+
+  function updateSectionField(
+    index: number,
+    field: "title" | "description",
+    value: string,
+  ) {
+    setSections((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, [field]: value } : s)),
+    );
+  }
+
+  function removeSection(index: number) {
+    setSections((prev) => prev.filter((_, i) => i !== index));
+  }
+
   function autoAssign() {
     // Distribute selected photos evenly across sections
     const ids = Array.from(selectedPhotoIds);
@@ -286,9 +292,11 @@ function NewReportPageInner() {
     return `${supabaseUrl}/storage/v1/object/public/photos/${storagePath}`;
   }
 
-  // Step validation
+  // Step validation. A preset is no longer required to advance — a report needs
+  // a job and at least one section (preset-seeded or added by hand). The
+  // "at least one section" rule is also re-checked at save time.
   function canProceedToStep2() {
-    return selectedJobId && selectedTemplateId;
+    return Boolean(selectedJobId) && sections.length > 0;
   }
 
   function canProceedToStep3() {
@@ -386,20 +394,30 @@ function NewReportPageInner() {
             )}
           </div>
 
-          {/* Template selection */}
+          {/* Section preset selection — optional. Pre-fills section
+              titles/descriptions only; sections can also be built by hand. */}
           <div className="bg-card rounded-xl border border-border p-5">
-            <label className="block text-sm font-semibold text-foreground mb-2">
-              Choose Template
+            <label className="block text-sm font-semibold text-foreground mb-1">
+              Section Preset{" "}
+              <span className="font-normal text-muted-foreground/60">
+                (optional)
+              </span>
             </label>
+            <p className="text-xs text-muted-foreground/60 mb-3">
+              Pre-fill sections from a saved preset, or build them by hand below.
+            </p>
             {templates.length === 0 ? (
-              <div className="text-center py-6">
-                <p className="text-sm text-muted-foreground/60">No templates available.</p>
-                <Link
-                  href="/reports/templates"
-                  className="text-sm text-primary hover:underline mt-1 inline-block"
-                >
-                  Create a template first
-                </Link>
+              <div className="text-center py-4">
+                <p className="text-sm text-muted-foreground/60">
+                  No presets yet — add sections by hand below, or{" "}
+                  <Link
+                    href="/reports/templates"
+                    className="text-primary hover:underline"
+                  >
+                    create a preset
+                  </Link>
+                  .
+                </p>
               </div>
             ) : (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
@@ -419,8 +437,7 @@ function NewReportPageInner() {
                     </p>
                     <p className="text-xs text-muted-foreground/60 mt-0.5 capitalize">
                       {tmpl.audience} &middot;{" "}
-                      {(tmpl.sections as unknown[]).length} sections &middot;{" "}
-                      {tmpl.photos_per_page}/page
+                      {(tmpl.sections as unknown[]).length} sections
                     </p>
                   </button>
                 ))}
@@ -428,19 +445,83 @@ function NewReportPageInner() {
             )}
           </div>
 
-          {/* Report title */}
-          {selectedTemplateId && (
-            <div className="bg-card rounded-xl border border-border p-5">
-              <label className="block text-sm font-semibold text-foreground mb-2">
-                Report Title
+          {/* Manual section editor — add / rename / edit description / remove.
+              Works whether sections were seeded from a preset or started empty. */}
+          <div className="bg-card rounded-xl border border-border p-5">
+            <div className="flex items-center justify-between mb-2">
+              <label className="block text-sm font-semibold text-foreground">
+                Sections
               </label>
-              <Input
-                value={reportTitle}
-                onChange={(e) => setReportTitle(e.target.value)}
-                placeholder="Enter report title..."
-              />
+              <span className="text-xs text-muted-foreground/60">
+                {sections.length} section{sections.length !== 1 ? "s" : ""}
+              </span>
             </div>
-          )}
+            {sections.length === 0 ? (
+              <p className="text-xs text-muted-foreground/60 mb-3">
+                No sections yet. Add one below — or pick a preset above — to start
+                building your report.
+              </p>
+            ) : (
+              <div className="space-y-3 mb-3">
+                {sections.map((section, si) => (
+                  <div
+                    key={si}
+                    className="rounded-lg border border-border p-3 space-y-2"
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-medium text-muted-foreground/60 w-5 shrink-0">
+                        {si + 1}.
+                      </span>
+                      <Input
+                        value={section.title}
+                        onChange={(e) =>
+                          updateSectionField(si, "title", e.target.value)
+                        }
+                        placeholder="Section title"
+                        className="flex-1"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeSection(si)}
+                        aria-label="Remove section"
+                        className="text-muted-foreground/60 hover:text-red-600 transition-colors p-1.5"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                    <Input
+                      value={section.description}
+                      onChange={(e) =>
+                        updateSectionField(si, "description", e.target.value)
+                      }
+                      placeholder="Description (optional)"
+                      className="ml-7"
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={addSection}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-dashed border-border text-muted-foreground hover:border-primary/40 hover:text-foreground transition-colors"
+            >
+              <Plus size={14} />
+              Add section
+            </button>
+          </div>
+
+          {/* Report title — always available, defaults to "Photo Report" */}
+          <div className="bg-card rounded-xl border border-border p-5">
+            <label className="block text-sm font-semibold text-foreground mb-2">
+              Report Title
+            </label>
+            <Input
+              value={reportTitle}
+              onChange={(e) => setReportTitle(e.target.value)}
+              placeholder="Enter report title..."
+            />
+          </div>
 
           {/* Next button */}
           <div className="flex justify-end">

--- a/src/lib/build-initial-sections.test.ts
+++ b/src/lib/build-initial-sections.test.ts
@@ -1,0 +1,58 @@
+// Issue #362 — Photo Report Rework, Slice 2.
+//
+// `buildInitialSections` is the single place that decides whether a new report
+// starts from a section preset or from a blank slate. Keeping that decision in
+// a pure helper (out of component state) makes it unit-testable and keeps the
+// wizard from re-deriving "preset vs blank" in scattered places.
+
+import { describe, expect, it } from "vitest";
+import { buildInitialSections } from "./build-initial-sections";
+import type { PhotoReportTemplate } from "@/lib/types";
+
+function makePreset(
+  sections: unknown[],
+  overrides: Partial<PhotoReportTemplate> = {},
+): PhotoReportTemplate {
+  return {
+    id: "preset-1",
+    name: "Insurance Adjuster Report",
+    audience: "adjuster",
+    sections,
+    cover_page: {},
+    photos_per_page: 4,
+    created_by: "tester",
+    created_at: "2026-05-29T00:00:00Z",
+    updated_at: "2026-05-29T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("buildInitialSections", () => {
+  it("returns an empty array when no preset is given", () => {
+    expect(buildInitialSections()).toEqual([]);
+  });
+
+  it("maps a preset's sections to title/description with empty photo_ids", () => {
+    const preset = makePreset([
+      { title: "Exterior", description: "Roof and siding" },
+      { title: "Interior", description: "Water damage" },
+    ]);
+
+    expect(buildInitialSections(preset)).toEqual([
+      { title: "Exterior", description: "Roof and siding", photo_ids: [] },
+      { title: "Interior", description: "Water damage", photo_ids: [] },
+    ]);
+  });
+
+  it("fills in an empty description when a preset section omits one", () => {
+    const preset = makePreset([{ title: "Overview" }]);
+
+    expect(buildInitialSections(preset)).toEqual([
+      { title: "Overview", description: "", photo_ids: [] },
+    ]);
+  });
+
+  it("returns an empty array for a preset that has no sections", () => {
+    expect(buildInitialSections(makePreset([]))).toEqual([]);
+  });
+});

--- a/src/lib/build-initial-sections.ts
+++ b/src/lib/build-initial-sections.ts
@@ -1,0 +1,31 @@
+// Issue #362 — Photo Report Rework, Slice 2.
+//
+// A photo report is built from an ordered list of sections. Those sections can
+// either be seeded from a "section preset" (a `photo_report_templates` row) or
+// added by hand. `buildInitialSections` is the single, pure place that turns an
+// optional preset into the report's starting sections — so the "start from
+// preset vs start blank" decision lives in one unit-testable spot instead of
+// being re-derived inside component state.
+
+import type { PhotoReportTemplate } from "@/lib/types";
+
+export interface ReportSection {
+  title: string;
+  description: string;
+  photo_ids: string[];
+}
+
+export function buildInitialSections(
+  preset?: PhotoReportTemplate | null,
+): ReportSection[] {
+  if (!preset) return [];
+  const presetSections = (preset.sections ?? []) as {
+    title?: string;
+    description?: string;
+  }[];
+  return presetSections.map((section) => ({
+    title: section.title ?? "",
+    description: section.description ?? "",
+    photo_ids: [],
+  }));
+}


### PR DESCRIPTION
## What & why

Slice 2 of the Photo Report Rework (#360, follow-up to #326). Reframes report
"templates" as **optional section presets** and lets a project manager build a
photo report from scratch — resolving the contradiction with ADR 0003
("templates are dead") where a template was previously mandatory to create any
report (it was the only way to get sections, auto-filled the title, and carried
a layout value).

Closes #362.

## Changes

- **Optional, relabeled preset picker** — "Section Preset (optional)". Choosing
  one pre-fills section titles/descriptions only; it no longer drives the report
  title or photos-per-page.
- **Manual section editor** in the setup step — add, rename, edit description,
  and remove sections, so a report can be built with no preset at all.
- **Step gating** no longer requires a preset: a job + at least one section
  (preset-seeded or hand-added) advances past setup; the at-least-one-section
  rule is preserved at save time.
- **Report title** is always visible/editable and defaults to "Photo Report".
- **`buildInitialSections(preset?)`** — new pure helper that owns the
  start-from-preset-vs-blank decision (unit-tested, kept out of component state).
- Switching or re-clicking presets now guards against silently discarding edited
  sections (`confirm()` before a destructive replace; re-clicking the active
  preset is a no-op).
- Removed dead `photosPerPage` wizard state and the misleading "X/page" hint on
  preset cards. `photo_report_templates` is **not** renamed or dropped — the
  relabel is UI-only.

Making photos-per-page a global setting lives in **#361** (parallel slice); this
PR only stops the wizard from setting it, and touches a disjoint set of files.

## Acceptance criteria

All 9 met (see the issue). Highlights:

- [x] Create + save a report with manual sections and **no** preset
- [x] Preset optional, labeled "section preset", pre-fills sections
- [x] Preset sets no photos-per-page on the report
- [x] Add / rename / edit-description / remove a section
- [x] Advance with a job + section, no preset; save still requires >= 1 section
- [x] Title always visible, defaults to "Photo Report"
- [x] Section-preset (templates) builder still usable
- [x] `buildInitialSections(preset?)` unit-tested
- [x] Wizard behavior test for manual-save and preset-prefill

## Testing

- `npx vitest run src/lib/build-initial-sections.test.ts src/app/reports/new/page.test.tsx` → **17 passing** (4 helper unit + 13 wizard behavior).
- Changed files are lint-clean and type-clean. `page.tsx` lint dropped from 10 problems on base to 8; the remainder are pre-existing (unrelated `set-state-in-effect`, dead imports, `<img>` hints).
- Built test-first (red → green → refactor). An adversarial multi-agent review flagged two minor items — silent section-replace when switching presets, and an untested save-time section guard — both addressed with tests in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
