### PR TITLE
docs(billing): Estimate/Invoice glossary + ADR 0007 for the estimate->invoice rework (#379)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,6 +122,19 @@ not active. The dashboard's "Jobs to advance" and "People to respond to"
 sections both filter to Active jobs only.
 _Avoid_: open job, current job, running job, in-progress job (that one is a specific status, not the whole alive set)
 
+**Estimate**:
+A priced proposal for a Job — line items grouped into sections, with markup,
+discount, and tax — that an Organization sends a customer for approval. The
+primary billing document, and the only thing an Invoice can be made from.
+_Avoid_: quote, proposal, bid (quote/bid fine in UI copy)
+
+**Invoice**:
+A request for payment for a Job, created only by converting an Estimate —
+never authored on its own. Unlike an Estimate it carries a due date, a payment
+state, and QuickBooks sync; a deposit or staged payment is a partial payment on
+the single Invoice, never a second Invoice.
+_Avoid_: bill (fine in UI copy), receipt
+
 **Target**:
 A row on the Referral Partners call list whose Lifecycle status is still
 Uncontacted (grey) or In progress (yellow) — i.e. someone we want to call
@@ -160,6 +173,7 @@ _Avoid_: stage, pipeline status, partner status
 - A **Job tag** ties one text or call event to exactly zero or one **Job**. A single Conversation may contain events with several different Job tags (or none).
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
+- A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).
 
 ## Example dialogue
 

--- a/docs/adr/0007-estimates-are-the-single-billing-entry-point.md
+++ b/docs/adr/0007-estimates-are-the-single-billing-entry-point.md
@@ -1,0 +1,84 @@
+# 0007 — Estimates are the single entry point for billing; invoices are conversion-only
+
+**Status:** Accepted
+**Date:** 2026-06-03
+
+## Context
+
+Issue #379 reworks how Estimates and Invoices relate. Today they are two
+independently-creatable documents per Job: an Invoice can be authored directly
+(`/invoices/new`, `create_invoices` permission) or produced by converting an
+Estimate (a copy with two-way links — `converted_to_invoice_id` /
+`converted_from_estimate_id`). The Job's **Overview** tab shows two parallel
+tables (estimates and invoices), and a standalone `/invoices` page lists every
+invoice across all jobs.
+
+The foundational question was whether an Invoice is a thing you *author* or a
+thing an Estimate *becomes* — and, if the latter, whether the two collapse into
+one record or stay distinct.
+
+## Decision
+
+**An Invoice can only be created by converting an Estimate.** Direct authoring
+is removed.
+
+- **The Invoice stays a separate record**, not merged into the Estimate. It keeps
+  its own due date, payment state (`draft → sent → partial → paid → voided`),
+  void-with-reason, and QuickBooks sync.
+- **Strictly 1:1.** An Estimate yields at most one Invoice. Deposits and progress
+  billing are **partial payments against that single Invoice**, never additional
+  Invoices.
+- **The Overview tab drops the invoices table.** The Estimate row is the working
+  document; on conversion it **flips to represent the Invoice** and becomes the
+  view/edit surface. The original Estimate is kept as a frozen, viewable record
+  (reached via the existing cross-link).
+- **An Invoice becomes official only when manually marked sent.** Until then it
+  is a draft living in Overview; it does **not** appear in the Financials tab and
+  does **not** count toward "Invoiced." "Sent" is a manual flip — there is no
+  requirement to email it from the app, and recipients are not modelled.
+- **The Financials tab tracks the sent Invoice** alongside payments and expenses.
+  The job's **Invoiced** figure — and the org-wide profitability dashboard —
+  count **sent-or-later Invoices only** (drafts and voided excluded).
+- **Row status colours are minimal:** yellow = converted Invoice awaiting review
+  (draft), blue = sent. Estimate rows and all other states are untinted. The
+  estimate **approved/rejected** step is dropped (draft → convert).
+- **The standalone `/invoices` list is removed.** Invoices are reached only
+  through their Job.
+
+See the **Estimate** and **Invoice** entries in [CONTEXT.md](../../CONTEXT.md).
+
+## Consequences
+
+- Editing the Invoice keeps the existing guard — **no edits once paid or
+  voided** — now reached through the flipped Overview row.
+- Counting only sent-or-later Invoices **fixes current over-counting**: today
+  [`margins.ts`](../../src/lib/accounting/margins.ts) sums every non-deleted
+  invoice regardless of status, so drafts and even voided invoices inflate
+  "Invoiced". This rule applies to both the per-job summary and the
+  profitability roll-up.
+- `create_invoices`, `/invoices/new`, and the `/invoices` list page are retired;
+  `convert_estimates` becomes the sole creation path.
+- Cross-job collections rely on the accounting dashboard's **AR aging**, which
+  already answers "who owes us across all jobs."
+- The estimate↔invoice cross-links remain; the "view original estimate" link
+  off a flipped row uses them.
+- The PDF "notes column" scaffold and the `PdfPreset` system are **out of scope**
+  for this ADR (they belong to issue #379's other two asks — line-item notes and
+  the PDF view rework).
+
+## Alternatives considered
+
+- **(B) Merge Estimate and Invoice into one record that flips state.** Rejected:
+  Invoices carry payment reconciliation, due dates, QuickBooks sync, and
+  void-with-reason that Estimates don't. Merging means rebuilding all of it and
+  migrating live financial data for little real gain. "An indicator showing that
+  an estimate has been converted" describes *pointing at* an Invoice, not
+  *becoming* one.
+- **Multiple Invoices per Estimate** (deposit/progress invoices as separate
+  documents). Rejected for now: deposits and draws are modelled as partial
+  payments on the single Invoice. Insurance jobs rarely pay in full anyway, so
+  partial-payment tracking already fits the reality.
+- **Keep the standalone `/invoices` list read-only.** Rejected: AR aging on the
+  accounting dashboard already covers the cross-job collections view.
+- **Surface the Invoice in Financials at conversion.** Rejected: a draft Invoice
+  is not a real receivable — only a sent Invoice is official.


### PR DESCRIPTION
Captured during a grill-with-docs session on #379: adds Estimate and Invoice glossary entries and the Job->Estimate->Invoice relationship to CONTEXT.md, and records ADR 0007 (invoices are created only by converting an estimate). The PRD lives in #381 and decomposes into slices #382-#387.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
