### PR TITLE
feat(invoices): official-invoice rule — Financials, Invoiced, profitability & QuickBooks (#383)

### DIFF
--- a/src/app/api/invoices/[id]/mark-sent/route.test.ts
+++ b/src/app/api/invoices/[id]/mark-sent/route.test.ts
@@ -19,6 +19,7 @@ import {
   fakeServiceClient,
   memberTables,
 } from "../../../__test-utils__/request-context-fakes";
+import { isOfficialInvoiceStatus } from "@/lib/invoice-status";
 
 const routeCtx = { params: Promise.resolve({ id: "inv-1" }) };
 
@@ -82,5 +83,33 @@ describe("POST /api/invoices/[id]/mark-sent (converted to withRequestContext)", 
     );
     const res = await POST(markSentRequest(), routeCtx);
     expect(res.status).toBe(404);
+  });
+
+  // #383 — marking a draft sent is the manual trigger that makes an invoice
+  // official. The route flips draft → sent and stamps sent_at; "sent" is a
+  // status the official-invoice rule counts as a real bill.
+  it("flips a draft to sent (official) and stamps sent_at", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+    const service = fakeServiceClient({
+      tables: { invoices: [{ id: "inv-1", status: "draft", deleted_at: null }] },
+    });
+    vi.mocked(createServiceClient).mockReturnValue(service as never);
+
+    const res = await POST(markSentRequest(), routeCtx);
+    expect(res.status).toBe(200);
+
+    const update = service.__mutations.find(
+      (m) => m.table === "invoices" && m.op === "update",
+    );
+    expect(update).toBeDefined();
+    const payload = update!.payload as { status: string; sent_at: string };
+    expect(payload.status).toBe("sent");
+    expect(isOfficialInvoiceStatus(payload.status)).toBe(true);
+    expect(typeof payload.sent_at).toBe("string");
   });
 });

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -7,6 +7,7 @@ import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
 import { photoUrl } from "@/lib/jobs/photo-url";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
+import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
 import { Badge } from "@/components/ui/badge";
@@ -147,9 +148,10 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         .order("created_at", { ascending: false }),
       supabase
         .from("invoices")
-        .select("id, total_amount")
+        .select("id, invoice_number, title, total_amount, status")
         .eq("job_id", jobId)
-        .is("deleted_at", null),
+        .is("deleted_at", null)
+        .in("status", [...OFFICIAL_INVOICE_STATUSES]),
       supabase
         .from("photos")
         .select("*")
@@ -486,6 +488,8 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         const collected = payments
           .filter((p) => p.status === "received")
           .reduce((sum, p) => sum + Number(p.amount), 0);
+        // `invoices` is fetched official-only (sent/partial/paid), so this is
+        // the official Invoiced total — drafts/voided are never summed.
         const invoiced = invoices.reduce((sum, inv) => sum + Number(inv.total_amount), 0);
         const crewLabor = job.estimated_crew_labor_cost ?? 0;
         const gross_margin = collected - expensesTotal - crewLabor;
@@ -494,6 +498,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           <FinancialsTab
             jobId={jobId}
             payments={payments}
+            invoices={invoices}
             summary={{
               invoiced,
               collected,

--- a/src/components/job-detail/financials-invoice-list.test.tsx
+++ b/src/components/job-detail/financials-invoice-list.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import { FinancialsInvoiceList, type FinancialsInvoice } from "./financials-invoice-list";
+
+function inv(overrides: Partial<FinancialsInvoice> = {}): FinancialsInvoice {
+  return {
+    id: "inv-1",
+    invoice_number: "INV-1001",
+    title: "Roof repair",
+    total_amount: 100,
+    status: "sent",
+    ...overrides,
+  };
+}
+
+// #383 — the Financials tab lists official invoices (sent/partial/paid) and each
+// entry clicks through to that invoice's View; drafts stay out. Click-through
+// keeps legacy/orphan invoices (no source estimate) reachable.
+describe("FinancialsInvoiceList", () => {
+  it("lists an official invoice as a link to its View and excludes drafts", () => {
+    render(
+      <FinancialsInvoiceList
+        invoices={[
+          inv({ id: "inv-sent", invoice_number: "INV-1001", status: "sent" }),
+          inv({ id: "inv-draft", invoice_number: "INV-1002", status: "draft" }),
+        ]}
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /INV-1001/ });
+    expect(link.getAttribute("href")).toBe("/invoices/inv-sent");
+
+    // The draft never appears in Financials.
+    expect(screen.queryByText("INV-1002")).toBeNull();
+  });
+
+  it("renders nothing when no invoice is official", () => {
+    const { container } = render(
+      <FinancialsInvoiceList
+        invoices={[inv({ status: "draft" }), inv({ status: "voided" })]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/job-detail/financials-invoice-list.tsx
+++ b/src/components/job-detail/financials-invoice-list.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import type { Invoice } from "@/lib/types";
+import { isOfficialInvoiceStatus } from "@/lib/invoice-status";
+
+export type FinancialsInvoice = Pick<
+  Invoice,
+  "id" | "invoice_number" | "title" | "total_amount" | "status"
+>;
+
+function fmtCurrency(n: number): string {
+  const hasCents = Math.round(n * 100) % 100 !== 0;
+  return n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: hasCents ? 2 : 0,
+    maximumFractionDigits: hasCents ? 2 : 0,
+  });
+}
+
+// Official invoices (sent/partial/paid) for the Job's Financials tab. Each row
+// clicks through to the invoice's View — which keeps legacy/orphan invoices (no
+// source estimate) reachable. Drafts/voided are filtered out via the shared
+// official-invoice rule, so they never surface here.
+export function FinancialsInvoiceList({ invoices }: { invoices: FinancialsInvoice[] }) {
+  const official = invoices.filter((inv) => isOfficialInvoiceStatus(inv.status));
+  if (official.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-neutral-200">Invoices</h3>
+      <ul className="divide-y divide-white/5 rounded-lg border border-white/10">
+        {official.map((inv) => (
+          <li key={inv.id}>
+            <Link
+              href={`/invoices/${inv.id}`}
+              className="flex items-center justify-between gap-3 px-4 py-3 hover:bg-white/5"
+            >
+              <span className="flex min-w-0 items-center gap-2">
+                <span className="font-mono text-xs text-neutral-400">{inv.invoice_number}</span>
+                <span className="truncate text-sm text-neutral-200">{inv.title}</span>
+              </span>
+              <span className="tabular-nums text-sm text-neutral-100">
+                {fmtCurrency(inv.total_amount)}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/job-detail/financials-tab.tsx
+++ b/src/components/job-detail/financials-tab.tsx
@@ -3,10 +3,12 @@
 import type { Payment } from "@/lib/types";
 import BillingSection from "@/components/billing/billing-section";
 import ExpensesSection from "@/components/expenses/expenses-section";
+import { FinancialsInvoiceList, type FinancialsInvoice } from "./financials-invoice-list";
 
 type Props = {
   jobId: string;
   payments: Payment[];
+  invoices: FinancialsInvoice[];
   summary: {
     invoiced: number;
     collected: number;
@@ -35,6 +37,7 @@ function fmtCurrency(n: number): string {
 export default function FinancialsTab({
   jobId,
   payments,
+  invoices,
   summary,
   onPaymentRecorded,
   onExpenseLogged,
@@ -60,6 +63,8 @@ export default function FinancialsTab({
           }
         />
       </div>
+
+      <FinancialsInvoiceList invoices={invoices} />
 
       <BillingSection
         jobId={jobId}

--- a/src/lib/accounting/margins.test.ts
+++ b/src/lib/accounting/margins.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+
+import { calculateJobMargin, aggregateMargins } from "./margins";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { fakeServiceClient } from "../../app/api/__test-utils__/request-context-fakes";
+
+type Row = Record<string, unknown>;
+
+function mockSupabase(tables: Record<string, Row[]>) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeServiceClient({ tables }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// #383 — the Job "Invoiced" total must count only official invoices
+// (sent/partial/paid). Drafts and voided are not real bills and must be
+// excluded, fixing the latent over-count where every non-deleted invoice
+// was summed.
+describe("calculateJobMargin — Invoiced counts only official invoices", () => {
+  it("sums sent/partial/paid and excludes draft/voided", async () => {
+    mockSupabase({
+      jobs: [
+        { id: "job-1", job_number: "J-1", status: "completed", estimated_crew_labor_cost: 0 },
+      ],
+      invoices: [
+        { job_id: "job-1", status: "sent", total_amount: 100, deleted_at: null },
+        { job_id: "job-1", status: "partial", total_amount: 50, deleted_at: null },
+        { job_id: "job-1", status: "paid", total_amount: 25, deleted_at: null },
+        { job_id: "job-1", status: "draft", total_amount: 999, deleted_at: null },
+        { job_id: "job-1", status: "voided", total_amount: 777, deleted_at: null },
+      ],
+      payments: [],
+      expenses: [],
+    });
+
+    const margin = await calculateJobMargin("job-1");
+
+    expect(margin.invoiced).toBe(175); // 100 + 50 + 25 — not 999 or 777
+  });
+});
+
+// #383 — the org-wide profitability roll-up must use the same official-only
+// rule so job and company numbers agree. Per-job Invoiced excludes draft/voided,
+// and a job whose only activity is a draft drops out of the report entirely
+// (no real bill, no payment, no expense → out of scope).
+describe("aggregateMargins — profitability counts only official invoices", () => {
+  it("excludes draft/voided from Invoiced and drops draft-only jobs from scope", async () => {
+    mockSupabase({
+      jobs: [
+        { id: "job-1", job_number: "J-1", status: "completed", estimated_crew_labor_cost: 0 },
+        { id: "job-2", job_number: "J-2", status: "completed", estimated_crew_labor_cost: 0 },
+        { id: "job-3", job_number: "J-3", status: "completed", estimated_crew_labor_cost: 0 },
+      ],
+      invoices: [
+        { job_id: "job-1", status: "sent", total_amount: 100, issued_date: "2026-05-01", deleted_at: null },
+        { job_id: "job-1", status: "draft", total_amount: 999, issued_date: "2026-05-01", deleted_at: null },
+        { job_id: "job-1", status: "voided", total_amount: 777, issued_date: "2026-05-01", deleted_at: null },
+        { job_id: "job-2", status: "paid", total_amount: 200, issued_date: "2026-05-01", deleted_at: null },
+        { job_id: "job-3", status: "draft", total_amount: 500, issued_date: "2026-05-01", deleted_at: null },
+      ],
+      payments: [],
+      expenses: [],
+    });
+
+    const rows = await aggregateMargins("2026-01-01", "2026-12-31", "all");
+
+    const byId = new Map(rows.map((r) => [r.jobId, r]));
+    expect(byId.get("job-1")?.invoiced).toBe(100); // sent only — not 1876
+    expect(byId.get("job-2")?.invoiced).toBe(200); // paid
+    expect(byId.has("job-3")).toBe(false); // draft-only job is not a real bill
+  });
+});

--- a/src/lib/accounting/margins.ts
+++ b/src/lib/accounting/margins.ts
@@ -11,6 +11,7 @@
 // mid-job numbers are misleading (expenses landed but collections haven't).
 
 import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
 export { marginPctBand, type MarginBand } from "./margin-bands";
 
 export type JobMargin = {
@@ -39,16 +40,17 @@ export async function calculateJobMargin(jobId: string): Promise<JobMargin> {
 
   const [jobRes, invoicesRes, paymentsRes, expensesRes] = await Promise.all([
     supabase.from("jobs").select("id, job_number, status, estimated_crew_labor_cost").eq("id", jobId).maybeSingle(),
-    supabase.from("invoices").select("total_amount").eq("job_id", jobId).is("deleted_at", null),
+    supabase.from("invoices").select("total_amount").eq("job_id", jobId).is("deleted_at", null)
+      .in("status", [...OFFICIAL_INVOICE_STATUSES]),
     supabase.from("payments").select("amount").eq("job_id", jobId).eq("status", "received"),
     supabase.from("expenses").select("amount").eq("job_id", jobId),
   ]);
 
   if (!jobRes.data) throw new Error(`Job ${jobId} not found`);
 
-  const invoiced = sum(invoicesRes.data, (r: any) => Number(r.total_amount));
-  const collected = sum(paymentsRes.data, (r: any) => Number(r.amount));
-  const expenses = sum(expensesRes.data, (r: any) => Number(r.amount));
+  const invoiced = sum(invoicesRes.data, (r: { total_amount: number | string | null }) => Number(r.total_amount));
+  const collected = sum(paymentsRes.data, (r: { amount: number | string | null }) => Number(r.amount));
+  const expenses = sum(expensesRes.data, (r: { amount: number | string | null }) => Number(r.amount));
   const crew_labor = Number(jobRes.data.estimated_crew_labor_cost ?? 0);
   const gross_margin = collected - expenses - crew_labor;
   const margin_pct = collected > 0 ? (gross_margin / collected) * 100 : null;
@@ -82,14 +84,18 @@ export async function aggregateMargins(
 ): Promise<JobMargin[]> {
   const supabase = await createServerSupabaseClient();
 
-  // Activity-based scoping: a job is in scope if it has an invoice, payment,
-  // or expense in the range. When startISO/endISO are null (All time), skip filtering.
+  // Activity-based scoping: a job is in scope if it has an official invoice
+  // (sent/partial/paid — see OFFICIAL_INVOICE_STATUSES), payment, or expense in
+  // the range. Drafts/voided are not real bills, so a job whose only activity is
+  // a draft invoice is out of scope and contributes nothing to Invoiced.
+  // When startISO/endISO are null (All time), skip range filtering.
   // We do this as a single round-trip by fetching all 4 tables in parallel and
   // joining in JS. This keeps the SQL simple and sidesteps needing new RPCs.
 
   const [jobsRes, invoicesRes, paymentsRes, expensesRes] = await Promise.all([
     supabase.from("jobs").select("id, job_number, status, estimated_crew_labor_cost, damage_type, property_address"),
-    supabase.from("invoices").select("job_id, total_amount, issued_date").is("deleted_at", null),
+    supabase.from("invoices").select("job_id, total_amount, issued_date").is("deleted_at", null)
+      .in("status", [...OFFICIAL_INVOICE_STATUSES]),
     supabase.from("payments").select("job_id, amount, received_date, status"),
     supabase.from("expenses").select("job_id, amount, expense_date"),
   ]);

--- a/src/lib/invoice-status.test.ts
+++ b/src/lib/invoice-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import {
+  isOfficialInvoiceStatus,
+  OFFICIAL_INVOICE_STATUSES,
+  type InvoiceStatus,
+} from "./invoice-status";
+
+// #383 — a single rule decides which invoice statuses are "official" (a real
+// bill): sent / partial / paid count; draft / voided do not. This is the
+// isolation test that every status maps to the correct official verdict.
+describe("isOfficialInvoiceStatus", () => {
+  const cases: Array<[InvoiceStatus, boolean]> = [
+    ["sent", true],
+    ["partial", true],
+    ["paid", true],
+    ["draft", false],
+    ["voided", false],
+  ];
+
+  it.each(cases)("classifies %s as official=%s", (status, expected) => {
+    expect(isOfficialInvoiceStatus(status)).toBe(expected);
+  });
+});
+
+describe("OFFICIAL_INVOICE_STATUSES", () => {
+  it("is exactly the official statuses", () => {
+    expect([...OFFICIAL_INVOICE_STATUSES]).toEqual(["sent", "partial", "paid"]);
+  });
+});

--- a/src/lib/invoice-status.ts
+++ b/src/lib/invoice-status.ts
@@ -1,0 +1,27 @@
+// src/lib/invoice-status.ts
+// Single source of truth for which invoice statuses are "official" — i.e. count
+// as a real bill. sent / partial / paid are official; draft / voided are not.
+//
+// Everything that cares about "is this a real bill" consults this rule instead
+// of hard-coding status lists: the Job Financials tab, the Job "Invoiced" total,
+// the org-wide profitability roll-up, and (mirrored in SQL) the QuickBooks gate.
+//
+// Pure, zero-runtime-dependency leaf — same pattern as margin-bands.ts — so both
+// client components and server modules can import it without dragging in the
+// server-only Supabase bundle.
+
+import type { Invoice } from "@/lib/types";
+
+export type InvoiceStatus = Invoice["status"];
+
+/** The invoice statuses that count as a real bill, in lifecycle order. */
+export const OFFICIAL_INVOICE_STATUSES = [
+  "sent",
+  "partial",
+  "paid",
+] as const satisfies readonly InvoiceStatus[];
+
+/** True when an invoice's status makes it official (a real bill). */
+export function isOfficialInvoiceStatus(status: InvoiceStatus | string): boolean {
+  return (OFFICIAL_INVOICE_STATUSES as readonly string[]).includes(status);
+}

--- a/supabase/migration-build79-official-invoice-rule.sql
+++ b/supabase/migration-build79-official-invoice-rule.sql
@@ -1,0 +1,201 @@
+-- ============================================
+-- Build 79 Migration: #383 — Official-invoice rule
+--
+-- Establishes a single source of truth, in SQL, for which invoice statuses are
+-- "official" (a real bill): sent / partial / paid count; draft / voided do not.
+-- This mirrors the TypeScript rule in src/lib/invoice-status.ts.
+--
+-- The build38 QuickBooks enqueue triggers and the payment-driven status
+-- recompute now CONSULT this function instead of hard-coding status lists. Only
+-- function bodies change (CREATE OR REPLACE) — the trigger BINDINGS from build38
+-- are untouched.
+--
+-- Behaviour is preserved for every real transition. Given the invoice state
+-- machine (draft -> {sent, voided}; sent -> {partial, paid, voided}; ...), the
+-- only non-official -> official transition that can occur is draft -> sent —
+-- exactly the create gate's previous literal. Phrasing the gate as
+-- "became official" (NOT official(OLD) AND official(NEW)) additionally hardens
+-- it against any future/bulk path that flips a draft straight to partial/paid.
+--
+-- Run in Supabase SQL Editor. All statements are CREATE OR REPLACE.
+-- ============================================
+
+-- 1. The rule. sent / partial / paid are official (a real bill); draft / voided
+--    are not. IMMUTABLE so PostgreSQL can inline it. Mirrors
+--    src/lib/invoice-status.ts (OFFICIAL_INVOICE_STATUSES).
+CREATE OR REPLACE FUNCTION is_official_invoice_status(p_status text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_status IN ('sent', 'partial', 'paid');
+$$;
+
+-- 2. Payment-driven status recompute (build38) — now consults the rule.
+--    Non-official statuses (draft / voided) remain terminal for this function.
+CREATE OR REPLACE FUNCTION recompute_invoice_status(p_invoice_id uuid)
+RETURNS text AS $$
+DECLARE
+  current_status text;
+  total numeric(10,2);
+  collected numeric(10,2);
+  new_status text;
+BEGIN
+  SELECT status, total_amount INTO current_status, total
+    FROM invoices WHERE id = p_invoice_id;
+  IF current_status IS NULL THEN RETURN NULL; END IF;
+  IF NOT is_official_invoice_status(current_status) THEN RETURN current_status; END IF;
+
+  SELECT COALESCE(SUM(amount), 0) INTO collected
+    FROM payments WHERE invoice_id = p_invoice_id AND status = 'received';
+
+  IF collected >= total AND total > 0 THEN
+    new_status := 'paid';
+  ELSIF collected > 0 THEN
+    new_status := 'partial';
+  ELSE
+    new_status := 'sent';
+  END IF;
+
+  IF new_status <> current_status THEN
+    UPDATE invoices SET status = new_status WHERE id = p_invoice_id;
+  END IF;
+  RETURN new_status;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. QuickBooks invoice enqueue (build38) — the gate that decides when an
+--    invoice reaches accounting. It now consults the rule:
+--      * a create is enqueued when an invoice BECOMES official (was not
+--        official, now is) — i.e. the draft -> sent flip;
+--      * post-sync edits enqueue an update while the invoice IS official.
+CREATE OR REPLACE FUNCTION trg_qb_enqueue_invoice_update()
+RETURNS trigger AS $$
+DECLARE
+  conn qb_connection;
+  contact_row contacts;
+  job_row jobs;
+  customer_log_id uuid;
+  sub_log_id uuid;
+  dep_id uuid;
+BEGIN
+  conn := qb_get_active_connection();
+  IF conn.id IS NULL THEN RETURN NEW; END IF;
+
+  -- Became official (draft -> sent): enqueue create, with cascading
+  -- customer/sub_customer deps.
+  IF NOT is_official_invoice_status(OLD.status) AND is_official_invoice_status(NEW.status) THEN
+    SELECT * INTO job_row FROM jobs WHERE id = NEW.job_id;
+    IF job_row.id IS NULL THEN RETURN NEW; END IF;
+    SELECT * INTO contact_row FROM contacts WHERE id = job_row.contact_id;
+    IF contact_row.id IS NULL THEN RETURN NEW; END IF;
+
+    -- Ensure parent customer is synced or queued.
+    IF contact_row.qb_customer_id IS NULL THEN
+      SELECT id INTO customer_log_id FROM qb_sync_log
+        WHERE entity_type = 'customer' AND entity_id = contact_row.id
+          AND status IN ('queued', 'failed') ORDER BY created_at DESC LIMIT 1;
+      IF customer_log_id IS NULL THEN
+        INSERT INTO qb_sync_log (entity_type, entity_id, action, status)
+          VALUES ('customer', contact_row.id, 'create', 'queued')
+          RETURNING id INTO customer_log_id;
+      END IF;
+    END IF;
+
+    -- Ensure sub-customer is synced or queued.
+    IF job_row.qb_subcustomer_id IS NULL THEN
+      SELECT id INTO sub_log_id FROM qb_sync_log
+        WHERE entity_type = 'sub_customer' AND entity_id = job_row.id
+          AND status IN ('queued', 'failed') ORDER BY created_at DESC LIMIT 1;
+      IF sub_log_id IS NULL THEN
+        INSERT INTO qb_sync_log (entity_type, entity_id, action, status, depends_on_log_id)
+          VALUES ('sub_customer', job_row.id, 'create', 'queued', customer_log_id)
+          RETURNING id INTO sub_log_id;
+      END IF;
+    END IF;
+
+    dep_id := sub_log_id;  -- may be NULL if sub already synced; that's fine.
+
+    INSERT INTO qb_sync_log (entity_type, entity_id, action, status, depends_on_log_id)
+      VALUES ('invoice', NEW.id, 'create', 'queued', dep_id);
+    RETURN NEW;
+  END IF;
+
+  -- Any-state → Voided: enqueue void, or coalesce with a queued create.
+  IF OLD.status <> 'voided' AND NEW.status = 'voided' THEN
+    -- Coalesce: if a queued 'create' exists for this invoice, delete it —
+    -- the invoice never reached QB so there's nothing to void.
+    DELETE FROM qb_sync_log
+      WHERE entity_type = 'invoice' AND entity_id = NEW.id
+        AND action = 'create' AND status = 'queued';
+    IF NEW.qb_invoice_id IS NOT NULL THEN
+      INSERT INTO qb_sync_log (entity_type, entity_id, action, status)
+        VALUES ('invoice', NEW.id, 'void', 'queued');
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- Official-invoice edits after sync: enqueue update when any field changed.
+  IF NEW.qb_invoice_id IS NOT NULL
+     AND is_official_invoice_status(NEW.status)
+     AND (
+       NEW.total_amount IS DISTINCT FROM OLD.total_amount
+       OR NEW.subtotal IS DISTINCT FROM OLD.subtotal
+       OR NEW.tax_rate IS DISTINCT FROM OLD.tax_rate
+       OR NEW.tax_amount IS DISTINCT FROM OLD.tax_amount
+       OR NEW.issued_date IS DISTINCT FROM OLD.issued_date
+       OR NEW.due_date IS DISTINCT FROM OLD.due_date
+       OR NEW.po_number IS DISTINCT FROM OLD.po_number
+       OR NEW.memo IS DISTINCT FROM OLD.memo
+       OR NEW.notes IS DISTINCT FROM OLD.notes
+     )
+  THEN
+    IF NOT EXISTS (
+      SELECT 1 FROM qb_sync_log
+      WHERE entity_type = 'invoice' AND entity_id = NEW.id
+        AND action = 'update' AND status = 'queued'
+    ) THEN
+      INSERT INTO qb_sync_log (entity_type, entity_id, action, status)
+        VALUES ('invoice', NEW.id, 'update', 'queued');
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 4. Line-item CRUD on a synced invoice (build38) — now consults the rule:
+--    only official invoices enqueue a QB update.
+CREATE OR REPLACE FUNCTION trg_qb_enqueue_line_item_change()
+RETURNS trigger AS $$
+DECLARE
+  inv invoices;
+  target_id uuid;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    target_id := OLD.invoice_id;
+  ELSE
+    target_id := NEW.invoice_id;
+  END IF;
+  SELECT * INTO inv FROM invoices WHERE id = target_id;
+  IF inv.id IS NULL OR inv.qb_invoice_id IS NULL THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+  END IF;
+  IF NOT is_official_invoice_status(inv.status) THEN
+    IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM qb_sync_log
+    WHERE entity_type = 'invoice' AND entity_id = inv.id
+      AND action = 'update' AND status = 'queued'
+  ) THEN
+    INSERT INTO qb_sync_log (entity_type, entity_id, action, status)
+      VALUES ('invoice', inv.id, 'update', 'queued');
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; ELSE RETURN NEW; END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ============================================
+-- End of build79 migration.
+-- ============================================

--- a/tests/integration/official-invoice-status.pg.test.ts
+++ b/tests/integration/official-invoice-status.pg.test.ts
@@ -1,0 +1,116 @@
+// Integration coverage for the #383 official-invoice rule at the SQL layer:
+// is_official_invoice_status(text) — the single rule deciding whether an invoice
+// status counts as a real bill (sent/partial/paid) or not (draft/voided). The
+// same migration rewrites the QuickBooks enqueue / status-recompute trigger
+// functions to consult this rule instead of hard-coding status lists.
+//
+// Harness mirrors apply-template.pg.test.ts: a throwaway embedded-postgres
+// cluster loading the LIVE migration SQL verbatim (no copy-paste drift), driven
+// through a raw `pg` client. The migration also re-defines the QuickBooks
+// trigger functions, whose %ROWTYPE declarations (qb_connection, contacts, jobs,
+// invoices) reference tables this focused cluster doesn't have — so we load with
+// `check_function_bodies = off`, which stores those bodies verbatim without
+// resolving their table refs (the triggers are never fired here). The function
+// under test needs no tables. Run with `npm run test:pg`.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+
+import EmbeddedPostgres from "embedded-postgres";
+import type { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const MIGRATION_SQL = readFileSync(
+  join(process.cwd(), "supabase", "migration-build79-official-invoice-rule.sql"),
+  "utf8",
+);
+
+/** Grab a free ephemeral port so the cluster never collides with a local PG. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+let pgServer: EmbeddedPostgres;
+let dataDir: string;
+let client: Client;
+
+const TEST_DB = "official_invoice_test";
+
+beforeAll(async () => {
+  // Data dir under the OS temp root, NOT the OneDrive-synced tree (OneDrive
+  // interferes with initdb's file locking).
+  dataDir = mkdtempSync(join(tmpdir(), "nookleus-pg-"));
+  pgServer = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    port: await freePort(),
+    user: "postgres",
+    password: "postgres",
+    persistent: false,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+
+  await pgServer.initialise();
+  await pgServer.start();
+  await pgServer.createDatabase(TEST_DB);
+
+  client = pgServer.getPgClient(TEST_DB);
+  await client.connect();
+
+  // Defer body validation so the QuickBooks trigger functions (whose %ROWTYPE
+  // decls reference tables absent from this focused cluster) load verbatim. The
+  // function under test references no tables and runs fine.
+  await client.query("SET check_function_bodies = off");
+  await client.query(MIGRATION_SQL);
+}, 120_000);
+
+afterAll(async () => {
+  if (client) await client.end().catch(() => {});
+  if (pgServer) await pgServer.stop().catch(() => {});
+  if (dataDir) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp-dir cleanup */
+    }
+  }
+});
+
+describe("is_official_invoice_status (#383)", () => {
+  // Every status maps to the correct official verdict — the SQL mirror of the
+  // TypeScript isOfficialInvoiceStatus isolation test.
+  const cases: Array<[string, boolean]> = [
+    ["sent", true],
+    ["partial", true],
+    ["paid", true],
+    ["draft", false],
+    ["voided", false],
+  ];
+
+  it.each(cases)("classifies %s as official=%s", async (status, expected) => {
+    const { rows } = await client.query<{ official: boolean }>(
+      "SELECT is_official_invoice_status($1) AS official",
+      [status],
+    );
+    expect(rows[0].official).toBe(expected);
+  });
+
+  it("treats an unknown status as not official (default-deny)", async () => {
+    const { rows } = await client.query<{ official: boolean }>(
+      "SELECT is_official_invoice_status($1) AS official",
+      ["archived"],
+    );
+    expect(rows[0].official).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #383.

## What & why
Establishes a single source of truth for which invoice statuses are **official** (a real bill): `sent`/`partial`/`paid` count; `draft`/`voided` don't. Everything that asks "is this a real bill" now consults the rule instead of hard-coding status lists.

## Changes
- **The rule** — `src/lib/invoice-status.ts`: `isOfficialInvoiceStatus()` + `OFFICIAL_INVOICE_STATUSES`, a pure client-safe leaf (mirrors `margin-bands.ts`). SQL mirror `is_official_invoice_status()` in `migration-build79`.
- **Invoiced total** (`calculateJobMargin`) and **org profitability** (`aggregateMargins`) sum official invoices only — fixes the latent over-count that summed every non-deleted invoice (incl. drafts/voided). A job whose only activity is a draft now drops out of the profitability report.
- **Financials tab** gains an official-invoice list (`FinancialsInvoiceList`); each row clicks through to `/invoices/[id]` (keeps orphan/legacy invoices reachable); drafts stay out.
- **QuickBooks** enqueue/recompute triggers consult the rule (build79). Behaviour-preserving — see note below.

## Acceptance criteria
- [x] Single rule classifies each status; consulted by Financials, the Invoiced aggregation, and the QB gate
- [x] Invoice can be manually marked sent (existing route; now covered by a transition test)
- [x] Marking sent surfaces it in Financials; drafts don't
- [x] Job "Invoiced" counts official only
- [x] Org profitability uses the same rule (job & company numbers agree)
- [x] Financials entry clicks through to the invoice View
- [x] QuickBooks pushes only after sent
- [x] Isolation tests (verdict + mixed-status per-job/profitability) and a mark-sent route test

## Test plan
- Changed-file vitest run: verdict isolation, mixed-status fixtures (per-job + profitability), mark-sent->official route, FinancialsInvoiceList component — **37 passed**.
- `npm run test:pg`: SQL verdicts for all 5 statuses + default-deny — **6 passed**.
- `tsc`: no new errors. Lint: new files clean.

## Behaviour-preserving QB rewrite
Re-phrasing the create gate as "became official" (`NOT official(OLD) AND official(NEW)`) is provably equal to the old `draft -> sent` literal given the invoice state machine. The three rewritten PL/pgSQL bodies were diffed against build38 and differ **only** by the rule substitutions.

## Deploy note
:warning: `migration-build79-official-invoice-rule.sql` must be applied in the Supabase SQL editor for the QB-gate change to take effect (this repo's migrations aren't auto-run). The TS/UI changes ship with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)