### PR TITLE
docs(phone): glossary terms + ADRs 0005/0006 for shipped phone subsystem

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -66,6 +66,55 @@ of thing. The settings UI groups these together because they share a shape
 being sent.
 _Avoid_: send config, mail rule, payment email / invoice email / contract email (use "Outgoing email for X")
 
+**Phone number**:
+A telephony endpoint (a single phone number provisioned through Nookleus's
+telephony backbone — Twilio, see [ADR 0006](docs/adr/0006-twilio-as-telephony-backbone.md)) that Nookleus uses to send and receive
+texts and voice calls on behalf of an Organization. Belongs to exactly one
+Organization. Comes in two kinds — a Shared phone number or a Personal
+phone number, parallel in shape to Email account / Shared email account /
+Personal email account but with a different content-privacy rule (see
+Conversation and [ADR 0005](docs/adr/0005-shared-and-personal-phone-numbers.md)).
+_Avoid_: line, extension, DID
+
+**Shared phone number**:
+A Phone number the whole Organization works from — e.g. the main `(555)
+555-COMPANY` line a Google/Yelp ad points to. Every member with phone
+access can text/call from it and read its incoming messages; only admins
+change its settings or release it.
+_Avoid_: company line, main line, marketing number
+
+**Personal phone number**:
+A Phone number owned by exactly one User. Used for one-on-one
+relationship texting/calling with a customer so the customer can reach a
+specific Crew Lead rather than the company switchboard. Content visibility
+is rule-bound (see Conversation) — not blanket-private like a Personal
+email account, because Job-related content stays team-visible. An admin
+can see the number exists and release it for offboarding, but cannot read
+its untagged content.
+_Avoid_: work cell, personal line, user number
+
+**Conversation**:
+The per-Contact threaded history of texts and voice calls between a
+Nookleus user (or the company on its Shared line) and one outside phone
+number. Threading is by Contact, iMessage-style — the same Contact across
+multiple Jobs and over months stays one thread. Each individual message
+or call inside a Conversation may carry a Job tag. The Phone-tab surface
+shows Conversations; the Job-card surface shows the slice of Conversation
+content tagged to that Job. Content visibility is governed by Job tag,
+not by number kind — see [ADR 0005](docs/adr/0005-shared-and-personal-phone-numbers.md).
+_Avoid_: chat, thread (in code — fine in UI copy), message log
+
+**Job tag**:
+The link from a single text/call event to a Job. Set automatically when
+the event has no ambiguity (outbound started from a Job page; inbound
+from a Contact with exactly one Active job) and prompted-for otherwise.
+Untagged events live only in the Phone tab; tagged events also surface on
+the Job's card. Visibility follows the tag: a Job-tagged event on a
+Personal phone number is team-visible (because Job content is company
+business), whereas an untagged event on the same Personal number is
+owner-only — see [ADR 0005](docs/adr/0005-shared-and-personal-phone-numbers.md).
+_Avoid_: job link, attribution, assignment
+
 **Active job**:
 A job that is still alive — its status is neither `completed` nor `cancelled`,
 and it has not been trashed (`deleted_at IS NULL`). A cancelled job is dead,
@@ -106,6 +155,9 @@ _Avoid_: stage, pipeline status, partner status
 - A **Request Context** always carries a **User client**; it carries a **Service client** only when the route opts in.
 - An **Email account** belongs to one **Organization**; a **Personal email account** is additionally owned by one **User**, a **Shared email account** by none.
 - An **Outgoing email** belongs to one **Organization** and names exactly one **Email account** (the mailbox the document is sent from). There is one Outgoing email per document kind per Organization.
+- A **Phone number** belongs to one **Organization**; a **Personal phone number** is additionally owned by one **User**, a **Shared phone number** by none.
+- A **Conversation** is identified by the pair (one of the Organization's Phone numbers, one outside phone number) and groups its events on the Contact whose phone number matches the outside number.
+- A **Job tag** ties one text or call event to exactly zero or one **Job**. A single Conversation may contain events with several different Job tags (or none).
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 

--- a/docs/adr/0005-shared-and-personal-phone-numbers.md
+++ b/docs/adr/0005-shared-and-personal-phone-numbers.md
@@ -1,0 +1,214 @@
+# ADR 0005 — Shared and Personal phone numbers
+
+Status: accepted, 2026-05-26
+
+## Context
+
+Nookleus is adding in-app communication with customers: two-way SMS,
+two-way MMS, voice calls (inbound + outbound + voicemail with
+transcription), and call recording. Today communication is happening
+through CallRail (for marketing tracking) and through Crew Leads' own
+personal cell phones (for one-on-one customer conversations), with no
+record of any of it inside Nookleus.
+
+We need to decide what a Phone number *is* in the domain model — who
+owns it, who sees what flows through it, and how it interacts with the
+Job and Contact entities — before we can write the schema, the RLS
+policies, the UI, or the Twilio integration.
+
+The natural reference point is ADR 0001 (Shared and Personal email
+accounts), which faced the same question and chose a hybrid: Shared
+accounts (Organization-wide, no individual owner, every email-permitted
+member reads and sends) plus Personal accounts (owned by one User,
+content-private to that User, admin can disconnect but cannot read).
+
+Phone differs from email in one substantive way: **a Personal phone
+number is paid for by the Organization, provisioned through the
+Organization's Twilio account, and predominantly used for Job-related
+work**. A Crew Lead's personal email account is plausibly *theirs*
+(their professional identity outlives the company); a Crew Lead's
+Nookleus-provisioned phone number is plausibly *the company's*. The
+content-private-by-default rule that fits email doesn't obviously fit
+phone — but a pure team-visible rule erases the only reason to have
+Personal numbers at all.
+
+## Decision
+
+Phone numbers split into two kinds, **and content visibility is governed
+by Job tag, not by number kind**:
+
+- **Shared phone number** — what `team@`-style email is for email.
+  Belongs to an Organization, no individual owner. Every member with
+  the `view_phone` permission reads its incoming messages and sends
+  from it; only an admin changes its settings, configures its inbound
+  answer rule, or releases it. Schema: `user_id IS NULL`.
+- **Personal phone number** — owned by exactly one User. Used for
+  one-on-one relationship texting/calling with a customer so the
+  customer can reach a specific Crew Lead rather than the company
+  switchboard. Schema: `user_id = <owner>`.
+
+Every text/call event carries an optional **Job tag** (set
+automatically when unambiguous; manually otherwise — see the Phone
+PRD's smart-attach rule). Content visibility flows from the tag, not
+from the number kind:
+
+| event | who can read it |
+| --- | --- |
+| Job-tagged event, on any number (Shared or Personal) | every member with `view_phone` who can see that Job |
+| Untagged event on a Shared number | every member with `view_phone` in the Organization |
+| Untagged event on a Personal number | the number's owner only |
+
+Two surfaces fall out of this:
+
+- The **Phone tab** in the nav is the per-user view of "messages on my
+  numbers." A user sees their accessible Shared numbers' conversations
+  and their own Personal number's conversations — including untagged
+  content on their own Personal.
+- The **Job card**'s Messages and Calls sections are the team view of
+  "messages tagged to this Job." Every Job-tagged event surfaces
+  there regardless of which number it happened on — Personal-number
+  events included.
+
+An admin can see in Settings → Phone that a User has a Personal
+number and which number it is, and can **release** that number for
+offboarding (the number goes back to the org's Twilio pool, can be
+re-assigned to a new owner so the customer relationship survives, or
+retired). An admin **cannot** read untagged Personal-number content.
+Job-tagged content on a Personal number an admin already has Job
+access to is visible to them via the Job — same as anyone else with
+`view_phone`.
+
+A single access-decision module is the only place that answers, for
+a given (caller, event) pair, whether the caller can read it. The
+User-client routes rely on RLS policies that encode this matrix; the
+Service-client routes apply it in code.
+
+### Alternatives considered
+
+**Copy ADR 0001 exactly (Personal = blanket content-private).** Every
+event on a Personal number is owner-only, including Job-related calls
+and texts. Rejected because **Job content is company business** — when
+Bob is on PTO and Eric needs to pick up Bob's customer's flood Job,
+the customer's previous texts and recordings about that Job have to be
+visible to Eric. Under the blanket-private rule they aren't, and Eric
+has to either call Bob to ask or fly blind. Email gets away with the
+blanket rule because email is less time-sensitive and less likely to
+carry the only record of an agreement; phone is the opposite on both.
+
+**Pure team-visible (Shared/Personal becomes just a default-number
+distinction, not a privacy distinction).** Every event on every
+number is visible to everyone with `view_phone`. Rejected because
+the only reason to give Crew Leads a Personal number at all is for
+**relationship-style customer contact** — and that includes occasional
+genuinely non-company conversations (a wrong number, an old friend
+who still has the work cell number, the Crew Lead's spouse texting
+to grab milk on the way home). Under pure team-visible those land
+in the team feed. The Crew Lead's response is to never use the
+Personal number for anything that isn't strictly Job-tagged, which
+defeats the point.
+
+**Pure-shared (no Personal numbers, like the current state of email
+before ADR 0001).** Rejected for the same reasons ADR 0001 rejected
+it: every Crew Lead texts and calls customers from one switchboard
+number, and the one-on-one relationship Crew Leads build with their
+customers (the thing that drives repeat work in disaster recovery)
+gets diluted into "you reached AAA Disaster Recovery."
+
+### Why admin-can-release-but-not-read on Personal numbers
+
+Same reason as ADR 0001: offboarding. When a Crew Lead leaves, their
+Personal number cannot stay with their credentials forever. Someone
+has to be able to release it, and that someone is the admin. The
+admin needs to **see** the number exists; they do **not** need to
+**read** its untagged content.
+
+Job-tagged content on the Personal number is already team-visible —
+admin can see it via the Job. The asymmetry is therefore narrower
+than it is in ADR 0001: untagged Personal content is the only thing
+hidden from admins.
+
+### Why visibility is by Job tag, not by number kind
+
+The first design pass mirrored ADR 0001 — Personal = content-private,
+period. The user pushed back during the design discussion: "Calls and
+texts that are specific to a job should be able to be seen across the
+team." That distinction (Job vs not-Job) maps directly to how the
+team thinks about communication — Job content is company business,
+not-Job content might be anything — and it lets the same Personal
+number carry both kinds of conversation without forcing the Crew Lead
+to use a separate phone for personal calls.
+
+The trust signal is the **tag**, not the number. The smart-attach rule
+applies tags automatically when there's no ambiguity (an outbound
+call started from the Job page, an inbound text from a Contact with
+exactly one Active job); the user tags ambiguous events; untagged
+events stay private.
+
+### Why no new permission key beyond `view_phone`
+
+`view_phone` is the direct analog of `view_email` and gates access
+to the Phone feature surface. It defaults ON for Crew Lead and Admin,
+OFF for Crew Member — same role defaults as email.
+
+Number management (provisioning Shared numbers, releasing Personal
+numbers) is gated on the admin role, not on a separate key. Same
+reasoning as ADR 0001's "no new permission key" section: a new key
+would either duplicate the admin role signal or, if granted to
+non-admins, weaken the boundary the access matrix depends on.
+
+## Consequences
+
+**Positive**
+
+- Crew Leads can connect a Nookleus-provisioned Personal number for
+  one-on-one customer texting/calling without surrendering full content
+  privacy (untagged conversations stay theirs) and without hiding Job
+  work from teammates (Job-tagged conversations are team-visible).
+- The team can pick up each other's Jobs without losing the customer's
+  prior context — every Job-tagged text, call, voicemail, and
+  recording is on the Job, regardless of which Crew Lead's number
+  handled it.
+- The Job card and the Phone tab tell two different stories with one
+  underlying data model — the Job's slice (tagged events) is for the
+  team; the Phone tab's slice (everything on numbers you have access
+  to) is for the individual user.
+- The privacy rule is captured once, in the phone-event-access module;
+  every route, every RLS policy, and every UI surface delegates. The
+  rule cannot drift across handlers.
+- Offboarding is clean: the admin releases the departed Crew Lead's
+  Personal number, re-assigns it to a new owner (preserving the
+  customer's saved-number continuity), and never has to read content
+  to do it.
+
+**Negative**
+
+- More subtle than ADR 0001's flat "Personal = private" rule. Two
+  privacy stories live in the same product (email's and phone's),
+  and they do not match each other. The phone rule has to be
+  documented carefully — both in this ADR and in `CONTEXT.md`'s
+  Conversation entry — because the natural reader assumption ("phone
+  is like email") is now wrong.
+- The smart-attach rule is now load-bearing for privacy, not just for
+  Job-page convenience. If smart-attach incorrectly tags an untagged
+  Personal conversation to a Job, the Crew Lead's private content
+  leaks to the team via the Job. The attach rule's bias is therefore
+  toward under-tagging: auto-tag only when there's exactly one Active
+  job for the Contact; never guess.
+- A future deviation (e.g. "admin can read Personal-number content for
+  quality control") would require a new ADR — the access module's
+  matrix is the source of truth and changes here are not silent.
+
+**Out of scope (deliberately)**
+
+- No re-classifying CallRail-era call records into Shared vs Personal.
+  CallRail goes away (ADR 0006); existing CallRail call data is not
+  migrated.
+- No audit log of admin releases of Personal numbers. If compliance
+  ever needs it, it's a follow-up.
+- No ownership transfer of Personal numbers between users. An admin
+  releases; the new owner re-claims the number under their own profile
+  (the number stays the same, the owner changes, the customer's saved
+  contact doesn't break).
+- No team-level access to Personal numbers (e.g. "Crew Leads on the
+  same team see each other's Personal threads"). The owner is the
+  owner; teammates see only Job-tagged content via the Job.

--- a/docs/adr/0006-twilio-as-telephony-backbone.md
+++ b/docs/adr/0006-twilio-as-telephony-backbone.md
@@ -1,0 +1,158 @@
+# ADR 0006 — Twilio as Nookleus's telephony backbone
+
+Status: accepted, 2026-05-26
+
+## Context
+
+The Phone feature (ADR 0005) requires a telephony vendor to provide
+the actual pipes: provision and own phone numbers, deliver SMS and
+MMS, route inbound voice calls, place outbound voice calls (via
+bridge first, then in-browser softphone, then native iOS via
+CallKit), record calls with the legally-required consent notice,
+take voicemail with automatic transcription, and handle A2P 10DLC
+registration for US business SMS.
+
+Today, Nookleus uses CallRail for marketing call tracking, and crew
+communication happens on individual cell phones outside the
+application. There is no programmable backbone in place.
+
+The vendor choice is architectural lock-in. The schema, the access
+module from ADR 0005, the webhook handlers, the SDKs in the iOS
+app and the future browser softphone — all of it is shaped by the
+vendor's API. Swapping vendors after the feature ships would mean
+porting numbers (a 2–3 week per-number process with carrier paperwork)
+and rewriting the integration surface end-to-end. The decision is
+deliberately scoped here so a future reader doesn't have to
+re-derive it from the code.
+
+## Decision
+
+Twilio is Nookleus's telephony backbone.
+
+We use the following Twilio surfaces:
+
+- **Programmable Messaging** for SMS and MMS, including A2P 10DLC
+  brand + campaign registration.
+- **Programmable Voice** with TwiML for inbound routing (ring-all /
+  round-robin / forward / voicemail per-number), outbound bridge
+  calling (the Layer 1 call mechanism), and recording with the
+  beep + spoken consent notice played at the start of every
+  recorded call.
+- **Voice JS SDK** for the Layer 2 in-browser softphone.
+- **Voice iOS SDK** + CallKit + PushKit for the Layer 2 native iOS
+  calling experience on the Nookleus iPhone app.
+- **Voice Intelligence** (or equivalent) for voicemail transcription.
+- **Conversations API** as the unified threading primitive — one
+  Twilio Conversation per (Nookleus phone number, outside phone
+  number) pair, mapped to Nookleus's Conversation entity on the
+  Contact whose phone matches the outside number.
+
+Twilio owns the numbers, the carrier relationships, and the A2P
+registration. Nookleus owns the UI, the privacy rules (ADR 0005), the
+Job-tag attachment logic, the permission model, and the data of record
+(every message and call event is persisted in Nookleus's database;
+Twilio is the transport, not the source of truth).
+
+### Alternatives considered
+
+**CallRail (existing vendor).** Rejected. CallRail is a marketing
+call-tracking product first and a communication product second. Its
+SMS is functional but spartan (limited MMS, weak group messaging);
+its Voice product has no in-browser SDK and no CallKit-grade iOS
+SDK, so the Layer 2 milestones are unreachable without bringing in
+a second vendor anyway. Building a "communicate from inside the
+app" feature on a tracking-first vendor's API is structurally wrong.
+ADR 0005's tag-based privacy model and the Conversations API
+mapping it relies on have no equivalent in CallRail.
+
+The user already pays for CallRail. The marketing-attribution use
+case CallRail does well (which marketing source rang the phone)
+was set aside during the design discussion — it can return as a
+separate later integration if the team ever misses it. Existing
+CallRail numbers port to Twilio with the Phone feature launch.
+
+**OpenPhone (their app + their API).** Rejected. OpenPhone is a
+polished phone application with a public API that lets external
+systems log conversations against records — it is built for "log
+into our app, talk to customers there, sync the data elsewhere."
+Nookleus's goal is the opposite: be the app the user opens to
+talk to customers. OpenPhone has no programmable Voice SDK for
+browser or iOS, so the Layer 2 in-app calling milestones are
+impossible without abandoning OpenPhone. Their recording is theirs,
+not ours. Using OpenPhone would mean the team uses two apps
+forever, which defeats the goal.
+
+**Plivo / Bandwidth / Telnyx (Twilio-shaped alternatives).** Not
+rejected for capability — these vendors can do most of what Twilio
+can do, often at lower per-unit cost. Rejected for ecosystem and
+maturity: Twilio's documentation, SDK quality (especially Voice JS
+and Voice iOS), A2P 10DLC tooling, and the Conversations API are
+ahead of the alternatives by enough that the cost difference is not
+worth the integration friction for a team this size. If volume ever
+makes the cost gap material, the Conversations-API-shaped data model
+makes migrating to a Twilio-shaped competitor tractable (not free —
+the SDKs would need swapping — but the data shape doesn't change).
+
+**RingCentral / Aircall / Dialpad / JustCall (turnkey business
+phone vendors).** Rejected for the same reason as OpenPhone: their
+APIs are integration surfaces around their own phone applications,
+not programmable telephony primitives. They optimize for "use our
+app and sync events outward"; we want "build our own UI and use the
+vendor as transport."
+
+**Hybrid (Twilio for communication + CallRail for attribution).**
+Considered. Rejected for this PRD because the user explicitly chose
+the full migration path during the design discussion. The hybrid
+remains viable as a later add-on if the team decides marketing
+attribution is worth a separate integration — the Phone feature's
+data shape doesn't preclude wiring CallRail back in alongside
+Twilio. Out of scope here.
+
+## Consequences
+
+**Positive**
+
+- Every Phone feature on the three-layer roadmap (bridge calling,
+  in-browser softphone, native iOS via CallKit, MMS, voicemail
+  transcription, recording, Conversations threading, A2P 10DLC) is a
+  first-class Twilio API. We never have to migrate to ship the next
+  layer.
+- The Conversations API gives us a natural mapping for ADR 0005's
+  per-Contact threading — one Twilio Conversation per
+  (Nookleus number, outside number) pair, with every message and
+  call event hung off it.
+- Twilio's A2P 10DLC tooling handles the messiest part of US business
+  SMS compliance (brand + campaign registration with The Campaign
+  Registry, carrier surcharges, throughput tiers). We do the
+  paperwork once.
+- One vendor, one contract, one set of webhooks, one set of SDKs.
+
+**Negative**
+
+- Pay-as-you-go pricing means a heavy-use month is more expensive
+  than a flat-rate competitor. Per-message and per-minute costs need
+  to be modeled so Organization billing (or per-number pricing
+  passed to customers) makes sense. Not a Day-1 problem; becomes one
+  once Phone usage grows.
+- The Twilio API surface is large. Discipline is needed about which
+  corners we use: Programmable Messaging + Programmable Voice +
+  Conversations + the Voice SDKs are in; Studio Flows, Flex,
+  Frontline, and other higher-level Twilio products are out (using
+  them would re-introduce the "use our app" problem we rejected
+  OpenPhone for).
+- Lock-in is real. Replacing Twilio after launch means porting every
+  number (carrier paperwork, ~2–3 weeks per batch) and rewriting
+  every integration surface. The data shape (per-Contact
+  Conversations + tagged events) is deliberately vendor-shaped to
+  avoid this risk, but the SDKs aren't portable.
+
+**Out of scope (deliberately)**
+
+- No use of Twilio Studio, Flex, or Frontline. The UI is Nookleus's.
+- No use of Twilio's hosted contact-center features. The team is
+  small; routing rules in TwiML are enough.
+- No multi-vendor abstraction layer over Twilio. Premature; would
+  cost real engineering time to defend against a swap that may
+  never happen. ADR-level data shape discipline is enough.
+- No marketing attribution integration. CallRail goes away with this
+  launch; if attribution returns it gets its own ADR.


### PR DESCRIPTION
## What

The phone subsystem (#304, #307–310, #368) merged with its code but without its domain documentation. This backfills it:

- **`CONTEXT.md`** glossary entries — Phone number, Shared / Personal phone number, Conversation, Job tag
- **ADR 0005** — Shared and Personal phone numbers (content visibility governed by Job tag, not number kind; a single `phone-event-access` module is the source of truth)
- **ADR 0006** — Twilio as the telephony backbone

These describe decisions the merged code already implements (`src/lib/phone/phone-event-access.ts`, `smart-attach.ts`, `opt-out-registry.ts`, `twilio-client.ts`, and `src/lib/phone/README.md`).

## Why renumbered

They were drafted locally as ADR 0003/0004 before `single-photo-report-layout` (0003) and `template-line-items-snapshot` (0004) merged in parallel at the same numbers. Renumbered to 0005/0006 to resolve the collision; all cross-references in `CONTEXT.md` and between the two ADRs were updated to match.

## Verification

- `docs/adr/` is now a clean 0001→0006 with no duplicate numbers
- No stale `ADR 0003` / `ADR 0004` references remain in the phone docs
- The ADR-0001 (email) references inside ADR 0005 were intentionally left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)
