### PR TITLE
feat(photos): background-preload the first screenful on Job open (#395)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase";
 import { escapeOrFilterValue } from "@/lib/postgrest";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
 import { photoUrl } from "@/lib/jobs/photo-url";
+import { pickPreloadUrls } from "@/lib/jobs/photo-preload";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
@@ -70,6 +71,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import JobPhotosTab from "@/components/job-photos-tab";
+import PhotoPreloader from "@/components/photo-preloader";
 import { useAuth } from "@/lib/auth-context";
 
 const propertyTypeLabels: Record<string, string> = {
@@ -78,6 +80,13 @@ const propertyTypeLabels: Record<string, string> = {
   commercial: "Commercial",
   condo: "Condo",
 };
+
+// Background preload (#395): when a Job opens we warm the newest Photo
+// previews so the Photos tab paints instantly when tapped, instead of starting
+// to load on tap. We prefetch only the rows the page already loaded (the
+// `.limit(12)` newest photos fetched below) — about a screenful — and no more,
+// so opening a Job and never tapping Photos costs little background data.
+const SCREENFUL_PRELOAD = 12;
 
 export default function JobDetail({ jobId }: { jobId: string }) {
   const { hasPermission, profile } = useAuth();
@@ -125,6 +134,14 @@ export default function JobDetail({ jobId }: { jobId: string }) {
   };
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+
+  // The grid-preview URLs to warm on Job open — the newest rows already in
+  // state, capped at a screenful. Reuses the grid's exact photoUrl(…, "grid")
+  // so the prefetch and the eventual <img> share a cache key.
+  const preloadUrls = useMemo(
+    () => pickPreloadUrls(photos, supabaseUrl, SCREENFUL_PRELOAD),
+    [photos, supabaseUrl],
+  );
 
   const fetchData = useCallback(async () => {
     const supabase = createClient();
@@ -959,6 +976,11 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           onSelectPhoto={(photo) => setSelectedPhoto(photo)}
         />
       )}
+
+      {/* Background-preload the newest Photo previews on Job open (#395) so the
+          Photos tab opens warm. Always mounted (not gated on the active tab),
+          renders nothing, and prefetches at low priority. */}
+      <PhotoPreloader urls={preloadUrls} />
 
       {/* Photo modals — always rendered regardless of tab */}
       <PhotoUploadModal

--- a/src/components/photo-preloader.tsx
+++ b/src/components/photo-preloader.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+import { preload } from "react-dom";
+
+/**
+ * Fire-and-forget, low-priority prefetch of a list of image URLs (#395).
+ *
+ * Renders nothing: it runs {@link preload} from an effect (after paint) so the
+ * Job page never waits on it, and `fetchPriority: "low"` keeps these previews
+ * behind everything the page actually needs to load first. The browser dedupes
+ * the prefetch against the grid's later `<img>` request for the same URL, so
+ * the Photos tab opens already warm.
+ */
+export default function PhotoPreloader({ urls }: { urls: string[] }) {
+  useEffect(() => {
+    urls.forEach((url) => preload(url, { as: "image", fetchPriority: "low" }));
+  }, [urls]);
+
+  return null;
+}

--- a/src/lib/jobs/photo-preload.test.ts
+++ b/src/lib/jobs/photo-preload.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { pickPreloadUrls } from "./photo-preload";
+
+const SUPABASE_URL = "https://proj.supabase.co";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("pickPreloadUrls — preserves the newest-first order of the loaded rows", () => {
+  it("returns one grid preview URL per photo, in the order given", () => {
+    const urls = pickPreloadUrls(
+      [
+        { annotated_path: null, storage_path: "originals/0.jpg" },
+        { annotated_path: null, storage_path: "originals/1.jpg" },
+        { annotated_path: null, storage_path: "originals/2.jpg" },
+      ],
+      SUPABASE_URL,
+      3,
+    );
+    expect(urls).toEqual([
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/0.jpg",
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/1.jpg",
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/2.jpg",
+    ]);
+  });
+});
+
+describe("pickPreloadUrls — caps at the screenful size", () => {
+  it("returns only the first `screenful` URLs when more photos are loaded", () => {
+    const urls = pickPreloadUrls(
+      [
+        { annotated_path: null, storage_path: "originals/0.jpg" },
+        { annotated_path: null, storage_path: "originals/1.jpg" },
+        { annotated_path: null, storage_path: "originals/2.jpg" },
+        { annotated_path: null, storage_path: "originals/3.jpg" },
+        { annotated_path: null, storage_path: "originals/4.jpg" },
+      ],
+      SUPABASE_URL,
+      2,
+    );
+    expect(urls).toEqual([
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/0.jpg",
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/1.jpg",
+    ]);
+  });
+
+  it("returns exactly the loaded rows when the count equals the screenful (no off-by-one)", () => {
+    const urls = pickPreloadUrls(
+      [
+        { annotated_path: null, storage_path: "originals/0.jpg" },
+        { annotated_path: null, storage_path: "originals/1.jpg" },
+      ],
+      SUPABASE_URL,
+      2,
+    );
+    expect(urls).toEqual([
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/0.jpg",
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/1.jpg",
+    ]);
+  });
+});
+
+describe("pickPreloadUrls — a Job with fewer Photos than a screenful", () => {
+  it("returns just the loaded rows, not padded to the screenful size", () => {
+    const urls = pickPreloadUrls(
+      [
+        { annotated_path: null, storage_path: "originals/0.jpg" },
+        { annotated_path: null, storage_path: "originals/1.jpg" },
+      ],
+      SUPABASE_URL,
+      12,
+    );
+    expect(urls).toEqual([
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/0.jpg",
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/1.jpg",
+    ]);
+  });
+});
+
+describe("pickPreloadUrls — an empty Job", () => {
+  it("returns an empty list when there are no Photos to preload", () => {
+    expect(pickPreloadUrls([], SUPABASE_URL, 12)).toEqual([]);
+  });
+});
+
+describe("pickPreloadUrls — uses the resolver's grid variant", () => {
+  // Preloading must warm the SAME small previews the grid renders, not the
+  // full-resolution originals (#395 / ADR 0008) — otherwise we'd waste data
+  // and still miss the grid's cache. With resize enabled, the "grid" variant
+  // yields a render/resize URL; "full" would yield the plain object URL.
+  it("preloads small resized previews (grid render URLs), not full-resolution originals", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const urls = pickPreloadUrls(
+      [{ annotated_path: null, storage_path: "originals/abc.jpg" }],
+      SUPABASE_URL,
+      12,
+    );
+    expect(urls).toEqual([
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+    ]);
+  });
+});

--- a/src/lib/jobs/photo-preload.ts
+++ b/src/lib/jobs/photo-preload.ts
@@ -1,0 +1,30 @@
+import { photoUrl, type PhotoUrlSource } from "./photo-url";
+
+/**
+ * Pick the grid-preview URLs to warm in the background when a Job opens.
+ *
+ * Background preload (#395 / ADR 0008): the Job page already holds the newest
+ * Photo rows it loaded for the header/summary, so on open we can quietly
+ * prefetch their previews — then tapping the Photos tab paints instantly
+ * instead of starting to load on tap.
+ *
+ * The list is **capped at `screenful`** so a user who opens a Job but never
+ * taps Photos wastes little data: we warm only what a first screen would show,
+ * never the whole (possibly hundreds-deep) library. A Job with fewer rows than
+ * a screenful returns just those; an empty Job returns `[]`.
+ *
+ * URLs come from the resolver's `"grid"` variant — the same small resized
+ * previews the grid `<img>` renders (see {@link photoUrl}) — so the prefetched
+ * request and the grid's request share a cache key and the warm hit lands.
+ * `photos` is expected newest-first (the order the page loaded them), and the
+ * returned URLs preserve that order.
+ */
+export function pickPreloadUrls(
+  photos: PhotoUrlSource[],
+  supabaseUrl: string,
+  screenful: number,
+): string[] {
+  return photos
+    .slice(0, screenful)
+    .map((photo) => photoUrl(photo, supabaseUrl, "grid"));
+}


### PR DESCRIPTION
## What & why

Closes #395 (child of #391; unblocked by #392). When a Job opens, quietly warm the newest Photo previews so the **Photos tab paints instantly** when tapped, instead of starting to load on tap.

## How

- **`pickPreloadUrls` (pure picker, `src/lib/jobs/photo-preload.ts`)** — takes the already-loaded newest Photo rows + a screenful size and returns the ordered, capped list of preview URLs to prefetch. Reuses `photoUrl(…, grid)` so each warmed URL is byte-identical to the grid `<img>` cache key.
- **`PhotoPreloader` (thin shell, `src/components/photo-preloader.tsx`)** — null-rendering client component that calls `ReactDOM.preload(url, { as: image, fetchPriority: low })` from a post-paint `useEffect`, so it never blocks the page.
- **`JobDetail` wiring** — mounts the preloader unconditionally (so it warms before the tab is tapped) over the 12 newest rows the page already loads (`SCREENFUL_PRELOAD = 12`). No extra query.

## Tests

`src/lib/jobs/photo-preload.test.ts` (6 cases, colocated, mirrors `cover-photo.test.ts`): ordering, screenful cap, exact boundary, fewer-than-a-screenful, empty Job, and a discriminating grid-variant proof (would fail under the `full` variant). 6/6 green.

## Verification

- New files lint clean; `job-detail.tsx` lint count unchanged vs `main` baseline (no new problems); `tsc` clean for all changed files.
- Adversarial multi-agent review across cache-coherence, non-blocking, acceptance-coverage and API-idiom lenses: ship as-is.

## Known limitations (out of #395 scope)

- **Tag filters** can't be pre-warmed — they don't exist at Job-open time. The default unfiltered first-tap view is warmed.
- The Photos tab still re-queries photo **rows** on open (pre-existing `JobPhotosTab` behavior). Image **bytes** are warm (the heavy part per ADR 0008); the light rows query still round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)