### PR TITLE
feat(photo-reports): cover title fallback + cover/document render tests (#363)

### DIFF
--- a/src/components/report-pdf-document.test.tsx
+++ b/src/components/report-pdf-document.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+
+import ReportPDFDocument from "./report-pdf-document";
+import { collectText, expandTree, findAll } from "./report-pdf/test-helpers";
+import type { CoverPageData } from "@/lib/cover-page-data";
+import type { DocumentPage, PhotoSlot } from "@/lib/build-report-document";
+
+const coverData: CoverPageData = {
+  logo: { kind: "text", name: "AAA Disaster Recovery" },
+  customerName: "Jane Doe",
+  propertyAddress: "123 Main St",
+  pointOfContact: { companyName: "AAA Disaster Recovery", phone: null, email: null },
+  insurance: { visible: false, carrier: "", claimNumber: "" },
+};
+
+// Mirrors the (private) ReportPhoto shape the document resolves slots against.
+// If the production prop type drifts, the `photos={photos}` prop below stops
+// type-checking.
+type DocPhoto = {
+  id: string;
+  url: string;
+  caption: string | null;
+  before_after_role: "before" | "after" | null;
+  taken_at: string | null;
+};
+
+const photos: Record<string, DocPhoto> = {
+  "ba-before": {
+    id: "ba-before",
+    url: "https://example.com/before.jpg",
+    caption: null,
+    before_after_role: "before",
+    taken_at: null,
+  },
+  "ba-after": {
+    id: "ba-after",
+    url: "https://example.com/after.jpg",
+    caption: null,
+    before_after_role: "after",
+    taken_at: null,
+  },
+  "pp-1": {
+    id: "pp-1",
+    url: "https://example.com/pp1.jpg",
+    caption: "Standalone shot",
+    before_after_role: null,
+    taken_at: null,
+  },
+};
+
+function slot(
+  photoId: string,
+  number: number,
+  caption: string | null = null,
+): PhotoSlot {
+  return {
+    photoId,
+    number,
+    caption,
+    takenAt: null,
+    takenBy: null,
+    orientation: "portrait",
+  };
+}
+
+// One page of every kind, in document order. Each kind's component emits a
+// marker that no other page produces, so finding all four markers proves each
+// kind routed to its own component.
+const pages: DocumentPage[] = [
+  { kind: "cover" },
+  { kind: "sectionDivider", title: "Demolition Scope", description: "Tear-out work" },
+  {
+    kind: "beforeAfterPair",
+    sectionTitle: "Restoration",
+    before: slot("ba-before", 1),
+    after: slot("ba-after", 2),
+  },
+  {
+    kind: "photoPage",
+    sectionTitle: "Findings",
+    slots: [slot("pp-1", 3, "Standalone shot")],
+    photosPerPage: 2,
+  },
+];
+
+describe("ReportPDFDocument", () => {
+  it("maps each page kind to its corresponding page component", () => {
+    const tree = expandTree(
+      <ReportPDFDocument
+        title="Mitigation Scope"
+        coverPageData={coverData}
+        coverPhotoUrl={null}
+        logoUrl={null}
+        reportDate="2026-05-19"
+        pages={pages}
+        photos={photos}
+      />,
+    );
+
+    const text = collectText(tree);
+
+    // cover -> CoverPage. "Point of contact" and the report title are unique to
+    // the cover; the page-header's hardcoded "Photo Report" label and the
+    // customer name appear on every other page, so they cannot identify it.
+    expect(text).toContain("Point of contact");
+    expect(text).toContain("Mitigation Scope");
+
+    // sectionDivider -> SectionDividerPage.
+    expect(text).toContain("Demolition Scope");
+    expect(text).toContain("Tear-out work");
+
+    // beforeAfterPair -> BeforeAfterPairPage.
+    expect(text).toContain("Before");
+    expect(text).toContain("After");
+
+    // photoPage -> PhotoPage (its slot caption).
+    expect(text).toContain("Standalone shot");
+
+    // One PDF page per document page, none dropped or duplicated, cover first.
+    const pageNodes = findAll(tree, (n) => n.type === "PAGE");
+    expect(pageNodes).toHaveLength(pages.length);
+    expect(collectText(pageNodes[0])).toContain("Point of contact");
+  });
+});

--- a/src/components/report-pdf/cover-page.test.tsx
+++ b/src/components/report-pdf/cover-page.test.tsx
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import CoverPage from "./cover-page";
+import type { CoverPageData } from "@/lib/cover-page-data";
+import { collectText, expandTree, findAll } from "./test-helpers";
+
+function makeData(overrides: Partial<CoverPageData> = {}): CoverPageData {
+  return {
+    logo: { kind: "text", name: "AAA Disaster Recovery" },
+    customerName: "Jane Doe",
+    propertyAddress: "123 Main St",
+    pointOfContact: {
+      companyName: "AAA Disaster Recovery",
+      phone: "555-1234",
+      email: "info@aaa.example",
+    },
+    insurance: { visible: true, carrier: "State Farm", claimNumber: "CLM-001" },
+    ...overrides,
+  };
+}
+
+describe("CoverPage", () => {
+  it('falls back to "Photo Report" when the title is empty', () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData()}
+        title=""
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("Photo Report");
+  });
+
+  it('still falls back to "Photo Report" when the title is only whitespace', () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData()}
+        title="   "
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("Photo Report");
+  });
+
+  it("renders a provided title unchanged, without the fallback", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData()}
+        title="Mitigation Scope"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Mitigation Scope");
+    expect(text).not.toContain("Photo Report");
+  });
+
+  it("renders the customer name from the cover data", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData({ customerName: "Acme Restoration LLC" })}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("Acme Restoration LLC");
+  });
+
+  it("renders the insurance block when it is visible", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData({
+          insurance: {
+            visible: true,
+            carrier: "State Farm",
+            claimNumber: "CLM-001",
+          },
+        })}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Insurance Carrier:");
+    expect(text).toContain("State Farm");
+    expect(text).toContain("Claim Number:");
+    expect(text).toContain("CLM-001");
+  });
+
+  it("omits the insurance block when it is hidden", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData({
+          insurance: { visible: false, carrier: "", claimNumber: "" },
+        })}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).not.toContain("Insurance Carrier:");
+    expect(text).not.toContain("Claim Number:");
+  });
+
+  it("renders the company name as a styled-text logo when there is no image logo", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData({ logo: { kind: "text", name: "AAA Disaster Recovery" } })}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("AAA Disaster Recovery");
+    // No image logo branch was taken, and no cover photo was supplied, so the
+    // page renders no IMAGE primitives at all.
+    expect(findAll(tree, (n) => n.type === "IMAGE")).toHaveLength(0);
+  });
+
+  it("renders the image logo when an image logo is provided", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData({ logo: { kind: "image", path: "logos/co.png" } })}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl="https://cdn.example/logo.png"
+      />,
+    );
+
+    const imageUrls = findAll(tree, (n) => n.type === "IMAGE").map(
+      (n) => n.props.src as string,
+    );
+    expect(imageUrls).toContain("https://cdn.example/logo.png");
+  });
+});

--- a/src/components/report-pdf/cover-page.tsx
+++ b/src/components/report-pdf/cover-page.tsx
@@ -135,7 +135,7 @@ export default function CoverPage({
         )}
       </View>
 
-      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.title}>{title.trim() ? title : "Photo Report"}</Text>
 
       {coverPhotoUrl ? (
         <Image src={coverPhotoUrl} style={styles.coverPhoto} />


### PR DESCRIPTION
Final slice (3) of parent **#360**. Adds the renderer-side cover-title fallback and the two render-shape tests #326 promised but never wrote. The wizard title default ("Photo Report") already shipped in #362.

## What changed
- **`cover-page.tsx`** (1 line): the cover title falls back to `"Photo Report"` when the report title is empty or whitespace-only — defense in depth so a report persisted with an empty title still renders a titled cover. `photo_reports.title` is `NOT NULL` but may be `""`, so this can't throw. The page-header's separate hardcoded running label is intentionally unaffected.
- **`cover-page.test.tsx`** (new): render-shape tests for the cover.
- **`report-pdf-document.test.tsx`** (new): page-kind → component mapping.

## Acceptance criteria
- [x] Empty/missing title renders `"Photo Report"`.
- [x] A set title renders unchanged (and the fallback does **not** fire).
- [x] Cover render test asserts: customer name; title incl. empty→fallback; insurance block visible vs hidden; styled-text logo vs image logo branch.
- [x] Document render test asserts each page kind (cover, sectionDivider, beforeAfterPair, photoPage) maps to its component, with one PDF page per document page.
- [x] Tests follow the existing render-shape pattern (content presence via `expandTree`/`collectText`/`findAll`, not pixel snapshots) and the suite passes.

## Test plan
- 9 new tests pass; full **component suite 267/267** (no regressions); lint **0 errors** on changed files; `tsc` clean on changed files.
- Full suite: 1700 pass / 2 fail — the 2 are pre-existing `referral-partners` worker-pollution flakiness (green in isolation), unrelated to this change.
- A 4-lens adversarial multi-agent review (each finding verified by 3 skeptics) returned **0 findings**.

Closes #363. Once merged, all four slices of #360 are done and the parent / #326 can close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)