### PR TITLE
fix(email): admins can create Email accounts without an explicit send_email grant (#431)

### DIFF
--- a/src/lib/email/email-account-access.test.ts
+++ b/src/lib/email/email-account-access.test.ts
@@ -224,24 +224,35 @@ describe("canCreateEmailAccount", () => {
 
   describe("belt-and-suspenders send_email re-check", () => {
     // The route wrapper already gates send_email. The function re-checks
-    // defensively — if a future caller wires the function in without the
-    // wrapper, the answer must still be no.
-    it("admin without send_email creating Shared: denied", () => {
+    // defensively — if a future caller wires it in without the wrapper, a
+    // non-admin with no send_email grant must still be denied. Admins are
+    // exempt: like the read-side evaluator and every other permission gate
+    // in the app, the admin role passes without holding the explicit grant.
+    it("admin without send_email creating Shared: allowed (admin bypass)", () => {
       expect(
         canCreateEmailAccount(
           caller({ role: "admin", grantedPermissions: [] }),
           shared(),
         ),
-      ).toBe(false);
+      ).toBe(true);
     });
 
-    it("admin without send_email creating Personal-as-self: denied", () => {
+    it("admin without send_email creating Personal-as-self: allowed (admin bypass)", () => {
       expect(
         canCreateEmailAccount(
           caller({ role: "admin", grantedPermissions: [] }),
           personal(ALICE),
         ),
-      ).toBe(false);
+      ).toBe(true);
+    });
+
+    it("admin without send_email creating Personal-on-behalf-of-another: allowed (admin bypass)", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "admin", grantedPermissions: [] }),
+          personal(BOB),
+        ),
+      ).toBe(true);
     });
 
     it("non-admin without send_email creating Personal-as-self: denied", () => {
@@ -249,6 +260,15 @@ describe("canCreateEmailAccount", () => {
         canCreateEmailAccount(
           caller({ role: "crew_lead", grantedPermissions: [] }),
           personal(ALICE),
+        ),
+      ).toBe(false);
+    });
+
+    it("non-admin without send_email creating Shared: denied (guard holds for the admin-only kind)", () => {
+      expect(
+        canCreateEmailAccount(
+          caller({ role: "crew_lead", grantedPermissions: [] }),
+          shared(),
         ),
       ).toBe(false);
     });

--- a/src/lib/email/email-account-access.ts
+++ b/src/lib/email/email-account-access.ts
@@ -156,8 +156,12 @@ export function canCreateEmailAccount(
   // Belt-and-suspenders: the email-area route wrapper gates send_email at
   // the door, but a future caller (CLI, server action, script) might wire
   // this function in without that wrapper. Re-check here so the answer is
-  // safe regardless of how we're called.
-  if (!caller.grantedPermissions.includes("send_email")) {
+  // safe regardless of how we're called. Admins are exempt — same as the
+  // read-side `evaluateSharedAccess` and the app-wide invariant that an
+  // admin passes a permission rule without holding the key; the guard
+  // still protects unwrapped non-admin callers.
+  const isAdmin = caller.role === "admin";
+  if (!isAdmin && !caller.grantedPermissions.includes("send_email")) {
     return false;
   }
   const evaluator = CREATE_EVALUATORS[proposed.kind];


### PR DESCRIPTION
Closes #431.

## What was wrong

An org **Admin** with no *explicit* `send_email` grant got a `403` when creating an Email account — Shared (org-wide) or Personal on behalf of a teammate. The route's permission gate let the admin through (admins bypass permission rules everywhere), but `canCreateEmailAccount`'s defensive "belt-and-suspenders" `send_email` re-check then rejected the empty grant list regardless of role.

This also surfaced as a direct contradiction between two tests for the identical scenario (admin, no `send_email`, create Shared):
- `route.test.ts` expected **allowed** — was **failing**.
- the `canCreateEmailAccount` "belt-and-suspenders" unit block expected **denied** — passing, deliberately.

## The fix (Option 1 from the PRD)

Exempt the `admin` role from the re-check:

```ts
const isAdmin = caller.role === "admin";
if (!isAdmin && !caller.grantedPermissions.includes("send_email")) {
  return false;
}
```

This mirrors the module's own **read** side (`evaluateSharedAccess` already uses `isAdmin || grants.includes("view_email")`) and the app-wide invariant that an admin passes a permission rule without holding the key. The guard still denies **unwrapped non-admin callers** — its actual purpose.

The two contradicting unit assertions were flipped to "admin -> allowed", resolving the contradiction in favour of the route's expectation.

## Tests

Followed TDD:
- **RED** — the two `route.test.ts` admin cases failed (`403`); flipping the unit assertions failed `expected false to be true` against unchanged code, proving they exercise the fix rather than passing vacuously.
- **GREEN** — both files pass: **40/40** (`email-account-access.test.ts` 25, `route.test.ts` 15).

Added unit coverage (flagged by review) for two belt-and-suspenders combinations that were previously untested:
- non-admin without `send_email` creating **Shared** -> still denied (guard holds for the admin-only kind);
- admin without `send_email` creating **Personal-on-behalf** -> allowed (the bypass, at the unit level).

A 4-lens adversarial review (privilege-escalation, completeness, contract-consistency, test-quality) found **no privilege escalation and no serious issues** — cross-org admins are still denied (the cross-org short-circuit runs before the admin exemption), and `canCreateEmailAccount` has exactly one caller (the POST route).

## Scope notes

- Pure-function change in the single-source-of-truth access module; no schema or API-contract change. Only the allow/deny outcome for an admin-without-explicit-grant flips (deny -> allow).
- `tsc --noEmit` on this branch still reports the two pre-existing #413 errors (`template-drag-end.test.tsx`, `sync-folder-incremental.test.ts`) because the branch is cut from `main` and #413's fixes live in PR #428 — **not touched here**; they clear once #428 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
