### PR TITLE
feat(overview): converting an estimate flips its Overview row into the invoice (#384)

### DIFF
--- a/src/components/job-detail/estimates-invoices-section.tsx
+++ b/src/components/job-detail/estimates-invoices-section.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
-import { Ban, CreditCard, Eye, Pencil, Plus, Trash2 } from "lucide-react";
+import { Ban, CreditCard, Eye, FileText, Pencil, Plus, Trash2 } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/button";
 import {
@@ -16,7 +16,12 @@ import {
   TableCell,
 } from "@/components/ui/table";
 import { formatCurrency } from "@/lib/format";
-import { STATUS_BADGE_CLASSES, formatStatusLabel, getStatusBadgeClasses } from "@/lib/estimate-status";
+import {
+  ROW_TINT_CLASSES,
+  formatStatusLabel,
+  getStatusBadgeClasses,
+} from "@/lib/estimate-status";
+import { buildBillingRows } from "@/lib/billing-rows";
 import { TrashConfirmDialog } from "@/components/trash/trash-confirm-dialog";
 import { ForceDeleteConfirmDialog } from "@/components/trash/force-delete-confirm-dialog";
 import { VoidConfirmDialog } from "@/components/void-confirm-dialog";
@@ -33,7 +38,15 @@ function capitalize(s: string): string {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// EstimatesInvoicesSection
+// EstimatesInvoicesSection (#384)
+//
+// The Job's Overview tab is one list of estimates. When an estimate is
+// converted, its row flips to represent the invoice — that same row becomes
+// where you view and edit the invoice — while the original estimate is kept as
+// a frozen, view-only record reachable via a link on the flipped row. The
+// derived shape of every row (plain estimate vs flipped invoice, the status
+// shown, the tint, which document view/edit target, the frozen link) comes from
+// the pure `buildBillingRows` transform; this component only renders it.
 // ─────────────────────────────────────────────────────────────────────────────
 
 interface EstimatesInvoicesSectionProps {
@@ -95,10 +108,7 @@ export function EstimatesInvoicesSection({ jobId }: EstimatesInvoicesSectionProp
         return;
       }
       const data = (await res.json()) as { rows: Invoice[] };
-      const sorted = (data.rows ?? []).slice().sort((a, b) =>
-        a.invoice_number.localeCompare(b.invoice_number)
-      );
-      setInvoices(sorted);
+      setInvoices(data.rows ?? []);
       setInvoicesError(null);
     } catch {
       setInvoicesError("Failed to load invoices");
@@ -276,15 +286,19 @@ export function EstimatesInvoicesSection({ jobId }: EstimatesInvoicesSectionProp
   const canView = !authLoading && hasPermission("view_estimates");
   const canEdit = !authLoading && hasPermission("edit_estimates");
   const canCreate = !authLoading && hasPermission("create_estimates");
-  const canCreateInvoices = !authLoading && hasPermission("create_invoices");
   const canEditInvoices = !authLoading && hasPermission("edit_invoices");
   const canViewInvoices = !authLoading && hasPermission("view_invoices");
   const canManageEstimates = !authLoading && hasPermission("manage_estimates");
   const canManageInvoices = !authLoading && hasPermission("manage_invoices");
 
+  const loading = estimates === null || invoices === null;
+  const loadError = error ?? invoicesError;
+  // One ordered list: estimates, with converted rows flipped to their invoice.
+  const rows = estimates && invoices ? buildBillingRows(estimates, invoices) : [];
+  const hasTrashed = trashedEstimates.length > 0 || trashedInvoices.length > 0;
+
   return (
     <div className="space-y-6 mb-6">
-      {/* ── Estimates card ─────────────────────────────────────────────────── */}
       <div className="bg-card rounded-xl border border-border p-5">
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-4">
@@ -312,123 +326,183 @@ export function EstimatesInvoicesSection({ jobId }: EstimatesInvoicesSectionProp
         </div>
 
         {/* Loading state */}
-        {estimates === null && !error && (
+        {loading && !loadError && (
           <p className="text-sm text-muted-foreground">Loading…</p>
         )}
 
         {/* Error state */}
-        {error && (
-          <p className="text-sm text-destructive">{error}</p>
-        )}
+        {loadError && <p className="text-sm text-destructive">{loadError}</p>}
 
         {/* Empty state */}
-        {estimates !== null && !error && estimates.length === 0 && (!showTrashed || trashedEstimates.length === 0) && (
+        {!loading && !loadError && rows.length === 0 && (!showTrashed || !hasTrashed) && (
           <p className="text-sm text-muted-foreground">
             No estimates yet — create one to get started.
           </p>
         )}
 
         {/* Table */}
-        {estimates !== null && !error && (estimates.length > 0 || (showTrashed && trashedEstimates.length > 0)) && (
+        {!loading && !loadError && (rows.length > 0 || (showTrashed && hasTrashed)) && (
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="w-24">#</TableHead>
+                <TableHead className="w-32">#</TableHead>
                 <TableHead>Title</TableHead>
                 <TableHead className="w-32 text-right">Total</TableHead>
                 <TableHead className="w-28">Status</TableHead>
-                <TableHead className="w-36">Actions</TableHead>
+                <TableHead className="w-44">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {estimates.map((est) => (
-                <TableRow key={est.id}>
-                  {/* Estimate number — monospace */}
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {est.estimate_number}
-                      </span>
-                      {est.converted_to_invoice_id && (
-                        <Link
-                          href={`/invoices/${est.converted_to_invoice_id}`}
-                          className="text-xs text-blue-600 hover:underline"
-                          title="View linked invoice"
-                        >
-                          → INV
-                        </Link>
-                      )}
-                    </div>
-                  </TableCell>
+              {rows.map((row) => {
+                const est = row.estimate;
+                const inv = row.invoice;
+                const isInvoice = row.kind === "invoice";
+                // The flipped/orphan row shows the invoice; a plain row the estimate.
+                const number = isInvoice ? inv!.invoice_number : est!.estimate_number;
+                const title = isInvoice ? inv!.title : est!.title;
+                const total = isInvoice ? inv!.total_amount : est!.total;
 
-                  {/* Title */}
-                  <TableCell className="max-w-xs truncate">
-                    {est.title}
-                  </TableCell>
-
-                  {/* Total */}
-                  <TableCell className="text-right tabular-nums">
-                    {formatCurrency(est.total)}
-                  </TableCell>
-
-                  {/* Status badge */}
-                  <TableCell>
-                    <span
-                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE_CLASSES[est.status]}`}
-                    >
-                      {formatStatusLabel(est.status)}
-                    </span>
-                  </TableCell>
-
-                  {/* Actions */}
-                  <TableCell>
-                    {authLoading ? (
-                      <span className="text-xs text-muted-foreground">Loading…</span>
-                    ) : (
-                      <div className="flex items-center gap-1">
-                        {canView && (
-                          <Link href={`/estimates/${est.id}`}>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-7 px-2 gap-1 text-xs"
-                              title="View estimate"
-                            >
-                              <Eye size={12} />
-                              View
-                            </Button>
-                          </Link>
-                        )}
-                        {canEdit && est.status !== "voided" && est.status !== "converted" && (
-                          <Link href={`/estimates/${est.id}/edit`}>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-7 px-2 gap-1 text-xs"
-                              title="Edit estimate"
-                            >
-                              <Pencil size={12} />
-                              Edit
-                            </Button>
-                          </Link>
-                        )}
-                        {canManageEstimates && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                            title="Move estimate to trash"
-                            aria-label="Move estimate to trash"
-                            onClick={() => setTrashTarget({ kind: "estimate", row: est })}
+                return (
+                  <TableRow key={row.id} className={ROW_TINT_CLASSES[row.tint]}>
+                    {/* Number — monospace, with the frozen-estimate link on flips */}
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono text-xs text-muted-foreground">
+                          {number}
+                        </span>
+                        {row.frozenEstimateId && (
+                          <Link
+                            href={`/estimates/${row.frozenEstimateId}`}
+                            className="inline-flex items-center gap-0.5 text-xs text-blue-600 hover:underline"
+                            title="View the original estimate (frozen)"
                           >
-                            <Trash2 size={14} />
-                          </Button>
+                            <FileText size={11} />
+                            Estimate
+                          </Link>
                         )}
                       </div>
-                    )}
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+
+                    {/* Title */}
+                    <TableCell className="max-w-xs truncate">{title}</TableCell>
+
+                    {/* Total */}
+                    <TableCell className="text-right tabular-nums">
+                      {formatCurrency(total)}
+                    </TableCell>
+
+                    {/* Status badge */}
+                    <TableCell>
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getStatusBadgeClasses(row.kind, row.statusShown)}`}
+                      >
+                        {formatStatusLabel(row.statusShown)}
+                      </span>
+                    </TableCell>
+
+                    {/* Actions — targeting the row's document (estimate or invoice) */}
+                    <TableCell>
+                      {authLoading ? (
+                        <span className="text-xs text-muted-foreground">Loading…</span>
+                      ) : (
+                        <div className="flex items-center gap-1">
+                          {/* View */}
+                          {((isInvoice && canViewInvoices) || (!isInvoice && canView)) && (
+                            <Link href={`/${row.document.kind}s/${row.document.id}`}>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 px-2 gap-1 text-xs"
+                                title={`View ${row.kind}`}
+                              >
+                                <Eye size={12} />
+                                View
+                              </Button>
+                            </Link>
+                          )}
+
+                          {/* Edit — gated by the row's edit guard (locked once paid/voided) */}
+                          {row.canEdit &&
+                            ((isInvoice && canEditInvoices) || (!isInvoice && canEdit)) && (
+                              <Link href={`/${row.document.kind}s/${row.document.id}/edit`}>
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-7 px-2 gap-1 text-xs"
+                                  title={`Edit ${row.kind}`}
+                                >
+                                  <Pencil size={12} />
+                                  Edit
+                                </Button>
+                              </Link>
+                            )}
+
+                          {/* Invoice-only: payment request */}
+                          {isInvoice &&
+                            canEditInvoices &&
+                            (inv!.status === "sent" || inv!.status === "partial") && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 w-7 p-0"
+                                title="Send payment request"
+                                aria-label="Send payment request"
+                                onClick={() => setPaymentRequestTarget(inv!)}
+                              >
+                                <CreditCard size={14} />
+                              </Button>
+                            )}
+
+                          {/* Invoice-only: void */}
+                          {isInvoice &&
+                            canManageInvoices &&
+                            inv!.status !== "voided" &&
+                            inv!.status !== "paid" && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                title="Void invoice"
+                                aria-label="Void invoice"
+                                disabled={isVoiding}
+                                onClick={() => setVoidTarget(inv!)}
+                              >
+                                <Ban size={14} />
+                              </Button>
+                            )}
+
+                          {/* Trash — the active document (invoice on a flip, else estimate) */}
+                          {isInvoice
+                            ? canManageInvoices && (
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                  title="Move invoice to trash"
+                                  aria-label="Move invoice to trash"
+                                  onClick={() => setTrashTarget({ kind: "invoice", row: inv! })}
+                                >
+                                  <Trash2 size={14} />
+                                </Button>
+                              )
+                            : canManageEstimates && (
+                                <Button
+                                  size="sm"
+                                  variant="ghost"
+                                  className="h-7 w-7 p-0 text-destructive hover:text-destructive"
+                                  title="Move estimate to trash"
+                                  aria-label="Move estimate to trash"
+                                  onClick={() => setTrashTarget({ kind: "estimate", row: est! })}
+                                >
+                                  <Trash2 size={14} />
+                                </Button>
+                              )}
+                        </div>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
 
               {/* Trashed estimate rows */}
               {showTrashed && trashedEstimates.map((est) => (
@@ -464,168 +538,6 @@ export function EstimatesInvoicesSection({ jobId }: EstimatesInvoicesSectionProp
                         Delete now
                       </button>
                     </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
-      </div>
-
-      {/* ── Invoices card ───────────────────────────────────────────────────── */}
-      <div className="bg-card rounded-xl border border-border p-5">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-base font-semibold text-foreground">Invoices</h3>
-          {authLoading ? null : canCreateInvoices ? (
-            <Link href={`/jobs/${jobId}/invoices/new`}>
-              <Button size="sm" variant="outline" className="gap-1.5">
-                <Plus size={14} />
-                New Invoice
-              </Button>
-            </Link>
-          ) : null}
-        </div>
-
-        {/* Loading state */}
-        {invoices === null && !invoicesError && (
-          <p className="text-sm text-muted-foreground">Loading…</p>
-        )}
-
-        {/* Error state */}
-        {invoicesError && (
-          <p className="text-sm text-destructive">{invoicesError}</p>
-        )}
-
-        {/* Empty state */}
-        {invoices !== null && !invoicesError && invoices.length === 0 && (!showTrashed || trashedInvoices.length === 0) && (
-          <p className="text-sm text-muted-foreground">
-            No invoices yet — create one to get started.
-          </p>
-        )}
-
-        {/* Table */}
-        {invoices !== null && !invoicesError && (invoices.length > 0 || (showTrashed && trashedInvoices.length > 0)) && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-32">#</TableHead>
-                <TableHead>Title</TableHead>
-                <TableHead className="w-32 text-right">Total</TableHead>
-                <TableHead className="w-28">Status</TableHead>
-                <TableHead className="w-36">Actions</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {invoices.map((inv) => (
-                <TableRow key={inv.id}>
-                  {/* Invoice number — monospace, with optional source-estimate link */}
-                  <TableCell>
-                    <div className="flex items-center gap-2">
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {inv.invoice_number}
-                      </span>
-                      {inv.converted_from_estimate_id && (
-                        <Link
-                          href={`/estimates/${inv.converted_from_estimate_id}`}
-                          className="text-xs text-blue-600 hover:underline"
-                          title="View source estimate"
-                        >
-                          ← EST
-                        </Link>
-                      )}
-                    </div>
-                  </TableCell>
-
-                  {/* Title */}
-                  <TableCell className="max-w-xs truncate">
-                    {inv.title}
-                  </TableCell>
-
-                  {/* Total */}
-                  <TableCell className="text-right tabular-nums">
-                    {formatCurrency(inv.total_amount)}
-                  </TableCell>
-
-                  {/* Status badge */}
-                  <TableCell>
-                    <span
-                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getStatusBadgeClasses("invoice", inv.status)}`}
-                    >
-                      {formatStatusLabel(inv.status)}
-                    </span>
-                  </TableCell>
-
-                  {/* Actions */}
-                  <TableCell>
-                    {authLoading ? (
-                      <span className="text-xs text-muted-foreground">Loading…</span>
-                    ) : (
-                      <div className="flex items-center gap-1">
-                        {canViewInvoices && (
-                          <Link href={`/invoices/${inv.id}`}>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-7 px-2 gap-1 text-xs"
-                              title="View invoice"
-                            >
-                              <Eye size={12} />
-                              View
-                            </Button>
-                          </Link>
-                        )}
-                        {canEditInvoices && inv.status !== "voided" && inv.status !== "paid" && (
-                          <Link href={`/invoices/${inv.id}/edit`}>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              className="h-7 px-2 gap-1 text-xs"
-                              title="Edit invoice"
-                            >
-                              <Pencil size={12} />
-                              Edit
-                            </Button>
-                          </Link>
-                        )}
-                        {canEditInvoices && (inv.status === "sent" || inv.status === "partial") && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="h-7 w-7 p-0"
-                            title="Send payment request"
-                            aria-label="Send payment request"
-                            onClick={() => setPaymentRequestTarget(inv)}
-                          >
-                            <CreditCard size={14} />
-                          </Button>
-                        )}
-                        {canManageInvoices && inv.status !== "voided" && inv.status !== "paid" && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                            title="Void invoice"
-                            aria-label="Void invoice"
-                            disabled={isVoiding}
-                            onClick={() => setVoidTarget(inv)}
-                          >
-                            <Ban size={14} />
-                          </Button>
-                        )}
-                        {canManageInvoices && (
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="h-7 w-7 p-0 text-destructive hover:text-destructive"
-                            title="Move invoice to trash"
-                            aria-label="Move invoice to trash"
-                            onClick={() => setTrashTarget({ kind: "invoice", row: inv })}
-                          >
-                            <Trash2 size={14} />
-                          </Button>
-                        )}
-                      </div>
-                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/lib/billing-rows.test.ts
+++ b/src/lib/billing-rows.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildBillingRows,
+  type BillingEstimateFields,
+  type BillingInvoiceFields,
+} from "./billing-rows";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tiny fixtures — the builder only reads these fields, so the full Estimate /
+// Invoice row types (which carry ~30 fields each) are structurally assignable.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function est(
+  o: Partial<BillingEstimateFields> & Pick<BillingEstimateFields, "id">,
+): BillingEstimateFields {
+  return {
+    status: "draft",
+    sequence_number: 1,
+    converted_to_invoice_id: null,
+    ...o,
+  };
+}
+
+function inv(
+  o: Partial<BillingInvoiceFields> & Pick<BillingInvoiceFields, "id">,
+): BillingInvoiceFields {
+  return {
+    status: "draft",
+    sequence_number: 1,
+    converted_from_estimate_id: null,
+    ...o,
+  };
+}
+
+// #384 — the billing-row builder is a pure transform: given a Job's estimates
+// and their linked invoices, produce the ordered Overview rows, each carrying
+// its derived state.
+describe("buildBillingRows", () => {
+  it("renders a plain estimate with no linked invoice as an estimate row", () => {
+    const rows = buildBillingRows([est({ id: "est-1", status: "draft" })], []);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "estimate",
+      statusShown: "draft",
+      document: { kind: "estimate", id: "est-1" },
+      frozenEstimateId: null,
+      tint: "none",
+    });
+    expect(rows[0].invoice).toBeNull();
+  });
+
+  it("flips a converted estimate's row to represent the linked invoice", () => {
+    const estimate = est({
+      id: "est-1",
+      status: "converted",
+      converted_to_invoice_id: "inv-1",
+    });
+    const invoice = inv({
+      id: "inv-1",
+      status: "sent",
+      converted_from_estimate_id: "est-1",
+    });
+
+    const rows = buildBillingRows([estimate], [invoice]);
+
+    // One estimate yields at most one invoice — the invoice does not appear as
+    // a second row; the estimate's row becomes the invoice.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "invoice",
+      statusShown: "sent",
+      document: { kind: "invoice", id: "inv-1" },
+      frozenEstimateId: "est-1",
+    });
+    expect(rows[0].invoice).toBe(invoice);
+    expect(rows[0].estimate).toBe(estimate);
+  });
+
+  it("renders a legacy orphan invoice (no source estimate) as its own invoice row", () => {
+    const orphan = inv({
+      id: "inv-9",
+      status: "paid",
+      converted_from_estimate_id: null,
+    });
+
+    const rows = buildBillingRows([], [orphan]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      kind: "invoice",
+      statusShown: "paid",
+      document: { kind: "invoice", id: "inv-9" },
+      frozenEstimateId: null, // no estimate behind it — nothing to link to
+    });
+    expect(rows[0].estimate).toBeNull();
+    expect(rows[0].invoice).toBe(orphan);
+  });
+
+  it("treats an invoice whose source estimate is absent as an orphan", () => {
+    const orphan = inv({
+      id: "inv-9",
+      converted_from_estimate_id: "est-gone", // points at an estimate not in the list
+    });
+
+    const rows = buildBillingRows([], [orphan]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ kind: "invoice", frozenEstimateId: null });
+    expect(rows[0].estimate).toBeNull();
+  });
+
+  // The tint and edit-guard surfaced through the flipped row, across the whole
+  // invoice lifecycle. Covers "voided invoice is handled": it stays flipped,
+  // untinted, locked, with the frozen-estimate link intact.
+  it.each([
+    ["draft", "yellow", true],
+    ["sent", "blue", true],
+    ["partial", "none", true],
+    ["paid", "none", false],
+    ["voided", "none", false],
+  ] as const)(
+    "a converted invoice in %s → tint %s, canEdit %s, still flipped with frozen link",
+    (status, tint, canEdit) => {
+      const rows = buildBillingRows(
+        [est({ id: "e", status: "converted", converted_to_invoice_id: "i" })],
+        [inv({ id: "i", status, converted_from_estimate_id: "e" })],
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        kind: "invoice",
+        statusShown: status,
+        tint,
+        canEdit,
+        frozenEstimateId: "e",
+      });
+    },
+  );
+
+  it("orders estimate-anchored rows by estimate sequence, then orphans by invoice sequence", () => {
+    const estimates = [
+      est({ id: "e2", sequence_number: 2 }),
+      est({
+        id: "e1",
+        sequence_number: 1,
+        status: "converted",
+        converted_to_invoice_id: "i-e1",
+      }),
+    ];
+    const invoices = [
+      inv({ id: "orphan-b", sequence_number: 20, converted_from_estimate_id: null }),
+      // The flipped invoice sorts by its estimate's sequence (1), not its own (99).
+      inv({ id: "i-e1", sequence_number: 99, converted_from_estimate_id: "e1" }),
+      inv({ id: "orphan-a", sequence_number: 10, converted_from_estimate_id: null }),
+    ];
+
+    const rows = buildBillingRows(estimates, invoices);
+
+    // Flipped rows keep the estimate's id; orphans carry the invoice's id.
+    expect(rows.map((r) => r.id)).toEqual(["e1", "e2", "orphan-a", "orphan-b"]);
+  });
+});

--- a/src/lib/billing-rows.ts
+++ b/src/lib/billing-rows.ts
@@ -1,0 +1,116 @@
+// src/lib/billing-rows.ts — the billing-row builder (#384).
+//
+// A pure transform: given a Job's estimates and their linked invoices, produce
+// the ordered Overview rows. Each row carries its derived state — plain estimate
+// vs flipped-to-invoice, the status to show, the row tint, which document
+// view/edit targets, whether it may still be edited, and the link to the frozen
+// original estimate. Encapsulates the "flip" and handles the edge cases:
+// converted, voided, and legacy invoices with no source estimate.
+//
+// Generic over the estimate/invoice shapes — it only reads the few fields below,
+// so the full Estimate / Invoice row types are accepted and carried through
+// untouched for the UI to render. See ADR 0007.
+
+import { rowTint, type RowTint, type EntityKind } from "@/lib/estimate-status";
+
+/** The estimate fields the builder reads. */
+export interface BillingEstimateFields {
+  id: string;
+  status: string;
+  sequence_number: number;
+  converted_to_invoice_id: string | null;
+}
+
+/** The invoice fields the builder reads. */
+export interface BillingInvoiceFields {
+  id: string;
+  status: string;
+  sequence_number: number;
+  converted_from_estimate_id: string | null;
+}
+
+export interface BillingRow<
+  E extends BillingEstimateFields = BillingEstimateFields,
+  I extends BillingInvoiceFields = BillingInvoiceFields,
+> {
+  /** Stable React key — the estimate's id for estimate-anchored rows. */
+  id: string;
+  /** Plain estimate vs flipped-to-invoice. */
+  kind: EntityKind;
+  /** The status to display: the estimate's, or the invoice's once flipped. */
+  statusShown: string;
+  /** Row tint derived from (kind, statusShown). */
+  tint: RowTint;
+  /** Which document the row's View / Edit target. */
+  document: { kind: EntityKind; id: string };
+  /** Whether the row's document may still be edited. */
+  canEdit: boolean;
+  /** The frozen original estimate to link to from a flipped row; null otherwise. */
+  frozenEstimateId: string | null;
+  /** The underlying records, carried through for rendering. */
+  estimate: E | null;
+  invoice: I | null;
+}
+
+export function buildBillingRows<
+  E extends BillingEstimateFields,
+  I extends BillingInvoiceFields,
+>(estimates: E[], invoices: I[]): BillingRow<E, I>[] {
+  const claimed = new Set<string>();
+  const bySequence = (a: { sequence_number: number }, b: { sequence_number: number }) =>
+    a.sequence_number - b.sequence_number;
+
+  // Each estimate anchors one row: a plain estimate, or — once converted — a
+  // row that flips to represent its linked invoice. Ordered by estimate sequence.
+  const estimateRows = [...estimates].sort(bySequence).map((estimate) => {
+    const invoice = estimate.converted_to_invoice_id
+      ? invoices.find((i) => i.id === estimate.converted_to_invoice_id) ?? null
+      : null;
+
+    if (invoice) {
+      claimed.add(invoice.id);
+      return invoiceRow(invoice, estimate);
+    }
+
+    return {
+      id: estimate.id,
+      kind: "estimate",
+      statusShown: estimate.status,
+      tint: rowTint("estimate", estimate.status),
+      document: { kind: "estimate", id: estimate.id },
+      canEdit: estimate.status !== "voided" && estimate.status !== "converted",
+      frozenEstimateId: null,
+      estimate,
+      invoice: null,
+    } satisfies BillingRow<E, I>;
+  });
+
+  // Legacy orphan invoices — never born from an estimate on this job — stay
+  // reachable as their own rows, with no frozen estimate behind them. Ordered
+  // after the estimates, by invoice sequence.
+  const orphanRows = invoices
+    .filter((invoice) => !claimed.has(invoice.id))
+    .sort(bySequence)
+    .map((invoice) => invoiceRow<E, I>(invoice, null));
+
+  return [...estimateRows, ...orphanRows];
+}
+
+// A row that represents an invoice — either a converted estimate's flipped row
+// (with the frozen original behind it) or a legacy orphan (estimate = null).
+function invoiceRow<
+  E extends BillingEstimateFields,
+  I extends BillingInvoiceFields,
+>(invoice: I, estimate: E | null): BillingRow<E, I> {
+  return {
+    id: (estimate ?? invoice).id,
+    kind: "invoice",
+    statusShown: invoice.status,
+    tint: rowTint("invoice", invoice.status),
+    document: { kind: "invoice", id: invoice.id },
+    canEdit: invoice.status !== "paid" && invoice.status !== "voided",
+    frozenEstimateId: estimate ? estimate.id : null,
+    estimate,
+    invoice,
+  };
+}

--- a/src/lib/estimate-status.test.ts
+++ b/src/lib/estimate-status.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { rowTint, type RowTint, type EntityKind } from "./estimate-status";
+
+// #384 — Status presentation: the Overview row tint draws attention only where
+// it's needed. A converted invoice still in draft is yellow ("ready for
+// review"); a sent invoice is blue; estimate rows and every other invoice state
+// are untinted. This is the isolation test that each (kind, status) pair yields
+// the expected tint.
+describe("rowTint", () => {
+  const cases: Array<[EntityKind, string, RowTint]> = [
+    // Invoice rows — only draft and sent are tinted.
+    ["invoice", "draft", "yellow"],
+    ["invoice", "sent", "blue"],
+    ["invoice", "partial", "none"],
+    ["invoice", "paid", "none"],
+    ["invoice", "voided", "none"],
+    // Estimate rows — colour is reserved for invoices, so always untinted.
+    ["estimate", "draft", "none"],
+    ["estimate", "sent", "none"],
+    ["estimate", "approved", "none"],
+    ["estimate", "rejected", "none"],
+    ["estimate", "converted", "none"],
+    ["estimate", "voided", "none"],
+  ];
+
+  it.each(cases)("tints (%s, %s) as %s", (kind, status, expected) => {
+    expect(rowTint(kind, status)).toBe(expected);
+  });
+});

--- a/src/lib/estimate-status.ts
+++ b/src/lib/estimate-status.ts
@@ -35,6 +35,31 @@ export function getStatusBadgeClasses(kind: EntityKind, status: string): string 
   return ESTIMATE_STATUS_BADGE_CLASSES[status as EstimateStatus] ?? "bg-zinc-100 text-zinc-700";
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Row tint (#384) — extends the status helpers with the Overview row tint.
+// Colour is reserved for the moments that need attention: a converted invoice
+// still in draft is yellow ("ready for review"), a sent invoice is blue, and
+// estimate rows plus every other invoice state are left untinted.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type RowTint = "yellow" | "blue" | "none";
+
+export function rowTint(kind: EntityKind, status: string): RowTint {
+  if (kind === "invoice") {
+    if (status === "draft") return "yellow";
+    if (status === "sent") return "blue";
+  }
+  return "none";
+}
+
+// Presentational map from semantic tint → row background class. Reuses the
+// existing badge palette (amber / blue); "none" leaves the row untinted.
+export const ROW_TINT_CLASSES: Record<RowTint, string> = {
+  yellow: "bg-amber-50",
+  blue: "bg-blue-50",
+  none: "",
+};
+
 // Polymorphic label — title-cases the status string.
 export function formatStatusLabel(kindOrStatus: EntityKind | string, status?: string): string {
   // Two-arg form: ("estimate" | "invoice", status)


### PR DESCRIPTION
Implements #384 — slice 3 of the #381 estimate/invoicing rework ([ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md)).

## What changed

The Job **Overview** tab is now a single ordered list of estimates. When an estimate is converted, its row **flips to represent the invoice** — the same row is where you view and edit the invoice — while the original estimate is kept as a **frozen, view-only** record reachable via a link on the flipped row.

The logic lives in two pure, isolation-tested modules:

- **`rowTint(kind, status)`** (`src/lib/estimate-status.ts`) — invoice+`draft` → yellow, invoice+`sent` → blue; estimate rows and every other state untinted.
- **`buildBillingRows(estimates, invoices)`** (`src/lib/billing-rows.ts`) — a generic deep transform producing the ordered rows, each carrying its derived state: plain estimate vs flipped-to-invoice, the status shown, the tint, which document view/edit target, the `canEdit` guard, and the frozen-estimate link. Handles converted, voided, and legacy orphan invoices (no source estimate).

`estimates-invoices-section.tsx` collapses from two parallel tables into one list driven by the builder (net −63 lines); all existing actions (trash, void, payment request, restore, show-trashed) are preserved.

## Acceptance criteria
- [x] One list of estimates, no separate invoices table
- [x] Converting flips the row; view/edit of the invoice from that row
- [x] Original estimate preserved view-only, reachable via a link on the flipped row
- [x] One estimate → at most one invoice
- [x] Tint: invoice+draft = yellow, sent = blue, everything else untinted
- [x] Invoice editing locked once paid or voided (surfaced through the flipped row)
- [x] Isolation tests on the row-builder
- [x] Isolation tests on the tint function

## Note on the edit guard
The issue says "editable while draft or sent"; ADR 0007 says the invoice "keeps the existing guard — no edits once paid or voided." I followed the ADR (so `partial` stays editable, matching the prior code) — the "draft or sent" phrasing is informal shorthand for "not paid/voided."

## Scope
Per a decision during the build, this PR covers exactly #384's acceptance criteria. Retiring `/invoices/new`, the standalone `/invoices` list, and the `create_invoices` permission (also named in the PRD's slice-3 description) is left for a separate slice.

## Testing
- **21 isolation tests** green (10 builder + 11 tint)
- `tsc --noEmit`: no new errors (only the 2 known pre-existing ones, in untouched files)
- ESLint: clean
- UI layer verified via typecheck + lint per the PRD convention (these surfaces aren't isolation-unit'd); not clicked through in a live app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
