### PR TITLE
feat(photos): top-first loading in the Job Photos grid (#394)

### DIFF
--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { createClient } from "@/lib/supabase";
 import { Photo, PhotoTag } from "@/lib/types";
 import { photoUrl } from "@/lib/jobs/photo-url";
+import { photoLoadPriority } from "@/lib/jobs/photo-load-priority";
 import { format } from "date-fns";
 import { Loader2, Plus, Star } from "lucide-react";
 import { toast } from "sonner";
@@ -22,6 +23,14 @@ interface JobPhotosTabProps {
 }
 
 const PAGE_SIZE = 50;
+
+// Top-first loading (#394): eagerly load a generous first-row batch of the
+// newest date group so the top of the grid paints immediately; the rest stay
+// lazy. The grid uses CSS auto-fill, so the real column count flexes with
+// width — 8 covers a full row on desktop for both view sizes, and is only a
+// few rows on mobile (still just the top of the screen). Over-covering is
+// harmless: eager loading is a hint, and the win is not lazy-loading the top.
+const EAGER_FIRST_ROW = 8;
 
 export default function JobPhotosTab({
   jobId,
@@ -464,7 +473,7 @@ export default function JobPhotosTab({
         </div>
       ) : (
         <div>
-          {groupedPhotos.map((group) => (
+          {groupedPhotos.map((group, groupIndex) => (
             <div key={group.date} className="mb-6">
               {/* Date header */}
               <div className="flex items-center gap-2.5 mb-3">
@@ -485,9 +494,16 @@ export default function JobPhotosTab({
                     : "repeat(auto-fill, minmax(160px, 1fr))",
                 }}
               >
-                {group.photos.map((photo) => {
+                {group.photos.map((photo, index) => {
                   const isSelected = selectedIds.has(photo.id);
                   const isCover = photo.id === coverPhotoId;
+                  // Only the newest group (groupIndex 0) has a visible top row;
+                  // every other group passes 0 columns, so all its images stay
+                  // lazy.
+                  const imgPriority = photoLoadPriority(
+                    index,
+                    groupIndex === 0 ? EAGER_FIRST_ROW : 0,
+                  );
                   return (
                     <div key={photo.id} className="cursor-pointer">
                       <div
@@ -514,7 +530,8 @@ export default function JobPhotosTab({
                           src={photoUrl(photo, supabaseUrl, "grid")}
                           alt={photo.caption || "Photo"}
                           className="w-full h-full object-cover"
-                          loading="lazy"
+                          loading={imgPriority.loading}
+                          fetchPriority={imgPriority.fetchPriority}
                         />
                         {/* User avatar */}
                         <div className="absolute bottom-1.5 left-1.5 w-6 h-6 rounded-full bg-[#2B5EA7] border-2 border-white flex items-center justify-center">

--- a/src/lib/jobs/photo-load-priority.test.ts
+++ b/src/lib/jobs/photo-load-priority.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { photoLoadPriority } from "./photo-load-priority";
+
+describe("photoLoadPriority — first row loads eagerly at high priority", () => {
+  it("loads the first image (index 0) eagerly at high priority", () => {
+    expect(photoLoadPriority(0, 8)).toEqual({
+      loading: "eager",
+      fetchPriority: "high",
+    });
+  });
+
+  it("loads the last image of the first row (index = columns - 1) eagerly", () => {
+    expect(photoLoadPriority(7, 8)).toEqual({
+      loading: "eager",
+      fetchPriority: "high",
+    });
+  });
+});
+
+describe("photoLoadPriority — second row and below stay lazy", () => {
+  it("loads the first image of the second row (index = columns) lazily", () => {
+    expect(photoLoadPriority(8, 8)).toEqual({
+      loading: "lazy",
+      fetchPriority: "auto",
+    });
+  });
+
+  it("loads a deep image far below the first row lazily", () => {
+    expect(photoLoadPriority(50, 8)).toEqual({
+      loading: "lazy",
+      fetchPriority: "auto",
+    });
+  });
+});
+
+describe("photoLoadPriority — date groups below the top of the grid", () => {
+  // Only the newest date group shows a visible top row, so every other group
+  // is rendered with columnsPerRow = 0 — meaning none of its images are eager.
+  it("loads every image lazily when there is no first row (columns = 0)", () => {
+    expect(photoLoadPriority(0, 0)).toEqual({
+      loading: "lazy",
+      fetchPriority: "auto",
+    });
+  });
+});

--- a/src/lib/jobs/photo-load-priority.ts
+++ b/src/lib/jobs/photo-load-priority.ts
@@ -1,0 +1,33 @@
+// How aggressively a grid Photo image should load. These are the two HTML
+// image-loading levers a plain <img> exposes (Next.js 16 deprecated the
+// next/image `priority` prop): eager + fetchPriority "high" makes the browser
+// fetch immediately at the front of the queue; lazy + "auto" defers until the
+// image nears the viewport.
+export interface PhotoLoadPriority {
+  loading: "eager" | "lazy";
+  fetchPriority: "high" | "auto";
+}
+
+const EAGER: PhotoLoadPriority = { loading: "eager", fetchPriority: "high" };
+const LAZY: PhotoLoadPriority = { loading: "lazy", fetchPriority: "auto" };
+
+/**
+ * Decide how a Job Photos grid image should load, given its position.
+ *
+ * Top-first loading (#391 / ADR 0008): the first row is what the user sees on
+ * arrival, so those images load eagerly at high priority and paint
+ * immediately; everything below stays lazy, so a Job with hundreds of Photos
+ * doesn't flood the network and the lower rows defer until scrolled into view.
+ *
+ * The first row is the first `columnsPerRow` images — indices
+ * `0 … columnsPerRow - 1`. The boundary is exact: `index === columnsPerRow`
+ * is already the first image of the second row, hence lazy. Passing
+ * `columnsPerRow = 0` makes every image lazy, which is how the grid marks the
+ * date groups below the top one (only the newest group has a visible top row).
+ */
+export function photoLoadPriority(
+  index: number,
+  columnsPerRow: number,
+): PhotoLoadPriority {
+  return index < columnsPerRow ? EAGER : LAZY;
+}


### PR DESCRIPTION
Closes #394.

## What
Top-first loading for the Job Photos grid: the first row paints immediately while the rest loads lazily as the user scrolls. Today every grid image is hard-`loading="lazy"`, which ironically defers the top.

## How
- **New pure rule** `src/lib/jobs/photo-load-priority.ts` — `photoLoadPriority(index, columnsPerRow)` returns `{ loading, fetchPriority }`: eager/high for the first row (`index < columnsPerRow`), lazy/auto otherwise. It owns the whole loading decision (deep module, mirroring `photo-url.ts`).
- **Colocated** `photo-load-priority.test.ts` (5 tests) mirroring `cover-photo.test.ts`'s scenario-driven shape: first row → eager/high, exact boundary at the column count → lazy, deeper indices → lazy, and `columnsPerRow = 0` → all lazy.
- **Wired** `src/components/job-photos-tab.tsx`: `photoLoadPriority(index, groupIndex === 0 ? EAGER_FIRST_ROW : 0)` drives each `<img>`'s `loading`/`fetchPriority`, replacing the blanket `loading="lazy"`. The grid is CSS `auto-fill`, so a fixed generous first-row batch (`EAGER_FIRST_ROW = 8`) is baked into the first paint; only the newest date group's top row goes eager.

## Notes
- Next.js 16 deprecated the `next/image` `priority` prop; the grid uses a plain `<img>`, so `loading="eager"` + `fetchPriority="high"` are the correct levers.
- Out of scope (untouched): all-Photos page, report builder, Job-card cover.

## Tests
- `src/lib/jobs/` suite: **34/34** pass (incl. the 5 new). `tsc` clean on touched files; ESLint adds zero new problems over the `origin/main` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)