### PR TITLE
test: fix pre-existing red tests — referral-partners fetch + 2 tsc test errors (#413)

### DIFF
--- a/src/app/referral-partners/[id]/page.test.tsx
+++ b/src/app/referral-partners/[id]/page.test.tsx
@@ -13,7 +13,7 @@
 // `src/components/referral-partners/referral-partner-worksheet.test.tsx`;
 // this file only verifies the page wires that component up correctly.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 
 vi.mock("@/lib/supabase-server", () => ({
@@ -48,6 +48,24 @@ import {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  // When the page renders the Worksheet, its Jobs-sent section fires a GET to
+  // /api/referral-partners/[id]/jobs on mount. jsdom has no document base URL,
+  // so an unstubbed relative fetch throws ERR_INVALID_URL and surfaces as an
+  // unhandled rejection that fails the file. These page tests don't assert on
+  // that call — the Worksheet's own fetch behaviour is pinned in
+  // referral-partner-worksheet.test.tsx — so stub fetch to a benign no-op.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ jobs: [] }),
+    })),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
 });
 
 function useUser(opts: Parameters<typeof fakeUserClient>[0]) {

--- a/src/components/estimate-builder/template-drag-end.test.tsx
+++ b/src/components/estimate-builder/template-drag-end.test.tsx
@@ -252,9 +252,11 @@ describe("EstimateBuilder template drag-end", () => {
   it("reorders a Line item within its own container (regression for existing reorder)", () => {
     // Use an entity with two items in the same container so we can swap them.
     const entity = makeTemplateEntity();
-    const s1 = entity.data.kind === undefined ? null : null;
-    void s1;
-    const template = (entity as { data: TemplateWithContents }).data;
+    // Narrow the builder union to its template variant via the discriminant
+    // (`kind` lives on the entity, not on `data`) so we can reach into
+    // `sections` without an `as` cast.
+    if (entity.kind !== "template") throw new Error("expected a template entity");
+    const template = entity.data;
     template.sections[0].items.push({
       id: "B",
       library_item_id: null,

--- a/src/lib/email/sync-folder-incremental.test.ts
+++ b/src/lib/email/sync-folder-incremental.test.ts
@@ -243,7 +243,10 @@ describe("syncFolderIncremental", () => {
         throw new Error("Mailbox unavailable");
       }),
       mailboxClose: vi.fn(async () => undefined),
-      fetch: vi.fn(),
+      // Typed so the mock matches ImapClientLike["fetch"] — a bare vi.fn()
+      // infers Mock<Procedure | Constructable>, which isn't callable as the
+      // fetch signature. It's never invoked here (mailboxOpen throws first).
+      fetch: vi.fn<ImapClientLike["fetch"]>(),
     };
 
     const result = await syncFolderIncremental({


### PR DESCRIPTION
Addresses **#413** — the three documented pre-existing red tests. Test files only; **no production code changed**.

## What changed

| # | File | Fix |
|---|------|-----|
| A | `src/app/referral-partners/[id]/page.test.tsx` | Stub global `fetch` in `beforeEach` (+ `afterEach` cleanup). The page tests render the Worksheet, whose Jobs-sent section fires a relative-URL GET on mount; jsdom has no base URL, so the unstubbed fetch threw `ERR_INVALID_URL` → 3 unhandled rejections. These tests don't assert on that call (the Worksheet's own fetch behaviour stays pinned in `referral-partner-worksheet.test.tsx`). |
| B1 | `src/components/estimate-builder/template-drag-end.test.tsx` | Narrow `BuilderEntity` via its `kind` discriminant (which lives on the entity, not on `data`) instead of dead code reading `entity.data.kind`. Fixes **TS2339** and drops an `as` cast. |
| B2 | `src/lib/email/sync-folder-incremental.test.ts` | Type the never-called fetch mock as `ImapClientLike["fetch"]`; a bare `vi.fn()` infers `Mock<Procedure \| Constructable>`, not callable as the fetch signature. Fixes **TS2322**. |

## Verification (independently re-checked)

- ✅ The three targeted test files pass — **13/13** tests; the 3 `ERR_INVALID_URL` unhandled rejections (A) are gone.
- ✅ Both #413 `tsc --noEmit` errors are eliminated — **B1** (`template-drag-end` TS2339) and **B2** (`sync-folder-incremental` TS2322) are present on `main`, absent on this branch.

## ⚠️ The two issue ACs ("full vitest green", "tsc 0 errors") are NOT met — and can't be, in this scope

> **Correction to earlier drafts of this description** (which claimed `tsc → 0 errors` and listed an "email-accounts 403 real bug" + a 5-file failure list): **all of that was inaccurate.** This PR removes only the two *#413-attributable* tsc errors; tsc and `vitest run` remain red for reasons unrelated to #413.

The remaining failures were independently re-verified and split into (i) a **broken local `node_modules` install** (`@react-pdf/renderer` / `imapflow` / `sharp` empty dirs → ~26 tsc errors + 17 import-failure test files; fixed by `npm ci`), (ii) a **Node-25 `localStorage` artifact** (this box runs Node 25; project targets Node 20), and (iii) a small set of **genuine, install-independent failures** (a stale `settings/templates` tab test, a real-or-stale `jobs/[id]/reports` 404→201, a flaky State-Farm picker test).

➡️ Full verified breakdown and the recommended split live in **#475**.

**Recommendation:** merge this for its documented scope (the three #413 fixes); track the rest in **#475**. #413's literal "full green / 0 errors" ACs can close once #475 lands and the suite is run on a healthy Node-20 install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
