### PR TITLE
feat(photos): route full-resolution Photo screens through the resolver (#393)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabase";
 import { escapeOrFilterValue } from "@/lib/postgrest";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
+import { photoUrl } from "@/lib/jobs/photo-url";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
@@ -975,9 +976,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         photo={selectedPhoto}
         allTags={tags}
         photoUrl={
-          selectedPhoto
-            ? `${supabaseUrl}/storage/v1/object/public/photos/${selectedPhoto.annotated_path || selectedPhoto.storage_path}`
-            : ""
+          selectedPhoto ? photoUrl(selectedPhoto, supabaseUrl, "full") : ""
         }
         onUpdated={() => {
           setSelectedPhoto(null);

--- a/src/components/photo-annotator.tsx
+++ b/src/components/photo-annotator.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Photo } from "@/lib/types";
+import { originalPhotoUrl } from "@/lib/jobs/photo-url";
 import { cn } from "@/lib/utils";
 import {
   Pencil,
@@ -414,7 +415,7 @@ export default function PhotoAnnotator({
 
     try {
       // Load the ORIGINAL image (not annotated) to avoid double-rendering
-      const photoUrl = `${supabaseUrl}/storage/v1/object/public/photos/${currentPhoto.storage_path}`;
+      const photoUrl = originalPhotoUrl(currentPhoto, supabaseUrl);
 
       const img = await new Promise<HTMLImageElement>((resolve, reject) => {
         const el = document.createElement("img");

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/build-report-document";
 import { resolveCoverPageData } from "@/lib/cover-page-data";
 import { resolvePhotosPerPage } from "@/lib/resolve-photos-per-page";
+import { photoUrl, reportCoverPhotoUrl } from "@/lib/jobs/photo-url";
 import type { CompanySettings } from "@/lib/types";
 
 interface ReportSection {
@@ -128,11 +129,7 @@ export async function generateReportPDF(reportId: string): Promise<string> {
       ? `${supabaseUrl}/storage/v1/object/public/company-assets/${coverPageData.logo.path}`
       : null;
 
-  const coverPhotoPath =
-    job.cover_photo?.annotated_path || job.cover_photo?.storage_path || null;
-  const coverPhotoUrl = coverPhotoPath
-    ? `${supabaseUrl}/storage/v1/object/public/photos/${coverPhotoPath}`
-    : null;
+  const coverPhotoUrl = reportCoverPhotoUrl(job.cover_photo, supabaseUrl);
 
   // 6. Collect body photos (body unchanged in slice 1)
   const allPhotoIds = new Set<string>();
@@ -159,10 +156,13 @@ export async function generateReportPDF(reportId: string): Promise<string> {
   const engineInputPhotos: Record<string, ReportPhotoInput> = {};
 
   for (const p of photoData || []) {
-    const path = p.annotated_path || p.storage_path;
     photos[p.id] = {
       id: p.id,
-      url: `${supabaseUrl}/storage/v1/object/public/photos/${path}`,
+      url: photoUrl(
+        { annotated_path: p.annotated_path, storage_path: p.storage_path },
+        supabaseUrl,
+        "full",
+      ),
       caption: p.caption,
       before_after_role: p.before_after_role,
       taken_at: p.taken_at,

--- a/src/lib/jobs/photo-url.test.ts
+++ b/src/lib/jobs/photo-url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { photoUrl } from "./photo-url";
+import { photoUrl, originalPhotoUrl, reportCoverPhotoUrl } from "./photo-url";
 
 const SUPABASE_URL = "https://proj.supabase.co";
 
@@ -69,6 +69,50 @@ describe("photoUrl — full variant", () => {
     );
     expect(url).toBe(
       "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+});
+
+describe("originalPhotoUrl — the annotator always edits the un-annotated original", () => {
+  it("returns the full-resolution original, ignoring any saved annotation", () => {
+    // The annotator must re-open the ORIGINAL so it doesn't paint new strokes
+    // on top of an already-annotated render. Even with a saved annotation, and
+    // even with resize enabled, it gets the original object URL.
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = originalPhotoUrl(
+      { annotated_path: "annotated/abc.jpg", storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+});
+
+describe("reportCoverPhotoUrl — the PDF cover photo", () => {
+  it("returns null when the job has no cover photo", () => {
+    expect(reportCoverPhotoUrl(null, SUPABASE_URL)).toBeNull();
+  });
+
+  it("uses the annotated copy at full resolution when the cover is annotated", () => {
+    // Resize on must not shrink the cover: reports stay print-quality.
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = reportCoverPhotoUrl(
+      { annotated_path: "annotated/cover.jpg", storage_path: "originals/cover.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/annotated/cover.jpg",
+    );
+  });
+
+  it("falls back to the stored original when the cover has no annotation", () => {
+    const url = reportCoverPhotoUrl(
+      { annotated_path: null, storage_path: "originals/cover.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/cover.jpg",
     );
   });
 });

--- a/src/lib/jobs/photo-url.ts
+++ b/src/lib/jobs/photo-url.ts
@@ -50,3 +50,48 @@ export function photoUrl(
   }
   return `${supabaseUrl}${PHOTOS_OBJECT_PREFIX}${path}`;
 }
+
+/**
+ * Resolve the full-resolution **original** image URL for a Photo, ignoring any
+ * saved annotation.
+ *
+ * The annotator must re-open the un-annotated original so new strokes aren't
+ * painted on top of an already-annotated render (double-rendering). Unlike the
+ * "full" variant of {@link photoUrl} — which shows the annotated copy when one
+ * exists — this always points at the stored original.
+ */
+export function originalPhotoUrl(
+  source: PhotoUrlSource,
+  supabaseUrl: string,
+): string {
+  return photoUrl(
+    { annotated_path: null, storage_path: source.storage_path },
+    supabaseUrl,
+    "full",
+  );
+}
+
+// A cover photo may not be set, and its paths arrive nullable from the report
+// query — narrower than PhotoUrlSource.
+export interface CoverPhotoSource {
+  annotated_path: string | null;
+  storage_path: string | null;
+}
+
+/**
+ * Resolve the full-resolution URL for a report's cover Photo, or `null` when
+ * the job has no usable cover.
+ *
+ * Like the "full" variant of {@link photoUrl}, it prefers the annotated copy
+ * when present; but a job may have no cover photo at all (or only empty paths),
+ * in which case the PDF must render its cover page without a photo rather than
+ * point at a broken URL.
+ */
+export function reportCoverPhotoUrl(
+  cover: CoverPhotoSource | null,
+  supabaseUrl: string,
+): string | null {
+  const path = cover?.annotated_path || cover?.storage_path;
+  if (!path) return null;
+  return photoUrl({ annotated_path: null, storage_path: path }, supabaseUrl, "full");
+}


### PR DESCRIPTION
Closes #393.

Routes the remaining in-scope Photo URLs through the resolver from #392 with the `"full"` variant, so every in-scope Photo URL is built in one tested place (ADR 0008). Behavior is unchanged — these screens still load full-resolution originals; "previews in the grid, full-res everywhere else" is now a single decision in the resolver instead of scattered string-building.

## Call sites rewired (all behavior-exact)

| Screen | File | Now uses |
|---|---|---|
| Single-Photo detail view | `src/components/job-detail.tsx` | `photoUrl(selectedPhoto, url, "full")` |
| Annotator | `src/components/photo-annotator.tsx` | `originalPhotoUrl(currentPhoto, url)` |
| PDF report — cover | `src/lib/generate-report-pdf.tsx` | `reportCoverPhotoUrl(job.cover_photo, url)` |
| PDF report — body | `src/lib/generate-report-pdf.tsx` | `photoUrl({ annotated_path, storage_path }, url, "full")` |

## Two tested helpers added to `photo-url.ts`

- **`originalPhotoUrl`** — the annotator's *always the un-annotated original* rule, so new strokes aren't painted on top of an already-annotated render (double-rendering). Unlike `"full"` on `photoUrl` (which prefers the annotated copy), this always points at the stored original.
- **`reportCoverPhotoUrl`** — full-resolution cover URL, or `null` when a job has no cover photo, so the PDF renders a photo-less cover rather than a broken URL.

Both route through `photoUrl(…, "full")`, so the resize flag never affects them.

## Acceptance criteria

- [x] Detail view, annotator, and PDF build Photo URLs via the resolver with the `"full"` variant
- [x] No hand-built `object/public/photos/…` strings remain in those three call sites (`grep` verified)
- [x] Full-resolution originals still load; annotation lands accurately; PDF/print quality unchanged
- [x] Behavior unchanged regardless of the resize flag (`"full"` always returns the original)

Out of scope per the issue (follow-on slices): the all-Photos page, report-builder thumbnails, the Job-card cover Photo, and — confirmed with the owner — the report **view** screen (`reports/[id]`).

## Tests

`src/lib/jobs/photo-url.test.ts` grows 7 → 11 (4 new, red→green): annotator ignores a saved annotation; cover returns `null` with no cover; cover prefers the annotated copy; cover falls back to storage.

- ✅ `npx vitest run src/lib/jobs/photo-url.test.ts` — 11/11
- ✅ `eslint` clean on all changed files; no new `tsc` errors
- ℹ️ Pre-existing suite failures (`@react-pdf/renderer`, `sharp`, `imapflow`, `twilio` not installed in the dev sandbox) are unrelated to this change and unaffected by it

🤖 Generated with [Claude Code](https://claude.com/claude-code)