### PR TITLE
chore(photos): sync photo schema snapshot + types to prod (#412)

### DIFF
--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -76,6 +76,9 @@ function makePhoto(overrides: Partial<Photo> = {}): Photo {
     before_after_pair_id: null,
     before_after_role: null,
     created_at: "2026-05-20T00:00:00Z",
+    organization_id: "org-1",
+    uploaded_from: "web",
+    client_capture_id: null,
     ...overrides,
   };
 }

--- a/src/components/job-cover-picker.test.tsx
+++ b/src/components/job-cover-picker.test.tsx
@@ -61,6 +61,9 @@ function makePhoto(overrides: Partial<Photo> = {}): Photo {
     before_after_pair_id: null,
     before_after_role: null,
     created_at: "2026-05-20T00:00:00Z",
+    organization_id: "org-1",
+    uploaded_from: "web",
+    client_capture_id: null,
     ...overrides,
   };
 }

--- a/src/lib/build-initial-sections.test.ts
+++ b/src/lib/build-initial-sections.test.ts
@@ -15,6 +15,7 @@ function makePreset(
 ): PhotoReportTemplate {
   return {
     id: "preset-1",
+    organization_id: "org-1",
     name: "Insurance Adjuster Report",
     audience: "adjuster",
     sections,

--- a/src/lib/jobs/jobs-with-cover.test.ts
+++ b/src/lib/jobs/jobs-with-cover.test.ts
@@ -26,6 +26,9 @@ function photo(overrides: Partial<Photo> = {}): Photo {
     before_after_pair_id: null,
     before_after_role: null,
     created_at: "2026-05-20T00:00:00Z",
+    organization_id: "org-1",
+    uploaded_from: "web",
+    client_capture_id: null,
     ...overrides,
   };
 }

--- a/src/lib/mobile/mock-photo-tags.ts
+++ b/src/lib/mobile/mock-photo-tags.ts
@@ -13,6 +13,7 @@ export const MOCK_PHOTO_TAGS: PhotoTag[] = [
     color: "#dc2626",
     created_by: "mock",
     created_at: "2026-04-29T00:00:00.000Z",
+    organization_id: "mock-org",
   },
   {
     id: "mock-tag-during",
@@ -20,6 +21,7 @@ export const MOCK_PHOTO_TAGS: PhotoTag[] = [
     color: "#f59e0b",
     created_by: "mock",
     created_at: "2026-04-29T00:00:00.000Z",
+    organization_id: "mock-org",
   },
   {
     id: "mock-tag-after",
@@ -27,6 +29,7 @@ export const MOCK_PHOTO_TAGS: PhotoTag[] = [
     color: "#16a34a",
     created_by: "mock",
     created_at: "2026-04-29T00:00:00.000Z",
+    organization_id: "mock-org",
   },
   {
     id: "mock-tag-damage",
@@ -34,6 +37,7 @@ export const MOCK_PHOTO_TAGS: PhotoTag[] = [
     color: "#7c3aed",
     created_by: "mock",
     created_at: "2026-04-29T00:00:00.000Z",
+    organization_id: "mock-org",
   },
   {
     id: "mock-tag-equipment",
@@ -41,5 +45,6 @@ export const MOCK_PHOTO_TAGS: PhotoTag[] = [
     color: "#0284c7",
     created_by: "mock",
     created_at: "2026-04-29T00:00:00.000Z",
+    organization_id: "mock-org",
   },
 ];

--- a/src/lib/mobile/use-photo-tags.ts
+++ b/src/lib/mobile/use-photo-tags.ts
@@ -22,7 +22,7 @@ export function usePhotoTags(): UsePhotoTagsResult {
         const supabase = createClient();
         const { data, error: fetchError } = await supabase
           .from("photo_tags")
-          .select("id, name, color, created_by, created_at")
+          .select("id, name, color, created_by, created_at, organization_id")
           .order("name");
         if (cancelled) return;
         if (fetchError) {

--- a/src/lib/photos-schema-drift.test.ts
+++ b/src/lib/photos-schema-drift.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Drift guard for the photo-system schema snapshot (issue #412).
+ *
+ * Every photo-domain table in production carries an `organization_id`
+ * (uuid NOT NULL, FK -> organizations) for multi-tenant isolation. The
+ * snapshot in `supabase/schema-photos.sql` had drifted and omitted it on all
+ * six tables. This test fails if any photo table's CREATE TABLE block stops
+ * declaring `organization_id`, catching a future re-drift before it ships.
+ *
+ * Vitest runs with the repo root as cwd, so the snapshot resolves relative to
+ * `process.cwd()`.
+ */
+const SCHEMA_PATH = path.join(process.cwd(), "supabase", "schema-photos.sql");
+
+const PHOTO_TABLES = [
+  "photos",
+  "photo_tags",
+  "photo_tag_assignments",
+  "photo_annotations",
+  "photo_report_templates",
+  "photo_reports",
+] as const;
+
+/**
+ * Return the body of `CREATE TABLE <table> ( ... );` from the snapshot. The
+ * statement terminator is a line-leading `);`; mid-column parens
+ * (`gen_random_uuid()`, `CHECK (... )`) never sit at the start of a line, so a
+ * non-greedy match stops at the real table terminator.
+ */
+function createTableBlock(sql: string, table: string): string {
+  const match = sql.match(
+    new RegExp(`CREATE TABLE ${table}\\s*\\(([\\s\\S]*?)\\n\\);`)
+  );
+  if (!match) {
+    throw new Error(
+      `No CREATE TABLE block found for "${table}" in schema-photos.sql`
+    );
+  }
+  return match[1];
+}
+
+describe("schema-photos.sql multi-tenant drift guard", () => {
+  const sql = readFileSync(SCHEMA_PATH, "utf8");
+
+  it.each(PHOTO_TABLES)(
+    "declares organization_id on the %s table",
+    (table) => {
+      const block = createTableBlock(sql, table);
+      expect(block).toMatch(/\borganization_id\b/);
+    }
+  );
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -154,6 +154,8 @@ export interface Payment {
 
 export interface Photo {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   job_id: string;
   storage_path: string;
   annotated_path: string | null;
@@ -167,6 +169,10 @@ export interface Photo {
   before_after_pair_id: string | null;
   before_after_role: "before" | "after" | null;
   created_at: string;
+  /** Capture origin, e.g. "web" | "mobile" (free text in the DB; no CHECK). */
+  uploaded_from: string;
+  /** Mobile offline-capture idempotency key; null for web uploads. */
+  client_capture_id: string | null;
   // Joined fields
   job?: Job;
   tags?: PhotoTag[];
@@ -174,6 +180,8 @@ export interface Photo {
 
 export interface PhotoTag {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   name: string;
   color: string;
   created_by: string;
@@ -182,6 +190,8 @@ export interface PhotoTag {
 
 export interface PhotoTagAssignment {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   photo_id: string;
   tag_id: string;
   created_at: string;
@@ -190,6 +200,8 @@ export interface PhotoTagAssignment {
 
 export interface PhotoAnnotation {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   photo_id: string;
   annotation_data: Record<string, unknown>;
   created_by: string;
@@ -199,6 +211,8 @@ export interface PhotoAnnotation {
 
 export interface PhotoReportTemplate {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   name: string;
   audience: "adjuster" | "customer" | "internal" | "general";
   sections: unknown[];

--- a/supabase/schema-photos.sql
+++ b/supabase/schema-photos.sql
@@ -2,6 +2,13 @@
 -- AAA Disaster Recovery — Photo System Schema
 -- Run this in the Supabase SQL Editor
 -- ============================================
+--
+-- Multi-tenancy note: every table below carries `organization_id`
+-- (uuid NOT NULL, FK -> organizations) and is guarded by a per-tenant
+-- `tenant_isolation_*` RLS policy. Those objects assume the core multi-tenant
+-- schema already exists — the `organizations` and `user_organizations` tables
+-- and the `nookleus.active_organization_id()` helper — just as this file
+-- already assumes `jobs` and `update_updated_at()`. Run the core schema first.
 
 -- ============================================
 -- 1. PHOTOS
@@ -22,7 +29,10 @@ CREATE TABLE photos (
   before_after_pair_id uuid REFERENCES photos(id),
   before_after_role text
     CHECK (before_after_role IN ('before', 'after')),
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
+  uploaded_from text NOT NULL DEFAULT 'web',   -- 'web' | 'mobile' (free text; no CHECK in prod)
+  client_capture_id text                       -- mobile offline-capture idempotency key (#65c)
 );
 
 -- ============================================
@@ -30,24 +40,28 @@ CREATE TABLE photos (
 -- ============================================
 CREATE TABLE photo_tags (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  name text UNIQUE NOT NULL,
+  name text NOT NULL,
   color text NOT NULL DEFAULT '#2B5EA7',
   created_by text NOT NULL DEFAULT 'Eric',
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id)
 );
 
--- Seed default tags
-INSERT INTO photo_tags (name, color) VALUES
-  ('Initial Damage', '#C41E2A'),
-  ('Moisture Reading', '#2B5EA7'),
-  ('Equipment Setup', '#633806'),
-  ('Drying Progress', '#0F6E56'),
-  ('Final Dry', '#085041'),
-  ('Mold Found', '#27500A'),
-  ('Repairs', '#6C5CE7'),
-  ('Customer Approval', '#7A5E00'),
-  ('Before', '#791F1F'),
-  ('After', '#0F6E56');
+-- Tag names are unique per Organization, not globally (see the
+-- photo_tags_org_name_key unique index below). Default tags are now seeded
+-- per-Organization by the app, so the original global seed INSERT no longer
+-- applies under multi-tenancy and is kept here only as a reference list:
+--   INSERT INTO photo_tags (name, color) VALUES
+--     ('Initial Damage', '#C41E2A'),
+--     ('Moisture Reading', '#2B5EA7'),
+--     ('Equipment Setup', '#633806'),
+--     ('Drying Progress', '#0F6E56'),
+--     ('Final Dry', '#085041'),
+--     ('Mold Found', '#27500A'),
+--     ('Repairs', '#6C5CE7'),
+--     ('Customer Approval', '#7A5E00'),
+--     ('Before', '#791F1F'),
+--     ('After', '#0F6E56');
 
 -- ============================================
 -- 3. PHOTO TAG ASSIGNMENTS (many-to-many)
@@ -57,6 +71,7 @@ CREATE TABLE photo_tag_assignments (
   photo_id uuid NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
   tag_id uuid NOT NULL REFERENCES photo_tags(id) ON DELETE CASCADE,
   created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id),
   UNIQUE(photo_id, tag_id)
 );
 
@@ -69,7 +84,8 @@ CREATE TABLE photo_annotations (
   annotation_data jsonb NOT NULL DEFAULT '{}',
   created_by text NOT NULL DEFAULT 'Eric',
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id)
 );
 
 -- ============================================
@@ -85,7 +101,8 @@ CREATE TABLE photo_report_templates (
   photos_per_page integer NOT NULL DEFAULT 2,
   created_by text NOT NULL DEFAULT 'Eric',
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id)
 );
 
 -- ============================================
@@ -105,7 +122,8 @@ CREATE TABLE photo_reports (
   created_by text NOT NULL DEFAULT 'Eric',
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
-  deleted_at timestamptz                       -- soft-delete for the recoverable trash (#402); NULL = not deleted
+  deleted_at timestamptz,                      -- soft-delete for the recoverable trash (#402); NULL = not deleted
+  organization_id uuid NOT NULL REFERENCES organizations(id)
 );
 
 -- ============================================
@@ -121,7 +139,7 @@ CREATE TRIGGER trg_photo_reports_updated_at
   BEFORE UPDATE ON photo_reports FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
 -- ============================================
--- ROW LEVEL SECURITY (open for now)
+-- ROW LEVEL SECURITY (multi-tenant isolation)
 -- ============================================
 ALTER TABLE photos ENABLE ROW LEVEL SECURITY;
 ALTER TABLE photo_tags ENABLE ROW LEVEL SECURITY;
@@ -130,12 +148,124 @@ ALTER TABLE photo_annotations ENABLE ROW LEVEL SECURITY;
 ALTER TABLE photo_report_templates ENABLE ROW LEVEL SECURITY;
 ALTER TABLE photo_reports ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Allow all on photos" ON photos FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on photo_tags" ON photo_tags FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on photo_tag_assignments" ON photo_tag_assignments FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on photo_annotations" ON photo_annotations FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on photo_report_templates" ON photo_report_templates FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on photo_reports" ON photo_reports FOR ALL USING (true) WITH CHECK (true);
+-- Each photo-domain table is scoped to the caller's active Organization: the
+-- row's organization_id must be non-null, equal to
+-- nookleus.active_organization_id(), and the caller must belong to that
+-- Organization (user_organizations). USING and WITH CHECK are identical so the
+-- same predicate gates reads, writes, and inserts.
+CREATE POLICY tenant_isolation_photos ON photos
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photos.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photos.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_photo_tags ON photo_tags
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_tags.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_tags.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_photo_tag_assignments ON photo_tag_assignments
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_tag_assignments.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_tag_assignments.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_photo_annotations ON photo_annotations
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_annotations.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_annotations.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_photo_report_templates ON photo_report_templates
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_report_templates.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_report_templates.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_photo_reports ON photo_reports
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_reports.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = photo_reports.organization_id
+    )
+  );
 
 -- ============================================
 -- INDEXES
@@ -146,6 +276,22 @@ CREATE INDEX idx_photo_tag_assignments_photo_id ON photo_tag_assignments(photo_i
 CREATE INDEX idx_photo_tag_assignments_tag_id ON photo_tag_assignments(tag_id);
 CREATE INDEX idx_photo_annotations_photo_id ON photo_annotations(photo_id);
 CREATE INDEX idx_photo_reports_job_id ON photo_reports(job_id);
+
+-- Per-tenant lookup indexes (one per photo-domain table)
+CREATE INDEX idx_photos_organization_id ON photos(organization_id);
+CREATE INDEX idx_photo_tags_organization_id ON photo_tags(organization_id);
+CREATE INDEX idx_photo_tag_assignments_organization_id ON photo_tag_assignments(organization_id);
+CREATE INDEX idx_photo_annotations_organization_id ON photo_annotations(organization_id);
+CREATE INDEX idx_photo_report_templates_organization_id ON photo_report_templates(organization_id);
+CREATE INDEX idx_photo_reports_organization_id ON photo_reports(organization_id);
+
+-- Tag names unique per Organization (replaces the old global UNIQUE(name))
+CREATE UNIQUE INDEX photo_tags_org_name_key ON photo_tags(organization_id, name);
+
+-- Mobile offline-capture idempotency: one row per (organization_id, client_capture_id)
+CREATE UNIQUE INDEX photos_org_client_capture_id_key
+  ON photos(organization_id, client_capture_id)
+  WHERE client_capture_id IS NOT NULL;
 
 -- ============================================
 -- STORAGE BUCKET FOR REPORT PDFs


### PR DESCRIPTION
Closes #412.

The photo-system schema snapshot (`supabase/schema-photos.sql`) and the
`Photo*` types had drifted from production's multi-tenancy build. This
reconciles both to mirror prod exactly (full prod-faithful, per the agreed
scope).

## `schema-photos.sql`
- `organization_id` (uuid NOT NULL, FK -> organizations) on **all six** photo
  tables, plus a per-tenant index on each
- `photos.uploaded_from` + `client_capture_id`, and the partial unique on
  `(organization_id, client_capture_id)`
- `photo_tags`: global `name UNIQUE` -> `UNIQUE(organization_id, name)`
- every `"Allow all"` RLS policy replaced with prod's `tenant_isolation_*`
- header note on the `organizations` / `user_organizations` /
  `nookleus.active_organization_id()` dependency; the obsolete global tag-seed
  `INSERT` is commented out (tags are now seeded per-Organization by the app)

## `types.ts`
- required `organization_id` added to `Photo`, `PhotoTag`,
  `PhotoTagAssignment`, `PhotoAnnotation`, `PhotoReportTemplate`
  (`PhotoReport` already had it from #400)
- `uploaded_from` / `client_capture_id` added to `Photo`
- fixtures + `use-photo-tags` `.select` updated for the new required fields

## Test / verification
- New `src/lib/photos-schema-drift.test.ts` guards each photo table's
  `organization_id` (RED before, GREEN after) against future re-drift
- `tsc --noEmit` clean for the touched types (only 2 unrelated pre-existing
  baseline errors remain)
- All photo-affected test files pass (52 tests); the few full-suite failures
  are pre-existing, non-photo, environmental
- **No DB migration**: every column already exists in prod and all six insert
  sites already supply `organization_id`. The edited snapshot + types were
  verified column-for-column against the live DB (columns, types, nullability,
  FKs, indexes, unique constraints, RLS policies) across all six tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
