### PR TITLE
feat(photo-report): slice 1 — schema foundation + write-up read-tolerance (#398)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -129,6 +129,31 @@ Files tab holds documents/attachments, which are a separate feature. When
 someone refers loosely to "the job's file" of pictures, they mean Photos.
 _Avoid_: image, attachment, media; "file" (that's the separate documents feature)
 
+**Photo Report**:
+A document an Organization generates from a Job's Photos — Sections of
+write-up plus the photos that evidence them — and exports as a PDF to hand
+an adjuster or property owner. Belongs to exactly one Job. Created and
+edited only from inside the Job: a report is started from the Job's Photos
+tab (select photos → Create report) and its existing reports are listed and
+reopened from the Job's Overview tab. There is no standalone reports area.
+_Avoid_: report (ambiguous — there is also the accounting/profitability report), photo log, gallery
+
+**Section** (of a Photo Report):
+One unit of a Photo Report: a heading, a one-page rich-text write-up
+(paragraphs and bullet/numbered lists), and the Photos that illustrate it.
+Renders as an intro page (heading + write-up, capped to one page) followed
+by the photo pages. Distinct from an **Estimate** Section, which is a group
+of priced line items — the two share only the word and no code.
+_Avoid_: chapter, page, group
+
+**Photo Report template**:
+A saved, reusable set of Sections (headings plus optional boilerplate
+write-up text) that an Organization starts a new Photo Report from, so
+common report structures aren't retyped; the result stays fully editable.
+Belongs to one Organization. Distinct from an **Estimate** template, a
+separate feature (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)).
+_Avoid_: preset (in code — "preset" is older UI copy), report template (unqualified), layout
+
 **Estimate**:
 A priced proposal for a Job — line items grouped into sections, with markup,
 discount, and tax — that an Organization sends a customer for approval. The
@@ -181,6 +206,8 @@ _Avoid_: stage, pipeline status, partner status
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 - A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).
+- A **Job** has zero or more **Photo Reports**; each Photo Report belongs to exactly one Job, gathers that Job's **Photos** into ordered **Sections**, and is created and edited only from within the Job. Reports are numbered per Job (Report #1, #2, …).
+- A **Photo Report template** belongs to one **Organization** and seeds a new Photo Report's **Sections**; applying one is a starting point, not a binding link.
 
 ## Example dialogue
 
@@ -191,3 +218,5 @@ _Avoid_: stage, pipeline status, partner status
 
 - "auth gate" was used for four near-identical route helpers (`requirePermission`, `requireAdmin`, `requireViewAccounting`, and an inline `requireLogExpenses`) — resolved: these collapse into the one **Request Context** wrapper.
 - "active" was being used for two unrelated concepts in `src/lib/accounting/margins.ts`: (a) a job with financial activity in a reporting period, and (b) a non-completed job (the user-facing filter pill on the Job Profitability page, which also folds cancelled jobs in with active ones). Neither matches the canonical **Active job** definition above. The dashboard rebuild adopts the canonical meaning; the accounting page is left as-is for now but is a cleanup candidate.
+- "section" is used for two unrelated concepts: an **Estimate** Section (a group of priced line items) and a **Photo Report** Section (a heading + one-page write-up + photos). Resolved: both keep the word but are always qualified by their document ("Estimate section" vs "Photo Report section"); they share no table, type, or component.
+- "template" is likewise overloaded: an **Estimate** template (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)) and a **Photo Report** template. Resolved: always qualify by document. Note the older Photo-Report builder UI also called these "presets" — the canonical term is **Photo Report template**; "preset" is an alias to retire.

--- a/docs/adr/0003-single-photo-report-layout.md
+++ b/docs/adr/0003-single-photo-report-layout.md
@@ -1,5 +1,7 @@
 # Single hardcoded photo report layout
 
+**Status:** Superseded in part by [ADR 0009](0009-photo-reports-are-an-in-job-narrative-document.md) (issue #390) — the "one minimal layout / every report serves the same audience" rationale is reversed for section content (Sections regain a one-page rich-text narrative). The global photos-per-page knob from the amendment below is retained.
+
 Photo reports previously supported per-template cover pages and configurable
 layouts via the `photo_report_templates` table. With the May 2026 rework
 (see issue #326), photo reports converge on **one** hardcoded layout — fixed

--- a/docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md
+++ b/docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md
@@ -1,0 +1,103 @@
+# Photo Reports are an in-job, section-narrative document
+
+**Status:** Accepted — supersedes [ADR 0003](0003-single-photo-report-layout.md) in part
+**Date:** 2026-06-04
+
+## Context
+
+[ADR 0003](0003-single-photo-report-layout.md) (the May 2026 rework, issue #326)
+collapsed Photo Reports to **one minimal hardcoded layout** — a near-empty
+section divider page (big title + one-line subtitle) followed by photo pages —
+on the reasoning that "every photo report this business produces serves the same
+audience and benefits from looking the same every time," and that template
+flexibility was unused.
+
+In practice the reports need to carry **narrative**: the business routinely
+writes full paragraphs and bullet-point findings / work-performed write-ups, and
+the one-line subtitle has nowhere to put them. Separately, creating a report is
+clunky — it happens off-job at a global `/reports/new` wizard whose first step is
+a "select job" dropdown even when you started from a specific job, and a job's
+existing reports are buried in an Overview card that only appears once a report
+already exists (so you cannot start a job's *first* report from the job at all).
+Issue #390 reworks both.
+
+## Decision
+
+1. **Photo Reports become an in-job feature.** A report is created from the
+   **Job's Photos tab** (select photos → "Create report", alongside the existing
+   Tag/Download/Delete bulk actions) and opens a **full-screen, job-scoped
+   builder**. A job's reports are listed and reopened for editing from the **Job's
+   Overview tab** (the documents tab, beside Estimates/Files/Contracts/Emails).
+   The standalone global `/reports` area (list + wizard + its left-nav item) is
+   **removed** — reports are reached only through their Job. Because creation
+   always starts inside a Job, the "select job" step disappears entirely.
+
+2. **Sections regain narrative structure.** A Section gains a **one-page
+   rich-text write-up** (paragraphs and bullet/numbered lists) authored with the
+   existing TipTap editor already used for Estimates/Invoices/contracts/email. It
+   renders as a **section intro page** (heading + write-up) followed by the photo
+   pages. The write-up is **capped to one page** via a conservatively tuned
+   character limit with a live counter. This reintroduces per-section narrative
+   that ADR 0003 had removed.
+
+3. **Reports are fully editable and managed like documents.** A report is
+   **auto-saved** as you work (it exists as a draft from the moment you start),
+   reopens into the same builder for editing, is **independently deletable into a
+   restorable trash** (new — today a report only vanishes via job CASCADE), is
+   attributed to the **actual creating user** with a "Prepared by {name}" line
+   (today every row is the literal string `'Eric'`; the preparer line was dropped
+   in ADR 0003's cleanup), is **numbered per Job** (Report #1, #2, …), and
+   carries an **editable report date**.
+
+4. **Photo Report templates are kept and upgraded.** They now carry **boilerplate
+   write-up text** per section (not just headings), seeding a new report you then
+   edit. They live in Settings now that the global Reports area is gone, ship a
+   couple of sensible defaults (incl. Findings / Work Performed), and the term
+   **"Photo Report template"** is canonical — the older "preset" UI wording
+   retires. The PDF's global photos-per-page knob (ADR 0003 amendment,
+   `company_settings.report_photos_per_page`) is **retained** for the photo pages.
+
+5. **Photos in the PDF get a more pronounced corner radius** (today's radius is
+   already rounded but subtle), pulled into one shared constant.
+
+## Consequences
+
+- This **reverses ADR 0003's "single minimal layout / same audience" rationale**
+  for section content, and re-grows the layout/editor/PDF surface area ADR 0003
+  deliberately shrank. Accepted because the minimal layout could not carry the
+  findings/work-performed narrative the business actually writes.
+- **Data-shape change** requiring a migration: the `photo_reports.sections` JSONB
+  element gains a rich-text `body`; new columns for per-job `report_number`,
+  `deleted_at` (soft-delete), an editable `report_date`, and real
+  user/preparer attribution. Old rows must be read-tolerant (a missing `body`
+  reads as empty).
+- `@react-pdf/renderer` does not render HTML, so a **rich-text → PDF-primitives
+  mapping** (paragraphs, bullet/numbered lists) must be built — the main new
+  engineering in the PDF generator.
+- The one-page cap is a **character limit, not pixel-exact** — the on-screen
+  editor and the PDF engine render differently, so the cap is tuned
+  conservatively rather than measured live.
+- Cleanup opportunity: ADR 0003 left `photo_report_templates.cover_page` /
+  `photos_per_page` and `photos.thumbnail_path` (ADR 0008) as dead-but-undropped
+  columns; this rework's migration is the natural place to finally drop them.
+- Existing generated PDFs in the `reports` bucket are not regenerated; they keep
+  their old layout as a historical record (consistent with ADR 0003).
+
+## Considered options
+
+- **Keep ADR 0003's minimal layout, only move creation in-job.** Rejected: it
+  ignores the actual driver — the reports need narrative, not just a tidier
+  create flow.
+- **Plain multi-line text instead of rich text.** Rejected: the business
+  specifically writes bullet-point lists, which plain text can't format.
+- **Interleave prose with photos, or one executive summary up front.** Rejected
+  in favor of a per-section intro page: it reuses the existing divider page,
+  reads cleanly ("here's what we found" → photo evidence), and avoids the much
+  harder flowing-layout work.
+- **Auto-shrink text, or a visual page-fill meter, to enforce one page.**
+  Rejected for a predictable character-limit-with-counter; auto-shrink risks
+  unreadably small text and a live meter still can't guarantee PDF fit.
+- **A dedicated "Reports" job tab.** Rejected by the owner in favor of
+  create-from-Photos + manage-in-Overview, avoiding a fourth job tab.
+- **Keep the global `/reports` page as a read-only cross-job index.** Rejected in
+  favor of fully committing to the in-job model.

--- a/src/lib/section-writeup.test.ts
+++ b/src/lib/section-writeup.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeSectionWriteup } from "./section-writeup";
+
+describe("normalizeSectionWriteup", () => {
+  it("returns an empty string for a missing write-up (null or undefined)", () => {
+    expect(normalizeSectionWriteup(null)).toBe("");
+    expect(normalizeSectionWriteup(undefined)).toBe("");
+  });
+
+  it("treats an empty or whitespace-only write-up as empty", () => {
+    expect(normalizeSectionWriteup("")).toBe("");
+    expect(normalizeSectionWriteup("   ")).toBe("");
+    expect(normalizeSectionWriteup("\n\t  ")).toBe("");
+  });
+
+  it("wraps a legacy plain-text line as a single paragraph", () => {
+    expect(normalizeSectionWriteup("Water damage in the kitchen")).toBe(
+      "<p>Water damage in the kitchen</p>",
+    );
+  });
+
+  it("escapes HTML-special characters in legacy plain text", () => {
+    expect(normalizeSectionWriteup("temp < 5 & humidity > 80")).toBe(
+      "<p>temp &lt; 5 &amp; humidity &gt; 80</p>",
+    );
+  });
+
+  it("passes an existing rich-text HTML write-up through unchanged", () => {
+    const html =
+      "<p>Findings:</p><ul><li>Soaked drywall</li><li>Mold &amp; mildew</li></ul>";
+    expect(normalizeSectionWriteup(html)).toBe(html);
+  });
+
+  it("recognizes a single formatted paragraph as rich text, not plain", () => {
+    const html = "<p>Significant <strong>water</strong> damage</p>";
+    expect(normalizeSectionWriteup(html)).toBe(html);
+  });
+});

--- a/src/lib/section-writeup.ts
+++ b/src/lib/section-writeup.ts
@@ -1,0 +1,34 @@
+/**
+ * A Photo Report Section's write-up is the one-page rich-text narrative stored
+ * in the Section's `description` field (see CONTEXT.md and ADR 0009). The field
+ * predates rich text, so what is actually on disk varies:
+ *
+ *   - a missing value (legacy rows, or a never-edited Section)
+ *   - a legacy one-line plain-text subtitle (pre-rework reports)
+ *   - new rich-text HTML authored in the TipTap editor (post-rework)
+ *
+ * `normalizeSectionWriteup` is the single, tested boundary that reads that messy
+ * field and returns one canonical shape: HTML in the subset
+ * `src/lib/pdf-renderer/html-to-pdf.tsx` understands (so a later slice can feed
+ * the result straight to `htmlToPdfNodes`). Nothing renders this yet — it is the
+ * read-tolerance foundation the narrative slices build on.
+ */
+
+// A value is treated as already-rich-text when it contains any tag from the
+// subset `htmlToPdfNodes` understands. Anything else is a legacy plain-text
+// line that gets escaped and wrapped as a single paragraph. The `\b` keeps
+// stray prose like "a < b" from looking like a tag.
+const RICH_TEXT_TAG = /<\/?(p|ul|ol|li|strong|b|em|i|br)\b[^>]*>/i;
+
+export function normalizeSectionWriteup(
+  description: string | null | undefined,
+): string {
+  const trimmed = description?.trim();
+  if (!trimmed) return "";
+  if (RICH_TEXT_TAG.test(trimmed)) return trimmed;
+  const escaped = trimmed
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  return `<p>${escaped}</p>`;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -215,6 +215,8 @@ export interface PhotoReport {
   job_id: string;
   template_id: string | null;
   title: string;
+  /** Per-Job report number ("Report #1, #2, ..."). Null until assigned (#400). */
+  report_number: number | null;
   report_date: string;
   sections: unknown[];
   pdf_path: string | null;
@@ -222,6 +224,8 @@ export interface PhotoReport {
   created_by: string;
   created_at: string;
   updated_at: string;
+  /** Soft-delete timestamp for the recoverable trash (#402). Null = not deleted. */
+  deleted_at: string | null;
 }
 
 export interface EmailAddress {

--- a/supabase/migration-354-photo-report-rework-schema.sql
+++ b/supabase/migration-354-photo-report-rework-schema.sql
@@ -1,0 +1,24 @@
+-- Issue #398 — Photo Report Rework, slice 1: schema foundation.
+-- See docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md.
+--
+-- Adds the two new photo_reports columns the rework needs, and nothing else.
+-- Both are nullable, so every existing report is untouched and keeps opening
+-- and generating exactly as before:
+--
+--   * report_number — the per-Job report number ("Report #1, #2, ..."). Left
+--     NULL here; the numbering logic that assigns it lands in slice 2a (#400).
+--   * deleted_at    — soft-delete timestamp for the recoverable trash. NULL
+--     means "not deleted" (the only state until the trash UI lands in #402).
+--
+-- Deliberately NOT in this migration: dropping the "dead" columns
+-- (photo_report_templates.cover_page / photos_per_page / audience and
+-- photos.thumbnail_path). Each is still read by live code today, so those drops
+-- move to the slices that delete the consuming code (#405/#406 for the template
+-- columns) or to a standalone thumbnail_path cleanup — ADR 0008 already defers
+-- the latter: "Dropping the column is a separate cleanup".
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS; re-running is a no-op.
+
+ALTER TABLE photo_reports
+  ADD COLUMN IF NOT EXISTS report_number integer,
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz;

--- a/supabase/schema-photos.sql
+++ b/supabase/schema-photos.sql
@@ -97,6 +97,7 @@ CREATE TABLE photo_reports (
   job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
   template_id uuid REFERENCES photo_report_templates(id),
   title text NOT NULL,
+  report_number integer,                       -- per-Job number ("Report #1, #2, ..."); assigned in #400
   report_date date NOT NULL DEFAULT CURRENT_DATE,
   sections jsonb NOT NULL DEFAULT '[]',
   pdf_path text,
@@ -104,7 +105,8 @@ CREATE TABLE photo_reports (
     CHECK (status IN ('draft', 'generated')),
   created_by text NOT NULL DEFAULT 'Eric',
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz                       -- soft-delete for the recoverable trash (#402); NULL = not deleted
 );
 
 -- ============================================


### PR DESCRIPTION
Slice 1 of the Photo Report rework. Lays the groundwork so every later slice builds safely — **no user-visible change yet**.

Parent PRD: #397
Closes #398

## What's in here

- **Migration (`migration-354`)** — adds two nullable columns to `photo_reports`:
  - `report_number` — the per-Job number ("Report #1, #2, …"); the numbering logic that fills it in lands in #400.
  - `deleted_at` — soft-delete timestamp for the recoverable trash (#402); `NULL` = not deleted.

  Both nullable, so **every existing report is untouched** and still opens/generates exactly as before.
- **`normalizeSectionWriteup()`** (`src/lib/section-writeup.ts`) — the single, tested boundary that reads a Section's write-up tolerantly: legacy plain text → one escaped `<p>`, already-HTML → passed through unchanged, missing/blank → empty. Nothing renders it yet; it's the read-tolerance foundation #403/#404 build on.
- **Types + schema snapshot** (`types.ts`, `schema-photos.sql`) updated to match. (DB types are hand-maintained in this repo — no `supabase gen types`.)
- **Docs landed** from the grilling session: ADR 0009, the ADR 0003 "superseded in part" note, and the CONTEXT.md glossary terms (Photo Report, Section, Photo Report template). ADR 0008 was already on `main`.

## Deviation from the ticket (approved by owner)

The ticket asked to **drop 4 "dead" columns**. They are not actually dead — all four are still read by live code, and ADR 0008 itself defers `photos.thumbnail_path`'s drop as "a separate cleanup." Per the owner's call, **all four drops are deferred** to the slices that delete the consuming code:
- `photo_report_templates.cover_page` / `photos_per_page` / `audience` → #405 / #406 (when the global Reports area is removed)
- `photos.thumbnail_path` → standalone cleanup (used by `cover-photo.ts`, `purge.ts`, photo bulk-delete)

## Database

The migration has **already been applied to the live project** (`eric@aaacontracting.com's Project`) and verified — both columns exist as nullable. ADD COLUMN nullable is non-rewriting and forward-compatible, so it's safe ahead of merge.

## Verification

- Report subsystem: **77 tests pass** (new `section-writeup` tests + existing report tests + #399 corner-radius), run together against current `main`.
- `tsc --noEmit`: **zero** photo-report-related errors. (Two pre-existing unrelated errors remain: an estimate-builder test and an email-sync mock — confirmed to pre-date this work.)
- The full suite's referral-partners failures are a pre-existing test-environment issue (relative-URL `fetch`), reproduced on the clean base with this work stashed.

## Note for a follow-up

The live `photo_reports` table has an `organization_id` column that neither `schema-photos.sql` nor `types.ts` reflects — pre-existing schema drift, out of scope here, worth a small cleanup ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)