### PR TITLE
feat(reports): Job Overview report list — always-on, reopen, recoverable trash, editable date (#402)

### DIFF
--- a/src/app/api/jobs/[id]/reports/[reportId]/delete/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/delete/route.test.ts
@@ -1,0 +1,81 @@
+// POST /api/jobs/[id]/reports/[reportId]/delete — soft-delete a Photo Report
+// into the recoverable trash (#402). These tests pin the `edit_jobs` gate
+// (same as the report create route) and that the handler stamps `deleted_at`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string, reportId: string) {
+  return { params: Promise.resolve({ id, reportId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/jobs/[id]/reports/[reportId]/delete", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without the edit_jobs grant", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("stamps deleted_at for a caller holding edit_jobs", async () => {
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(client.__mutations).toContainEqual(
+      expect.objectContaining({
+        table: "photo_reports",
+        op: "update",
+        payload: { deleted_at: expect.any(String) },
+      }),
+    );
+  });
+});

--- a/src/app/api/jobs/[id]/reports/[reportId]/delete/route.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/delete/route.ts
@@ -1,0 +1,33 @@
+// POST /api/jobs/[id]/reports/[reportId]/delete — move a Photo Report to the
+// recoverable trash (#402). Sets photo_reports.deleted_at = now(); the row
+// stays in the DB and drops out of the Job Overview's active list until it is
+// restored. Mirrors the Job soft-delete route. Gated like the report create
+// route (`edit_jobs`). Job CASCADE delete still hard-removes the row.
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+export const POST = withRequestContext(
+  { permission: "edit_jobs" },
+  async (
+    _request,
+    ctx,
+    { params }: { params: Promise<{ id: string; reportId: string }> },
+  ) => {
+    const { id: jobId, reportId } = await params;
+
+    // Scope by job_id as well as id so a report can only be trashed through its
+    // own Job, and `.is("deleted_at", null)` keeps the write to active rows
+    // (re-deleting an already-trashed report is a no-op, never a re-stamp).
+    const { error } = await ctx.supabase
+      .from("photo_reports")
+      .update({ deleted_at: new Date().toISOString() })
+      .eq("id", reportId)
+      .eq("job_id", jobId)
+      .is("deleted_at", null);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/jobs/[id]/reports/[reportId]/restore/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/restore/route.test.ts
@@ -1,0 +1,81 @@
+// POST /api/jobs/[id]/reports/[reportId]/restore — pull a Photo Report back out
+// of the recoverable trash (#402). Pins the `edit_jobs` gate and that the
+// handler clears `deleted_at`.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string, reportId: string) {
+  return { params: Promise.resolve({ id, reportId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/jobs/[id]/reports/[reportId]/restore", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without the edit_jobs grant", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("clears deleted_at for a caller holding edit_jobs", async () => {
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(client.__mutations).toContainEqual(
+      expect.objectContaining({
+        table: "photo_reports",
+        op: "update",
+        payload: { deleted_at: null },
+      }),
+    );
+  });
+});

--- a/src/app/api/jobs/[id]/reports/[reportId]/restore/route.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/restore/route.ts
@@ -1,0 +1,28 @@
+// POST /api/jobs/[id]/reports/[reportId]/restore — pull a Photo Report back out
+// of the trash (#402). Clears photo_reports.deleted_at so the report returns to
+// the Job Overview's active list. Mirrors the Job restore route and is
+// idempotent: restoring an already-active report is a no-op.
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+export const POST = withRequestContext(
+  { permission: "edit_jobs" },
+  async (
+    _request,
+    ctx,
+    { params }: { params: Promise<{ id: string; reportId: string }> },
+  ) => {
+    const { id: jobId, reportId } = await params;
+
+    const { error } = await ctx.supabase
+      .from("photo_reports")
+      .update({ deleted_at: null })
+      .eq("id", reportId)
+      .eq("job_id", jobId);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -7,6 +7,7 @@ import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoTag, PhotoReport, Email } from "@/lib/types";
 import { photoUrl } from "@/lib/jobs/photo-url";
 import { pickPreloadUrls } from "@/lib/jobs/photo-preload";
+import { partitionPhotoReportsByTrash } from "@/lib/photo-report-trash";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
 import FinancialsTab from "@/components/job-detail/financials-tab";
@@ -56,6 +57,7 @@ import {
   Copy,
   Trash2,
   RotateCcw,
+  ChevronDown,
 } from "lucide-react";
 import { canDeleteJobs } from "@/lib/jobs/auth";
 import {
@@ -144,6 +146,15 @@ export default function JobDetail({ jobId }: { jobId: string }) {
     [photos, supabaseUrl],
   );
 
+  // Split the Job's reports into the active list (always shown in the Overview)
+  // and the recoverable trash (behind a disclosure). The predicate is the
+  // single source of truth for "active vs trashed" (#402).
+  const { active: activeReports, trashed: trashedReports } = useMemo(
+    () => partitionPhotoReportsByTrash(reports),
+    [reports],
+  );
+  const [trashOpen, setTrashOpen] = useState(false);
+
   const fetchData = useCallback(async () => {
     const supabase = createClient();
 
@@ -180,11 +191,13 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         .select("id", { count: "exact", head: true })
         .eq("job_id", jobId),
       supabase.from("photo_tags").select("*").order("name"),
+      // Fetch every report for the Job — active and trashed — and split them
+      // with the trash predicate below. The Overview's active list and its
+      // trash disclosure are two views of this one fetch (#402).
       supabase
         .from("photo_reports")
         .select("*")
         .eq("job_id", jobId)
-        .is("deleted_at", null)
         .order("created_at", { ascending: false }),
       supabase
         .from("emails")
@@ -299,6 +312,30 @@ export default function JobDetail({ jobId }: { jobId: string }) {
       return;
     }
     toast.success("Job restored.");
+    fetchData();
+  }
+
+  async function trashReport(reportId: string) {
+    const res = await fetch(`/api/jobs/${jobId}/reports/${reportId}/delete`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      toast.error("Couldn't move report to trash.");
+      return;
+    }
+    toast.success("Report moved to trash.");
+    fetchData();
+  }
+
+  async function restoreReport(reportId: string) {
+    const res = await fetch(`/api/jobs/${jobId}/reports/${reportId}/restore`, {
+      method: "POST",
+    });
+    if (!res.ok) {
+      toast.error("Couldn't restore report.");
+      return;
+    }
+    toast.success("Report restored.");
     fetchData();
   }
 
@@ -812,67 +849,89 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         onChanged={fetchData}
       />
 
-      {/* Reports */}
-      {reports.length > 0 && (
-        <div className="bg-card rounded-xl border border-border p-5 mb-6">
-          <div className="flex items-center justify-between mb-4">
-            <h3 className="text-base font-semibold text-foreground">
-              <FileText size={16} className="inline mr-2 -mt-0.5" />
-              Reports ({reports.length})
-            </h3>
-            <span className="text-xs text-muted-foreground">
-              Start a new report from the Photos tab
-            </span>
-          </div>
+      {/* Reports — always shown (even with none) so a Job's first report can be
+          started and found here, beside the other documents (#402). */}
+      <div className="bg-card rounded-xl border border-border p-5 mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-base font-semibold text-foreground">
+            <FileText size={16} className="inline mr-2 -mt-0.5" />
+            Reports ({activeReports.length})
+          </h3>
+          <span className="text-xs text-muted-foreground">
+            Start a new report from the Photos tab
+          </span>
+        </div>
+        {activeReports.length === 0 ? (
+          <p className="text-sm text-muted-foreground/60 py-2">
+            No reports yet. Select photos in the Photos tab and choose
+            &ldquo;Create report&rdquo; to start one.
+          </p>
+        ) : (
           <div className="space-y-2">
-            {reports.map((report) => (
-              <Link
-                key={report.id}
-                href={`/jobs/${jobId}/reports/${report.id}`}
-                className="flex items-center justify-between p-3 rounded-lg border border-border/50 hover:border-border hover:bg-accent/50 transition-all"
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <div
-                    className={cn(
-                      "w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0",
-                      report.status === "generated"
-                        ? "bg-primary/10"
-                        : "bg-vibrant-purple/10"
-                    )}
-                  >
-                    <FileText
-                      size={14}
-                      className={
-                        report.status === "generated"
-                          ? "text-primary"
-                          : "text-vibrant-purple"
-                      }
-                    />
-                  </div>
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-foreground truncate">
-                      {report.title}
-                    </p>
-                    <p className="text-xs text-muted-foreground/60">
-                      {format(new Date(report.report_date), "MMM d, yyyy")}
-                    </p>
-                  </div>
-                </div>
-                <Badge
-                  className={cn(
-                    "text-[10px] px-1.5 py-0 rounded capitalize flex-shrink-0",
-                    report.status === "generated"
-                      ? "bg-[#E1F5EE] text-[#085041]"
-                      : "bg-[#F3F0FF] text-[#5B4DB5]"
-                  )}
+            {activeReports.map((report) => (
+              <div key={report.id} className="flex items-center gap-2">
+                <Link
+                  href={`/jobs/${jobId}/reports/${report.id}`}
+                  className="flex-1 min-w-0 flex items-center justify-between p-3 rounded-lg border border-border/50 hover:border-border hover:bg-accent/50 transition-all"
                 >
-                  {report.status}
-                </Badge>
-              </Link>
+                  <ReportRowContent report={report} />
+                </Link>
+                {hasPermission("edit_jobs") && (
+                  <button
+                    type="button"
+                    onClick={() => trashReport(report.id)}
+                    aria-label="Move report to trash"
+                    title="Move to trash"
+                    className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors shrink-0"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                )}
+              </div>
             ))}
           </div>
-        </div>
-      )}
+        )}
+
+        {/* Recoverable trash — restore a report deleted by mistake (#402). */}
+        {trashedReports.length > 0 && (
+          <div className="mt-4 border-t border-border/50 pt-3">
+            <button
+              type="button"
+              onClick={() => setTrashOpen((v) => !v)}
+              aria-expanded={trashOpen}
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Trash2 size={12} />
+              Trash ({trashedReports.length})
+              <ChevronDown
+                size={12}
+                className={cn("transition-transform", trashOpen && "rotate-180")}
+              />
+            </button>
+            {trashOpen && (
+              <div className="space-y-2 mt-3">
+                {trashedReports.map((report) => (
+                  <div key={report.id} className="flex items-center gap-2">
+                    <div className="flex-1 min-w-0 flex items-center justify-between p-3 rounded-lg border border-border/50 bg-muted/30 opacity-70">
+                      <ReportRowContent report={report} />
+                    </div>
+                    {hasPermission("edit_jobs") && (
+                      <button
+                        type="button"
+                        onClick={() => restoreReport(report.id)}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-border bg-card px-3 py-1.5 text-sm font-medium text-foreground hover:bg-accent shrink-0"
+                      >
+                        <RotateCcw size={14} />
+                        Restore
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
 
       {/* Emails */}
       <div className="bg-card rounded-xl border border-border p-5 mb-6">
@@ -1047,6 +1106,53 @@ function InfoRow({
         <p className="text-foreground">{value}</p>
       </div>
     </div>
+  );
+}
+
+// The icon + title + date and the status badge of one report row, shared by
+// the active list (wrapped in a Link to the builder) and the trash disclosure
+// (wrapped in a plain, non-clickable div) — #402.
+function ReportRowContent({ report }: { report: PhotoReport }) {
+  return (
+    <>
+      <div className="flex items-center gap-3 min-w-0">
+        <div
+          className={cn(
+            "w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0",
+            report.status === "generated"
+              ? "bg-primary/10"
+              : "bg-vibrant-purple/10"
+          )}
+        >
+          <FileText
+            size={14}
+            className={
+              report.status === "generated"
+                ? "text-primary"
+                : "text-vibrant-purple"
+            }
+          />
+        </div>
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">
+            {report.title}
+          </p>
+          <p className="text-xs text-muted-foreground/60">
+            {format(new Date(report.report_date), "MMM d, yyyy")}
+          </p>
+        </div>
+      </div>
+      <Badge
+        className={cn(
+          "text-[10px] px-1.5 py-0 rounded capitalize flex-shrink-0",
+          report.status === "generated"
+            ? "bg-[#E1F5EE] text-[#085041]"
+            : "bg-[#F3F0FF] text-[#5B4DB5]"
+        )}
+      >
+        {report.status}
+      </Badge>
+    </>
   );
 }
 

--- a/src/lib/photo-report-trash.test.ts
+++ b/src/lib/photo-report-trash.test.ts
@@ -1,0 +1,62 @@
+// Issue #402 — Photo Report Rework, Slice 2c.
+//
+// The recoverable-trash split for Photo Reports. A report is "active" while its
+// `deleted_at` is null and "trashed" once it carries a timestamp — the same
+// canonical rule the rest of the platform uses for a soft-deleted row
+// (`deleted_at IS NULL`, the Active-job rule). This is the single, pure place
+// that owns that decision so the Overview list, the trash view, and any future
+// guard all agree on what counts as active.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isActivePhotoReport,
+  isTrashedPhotoReport,
+  partitionPhotoReportsByTrash,
+} from "./photo-report-trash";
+
+describe("isActivePhotoReport", () => {
+  it("treats a report with no deleted_at as active", () => {
+    expect(isActivePhotoReport({ deleted_at: null })).toBe(true);
+  });
+
+  it("treats a report carrying a deleted_at timestamp as not active", () => {
+    expect(
+      isActivePhotoReport({ deleted_at: "2026-06-04T17:00:00.000Z" }),
+    ).toBe(false);
+  });
+});
+
+describe("isTrashedPhotoReport", () => {
+  it("is the inverse of active: a timestamp means trashed", () => {
+    expect(
+      isTrashedPhotoReport({ deleted_at: "2026-06-04T17:00:00.000Z" }),
+    ).toBe(true);
+    expect(isTrashedPhotoReport({ deleted_at: null })).toBe(false);
+  });
+});
+
+describe("partitionPhotoReportsByTrash", () => {
+  it("splits a mixed list into active and trashed, preserving order", () => {
+    const reports = [
+      { id: "a", deleted_at: null },
+      { id: "b", deleted_at: "2026-06-04T10:00:00.000Z" },
+      { id: "c", deleted_at: null },
+      { id: "d", deleted_at: "2026-06-04T11:00:00.000Z" },
+    ];
+
+    const { active, trashed } = partitionPhotoReportsByTrash(reports);
+
+    expect(active.map((r) => r.id)).toEqual(["a", "c"]);
+    expect(trashed.map((r) => r.id)).toEqual(["b", "d"]);
+  });
+
+  it("returns two empty buckets for a Job with no reports yet", () => {
+    // The always-visible Overview list relies on this: no reports still yields
+    // a (rendered) empty active list rather than nothing at all (AC #1).
+    expect(partitionPhotoReportsByTrash([])).toEqual({
+      active: [],
+      trashed: [],
+    });
+  });
+});

--- a/src/lib/photo-report-trash.ts
+++ b/src/lib/photo-report-trash.ts
@@ -1,0 +1,40 @@
+// Issue #402 — Photo Report Rework, Slice 2c.
+//
+// The recoverable-trash split for Photo Reports. A report is "active" while its
+// `deleted_at` is null and "trashed" once it carries a timestamp — the same
+// canonical rule the rest of the platform uses for a soft-deleted row
+// (`deleted_at IS NULL`, the Active-job rule). Keeping that decision in one pure
+// place means the Overview list, the trash view, and any future guard all agree
+// on what counts as active.
+
+/** The single field the trash split reads. */
+export interface TrashableReport {
+  deleted_at: string | null;
+}
+
+/** A Photo Report is active until it has been moved to the trash. */
+export function isActivePhotoReport(report: TrashableReport): boolean {
+  return report.deleted_at === null;
+}
+
+/** A Photo Report is trashed once it carries a `deleted_at` timestamp. */
+export function isTrashedPhotoReport(report: TrashableReport): boolean {
+  return !isActivePhotoReport(report);
+}
+
+/**
+ * Split a mixed report list into the active rows and the trashed rows,
+ * preserving the input order within each bucket. The Overview fetches a Job's
+ * reports once and partitions here, so the always-visible active list and the
+ * trash disclosure are two views of the same fetch rather than two queries.
+ */
+export function partitionPhotoReportsByTrash<T extends TrashableReport>(
+  reports: T[],
+): { active: T[]; trashed: T[] } {
+  const active: T[] = [];
+  const trashed: T[] = [];
+  for (const report of reports) {
+    (isActivePhotoReport(report) ? active : trashed).push(report);
+  }
+  return { active, trashed };
+}


### PR DESCRIPTION
Implements #402 (Photo Report rework — slice: Job Overview report list, reopen, recoverable trash, editable date). Parent PRD #397; unblocked by #400 (PR #422).

## What this slice adds
- **Trash predicate module** (`src/lib/photo-report-trash.ts`, built test-first) — `isActivePhotoReport` / `isTrashedPhotoReport` / `partitionPhotoReportsByTrash`, mirroring the canonical `deleted_at IS NULL` Active-job rule. (AC #6)
- **Always-visible active list** in the Job Overview — fetches *all* of a Job's reports, partitions with the predicate, and always renders the Reports card (with an empty state) beside the other documents. Removes the `reports.length > 0` gate that blocked creating a Job's first report from the Job. (AC #1)
- **Delete → recoverable trash** — `POST /api/jobs/[id]/reports/[reportId]/delete` (mirrors the jobs soft-delete route, gated `edit_jobs`); per-row trash affordance; the row sets `deleted_at` and leaves the active list. (AC #4)
- **Restore** — `POST /api/jobs/[id]/reports/[reportId]/restore`; a "Trash (N)" disclosure lists trashed reports with Restore; clearing `deleted_at` returns the row to the active list. (AC #5)

Reopen-in-builder (AC #2) and the editable report date defaulting to today (AC #3) were delivered in #400 and are verified here (no new code — schema is `report_date date NOT NULL DEFAULT CURRENT_DATE` and the builder already exposes/auto-saves it).

## Tests
- **11 new tests, all green**: 5 predicate (red→green per behavior), 3 delete-route, 3 restore-route (permission gate + recorded payload).
- Typecheck clean on all changed files; **no new lint problems** (`job-detail.tsx` has the identical pre-existing problem count on `main`).
- Full unit suite: **+11 passing, 0 new failures**. The 2 pre-existing `referral-partners` failures reproduce identically on `main` (cross-file `fetch` URL pollution, unrelated to this change).

## Acceptance criteria
- [x] Overview always lists active reports (even when none), beside other documents.
- [x] Clicking a report reopens it in the same builder; editing == creating (#400).
- [x] Report date editable, defaults to today (#400 + schema default).
- [x] Deleting moves a report to a recoverable trash (`deleted_at`) and it leaves the active list.
- [x] A trashed report can be restored (clears `deleted_at`) and reappears in the active list.
- [x] The active/trashed predicate is covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)