### PR TITLE
feat(photos): flag-gated resized Photo previews in the Job grid (#392)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,6 +122,13 @@ not active. The dashboard's "Jobs to advance" and "People to respond to"
 sections both filter to Active jobs only.
 _Avoid_: open job, current job, running job, in-progress job (that one is a specific status, not the whole alive set)
 
+**Photo**:
+A single image — or short video — captured on a Job and shown in the Job's
+Photos tab. Belongs to exactly one Job. Distinct from a **File**: the Job's
+Files tab holds documents/attachments, which are a separate feature. When
+someone refers loosely to "the job's file" of pictures, they mean Photos.
+_Avoid_: image, attachment, media; "file" (that's the separate documents feature)
+
 **Estimate**:
 A priced proposal for a Job — line items grouped into sections, with markup,
 discount, and tax — that an Organization sends a customer for approval. The

--- a/docs/adr/0008-resize-grid-photos-at-the-storage-layer.md
+++ b/docs/adr/0008-resize-grid-photos-at-the-storage-layer.md
@@ -1,0 +1,78 @@
+# 0008 — Resize grid photos at the storage layer via Supabase image transformation
+
+**Status:** Accepted
+**Date:** 2026-06-04
+
+## Context
+
+Issue #388. Viewing a Job's Photos is slow, and photos lower on the page often
+paint *before* the ones at the top. Root cause: every square in every photo grid
+downloads the **full-resolution original** (multi-MB camera files) — see
+[job-photos-tab.tsx:513](../../src/components/job-photos-tab.tsx:513) — with no
+size variant and no load priority, so whichever file happens to be smallest wins
+the paint race. The `photos.thumbnail_path` column exists but is never written or
+read; there is no thumbnail pipeline and no image transformation anywhere in the
+codebase.
+
+The grids need a small **preview** variant; the single-photo detail view, the
+annotator, and PDF report generation must keep using full-resolution originals.
+
+The app deploys to Vercel (Next.js 16, non-standard per `AGENTS.md`) and the iOS
+app is a Capacitor WebView pointed at the live Vercel URL
+([capacitor.config.ts:9](../../capacitor.config.ts:9)), so any web-side fix
+reaches iOS unchanged. Supabase storage is on the **free plan**, where image
+transformation is not available.
+
+## Decision
+
+**Resize grid photos at the storage layer using Supabase's image transformation
+(`render/image`) endpoint, which requires upgrading the Supabase org to Pro.**
+
+- All photo-grid URLs go through a single helper — `photoUrl(path, { size })` —
+  replacing the ~5 hand-built `…/object/public/photos/${path}` strings. Grids
+  request a preview size; detail / annotator / PDF request the original.
+- A preview is `…/storage/v1/render/image/public/photos/{path}?width=…&quality=…&resize=cover`;
+  the original is the existing `…/storage/v1/object/public/photos/{path}`.
+- Because resizing follows whatever path the helper is given, an **annotated**
+  photo's preview is the resized *annotated* image automatically — no separate
+  thumbnail to regenerate on edit.
+- **Prerequisite (user action, not the agent's):** upgrade Supabase org *AAA
+  Disaster Recovery* to Pro (~$25/mo) and enable image transformation. The work
+  is blocked on this.
+
+## Consequences
+
+- Recurring ~$25/mo Supabase Pro cost. Offset: Pro raises the bandwidth cap, and
+  previews cut per-view bytes by ~99%, relieving the pressure the full-res grids
+  put on the free plan's egress limit today.
+- Grid image quality drops slightly (intended). The detail view, annotator, and
+  PDF stay full-resolution, so report/print fidelity is unchanged.
+- The fix benefits **all existing photos immediately** — no backfill, because
+  transformation is on-the-fly from the original already in storage.
+- The dead `photos.thumbnail_path` column stays dead; this approach needs no
+  stored thumbnail. Dropping the column is a separate cleanup.
+- Lock-in is mild: the helper is the single seam. Swapping to `next/image` or
+  pre-generated thumbnails later means changing one function (plus, for pre-gen,
+  a backfill).
+
+## Alternatives considered
+
+- **(A) Vercel image optimization via `next/image`.** No Supabase upgrade, likely
+  $0 to start. Rejected as the primary path: the app runs a customized Next.js 16
+  (`AGENTS.md` warns it is not stock), so `<Image>` carries integration risk;
+  Vercel's free image quota caps distinct source images per month, which a
+  photo-heavy disaster-recovery business could exceed and be pushed to a paid
+  tier anyway; and it routes originals through Vercel's optimizer rather than
+  keeping resizing next to the data. **Kept as the fallback** if the Pro cost is
+  later judged not worth it — the `photoUrl` helper makes the switch a one-place
+  change.
+- **(C) Pre-generated thumbnails at upload + backfill.** No monthly fee on any
+  plan. Rejected: most engineering (two upload paths — web and the mobile upload
+  queue — plus a one-time backfill over existing photos), existing photos stay
+  slow until the backfill runs, and an annotated photo would need its thumbnail
+  regenerated on every edit. The owner chose predictable reliability over
+  avoiding the $25/mo.
+- **Only reorder loads, keep full-size images.** Rejected: fixes the ordering
+  symptom but not "slow in general" — full-size images stay heavy.
+
+See the **Photo** entry in [CONTEXT.md](../../CONTEXT.md).

--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase";
 import { Photo, PhotoTag } from "@/lib/types";
+import { photoUrl } from "@/lib/jobs/photo-url";
 import { format } from "date-fns";
 import { Loader2, Plus, Star } from "lucide-react";
 import { toast } from "sonner";
@@ -510,7 +511,7 @@ export default function JobPhotosTab({
                         }}
                       >
                         <img
-                          src={`${supabaseUrl}/storage/v1/object/public/photos/${photo.annotated_path || photo.storage_path}`}
+                          src={photoUrl(photo, supabaseUrl, "grid")}
                           alt={photo.caption || "Photo"}
                           className="w-full h-full object-cover"
                           loading="lazy"

--- a/src/lib/jobs/photo-url.test.ts
+++ b/src/lib/jobs/photo-url.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { photoUrl } from "./photo-url";
+
+const SUPABASE_URL = "https://proj.supabase.co";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("photoUrl — grid variant, resize flag off", () => {
+  it("returns the original object URL when resize is disabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "");
+    const url = photoUrl(
+      { annotated_path: null, storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+});
+
+describe("photoUrl — grid variant, resize flag on", () => {
+  it("returns the resized render/image URL when resize is enabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: null, storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+});
+
+describe("photoUrl — annotated photo", () => {
+  it("builds the preview from the annotated path when present", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: "annotated/abc.jpg", storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+
+  it("falls back to the storage path when the annotation path is empty (grid, resize on)", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: "", storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+});
+
+describe("photoUrl — full variant", () => {
+  it("returns the original URL even when resize is enabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: null, storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+      "full",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+});
+
+describe("photoUrl — unsupported format (grid, resize on)", () => {
+  it("serves the original for a format the resizer can't transform (HEIC)", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: null, storage_path: "originals/img.heic" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/img.heic",
+    );
+  });
+
+  it("still resizes when the extension is uppercase (cameras emit .JPG)", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = photoUrl(
+      { annotated_path: null, storage_path: "originals/IMG_0042.JPG" },
+      SUPABASE_URL,
+      "grid",
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/IMG_0042.JPG?width=400&quality=60&resize=cover",
+    );
+  });
+});

--- a/src/lib/jobs/photo-url.ts
+++ b/src/lib/jobs/photo-url.ts
@@ -1,0 +1,52 @@
+// The subset of a photo row the URL resolver reads.
+export interface PhotoUrlSource {
+  annotated_path: string | null;
+  storage_path: string;
+}
+
+// Where the URL is used: the grid wants a small preview; everywhere else
+// (single-photo detail, annotator, PDF) wants the full-resolution original.
+export type PhotoVariant = "grid" | "full";
+
+const PHOTOS_OBJECT_PREFIX = "/storage/v1/object/public/photos/";
+const PHOTOS_RENDER_PREFIX = "/storage/v1/render/image/public/photos/";
+
+// Grid-preview transform parameters. Sensible starting point per ADR 0008
+// (~grid-square width, moderate quality, square crop); tune at go-live.
+const GRID_PREVIEW_QUERY = "?width=400&quality=60&resize=cover";
+
+// Formats Supabase image transformation can resize. A Photo's stored file
+// may be something the transformer rejects — a HEIC original from a web
+// upload, or a short video — in which case we must serve it untouched rather
+// than hand the grid a broken render URL.
+const RESIZABLE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "webp", "avif", "gif"]);
+
+function isResizable(path: string): boolean {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return RESIZABLE_EXTENSIONS.has(ext);
+}
+
+// Resizing requires Supabase Pro image transformation; until that is enabled
+// the flag stays off and the grid serves originals (no worse than today).
+function isResizeEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_PHOTO_RESIZE_ENABLED === "true";
+}
+
+/**
+ * Resolve the public image URL for a job's Photo.
+ *
+ * The single place Photo grid/detail URLs are built (see ADR 0008). The
+ * "grid" variant returns a small resized preview when image transformation
+ * is enabled, otherwise the original; "full" always returns the original.
+ */
+export function photoUrl(
+  source: PhotoUrlSource,
+  supabaseUrl: string,
+  variant: PhotoVariant,
+): string {
+  const path = source.annotated_path || source.storage_path;
+  if (variant === "grid" && isResizeEnabled() && isResizable(path)) {
+    return `${supabaseUrl}${PHOTOS_RENDER_PREFIX}${path}${GRID_PREVIEW_QUERY}`;
+  }
+  return `${supabaseUrl}${PHOTOS_OBJECT_PREFIX}${path}`;
+}


### PR DESCRIPTION
## Summary

Implements slice #392 of the photo-loading work (PRD #391): flag-gated resized previews in the Job Photos grid, behind a single Photo URL resolver per [ADR 0008](docs/adr/0008-resize-grid-photos-at-the-storage-layer.md).

- **New deep module `photoUrl()`** (`src/lib/jobs/photo-url.ts`) — the single place Job Photo grid/detail URLs are built. `"grid"` returns a Supabase `render/image` preview when `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED` is on, otherwise the original; `"full"` always returns the original. Mirrors the existing `resolveCoverPhotoUrl` prior art.
- **Flag-gated & safe to merge now.** With the flag off (default), the grid produces a byte-identical URL to before — no behavior change until the Supabase Pro upgrade lands and the flag is flipped.
- **Format guard.** Unsupported formats (HEIC from web uploads, short videos) fall through to the original, so a stray upload can't hand the grid a broken render URL.
- **Grid wired** (`src/components/job-photos-tab.tsx`) — two-line change; `loading="lazy"` preserved (top-first loading is slice #394).
- **7 colocated unit tests**, all green, mirroring `cover-photo.test.ts`.
- Lands the decision record this slice implements: the **Photo** glossary term (`CONTEXT.md`) and **ADR 0008**.

## Test plan

- `npx vitest run src/lib/jobs/photo-url.test.ts` → 7 passing (grid on/off, full, annotated preference, empty fallback, HEIC→original, uppercase extension).
- Flag off ⇒ grid URL identical to the prior inline string (no visible change today).

## Remaining (go-live, HITL — not in this PR)

Flipping `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED` on, tuning preview sharpness, and verifying on web + iOS — gated on the Supabase Pro upgrade (a billing/ops action).

Closes #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
