### PR TITLE
feat(photo-report): rich-text Section write-ups + PDF section intro page (#403)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -49,6 +49,30 @@ vi.mock("@/lib/generate-report-pdf", () => ({
   generateReportPDF: vi.fn(async () => "job-1/report-1.pdf"),
 }));
 
+// The section write-up uses the shared TipTap editor (issue #403). It is heavy,
+// contenteditable-driven, and tested elsewhere; here we stub it with a textarea
+// that mirrors its real contract — seeded once from `content`, emitting HTML via
+// `onChange` — so we can assert the builder loads and persists the write-up HTML.
+vi.mock("@/components/tiptap-editor", () => ({
+  default: ({
+    content,
+    onChange,
+    placeholder,
+  }: {
+    content: string;
+    onChange: (html: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="tiptap-stub"
+      aria-label="Section write-up"
+      placeholder={placeholder}
+      defaultValue={content}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
 import PhotoReportBuilder from "./photo-report-builder";
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
@@ -172,5 +196,42 @@ describe("PhotoReportBuilder auto-save", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("loads the section write-up into the rich-text editor and auto-saves edits as HTML", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          {
+            title: "Findings",
+            description: "<p>Existing finding</p>",
+            photo_ids: ["p1"],
+          },
+        ],
+      }),
+    );
+
+    // The existing write-up is handed to the TipTap editor for editing.
+    const editor = screen.getByTestId("tiptap-stub") as HTMLTextAreaElement;
+    expect(editor.value).toBe("<p>Existing finding</p>");
+
+    // Editing emits HTML; the debounced auto-save persists it into the section's
+    // `description` with no explicit Save, exactly like the title field.
+    act(() => {
+      fireEvent.change(editor, {
+        target: { value: "<p>Existing finding</p><ul><li>New item</li></ul>" },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: { description: string }[];
+    };
+    expect(payload.sections[0].description).toBe(
+      "<p>Existing finding</p><ul><li>New item</li></ul>",
+    );
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { createClient } from "@/lib/supabase";
 import { photoUrl } from "@/lib/jobs/photo-url";
 import { generateReportPDF } from "@/lib/generate-report-pdf";
+import TiptapEditor from "@/components/tiptap-editor";
 import {
   initBuilderState,
   photoReportBuilderReducer,
@@ -190,19 +191,19 @@ export default function PhotoReportBuilder({
                 placeholder="Section heading"
                 className="w-full rounded-lg border border-border bg-background px-3 py-2 text-base font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
-              <textarea
-                aria-label="Section write-up"
-                value={section.description}
-                onChange={(e) =>
+              {/* Rich-text write-up (issue #403): the same TipTap editor used on
+                  Estimates / Invoices / contracts. Its HTML is stored in the
+                  Section's `description` and auto-saved like every other edit. */}
+              <TiptapEditor
+                content={section.description}
+                onChange={(html) =>
                   dispatch({
                     type: "setSectionWriteup",
                     index,
-                    writeup: e.target.value,
+                    writeup: html,
                   })
                 }
-                placeholder="Write-up"
-                rows={4}
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                placeholder="Write-up — what you found, what you did…"
               />
               <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
                 {section.photo_ids.map((photoId) => {

--- a/src/components/report-pdf/section-divider-page.test.tsx
+++ b/src/components/report-pdf/section-divider-page.test.tsx
@@ -202,6 +202,27 @@ describe("SectionDividerPage", () => {
     }
   });
 
+  it("renders a heading-in-write-up as clean text, never the raw <h2> source", () => {
+    // The bare-StarterKit editor lets a user produce a heading (e.g. "## ").
+    // The intro page must show its text, not leak `h2>` or the literal tag.
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Findings"
+        description="<h2>Demo Findings</h2><p>Water intrusion along the north wall.</p>"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Demo Findings");
+    expect(text).toContain("Water intrusion along the north wall.");
+    expect(text).not.toContain("h2>");
+    expect(text).not.toContain("<h2");
+  });
+
   it("renders heading-only when the write-up is an emptied list (no stray bullet block)", () => {
     // A user who starts a bullet then clears it can leave an empty list behind;
     // that is still an empty write-up — heading only, no blank bullet.

--- a/src/components/report-pdf/section-divider-page.test.tsx
+++ b/src/components/report-pdf/section-divider-page.test.tsx
@@ -103,4 +103,121 @@ describe("SectionDividerPage", () => {
     expect(text).toContain("Living Room");
     expect(text).toContain("2 / 5");
   });
+
+  // ── The write-up is rich text (issue #403) ─────────────────────────────────
+  // The Section write-up is now HTML authored in the TipTap editor, stored in
+  // `description`. The intro page renders it through the shared HTML→PDF
+  // mapping, so a bullet list becomes real bullet rows rather than the literal
+  // `<ul>…</ul>` source string.
+  it("renders a bullet-list write-up as bullet rows, not raw HTML", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Findings"
+        description="<ul><li>Buckled flooring</li><li>Standing water</li></ul>"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    // Bullet glyph + item text, emitted by htmlToPdfNodes.
+    expect(text).toContain("• Buckled flooring");
+    expect(text).toContain("• Standing water");
+    // The raw list tags must not leak into the rendered text.
+    expect(text).not.toContain("<ul>");
+    expect(text).not.toContain("<li>");
+  });
+
+  it("renders a numbered-list write-up with 1./2. markers", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Work performed"
+        description="<ol><li>Extracted standing water</li><li>Set air movers</li></ol>"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={3}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("1. Extracted standing water");
+    expect(text).toContain("2. Set air movers");
+    expect(text).not.toContain("<ol>");
+  });
+
+  it("renders bold and italic runs from the write-up as styled text", () => {
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Findings"
+        description="<p>Severe <strong>structural</strong> and <em>cosmetic</em> damage.</p>"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    expect(collectText(tree)).toContain("Severe structural and cosmetic damage.");
+
+    const boldRun = findAll(
+      tree,
+      (n) => n.type === "TEXT" && n.props.children === "structural",
+    )
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontWeight === "bold");
+    expect(boldRun).toBeDefined();
+
+    const italicRun = findAll(
+      tree,
+      (n) => n.type === "TEXT" && n.props.children === "cosmetic",
+    )
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontStyle === "italic");
+    expect(italicRun).toBeDefined();
+  });
+
+  it("renders heading-only (no block) for a TipTap-empty write-up", () => {
+    // TipTap serialises a blank editor as `<p></p>`; a stray space saves as
+    // `<p> </p>`. Neither must produce a write-up block on the intro page.
+    for (const description of ["<p></p>", "<p>   </p>"]) {
+      const tree = expandTree(
+        <SectionDividerPage
+          title="Just photos"
+          description={description}
+          customerName="Jane Doe"
+          reportDate="2026-05-19"
+          pageNumber={2}
+          totalPages={9}
+        />,
+      );
+
+      const text = collectText(tree);
+      expect(text).toContain("Just photos");
+      expect(text).not.toContain("<p>");
+      // No bullet or list markers where an empty write-up would have rendered.
+      expect(text).not.toContain("•");
+    }
+  });
+
+  it("renders heading-only when the write-up is an emptied list (no stray bullet block)", () => {
+    // A user who starts a bullet then clears it can leave an empty list behind;
+    // that is still an empty write-up — heading only, no blank bullet.
+    const tree = expandTree(
+      <SectionDividerPage
+        title="Just photos"
+        description="<ul><li><p></p></li></ul>"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+        pageNumber={2}
+        totalPages={9}
+      />,
+    );
+
+    const text = collectText(tree);
+    expect(text).toContain("Just photos");
+    expect(text).not.toContain("•");
+  });
 });

--- a/src/components/report-pdf/section-divider-page.tsx
+++ b/src/components/report-pdf/section-divider-page.tsx
@@ -4,6 +4,8 @@ import { Page, StyleSheet, Text, View } from "@react-pdf/renderer";
 
 import PageFooter from "./page-footer";
 import PageHeader from "./page-header";
+import { htmlToPdfNodes } from "@/lib/pdf-renderer/html-to-pdf";
+import { normalizeSectionWriteup } from "@/lib/section-writeup";
 
 const colors = {
   text: "#1A1A1A",
@@ -20,10 +22,19 @@ const styles = StyleSheet.create({
     color: colors.text,
   },
   body: {
+    // Horizontal margins come from the Page's paddingHorizontal; the write-up
+    // then spans the same content width as the photo pages.
     flex: 1,
-    justifyContent: "center",
     alignItems: "center",
-    paddingHorizontal: 40,
+  },
+  // An empty write-up keeps the clean centered-title divider look.
+  bodyCentered: {
+    justifyContent: "center",
+  },
+  // With a write-up the page becomes a top-down intro: heading, then narrative.
+  bodyWithWriteup: {
+    justifyContent: "flex-start",
+    paddingTop: 72,
   },
   title: {
     fontSize: 36,
@@ -31,12 +42,16 @@ const styles = StyleSheet.create({
     color: colors.text,
     textAlign: "center",
   },
-  description: {
-    marginTop: 24,
-    fontSize: 14,
-    color: colors.muted,
-    textAlign: "center",
-    lineHeight: 1.4,
+  // The rich-text write-up reads as the page's body copy: full width, left
+  // aligned, a touch larger than the photo-page captions. htmlToPdfNodes emits
+  // the paragraphs / bullet rows; this View only sets the inherited typography.
+  writeup: {
+    marginTop: 28,
+    width: "100%",
+    fontSize: 12,
+    lineHeight: 1.5,
+    color: colors.text,
+    textAlign: "left",
   },
 });
 
@@ -57,16 +72,21 @@ export default function SectionDividerPage({
   pageNumber,
   totalPages,
 }: SectionDividerPageProps) {
-  const hasDescription = description != null && description.length > 0;
+  // The write-up is rich-text HTML stored in `description` (issue #403). Read
+  // it through the slice-1 normalizer so legacy one-line subtitles and missing
+  // values are tolerated, then map the subset to PDF primitives. An empty
+  // write-up yields no nodes, so the intro page is heading-only — no blank block.
+  const writeupNodes = htmlToPdfNodes(normalizeSectionWriteup(description));
+  const hasWriteup = writeupNodes.length > 0;
 
   return (
     <Page size="LETTER" style={styles.page}>
       <PageHeader customerName={customerName} reportDate={reportDate} />
-      <View style={styles.body}>
+      <View
+        style={[styles.body, hasWriteup ? styles.bodyWithWriteup : styles.bodyCentered]}
+      >
         <Text style={styles.title}>{title}</Text>
-        {hasDescription ? (
-          <Text style={styles.description}>{description}</Text>
-        ) : null}
+        {hasWriteup ? <View style={styles.writeup}>{writeupNodes}</View> : null}
       </View>
       <PageFooter
         sectionTitle={title}

--- a/src/lib/build-report-document.test.ts
+++ b/src/lib/build-report-document.test.ts
@@ -637,4 +637,51 @@ describe("buildReportDocument", () => {
       1, 2, 3, 4, 5, 6,
     ]);
   });
+
+  it("plans cover → per-Section intro → photo pages, forwarding each Section's rich-text write-up to its intro page", () => {
+    // Issue #403: the section divider is the Section's intro page (heading +
+    // write-up). The planner keeps its interface — it forwards the write-up
+    // HTML verbatim on the divider and the renderer maps it to PDF primitives.
+    const pages = buildReportDocument({
+      sections: [
+        makeSection({
+          title: "Findings",
+          description: "<p>What we found.</p><ul><li>Buckled flooring</li></ul>",
+          photoIds: ["a", "b"],
+        }),
+        makeSection({
+          title: "Work performed",
+          description: "<p>What we did.</p>",
+          photoIds: ["c"],
+        }),
+      ],
+      photos: {
+        a: makePhoto({ id: "a" }),
+        b: makePhoto({ id: "b" }),
+        c: makePhoto({ id: "c" }),
+      },
+      photosPerPage: 2,
+    });
+
+    // Each Section's intro page sits immediately before that Section's photos.
+    expect(pages.map((p) => p.kind)).toEqual([
+      "cover",
+      "sectionDivider",
+      "photoPage",
+      "sectionDivider",
+      "photoPage",
+    ]);
+
+    const intros = pages.filter((p) => p.kind === "sectionDivider") as Extract<
+      DocumentPage,
+      { kind: "sectionDivider" }
+    >[];
+    expect(intros.map((d) => d.title)).toEqual(["Findings", "Work performed"]);
+    // Write-up HTML is passed through untouched (the renderer, not the planner,
+    // turns it into paragraphs / bullet rows).
+    expect(intros[0].description).toBe(
+      "<p>What we found.</p><ul><li>Buckled flooring</li></ul>",
+    );
+    expect(intros[1].description).toBe("<p>What we did.</p>");
+  });
 });

--- a/src/lib/pdf-renderer/html-to-pdf.test.tsx
+++ b/src/lib/pdf-renderer/html-to-pdf.test.tsx
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import { htmlToPdfNodes } from "./html-to-pdf";
+import {
+  collectText,
+  expandTree,
+  findAll,
+} from "@/components/report-pdf/test-helpers";
+
+// htmlToPdfNodes is the minimal HTML → @react-pdf mapping shared by estimate /
+// invoice statements (StatementBlock) and now the Photo Report section intro
+// page (issue #403). It only understands the subset the TipTap editor emits.
+// These tests pin that contract because the intro page makes it load-bearing.
+
+// Expand the returned primitive nodes and read their concatenated text.
+function text(html: string | null | undefined): string {
+  return collectText(expandTree(htmlToPdfNodes(html)));
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, s) => ({ ...acc, ...flattenStyle(s) }),
+      {},
+    );
+  }
+  if (style && typeof style === "object") return style as Record<string, unknown>;
+  return {};
+}
+
+// Every top-level paragraph is a TEXT node carrying the block marginBottom; the
+// bullet glyph / number is a separate narrow TEXT inside a row VIEW. Counting
+// the paragraph-level TEXT nodes (those with a marginBottom) approximates "how
+// many blocks did we emit".
+function paragraphCount(html: string): number {
+  const tree = expandTree(htmlToPdfNodes(html));
+  return findAll(
+    tree,
+    (n) => n.type === "TEXT" && flattenStyle(n.props.style).marginBottom === 4,
+  ).length;
+}
+
+describe("htmlToPdfNodes", () => {
+  it("returns nothing for empty, null, or undefined input", () => {
+    expect(htmlToPdfNodes("")).toHaveLength(0);
+    expect(htmlToPdfNodes(null)).toHaveLength(0);
+    expect(htmlToPdfNodes(undefined)).toHaveLength(0);
+  });
+
+  it("renders each <p> as its own paragraph, in document order", () => {
+    expect(text("<p>First paragraph.</p><p>Second paragraph.</p>")).toBe(
+      "First paragraph.Second paragraph.",
+    );
+    expect(paragraphCount("<p>First paragraph.</p><p>Second paragraph.</p>")).toBe(
+      2,
+    );
+  });
+
+  it("renders a <ul> as bullet rows", () => {
+    expect(text("<ul><li>Alpha</li><li>Beta</li></ul>")).toBe("• Alpha• Beta");
+  });
+
+  it("renders an <ol> as numbered rows, counting from 1", () => {
+    expect(text("<ol><li>One</li><li>Two</li><li>Three</li></ol>")).toBe(
+      "1. One2. Two3. Three",
+    );
+  });
+
+  it("tolerates TipTap's <li><p>…</p></li> list serialization", () => {
+    // StarterKit wraps list-item content in a paragraph; the bullet text must
+    // still come through without the inner <p> leaking.
+    expect(text("<ul><li><p>Wrapped item</p></li></ul>")).toBe("• Wrapped item");
+  });
+
+  it("applies bold styling to <strong> and italic to <em> runs", () => {
+    const tree = expandTree(
+      htmlToPdfNodes("<p>Plain <strong>bold</strong> and <em>italic</em>.</p>"),
+    );
+
+    const bold = findAll(tree, (n) => n.type === "TEXT" && n.props.children === "bold")
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontWeight === "bold");
+    expect(bold).toBeDefined();
+
+    const italic = findAll(
+      tree,
+      (n) => n.type === "TEXT" && n.props.children === "italic",
+    )
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontStyle === "italic");
+    expect(italic).toBeDefined();
+  });
+
+  it("guards against empty / whitespace-only paragraphs", () => {
+    expect(htmlToPdfNodes("<p></p>")).toHaveLength(0);
+    expect(htmlToPdfNodes("<p>   </p>")).toHaveLength(0);
+    // A blank paragraph between two real ones is dropped, not rendered blank.
+    expect(text("<p>real</p><p></p><p>also</p>")).toBe("realalso");
+    expect(paragraphCount("<p>real</p><p></p><p>also</p>")).toBe(2);
+  });
+
+  it("strips <img> tags entirely, keeping the surrounding text", () => {
+    const out = text('<p>Before<img src="photo.jpg" />After</p>');
+    expect(out).toBe("BeforeAfter");
+    expect(out).not.toContain("photo.jpg");
+    // A lone image produces no node at all.
+    expect(htmlToPdfNodes('<img src="lonely.jpg">')).toHaveLength(0);
+  });
+
+  it("treats <b>/<i> the same as <strong>/<em>", () => {
+    const tree = expandTree(
+      htmlToPdfNodes("<p>Plain <b>bold-alt</b> and <i>italic-alt</i>.</p>"),
+    );
+
+    const bold = findAll(
+      tree,
+      (n) => n.type === "TEXT" && n.props.children === "bold-alt",
+    )
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontWeight === "bold");
+    expect(bold).toBeDefined();
+
+    const italic = findAll(
+      tree,
+      (n) => n.type === "TEXT" && n.props.children === "italic-alt",
+    )
+      .map((n) => flattenStyle(n.props.style))
+      .find((s) => s.fontStyle === "italic");
+    expect(italic).toBeDefined();
+  });
+
+  it("drops empty lists and empty / whitespace-only list items", () => {
+    // An empty list must yield NO node, so an "empty write-up" stays empty and
+    // the intro page renders heading-only (no stray bullet block).
+    expect(htmlToPdfNodes("<ul></ul>")).toHaveLength(0);
+    expect(htmlToPdfNodes("<ol></ol>")).toHaveLength(0);
+    expect(htmlToPdfNodes("<ul><li>   </li></ul>")).toHaveLength(0);
+    // TipTap serialises a blank list item as <li><p></p></li>.
+    expect(htmlToPdfNodes("<ul><li><p></p></li></ul>")).toHaveLength(0);
+    // A blank item among real ones is skipped; numbering stays continuous.
+    expect(text("<ul><li>Real</li><li>   </li></ul>")).toBe("• Real");
+    expect(text("<ol><li>One</li><li>  </li><li>Two</li></ol>")).toBe(
+      "1. One2. Two",
+    );
+  });
+});

--- a/src/lib/pdf-renderer/html-to-pdf.test.tsx
+++ b/src/lib/pdf-renderer/html-to-pdf.test.tsx
@@ -143,4 +143,71 @@ describe("htmlToPdfNodes", () => {
       "1. One2. Two",
     );
   });
+
+  // ── The editor is bare StarterKit, so it emits more than the original subset.
+  // Anything we don't render richly must degrade to clean text — never leak a
+  // tag-name fragment (e.g. "h2>") or collapse content silently. (Issue #403.)
+
+  it("turns a hard break (<br>) into a line break, not a run-together line", () => {
+    // Shift+Enter is a common authoring action; the two lines must stay split.
+    expect(text("<p>Line one<br>Line two</p>")).toBe("Line one\nLine two");
+    expect(text("<p>Line one<br/>Line two</p>")).toBe("Line one\nLine two");
+    expect(text("<p>Line one<br />Line two</p>")).toBe("Line one\nLine two");
+  });
+
+  it("renders headings as plain paragraphs, never leaking the tag name", () => {
+    expect(text("<h2>Demo Findings</h2>")).toBe("Demo Findings");
+    expect(text("<h1>Title</h1><p>Body</p>")).toBe("TitleBody");
+    expect(paragraphCount("<h1>Title</h1><p>Body</p>")).toBe(2);
+    // The tag-name fragment that used to leak must be gone.
+    expect(text("<h2>Demo Findings</h2>")).not.toContain("h2>");
+  });
+
+  it("renders a blockquote's text without leaking the wrapper tags", () => {
+    const out = text("<blockquote><p>Quote text</p></blockquote>");
+    expect(out).toBe("Quote text");
+    expect(out).not.toContain("blockquote>");
+  });
+
+  it("renders a code block's text without leaking <pre>/<code> fragments", () => {
+    const out = text("<pre><code>const x = 1;</code></pre>");
+    expect(out).toBe("const x = 1;");
+    expect(out).not.toContain("pre>");
+    expect(out).not.toContain("code>");
+  });
+
+  it("keeps inline <code> text, dropping only the styling tags", () => {
+    expect(text("<p>Run <code>npm test</code> now</p>")).toBe("Run npm test now");
+  });
+
+  it("strips horizontal rules without leaving a stray hr> line", () => {
+    const out = text("<p>Above</p><hr><p>Below</p>");
+    expect(out).toBe("AboveBelow");
+    expect(out).not.toContain("hr>");
+    expect(paragraphCount("<p>Above</p><hr><p>Below</p>")).toBe(2);
+  });
+
+  it("renders nested lists in document order, indented, with no dropped siblings or leaked tags", () => {
+    const nested =
+      "<ul><li><p>Parent</p><ul><li><p>Child A</p></li><li><p>Child B</p></li></ul></li><li><p>Sibling</p></li></ul>";
+    const out = text(nested);
+    // Every item survives, in order — including the sibling that the old
+    // non-greedy regex dropped.
+    expect(out).toBe("• Parent• Child A• Child B• Sibling");
+    // No structural tag fragments leak.
+    for (const leak of ["li>", "ul>", "/li", "/ul"]) {
+      expect(out).not.toContain(leak);
+    }
+    // Four real bullet rows (each a flex row with a bullet + text).
+    const rows = findAll(
+      expandTree(htmlToPdfNodes(nested)),
+      (n) => n.type === "VIEW" && flattenStyle(n.props.style).flexDirection === "row",
+    );
+    expect(rows).toHaveLength(4);
+    // Children are indented further than their parent.
+    const indents = rows.map((r) => Number(flattenStyle(r.props.style).marginLeft) || 0);
+    expect(indents[1]).toBeGreaterThan(indents[0]);
+    expect(indents[2]).toBeGreaterThan(indents[0]);
+    expect(indents[3]).toBe(indents[0]);
+  });
 });

--- a/src/lib/pdf-renderer/html-to-pdf.tsx
+++ b/src/lib/pdf-renderer/html-to-pdf.tsx
@@ -1,8 +1,14 @@
 // src/lib/pdf-renderer/html-to-pdf.tsx — minimal HTML → @react-pdf converter.
-// Statements (estimate/invoice opening + closing) are stored as HTML strings by
-// the Tiptap editor in src/components/estimate-builder/statement-editor.tsx. We
-// only support the subset the editor produces: <p>, <strong>/<b>, <em>/<i>,
-// <ul>, <ol>, <li>, <br>. Image nodes are stripped (out of scope for v1).
+// HTML strings come from the Tiptap editor: estimate/invoice statements
+// (src/components/estimate-builder/statement-editor.tsx) and Photo Report
+// section write-ups (issue #403). The editor is bare StarterKit, so it can emit
+// more than we render richly — headings, blockquotes, code blocks, horizontal
+// rules, hard breaks, links, nested lists. We render the common subset (<p>,
+// <strong>/<b>, <em>/<i>, <ul>/<ol>/<li> with nesting) and DEGRADE everything
+// else to clean text: a heading/blockquote/code block becomes a plain
+// paragraph, an <hr>/<img> is dropped, a <br> becomes a line break, and unknown
+// inline tags (links, <span>, <s>, <u>, inline <code>) keep their text. The one
+// hard rule: never leak a tag-name fragment (e.g. "h2>") into the PDF.
 
 import { Text, View } from "@react-pdf/renderer";
 import type { JSX } from "react";
@@ -18,9 +24,9 @@ function runsHaveContent(runs: Run[]): boolean {
 
 // Tokenize a fragment of HTML into plain runs. Naive parser sufficient for the
 // editor's output; not a general HTML parser. Any tag is consumed: <strong>/<b>
-// and <em>/<i> toggle styling, and every other tag — notably the <p> TipTap
-// wraps list-item content in (`<li><p>…</p></li>`), plus <br>/<span> — is simply
-// dropped so no angle-bracket remnants leak into the rendered text.
+// and <em>/<i> toggle styling, and every other inline tag — links, <span>, the
+// <p> TipTap wraps list-item content in — is simply dropped so no angle-bracket
+// remnants leak into the rendered text.
 function tokenize(html: string): Run[] {
   const runs: Run[] = [];
   const re = /<(\/?)([a-z][a-z0-9]*)\b[^>]*>|([^<]+)/gi;
@@ -57,54 +63,206 @@ function renderRuns(runs: Run[], keyPrefix: string): JSX.Element[] {
   });
 }
 
-// Splits the HTML into block-level chunks (<p>, <ul>, <ol>, top-level text).
-// Returns an array of <View> / <Text> nodes. Empty / whitespace-only string
-// returns an empty array.
+// Fold the tags we don't render richly onto ones we do, or strip them, BEFORE
+// parsing — so the block scanner only ever sees <p>/<ul>/<ol> plus inline runs,
+// and no unsupported tag can leak its name as text.
+function normalizeBlocks(html: string): string {
+  return html
+    .replace(/<img[^>]*>/gi, "") // images are out of scope — drop entirely
+    .replace(/<hr\s*\/?>/gi, "") // horizontal rules carry no text — drop
+    .replace(/<br\s*\/?>/gi, "\n") // hard break → newline inside the paragraph
+    .replace(/<h[1-6]\b[^>]*>/gi, "<p>") // headings render as plain paragraphs
+    .replace(/<\/h[1-6]\s*>/gi, "</p>")
+    .replace(/<blockquote\b[^>]*>/gi, "") // unwrap blockquote; its inner <p> stays
+    .replace(/<\/blockquote\s*>/gi, "")
+    .replace(/<pre\b[^>]*>/gi, "<p>") // code block → paragraph
+    .replace(/<\/pre\s*>/gi, "</p>")
+    .replace(/<code\b[^>]*>/gi, "") // drop inline / code-block <code> styling tags
+    .replace(/<\/code\s*>/gi, "");
+}
+
+// Find the match for the tag that closes the element opened at `from`, counting
+// nested opens of the same tag so <ul>/<ol>/<li> nesting is respected (a naive
+// non-greedy regex would stop at the FIRST inner close and corrupt the tree).
+// `from` must point just past the opening tag. Returns the RegExpMatchArray for
+// the matching close tag (so callers get both `.index` and its length), or null.
+function findMatchingClose(
+  html: string,
+  tag: string,
+  from: number,
+): RegExpExecArray | null {
+  const re = new RegExp(`<(/?)${tag}\\b[^>]*>`, "gi");
+  re.lastIndex = from;
+  let depth = 1;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) {
+    if (m[1] === "/") {
+      depth -= 1;
+      if (depth === 0) return m;
+    } else {
+      depth += 1;
+    }
+  }
+  return null;
+}
+
+// Split a list item's inner HTML into its direct (inline) content and any
+// nested lists, so the bullet text and its sub-list render separately.
+function splitNestedLists(liInner: string): {
+  direct: string;
+  nested: Array<{ type: "ul" | "ol"; inner: string }>;
+} {
+  let direct = "";
+  const nested: Array<{ type: "ul" | "ol"; inner: string }> = [];
+  const openRe = /<(ul|ol)\b[^>]*>/gi;
+  let pos = 0;
+  while (pos < liInner.length) {
+    openRe.lastIndex = pos;
+    const m = openRe.exec(liInner);
+    if (!m) {
+      direct += liInner.slice(pos);
+      break;
+    }
+    direct += liInner.slice(pos, m.index);
+    const type = m[1].toLowerCase() as "ul" | "ol";
+    const contentStart = m.index + m[0].length;
+    const close = findMatchingClose(liInner, type, contentStart);
+    nested.push({
+      type,
+      inner: close ? liInner.slice(contentStart, close.index) : liInner.slice(contentStart),
+    });
+    pos = close ? close.index + close[0].length : liInner.length;
+  }
+  return { direct, nested };
+}
+
+// Render the rows of a <ul>/<ol> as flat indented bullet rows in document order.
+// Nested lists recurse with deeper indentation; blank items are skipped and
+// numbering stays continuous. Returns row Views (empty array ⇒ nothing to show).
+function renderListRows(
+  inner: string,
+  listType: "ul" | "ol",
+  keyPrefix: string,
+  depth: number,
+): JSX.Element[] {
+  const rows: JSX.Element[] = [];
+  const liOpenRe = /<li\b[^>]*>/gi;
+  let pos = 0;
+  let number = 0;
+  let idx = 0;
+  while (pos < inner.length) {
+    liOpenRe.lastIndex = pos;
+    const m = liOpenRe.exec(inner);
+    if (!m) break;
+    const contentStart = m.index + m[0].length;
+    const close = findMatchingClose(inner, "li", contentStart);
+    const liInner = close ? inner.slice(contentStart, close.index) : inner.slice(contentStart);
+    pos = close ? close.index + close[0].length : inner.length;
+
+    const { direct, nested } = splitNestedLists(liInner);
+    const runs = tokenize(direct);
+    // Skip empty / whitespace-only items (e.g. TipTap's <li><p></p></li>), the
+    // same guard paragraphs use, so a blank item is not a stray bullet.
+    if (runsHaveContent(runs)) {
+      const bullet = listType === "ul" ? "• " : `${number + 1}. `;
+      rows.push(
+        <View
+          key={`${keyPrefix}-i${idx}`}
+          style={{ flexDirection: "row", marginBottom: 2, marginLeft: depth * 16 }}
+        >
+          <Text style={{ width: 16 }}>{bullet}</Text>
+          <Text style={{ flex: 1 }}>{renderRuns(runs, `${keyPrefix}-i${idx}`)}</Text>
+        </View>,
+      );
+      number += 1;
+      idx += 1;
+    }
+    for (const child of nested) {
+      rows.push(...renderListRows(child.inner, child.type, `${keyPrefix}-n${idx}`, depth + 1));
+      idx += 1;
+    }
+  }
+  return rows;
+}
+
+// Convert a subset of editor HTML into an array of <View> / <Text> nodes.
+// Empty / whitespace-only input returns an empty array. The scan recognizes
+// <p>, <ul>, <ol> as blocks (lists nest); unrecognized open tags are skipped
+// (their inner content still renders) and stray close tags are dropped, so a
+// tag name can never surface as visible body text.
 export function htmlToPdfNodes(html: string | null | undefined): JSX.Element[] {
   if (!html) return [];
-  // Strip images outright.
-  const cleaned = html.replace(/<img[^>]*>/gi, "");
-  // Match top-level blocks. Anything not inside a block becomes a paragraph.
-  const blockRe = /<(p|ul|ol)>([\s\S]*?)<\/\1>|([^<]+)/gi;
+  const cleaned = normalizeBlocks(html);
   const out: JSX.Element[] = [];
+  let pos = 0;
   let i = 0;
-  for (const m of cleaned.matchAll(blockRe)) {
-    const tag = m[1]?.toLowerCase();
-    const inner = m[2];
-    const stray = m[3]?.trim();
-    if (tag === "p") {
-      const runs = tokenize(inner);
-      if (runsHaveContent(runs)) {
-        out.push(<Text key={`p-${i}`} style={{ marginBottom: 4 }}>{renderRuns(runs, `p-${i}`)}</Text>);
-      }
-    } else if (tag === "ul" || tag === "ol") {
-      const items: JSX.Element[] = [];
-      let li = 0;
-      const liRe = /<li>([\s\S]*?)<\/li>/gi;
-      for (const liM of inner.matchAll(liRe)) {
-        const runs = tokenize(liM[1]);
-        // Skip empty / whitespace-only items (e.g. TipTap's <li><p></p></li>),
-        // the same guard paragraphs use, so a blank item is not a stray bullet.
-        if (!runsHaveContent(runs)) continue;
-        const bullet = tag === "ul" ? "• " : `${li + 1}. `;
-        items.push(
-          <View key={`l-${i}-${li}`} style={{ flexDirection: "row", marginBottom: 2 }}>
-            <Text style={{ width: 16 }}>{bullet}</Text>
-            <Text style={{ flex: 1 }}>{renderRuns(runs, `l-${i}-${li}`)}</Text>
-          </View>,
-        );
-        li += 1;
-      }
-      // A genuinely empty (or all-blank) list contributes nothing, so an empty
-      // write-up stays empty and the intro page renders heading-only.
-      if (items.length > 0) out.push(<View key={`list-${i}`}>{items}</View>);
-    } else if (stray) {
+  let stray = "";
+
+  const flushStray = () => {
+    if (stray) {
       const runs = tokenize(stray);
       if (runsHaveContent(runs)) {
-        out.push(<Text key={`s-${i}`} style={{ marginBottom: 4 }}>{renderRuns(runs, `s-${i}`)}</Text>);
+        out.push(
+          <Text key={`s-${i}`} style={{ marginBottom: 4 }}>{renderRuns(runs, `s-${i}`)}</Text>,
+        );
+        i += 1;
       }
+      stray = "";
     }
-    i += 1;
+  };
+
+  while (pos < cleaned.length) {
+    const lt = cleaned.indexOf("<", pos);
+    if (lt === -1) {
+      stray += cleaned.slice(pos);
+      break;
+    }
+    if (lt > pos) stray += cleaned.slice(pos, lt);
+
+    const tagMatch = /^<(\/?)([a-z][a-z0-9]*)\b[^>]*>/i.exec(cleaned.slice(lt));
+    if (!tagMatch) {
+      // A lone '<' that doesn't start a tag — keep it as text, advance one char.
+      stray += "<";
+      pos = lt + 1;
+      continue;
+    }
+    const isClose = tagMatch[1] === "/";
+    const tag = tagMatch[2].toLowerCase();
+    const afterOpen = lt + tagMatch[0].length;
+
+    if (isClose) {
+      // A stray top-level close tag — drop it (no leak).
+      pos = afterOpen;
+      continue;
+    }
+    if (tag === "p" || tag === "ul" || tag === "ol") {
+      flushStray();
+      const close = findMatchingClose(cleaned, tag, afterOpen);
+      const inner = close ? cleaned.slice(afterOpen, close.index) : cleaned.slice(afterOpen);
+      pos = close ? close.index + close[0].length : cleaned.length;
+      if (tag === "p") {
+        const runs = tokenize(inner);
+        if (runsHaveContent(runs)) {
+          out.push(
+            <Text key={`p-${i}`} style={{ marginBottom: 4 }}>{renderRuns(runs, `p-${i}`)}</Text>,
+          );
+          i += 1;
+        }
+      } else {
+        const rows = renderListRows(inner, tag, `list-${i}`, 0);
+        // A genuinely empty (or all-blank) list contributes nothing, so an empty
+        // write-up stays empty and the intro page renders heading-only.
+        if (rows.length > 0) {
+          out.push(<View key={`list-${i}`}>{rows}</View>);
+          i += 1;
+        }
+      }
+    } else {
+      // Unrecognized open tag (e.g. a top-level inline wrapper) — skip the tag
+      // itself; its inner content keeps flowing through the scan.
+      pos = afterOpen;
+    }
   }
+  flushStray();
   return out;
 }

--- a/src/lib/pdf-renderer/html-to-pdf.tsx
+++ b/src/lib/pdf-renderer/html-to-pdf.tsx
@@ -17,20 +17,23 @@ function runsHaveContent(runs: Run[]): boolean {
 }
 
 // Tokenize a fragment of HTML into plain runs. Naive parser sufficient for the
-// editor's output; not a general HTML parser.
+// editor's output; not a general HTML parser. Any tag is consumed: <strong>/<b>
+// and <em>/<i> toggle styling, and every other tag — notably the <p> TipTap
+// wraps list-item content in (`<li><p>…</p></li>`), plus <br>/<span> — is simply
+// dropped so no angle-bracket remnants leak into the rendered text.
 function tokenize(html: string): Run[] {
   const runs: Run[] = [];
-  const re = /<\/?(strong|b|em|i)>|([^<]+)/gi;
+  const re = /<(\/?)([a-z][a-z0-9]*)\b[^>]*>|([^<]+)/gi;
   let bold = false;
   let italic = false;
   for (const m of html.matchAll(re)) {
-    const tag = m[1];
-    const text = m[2];
+    const tag = m[2]?.toLowerCase();
+    const text = m[3];
     if (tag) {
-      const isClose = m[0].startsWith("</");
-      const t = tag.toLowerCase();
-      if (t === "strong" || t === "b") bold = !isClose;
-      else if (t === "em" || t === "i") italic = !isClose;
+      const isClose = m[1] === "/";
+      if (tag === "strong" || tag === "b") bold = !isClose;
+      else if (tag === "em" || tag === "i") italic = !isClose;
+      // Any other tag is a no-op formatting boundary.
     } else if (text) {
       const decoded = text
         .replace(/&nbsp;/g, " ")
@@ -80,6 +83,9 @@ export function htmlToPdfNodes(html: string | null | undefined): JSX.Element[] {
       const liRe = /<li>([\s\S]*?)<\/li>/gi;
       for (const liM of inner.matchAll(liRe)) {
         const runs = tokenize(liM[1]);
+        // Skip empty / whitespace-only items (e.g. TipTap's <li><p></p></li>),
+        // the same guard paragraphs use, so a blank item is not a stray bullet.
+        if (!runsHaveContent(runs)) continue;
         const bullet = tag === "ul" ? "• " : `${li + 1}. `;
         items.push(
           <View key={`l-${i}-${li}`} style={{ flexDirection: "row", marginBottom: 2 }}>
@@ -89,7 +95,9 @@ export function htmlToPdfNodes(html: string | null | undefined): JSX.Element[] {
         );
         li += 1;
       }
-      out.push(<View key={`list-${i}`}>{items}</View>);
+      // A genuinely empty (or all-blank) list contributes nothing, so an empty
+      // write-up stays empty and the intro page renders heading-only.
+      if (items.length > 0) out.push(<View key={`list-${i}`}>{items}</View>);
     } else if (stray) {
       const runs = tokenize(stray);
       if (runsHaveContent(runs)) {

--- a/src/lib/section-writeup.test.ts
+++ b/src/lib/section-writeup.test.ts
@@ -36,4 +36,17 @@ describe("normalizeSectionWriteup", () => {
     const html = "<p>Significant <strong>water</strong> damage</p>";
     expect(normalizeSectionWriteup(html)).toBe(html);
   });
+
+  it("treats a heading-only write-up as rich text, not plain (no wholesale escaping)", () => {
+    // The bare-StarterKit editor can emit a heading with no wrapping <p> (e.g.
+    // typing "## Findings"). It must reach the renderer as HTML, not be escaped
+    // and shown to the customer as literal `<h2>…</h2>` source.
+    const html = "<h2>Findings</h2>";
+    expect(normalizeSectionWriteup(html)).toBe(html);
+  });
+
+  it("treats a code-block-only write-up as rich text, not plain", () => {
+    const html = "<pre><code>const x = 1;</code></pre>";
+    expect(normalizeSectionWriteup(html)).toBe(html);
+  });
 });

--- a/src/lib/section-writeup.ts
+++ b/src/lib/section-writeup.ts
@@ -14,18 +14,21 @@
  * read-tolerance foundation the narrative slices build on.
  */
 
-// A value is treated as already-rich-text when it contains any tag from the
-// subset `htmlToPdfNodes` understands. Anything else is a legacy plain-text
-// line that gets escaped and wrapped as a single paragraph. The `\b` keeps
-// stray prose like "a < b" from looking like a tag.
-const RICH_TEXT_TAG = /<\/?(p|ul|ol|li|strong|b|em|i|br)\b[^>]*>/i;
+// A value is treated as already-rich-text when it contains ANY HTML tag — not
+// just the subset we render richly. The editor is bare StarterKit, so a write-up
+// can be made entirely of tags we fold to plain text downstream (a heading, a
+// code block); those must still reach `htmlToPdfNodes` as HTML rather than be
+// escaped and shown to the customer as literal `<h2>…</h2>` source. Anything with
+// no tag is a legacy plain-text line that gets escaped and wrapped as a single
+// paragraph. The `[a-z]` after `<` keeps stray prose like "a < b" from matching.
+const HTML_TAG = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
 export function normalizeSectionWriteup(
   description: string | null | undefined,
 ): string {
   const trimmed = description?.trim();
   if (!trimmed) return "";
-  if (RICH_TEXT_TAG.test(trimmed)) return trimmed;
+  if (HTML_TAG.test(trimmed)) return trimmed;
   const escaped = trimmed
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")


### PR DESCRIPTION
Closes #403

Implements #403 (Photo Report rework — slice: Section rich-text write-up + PDF section intro page). Parent PRD #397; decisions in [ADR 0009](docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md).

## What changed
- **Builder** (`photo-report-builder.tsx`): the section write-up is now edited with the shared `TiptapEditor` (same editor used on Estimates/Invoices/contracts). Its HTML flows through the existing `setSectionWriteup` reducer action into the Section's existing `description` field and auto-saves like every other edit.
- **PDF intro page** (`report-pdf/section-divider-page.tsx`): the section divider is now a section **intro page** — heading + rich-text write-up (paragraphs, bullet/numbered lists, bold/italic) — followed by the Section's photo pages. Read through the slice-1 `normalizeSectionWriteup()` tolerance and mapped via the shared `htmlToPdfNodes()`. An empty write-up renders **heading + photos only** (no blank block).
- **`htmlToPdfNodes()` hardening** (shared with estimate/invoice statements, now load-bearing for lists):
  - the tokenizer consumes *any* tag, fixing TipTap's `<li><p>…</p></li>` list serialization — previously the `<p>` remnants leaked into the rendered text and bullet/numbered lists were mangled (this also silently affected estimate/invoice statements);
  - empty / whitespace-only list items and empty lists now produce no node, so an emptied list is a truly empty write-up.
- Dropped the intro page's redundant horizontal padding so the write-up spans the same content width as the photo pages.

`buildReportDocument()` keeps its interface (no planner logic change); `generate-report-pdf.tsx` already forwards `description`.

## Acceptance criteria
- [x] Section write-up edited with the existing TiptapEditor; output HTML stored in the Section's `description`.
- [x] PDF renders each Section as an intro page (heading + write-up) followed by its photo pages.
- [x] A Section with an empty write-up renders heading + photos only (no blank intro block) — including emptied lists.
- [x] `htmlToPdfNodes()` test covers paragraphs, bullet vs numbered lists, bold/italic runs, the empty-paragraph guard, and `<img>` stripping.
- [x] `buildReportDocument` test asserts the cover → per-Section intro → photo-pages plan.

## Testing
- New `src/lib/pdf-renderer/html-to-pdf.test.tsx`; extended `section-divider-page`, `photo-report-builder` (TiptapEditor mocked), and `build-report-document` tests. All touched-area tests green (49 across the 6 affected files); `tsc` clean for the changed files; `eslint` clean.
- An adversarial multi-agent review ran over the diff. In-scope findings were fixed (empty-list stray block; redundant intro padding; `<b>/<i>` coverage). Deliberately deferred: the one-page cap + live counter (ADR 0009 — separate slice, per scope decision); `key={index}` section identity (pre-existing from #400, belongs to slice 2b/#401).

## Notes
- The full unit suite shows ~7 **pre-existing flaky** failures in unrelated subsystems (email accounts route, intake-form #195, estimate drag-end) plus jsdom relative-URL errors in referral-partners — counts vary between identical runs and none touch the files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Update — rich-text renderer hardened (commit 36e825d)

A follow-up audit found the section write-up editor is **bare StarterKit**, which emits more than `htmlToPdfNodes` rendered — headings, blockquotes, code blocks, `<hr>`, hard breaks (`<br>` / Shift+Enter), and nested lists. The renderer leaked tag-name fragments (e.g. `h2>`) into the customer PDF or silently collapsed content (`Line oneLine two`). Hardened in this PR:

- `htmlToPdfNodes`: normalize unsupported blocks before parsing (`<br>`→line break, headings/`<pre>`→paragraphs, unwrap `<blockquote>`, strip `<hr>`/`<img>`, drop `<code>` styling); replaced the non-greedy list regex with a **depth-aware scanner** that recurses nested lists (no dropped siblings, no leaked `</li>`/`</ul>`).
- `normalizeSectionWriteup`: detection inverted to treat **any** HTML tag as rich text, so a heading-only / code-only write-up is never escaped and shown as raw source.
- TDD coverage added for each case.

**Bonus:** the same latent leak in estimate/invoice **statements** (shared `StatementBlock`) is fixed too — links / merge-field pills / `<br>` previously rendered raw markup, now render clean text.
