### PR TITLE
feat(reports): section management + photo assignment in the Photo Report builder (#401)

### DIFF
--- a/src/app/jobs/[id]/reports/[reportId]/page.tsx
+++ b/src/app/jobs/[id]/reports/[reportId]/page.tsx
@@ -5,7 +5,6 @@ import { AlertCircle } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
 import PhotoReportBuilder from "@/components/photo-report-builder";
-import type { ReportSection } from "@/lib/build-initial-sections";
 import type { Photo, PhotoReport } from "@/lib/types";
 
 // The full-screen, Job-scoped Photo Report builder route (#400). Rendered
@@ -54,19 +53,16 @@ export default async function PhotoReportBuilderPage({
     notFound();
   }
 
-  const photoIds = (report.sections as ReportSection[]).flatMap(
-    (section) => section.photo_ids,
-  );
-
-  let photos: Photo[] = [];
-  if (photoIds.length > 0) {
-    const { data } = await supabase
-      .from("photos")
-      .select("*")
-      .in("id", photoIds)
-      .returns<Photo[]>();
-    photos = data ?? [];
-  }
+  // Load every photo on the Job (not just the ones already in the report) so
+  // the builder can add photos beyond the original selection (#401). Mirrors
+  // the Job Photos tab's ordering.
+  const { data: photoData } = await supabase
+    .from("photos")
+    .select("*")
+    .eq("job_id", jobId)
+    .order("created_at", { ascending: false })
+    .returns<Photo[]>();
+  const photos: Photo[] = photoData ?? [];
 
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 

--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -1,10 +1,13 @@
-// Issue #400 — Photo Report Rework, Slice 2a.
+// Issue #401 — Photo Report Rework, Slice 2b (extends #400, Slice 2a).
 //
-// Auto-save behavior for the in-Job Photo Report builder: editing persists a
-// debounced write with no explicit Save click, and nothing is written until an
-// edit actually happens. Mounts the real builder and drives it through the DOM,
-// mocking the Supabase client (to capture the write), next/navigation, sonner,
-// and the PDF generator. Follows the RTL pattern in estimate-drag-end.test.tsx.
+// Behavior of the in-Job Photo Report builder driven through the DOM: auto-save
+// (a debounced write with no explicit Save click, nothing written until an edit
+// happens) plus the slice-2b Section-management and photo-assignment operations
+// (add section, drag a photo into a section, remove a photo, reorder, remove a
+// section). Mounts the real builder, mocking the Supabase client (to capture the
+// write), @dnd-kit/core's DndContext (to capture onDragEnd), next/navigation,
+// sonner, and the PDF generator. Follows the RTL pattern in
+// estimate-drag-end.test.tsx.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
@@ -49,6 +52,30 @@ vi.mock("@/lib/generate-report-pdf", () => ({
   generateReportPDF: vi.fn(async () => "job-1/report-1.pdf"),
 }));
 
+// Mock @dnd-kit/core's DndContext to a passthrough that captures the real
+// onDragEnd, so a test can fire a synthetic drag without a pointer (the dnd-kit
+// RTL pattern from estimate-drag-end.test.tsx). The sortable hooks tolerate the
+// absent provider and render fine.
+let capturedOnDragEnd: ((e: unknown) => void) | null = null;
+vi.mock("@dnd-kit/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragEnd?: (e: unknown) => void;
+    }) => {
+      capturedOnDragEnd = onDragEnd ?? null;
+      return <>{children}</>;
+    },
+  };
+});
+
+import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
@@ -73,12 +100,21 @@ function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
 
 const noPhotos: Photo[] = [];
 
-function renderBuilder(report = makeReport()) {
+function makePhoto(id: string): Photo {
+  return {
+    id,
+    storage_path: `job-1/${id}.jpg`,
+    annotated_path: null,
+    caption: null,
+  } as Photo;
+}
+
+function renderBuilder(report = makeReport(), photos: Photo[] = noPhotos) {
   return render(
     <PhotoReportBuilder
       jobId="job-1"
       report={report}
-      photos={noPhotos}
+      photos={photos}
       supabaseUrl="https://example.supabase.co"
     />,
   );
@@ -172,5 +208,182 @@ describe("PhotoReportBuilder auto-save", () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(screen.getByText("Saved")).toBeTruthy();
+  });
+});
+
+describe("PhotoReportBuilder section + photo management", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    capturedOnDragEnd = null;
+    vi.useFakeTimers();
+  });
+
+  function lastSavedSections() {
+    const calls = h.updateMock.mock.calls;
+    return calls[calls.length - 1][0].sections as Array<{
+      title: string;
+      description: string;
+      photo_ids: string[];
+    }>;
+  }
+
+  it("adds a section and auto-saves it", async () => {
+    renderBuilder();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /add section/i }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const sections = lastSavedSections();
+    expect(sections).toHaveLength(2);
+    expect(sections[1].title).toBe("New section");
+  });
+
+  it("assigns a photo dragged from the tray into a section and auto-saves", async () => {
+    const report = makeReport({
+      sections: [{ title: "Photos", description: "", photo_ids: [] }],
+    });
+    renderBuilder(report, [makePhoto("p2")]);
+
+    // Synthetic drag of the tray photo p2 onto section 0 (no pointer needed).
+    act(() => {
+      capturedOnDragEnd?.({
+        active: {
+          id: "p2",
+          data: { current: { type: "photo", photoId: "p2" } },
+        },
+        over: {
+          id: "section-0",
+          data: { current: { type: "section", index: 0 } },
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(lastSavedSections()[0].photo_ids).toEqual(["p2"]);
+  });
+
+  it("removes a photo from the report and auto-saves", async () => {
+    const report = makeReport({
+      sections: [{ title: "Photos", description: "", photo_ids: ["p1"] }],
+    });
+    renderBuilder(report, [makePhoto("p1")]);
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Remove photo from report"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(lastSavedSections()[0].photo_ids).toEqual([]);
+  });
+
+  it("reorders sections via drag and auto-saves the new order", async () => {
+    const report = makeReport({
+      sections: [
+        { title: "A", description: "", photo_ids: [] },
+        { title: "B", description: "", photo_ids: [] },
+      ],
+    });
+    renderBuilder(report);
+
+    act(() => {
+      capturedOnDragEnd?.({
+        active: { id: "section-0", data: { current: { type: "section", index: 0 } } },
+        over: { id: "section-1", data: { current: { type: "section", index: 1 } } },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(lastSavedSections().map((s) => s.title)).toEqual(["B", "A"]);
+  });
+
+  it("confirms before removing a section with photos, dropping its photos on confirm", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const report = makeReport({
+      sections: [{ title: "Photos", description: "", photo_ids: ["p1"] }],
+    });
+    renderBuilder(report, [makePhoto("p1")]);
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Remove section"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(lastSavedSections()).toHaveLength(0);
+    confirmSpy.mockRestore();
+  });
+
+  it("keeps a photo-bearing section when the remove is cancelled", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    const report = makeReport({
+      sections: [{ title: "Photos", description: "", photo_ids: ["p1"] }],
+    });
+    renderBuilder(report, [makePhoto("p1")]);
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Remove section"));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(h.updateMock).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  it("never persists an empty report date, but still saves a valid one", async () => {
+    renderBuilder();
+    const dateInput = screen.getByLabelText("Report date");
+
+    // Clearing the native date picker must not trigger a (failing) save.
+    act(() => {
+      fireEvent.change(dateInput, { target: { value: "" } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    // A real date still persists.
+    act(() => {
+      fireEvent.change(dateInput, { target: { value: "2026-07-01" } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    expect(h.updateMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ report_date: "2026-07-01" }),
+    );
+  });
+
+  it("counts only photos that still exist in a section's label", () => {
+    const report = makeReport({
+      sections: [{ title: "Photos", description: "", photo_ids: ["p1", "ghost"] }],
+    });
+    renderBuilder(report, [makePhoto("p1")]);
+
+    // "ghost" no longer resolves to a Photo, so the label shows 1, not 2.
+    const label = screen.getByText(
+      (_, el) =>
+        el?.tagName === "P" && (el.textContent ?? "").startsWith("1 photo"),
+    );
+    expect(label).toBeTruthy();
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -2,7 +2,32 @@
 
 import { useEffect, useReducer, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, FileDown, Loader2 } from "lucide-react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useDraggable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ArrowLeft,
+  FileDown,
+  GripVertical,
+  Loader2,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { createClient } from "@/lib/supabase";
@@ -12,6 +37,7 @@ import {
   initBuilderState,
   photoReportBuilderReducer,
 } from "@/lib/photo-report-builder";
+import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
 import type { ReportSection } from "@/lib/build-initial-sections";
 import type { Photo, PhotoReport } from "@/lib/types";
 
@@ -24,7 +50,7 @@ type SaveStatus = "idle" | "saving" | "saved" | "error";
 interface PhotoReportBuilderProps {
   jobId: string;
   report: PhotoReport;
-  /** Photos referenced by the report's sections, for thumbnails. */
+  /** All of the Job's photos, so any can be added to the report (#401). */
   photos: Photo[];
   supabaseUrl: string;
 }
@@ -85,6 +111,21 @@ export default function PhotoReportBuilder({
     state.revision,
     report.id,
   ]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const action = resolvePhotoReportDragEnd(event);
+    if (action) dispatch(action);
+  }
+
+  // Photos already placed in a Section vs. the rest of the Job's photos, which
+  // sit in the "not in the report" tray and can be dragged into any Section.
+  const assignedIds = new Set(state.sections.flatMap((s) => s.photo_ids));
+  const availablePhotos = photos.filter((p) => !assignedIds.has(p.id));
 
   const handleGenerate = async () => {
     setGenerating(true);
@@ -162,74 +203,326 @@ export default function PhotoReportBuilder({
                 type="date"
                 aria-label="Report date"
                 value={state.reportDate}
-                onChange={(e) =>
-                  dispatch({ type: "setReportDate", reportDate: e.target.value })
-                }
+                onChange={(e) => {
+                  // Native date inputs can be cleared to "". report_date is a
+                  // NOT NULL column, so never persist an empty date — ignore the
+                  // change and keep the last valid one.
+                  if (e.target.value) {
+                    dispatch({
+                      type: "setReportDate",
+                      reportDate: e.target.value,
+                    });
+                  }
+                }}
                 className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
               />
             </label>
           </div>
 
-          {/* Sections */}
-          {state.sections.map((section, index) => (
-            <section
-              key={index}
-              className="rounded-xl border border-border bg-card p-4 space-y-3"
+          {/*
+            Slice-2b drag wiring. Two known low-severity follow-ups, left for a
+            later slice (no data impact here, controlled inputs keep displayed
+            values correct):
+              - Sections are addressed by array index (React key + sortable id),
+                because ReportSection has no stable id. A stable per-section id
+                would smooth dnd reorder animations and keep input focus/caret
+                pinned to a section across a reorder; it also touches the
+                persisted sections shape, so it is deferred.
+              - closestCenter targets the nearest section *center*; on very tall
+                section cards a photo dropped near an edge can land in the
+                neighbouring section. A pointer-based strategy would be more
+                precise.
+          */}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            {/* Sections */}
+            <SortableContext
+              items={state.sections.map((_, i) => `section-${i}`)}
+              strategy={verticalListSortingStrategy}
             >
-              <input
-                type="text"
-                aria-label="Section heading"
-                value={section.title}
-                onChange={(e) =>
-                  dispatch({
-                    type: "setSectionHeading",
-                    index,
-                    heading: e.target.value,
-                  })
-                }
-                placeholder="Section heading"
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-base font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
-              />
-              <textarea
-                aria-label="Section write-up"
-                value={section.description}
-                onChange={(e) =>
-                  dispatch({
-                    type: "setSectionWriteup",
-                    index,
-                    writeup: e.target.value,
-                  })
-                }
-                placeholder="Write-up"
-                rows={4}
-                className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
-              />
-              <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
-                {section.photo_ids.map((photoId) => {
-                  const photo = photosById.get(photoId);
-                  if (!photo) return null;
-                  return (
-                    <div
-                      key={photoId}
-                      className="aspect-square overflow-hidden rounded-lg"
-                    >
-                      <img
-                        src={photoUrl(photo, supabaseUrl, "grid")}
-                        alt={photo.caption || "Photo"}
-                        className="h-full w-full object-cover"
-                      />
-                    </div>
-                  );
-                })}
+              <div className="space-y-4">
+                {state.sections.map((section, index) => (
+                  <SortableSection
+                    key={index}
+                    index={index}
+                    section={section}
+                    photosById={photosById}
+                    supabaseUrl={supabaseUrl}
+                    dispatch={dispatch}
+                  />
+                ))}
               </div>
-              <p className="text-xs text-muted-foreground">
-                {section.photo_ids.length} photo
-                {section.photo_ids.length === 1 ? "" : "s"}
-              </p>
-            </section>
-          ))}
+            </SortableContext>
+
+            <button
+              type="button"
+              onClick={() => dispatch({ type: "addSection" })}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+            >
+              <Plus size={15} />
+              Add section
+            </button>
+
+            {/* Photos not yet in the report — drag into a Section to add. */}
+            <PhotoTray photos={availablePhotos} supabaseUrl={supabaseUrl} />
+          </DndContext>
         </div>
       </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SortableSection — a draggable/reorderable Section that is also the drop target
+// for photos dragged into it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function SortableSection({
+  index,
+  section,
+  photosById,
+  supabaseUrl,
+  dispatch,
+}: {
+  index: number;
+  section: ReportSection;
+  photosById: Map<string, Photo>;
+  supabaseUrl: string;
+  dispatch: React.Dispatch<
+    Parameters<typeof photoReportBuilderReducer>[1]
+  >;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: `section-${index}`, data: { type: "section", index } });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  function handleRemove() {
+    if (
+      section.photo_ids.length > 0 &&
+      !window.confirm(
+        "Delete this section? Its photos will be removed from the report (they stay on the job).",
+      )
+    ) {
+      return;
+    }
+    dispatch({ type: "removeSection", index });
+  }
+
+  // Count only photos that still resolve to a real Photo: an id can dangle if
+  // the photo was deleted from the Job after being added to the report, and the
+  // grid skips those — so the label must not count them.
+  const visibleCount = section.photo_ids.filter((id) =>
+    photosById.has(id),
+  ).length;
+
+  return (
+    <section
+      ref={setNodeRef}
+      style={style}
+      className="rounded-xl border border-border bg-card p-4 space-y-3"
+    >
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Drag to reorder section"
+          className="cursor-grab touch-none text-muted-foreground hover:text-foreground"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical size={16} />
+        </button>
+        <input
+          type="text"
+          aria-label="Section heading"
+          value={section.title}
+          onChange={(e) =>
+            dispatch({
+              type: "setSectionHeading",
+              index,
+              heading: e.target.value,
+            })
+          }
+          placeholder="Section heading"
+          className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-base font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+        />
+        <button
+          type="button"
+          aria-label="Remove section"
+          onClick={handleRemove}
+          className="text-muted-foreground hover:text-destructive transition-colors"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+
+      <textarea
+        aria-label="Section write-up"
+        value={section.description}
+        onChange={(e) =>
+          dispatch({
+            type: "setSectionWriteup",
+            index,
+            writeup: e.target.value,
+          })
+        }
+        placeholder="Write-up"
+        rows={4}
+        className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+      />
+
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
+        {section.photo_ids.map((photoId) => {
+          const photo = photosById.get(photoId);
+          if (!photo) return null;
+          return (
+            <DraggablePhoto
+              key={photoId}
+              photo={photo}
+              sectionIndex={index}
+              supabaseUrl={supabaseUrl}
+              dispatch={dispatch}
+            />
+          );
+        })}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {visibleCount} photo{visibleCount === 1 ? "" : "s"} — drag photos here to
+        add them
+      </p>
+    </section>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DraggablePhoto — a photo inside a Section: drag it to another Section, or
+// remove it from the report.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function DraggablePhoto({
+  photo,
+  sectionIndex,
+  supabaseUrl,
+  dispatch,
+}: {
+  photo: Photo;
+  sectionIndex: number;
+  supabaseUrl: string;
+  dispatch: React.Dispatch<
+    Parameters<typeof photoReportBuilderReducer>[1]
+  >;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({
+      id: photo.id,
+      data: { type: "photo", photoId: photo.id, sectionIndex },
+    });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="group relative aspect-square overflow-hidden rounded-lg"
+    >
+      <img
+        src={photoUrl(photo, supabaseUrl, "grid")}
+        alt={photo.caption || "Photo"}
+        className="h-full w-full cursor-grab touch-none object-cover"
+        {...attributes}
+        {...listeners}
+      />
+      <button
+        type="button"
+        aria-label="Remove photo from report"
+        onClick={() =>
+          dispatch({ type: "removePhotoFromReport", photoId: photo.id })
+        }
+        className="absolute right-1 top-1 rounded-full bg-black/55 p-1 text-white opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+      >
+        <X size={12} />
+      </button>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PhotoTray — the Job's photos that are not yet in the report; drag one into a
+// Section to add it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function PhotoTray({
+  photos,
+  supabaseUrl,
+}: {
+  photos: Photo[];
+  supabaseUrl: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-muted/30 p-4">
+      <h2 className="mb-2 text-xs font-medium text-muted-foreground">
+        Photos not in the report
+      </h2>
+      {photos.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Every photo on this job is already in the report.
+        </p>
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+          {photos.map((photo) => (
+            <TrayPhoto key={photo.id} photo={photo} supabaseUrl={supabaseUrl} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TrayPhoto({
+  photo,
+  supabaseUrl,
+}: {
+  photo: Photo;
+  supabaseUrl: string;
+}) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } =
+    useDraggable({ id: photo.id, data: { type: "photo", photoId: photo.id } });
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="aspect-square overflow-hidden rounded-lg"
+    >
+      <img
+        src={photoUrl(photo, supabaseUrl, "grid")}
+        alt={photo.caption || "Photo"}
+        className="h-full w-full cursor-grab touch-none object-cover"
+        {...attributes}
+        {...listeners}
+      />
     </div>
   );
 }

--- a/src/lib/photo-report-builder.test.ts
+++ b/src/lib/photo-report-builder.test.ts
@@ -1,9 +1,9 @@
-// Issue #400 — Photo Report Rework, Slice 2a.
+// Issue #401 — Photo Report Rework, Slice 2b (extends #400, Slice 2a).
 //
 // Tests for the pure "builder brain": turning a photo selection into the one
-// default Section a new report starts with, and the reducer that holds the
-// report while it is being edited (tracking what changed so auto-save knows
-// when to fire).
+// default Section a new report starts with, the reducer that holds the report
+// while it is being edited (tracking what changed so auto-save knows when to
+// fire), and the slice-2b Section-management + photo-assignment operations.
 
 import { describe, expect, it } from "vitest";
 
@@ -129,6 +129,163 @@ describe("photoReportBuilderReducer", () => {
       revision: second.revision,
     });
     expect(afterCurrentSave.dirty).toBe(false);
+  });
+
+  it("adds a new empty section to the end and marks the report dirty", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, { type: "addSection" });
+    expect(next.sections).toHaveLength(before.sections.length + 1);
+    const added = next.sections[next.sections.length - 1];
+    expect(added.title).toBe("New section");
+    expect(added.description).toBe("");
+    expect(added.photo_ids).toEqual([]);
+    // The sections that were already there are untouched.
+    expect(next.sections[0]).toEqual(before.sections[0]);
+    expect(next.dirty).toBe(true);
+  });
+
+  it("removes the section at the given index, dropping its photos from the report, and marks dirty", () => {
+    // A two-section report: [ Photos(p1,p2), New section() ].
+    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    const next = photoReportBuilderReducer(before, {
+      type: "removeSection",
+      index: 0,
+    });
+    expect(next.sections).toHaveLength(1);
+    expect(next.sections[0].title).toBe("New section");
+    // The removed section's photos are gone from the report entirely.
+    expect(next.sections.flatMap((s) => s.photo_ids)).not.toContain("p1");
+    expect(next.dirty).toBe(true);
+  });
+
+  it("ignores a remove for a section index that does not exist", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "removeSection",
+      index: 5,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("reorders a section to a new position and marks dirty", () => {
+    const before = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [
+        { title: "A", description: "", photo_ids: [] },
+        { title: "B", description: "", photo_ids: [] },
+        { title: "C", description: "", photo_ids: [] },
+      ],
+    });
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderSection",
+      from: 0,
+      to: 2,
+    });
+    expect(next.sections.map((s) => s.title)).toEqual(["B", "C", "A"]);
+    expect(next.dirty).toBe(true);
+  });
+
+  it("ignores a reorder with an out-of-range index", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderSection",
+      from: 0,
+      to: 9,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("treats reordering a section onto itself as a no-op", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderSection",
+      from: 0,
+      to: 0,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("assigns a photo into a section, appending it and marking dirty", () => {
+    // [ Photos(p1,p2), New section() ].
+    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    // Add a photo that is not yet anywhere in the report (add-to-report).
+    const next = photoReportBuilderReducer(before, {
+      type: "assignPhotoToSection",
+      photoId: "p9",
+      sectionIndex: 1,
+    });
+    expect(next.sections[1].photo_ids).toEqual(["p9"]);
+    expect(next.sections[0].photo_ids).toEqual(["p1", "p2"]);
+    expect(next.dirty).toBe(true);
+  });
+
+  it("moving a photo to another section removes it from the section it was in", () => {
+    // [ Photos(p1,p2), New section() ]; move p1 into section 1.
+    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    const next = photoReportBuilderReducer(before, {
+      type: "assignPhotoToSection",
+      photoId: "p1",
+      sectionIndex: 1,
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p2"]);
+    expect(next.sections[1].photo_ids).toEqual(["p1"]);
+  });
+
+  it("treats assigning a photo to the section it already occupies as a no-op", () => {
+    // loaded(): [ Photos(p1,p2) ]. p1 is already (only) in section 0, so
+    // re-assigning it there must change nothing — no reorder, no dirty, and the
+    // exact same state object back (mirrors removePhotoFromReport's no-op).
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "assignPhotoToSection",
+      photoId: "p1",
+      sectionIndex: 0,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("ignores assigning a photo to a section index that does not exist", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "assignPhotoToSection",
+      photoId: "p1",
+      sectionIndex: 9,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("removes a photo from the report, taking it out of its section and marking dirty", () => {
+    const before = loaded(); // [ Photos(p1,p2) ]
+    const next = photoReportBuilderReducer(before, {
+      type: "removePhotoFromReport",
+      photoId: "p1",
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p2"]);
+    expect(next.dirty).toBe(true);
+  });
+
+  it("ignores removing a photo that is not in the report", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "removePhotoFromReport",
+      photoId: "not-in-report",
+    });
+    expect(next).toBe(before);
+  });
+
+  it("bumps the revision on a section edit so an in-flight save cannot strand it", () => {
+    const before = loaded();
+    expect(
+      photoReportBuilderReducer(before, { type: "addSection" }).revision,
+    ).toBeGreaterThan(before.revision);
+    expect(
+      photoReportBuilderReducer(before, {
+        type: "assignPhotoToSection",
+        photoId: "p9",
+        sectionIndex: 0,
+      }).revision,
+    ).toBeGreaterThan(before.revision);
   });
 
   it("does not mutate the state it was handed", () => {

--- a/src/lib/photo-report-builder.ts
+++ b/src/lib/photo-report-builder.ts
@@ -1,4 +1,4 @@
-// Issue #400 — Photo Report Rework, Slice 2a.
+// Issue #401 — Photo Report Rework, Slice 2b (extends #400, Slice 2a).
 //
 // The pure "builder brain" for the in-Job Photo Report builder. It has no React
 // in it on purpose: the component wraps `photoReportBuilderReducer` in
@@ -7,15 +7,21 @@
 // (dispatch an action, assert the next state) and reusable on the server (the
 // create route uses `buildDefaultReportSections` to seed the draft row).
 //
-// Slice 2a holds a single default Section containing all the selected photos and
-// supports editing the report title/date and that section's heading + plain
-// write-up. Full multi-Section management and photo assignment are slice 2b, so
-// the action set is deliberately small and meant to grow.
+// Slice 2a seeded a report with a single default Section and supported editing
+// the report title/date and a Section's heading + plain write-up. Slice 2b grows
+// the action set to full Section management (add / remove / reorder) and photo
+// assignment (assign a photo to a Section, which also covers adding it to the
+// report and moving it between Sections; remove a photo from the report) — see
+// `photo-report-drag.ts` for the dnd-kit drag-end → action mapping. Photos live
+// only inside Sections (no holding pool); a photo lives in at most one Section.
 
 import type { ReportSection } from "./build-initial-sections";
 
 /** Heading the lone starter Section gets until the user renames it. */
 const DEFAULT_SECTION_TITLE = "Photos";
+
+/** Heading a freshly added (empty) Section gets until the user renames it. */
+const NEW_SECTION_TITLE = "New section";
 
 /**
  * Turn a photo selection into the one default Section a new report starts with
@@ -60,6 +66,11 @@ export type PhotoReportBuilderAction =
   | { type: "setReportDate"; reportDate: string }
   | { type: "setSectionHeading"; index: number; heading: string }
   | { type: "setSectionWriteup"; index: number; writeup: string }
+  | { type: "addSection" }
+  | { type: "removeSection"; index: number }
+  | { type: "reorderSection"; from: number; to: number }
+  | { type: "assignPhotoToSection"; photoId: string; sectionIndex: number }
+  | { type: "removePhotoFromReport"; photoId: string }
   | { type: "markSaved"; revision: number };
 
 /**
@@ -128,6 +139,100 @@ export function photoReportBuilderReducer(
         dirty: true,
         revision: state.revision + 1,
       };
+    case "addSection":
+      return {
+        ...state,
+        sections: [
+          ...state.sections,
+          { title: NEW_SECTION_TITLE, description: "", photo_ids: [] },
+        ],
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    case "removeSection":
+      // Removing a Section drops it and the photos it held from the report
+      // (photos live only inside Sections — there is no holding pool). The
+      // photos still exist on the Job, so they can be re-added later.
+      if (!isSectionIndex(state, action.index)) return state;
+      return {
+        ...state,
+        sections: state.sections.filter((_, i) => i !== action.index),
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    case "reorderSection": {
+      // Move a Section from one position to another, matching dnd-kit's
+      // arrayMove: the dragged Section lands at the target index and the others
+      // shift to fill the gap.
+      const { from, to } = action;
+      if (!isSectionIndex(state, from) || !isSectionIndex(state, to)) {
+        return state;
+      }
+      if (from === to) return state;
+      const sections = [...state.sections];
+      const [moved] = sections.splice(from, 1);
+      sections.splice(to, 0, moved);
+      return {
+        ...state,
+        sections,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    }
+    case "assignPhotoToSection": {
+      // Place a photo into exactly one Section. This single action covers
+      // adding a photo to the report (it was nowhere yet) and moving it between
+      // Sections (it gets removed from wherever it was first), keeping the
+      // invariant that a photo lives in at most one Section.
+      if (!isSectionIndex(state, action.sectionIndex)) return state;
+      // No-op when the photo already lives only in the target Section: there is
+      // nothing to add or move, so leave state untouched (preserve referential
+      // identity, don't dirty, don't reorder within the Section).
+      const alreadyInTarget =
+        state.sections[action.sectionIndex].photo_ids.includes(action.photoId);
+      const inAnotherSection = state.sections.some(
+        (section, i) =>
+          i !== action.sectionIndex &&
+          section.photo_ids.includes(action.photoId),
+      );
+      if (alreadyInTarget && !inAnotherSection) return state;
+      const sections = state.sections.map((section, i) => {
+        const without = section.photo_ids.filter((id) => id !== action.photoId);
+        if (i === action.sectionIndex) {
+          return { ...section, photo_ids: [...without, action.photoId] };
+        }
+        if (without.length === section.photo_ids.length) return section;
+        return { ...section, photo_ids: without };
+      });
+      return {
+        ...state,
+        sections,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    }
+    case "removePhotoFromReport": {
+      // Take a photo out of whatever Section holds it (there is at most one).
+      // Since photos live only inside Sections, this is the same as removing it
+      // from the report. A no-op (photo not present) leaves state untouched so
+      // it does not needlessly mark the report dirty.
+      let removed = false;
+      const sections = state.sections.map((section) => {
+        if (!section.photo_ids.includes(action.photoId)) return section;
+        removed = true;
+        return {
+          ...section,
+          photo_ids: section.photo_ids.filter((id) => id !== action.photoId),
+        };
+      });
+      if (!removed) return state;
+      return {
+        ...state,
+        sections,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    }
     case "markSaved":
       // Only clear dirty if the write that just landed was for the *current*
       // revision. If an edit happened while the save was in flight, the state

--- a/src/lib/photo-report-drag.test.ts
+++ b/src/lib/photo-report-drag.test.ts
@@ -1,0 +1,64 @@
+// Issue #401 — Photo Report Rework, Slice 2b.
+//
+// Tests for the pure drag-end resolver: it maps a dnd-kit DragEndEvent (active +
+// over, each carrying a `data.current` descriptor the builder attaches) into a
+// single builder reducer action, or null when the drop is a no-op. Isolated from
+// React so it can be unit tested in plain Node (mirrors move-line-item.ts).
+
+import { describe, expect, it } from "vitest";
+
+import { resolvePhotoReportDragEnd } from "./photo-report-drag";
+
+function section(id: string, index: number) {
+  return { id, data: { current: { type: "section", index } } };
+}
+
+function photo(id: string, sectionIndex: number) {
+  return { id, data: { current: { type: "photo", photoId: id, sectionIndex } } };
+}
+
+describe("resolvePhotoReportDragEnd", () => {
+  it("maps a section dropped onto another section to a reorder", () => {
+    const action = resolvePhotoReportDragEnd({
+      active: section("s0", 0),
+      over: section("s2", 2),
+    });
+    expect(action).toEqual({ type: "reorderSection", from: 0, to: 2 });
+  });
+
+  it("returns null when there is no drop target", () => {
+    expect(
+      resolvePhotoReportDragEnd({ active: section("s0", 0), over: null }),
+    ).toBeNull();
+  });
+
+  it("maps a photo dropped onto a section to an assignment into that section", () => {
+    const action = resolvePhotoReportDragEnd({
+      active: photo("p1", 0),
+      over: section("s1", 1),
+    });
+    expect(action).toEqual({
+      type: "assignPhotoToSection",
+      photoId: "p1",
+      sectionIndex: 1,
+    });
+  });
+
+  it("treats dropping a photo back onto its own section as a no-op", () => {
+    // No within-section reordering this slice — a same-section drop changes
+    // nothing rather than surprising the user by jumping the photo to the end.
+    // (Sections are the only drop targets, so `over` is always a section.)
+    expect(
+      resolvePhotoReportDragEnd({ active: photo("p1", 0), over: section("s0", 0) }),
+    ).toBeNull();
+  });
+
+  it("returns null for an unrecognized drag descriptor", () => {
+    expect(
+      resolvePhotoReportDragEnd({
+        active: { id: "x", data: { current: { type: "mystery" } } },
+        over: section("s1", 1),
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/photo-report-drag.ts
+++ b/src/lib/photo-report-drag.ts
@@ -1,0 +1,68 @@
+// Issue #401 — Photo Report Rework, Slice 2b.
+//
+// The pure drag-end resolver for the in-Job Photo Report builder. It maps a
+// dnd-kit DragEndEvent into a single builder reducer action (or null for a
+// no-op), so the component's onDragEnd is a one-liner and the mapping is unit
+// testable without React. Mirrors estimate-builder/move-line-item.ts.
+//
+// The builder attaches a `data.current` descriptor to each node:
+//   - a Section container (the only drop target): { type: "section", index }
+//   - a Photo (a drag source only): { type: "photo", photoId, sectionIndex? }
+//     A photo already in a Section carries its sectionIndex; a photo in the "not
+//     in the report" tray carries none. Photos are draggable but not droppable,
+//     so a drop's `over` is always a Section (or null).
+
+import type { PhotoReportBuilderAction } from "./photo-report-builder";
+
+interface DragNode {
+  id: string | number;
+  data?: { current?: Record<string, unknown> | null } | null;
+}
+
+export interface PhotoReportDragEndEvent {
+  active: DragNode;
+  over?: DragNode | null;
+}
+
+export function resolvePhotoReportDragEnd(
+  event: PhotoReportDragEndEvent,
+): PhotoReportBuilderAction | null {
+  const { active, over } = event;
+  if (!over) return null;
+  const activeData = active.data?.current ?? null;
+  const overData = over.data?.current ?? null;
+  if (!activeData || !overData) return null;
+
+  if (activeData.type === "section") {
+    const from = numberOrNull(activeData.index);
+    const to = overData.type === "section" ? numberOrNull(overData.index) : null;
+    if (from === null || to === null || from === to) return null;
+    return { type: "reorderSection", from, to };
+  }
+
+  if (activeData.type === "photo") {
+    const photoId = typeof activeData.photoId === "string" ? activeData.photoId : null;
+    const sectionIndex = dropTargetSectionIndex(overData);
+    if (photoId === null || sectionIndex === null) return null;
+    // A photo dropped back onto the Section it already belongs to is a no-op (no
+    // within-section reordering this slice). Tray photos carry no sectionIndex,
+    // so they always assign.
+    if (numberOrNull(activeData.sectionIndex) === sectionIndex) return null;
+    return { type: "assignPhotoToSection", photoId, sectionIndex };
+  }
+
+  return null;
+}
+
+// The Section index a drop lands in. Sections are the only drop targets (photos
+// are draggable but not droppable), so a drop's `over` is always a Section.
+function dropTargetSectionIndex(
+  overData: Record<string, unknown>,
+): number | null {
+  if (overData.type === "section") return numberOrNull(overData.index);
+  return null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}


### PR DESCRIPTION
## What this is

Slice 2b of the Photo Report rework (PRD #397, builds on #400). The full-screen, Job-scoped builder now supports **multi-Section management** and **arranging photos among Sections**, all through the existing debounced auto-save.

Closes #401.

## Behaviour

- **Sections:** add, remove, and **drag to reorder**. Removing a Section drops its photos from the report (they stay on the Job and can be re-added) — per the owner's decision.
- **Photos:** **drag** a photo to assign it to a Section. One action covers adding a photo to the report, and moving it between Sections; a photo lives in **exactly one** Section. Remove a photo from the report from its thumbnail.
- **Not locked to the original selection:** the builder page now loads **all** of the Job's photos (RLS-scoped to the active Organization), and a "not in the report" tray lets you drag any of them in.
- **Auto-save:** every new operation flows through the same revision-guarded debounced write from slice 2a, so nothing is lost when an edit lands during an in-flight save.

Out of scope for this slice (per PRD/ADR 0009): rich-text (TipTap) write-ups and the one-page cap.

## Design

Two pure, fully unit-tested modules do the work; the React component is a thin layer over them (mirrors the estimate builder's `move-line-item.ts` pattern):

- `photo-report-builder.ts` — the reducer gains `addSection` / `removeSection` / `reorderSection` / `assignPhotoToSection` / `removePhotoFromReport`.
- `photo-report-drag.ts` (new) — maps a `@dnd-kit` drag-end into a single reducer action.

Sections are addressed by index (the persisted `sections` JSON has no per-section id), so the dnd ids/keys are index-based this slice — a documented, low-impact follow-up (see the comment in the builder).

## Notable fix found in review

An adversarial multi-agent review caught a real data-loss path: clearing the report-date input sent `report_date: ""` to a `NOT NULL date` column, which errored the save and left the builder permanently dirty (silent session-wide save loss). The date input now ignores empty values. The same review also tightened `assignPhotoToSection` to a true no-op when nothing changes, removed an unreachable drag branch, and fixed a photo-count label that counted deleted-photo ids.

## Tests

- 41 tests across the reducer, the drag resolver, and the component (auto-save, add section, drag-assign from the tray, remove photo, reorder by drag, remove-section confirm, empty-date guard, dangling-id count).
- `tsc` and `eslint` clean on the changed files; full suite shows no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
