### PR TITLE
perf(jobs): serve resized previews for the Job cover photo (#420)

### DIFF
--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import type { Job, Photo } from "@/lib/types";
@@ -59,6 +59,8 @@ vi.mock("@/lib/supabase", () => {
 });
 
 import JobComfortableRow from "./job-comfortable-row";
+
+afterEach(() => vi.unstubAllEnvs());
 
 function makePhoto(overrides: Partial<Photo> = {}): Photo {
   return {
@@ -236,5 +238,29 @@ describe("JobComfortableRow — cover updates in place (#164)", () => {
       ).toBeDefined(),
     );
     expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});
+
+describe("JobComfortableRow — resized cover preview (#420)", () => {
+  it("requests the grid-variant preview for the cover thumbnail when resize is enabled", () => {
+    // Acceptance #1 at the display boundary: the Comfortable row's small
+    // cover thumbnail must not pull a multi-MB original. With image
+    // transformation on, its <img> src is the resized render URL.
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    render(
+      <JobComfortableRow
+        job={makeJob({
+          cover_photo: makePhoto({ storage_path: "job-1/cover.jpg" }),
+        })}
+      />,
+    );
+
+    const cover = screen
+      .getByRole("button", { name: "Change cover photo" })
+      .querySelector("img");
+    expect(cover?.getAttribute("src")).toContain(
+      "/storage/v1/render/image/public/photos/",
+    );
+    expect(cover?.getAttribute("src")).toContain("width=400");
   });
 });

--- a/src/components/job-cover-picker.test.tsx
+++ b/src/components/job-cover-picker.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 import type { Photo } from "@/lib/types";
@@ -72,6 +72,8 @@ beforeEach(() => {
   photosResult = { data: [], error: null };
   coverUpdate = null;
 });
+
+afterEach(() => vi.unstubAllEnvs());
 
 describe("JobCoverPicker — photo list (#164)", () => {
   it("renders a choosable option for each of the job's photos", async () => {
@@ -161,6 +163,38 @@ describe("JobCoverPicker — current cover marker (#164)", () => {
 
     expect(await screen.findByRole("button", { name: "Kitchen" })).toBeDefined();
     expect(screen.queryByText("Current cover")).toBeNull();
+  });
+});
+
+describe("JobCoverPicker — resized previews (#420)", () => {
+  it("requests the grid-variant preview for each cover option when resize is enabled", async () => {
+    // Acceptance #1 at the display boundary: the picker grid squares are
+    // small previews, so with image transformation on each option's <img>
+    // src is the resized render URL rather than the multi-MB original.
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    photosResult = {
+      data: [
+        makePhoto({ id: "p-1", caption: "Kitchen", storage_path: "job-1/kitchen.jpg" }),
+      ],
+      error: null,
+    };
+
+    render(
+      <JobCoverPicker
+        jobId="job-1"
+        currentCoverPhotoId={null}
+        supabaseUrl="https://proj.supabase.co"
+        onClose={() => {}}
+        onCoverChosen={() => {}}
+      />,
+    );
+
+    const option = await screen.findByRole("button", { name: "Kitchen" });
+    const img = option.querySelector("img");
+    expect(img?.getAttribute("src")).toContain(
+      "/storage/v1/render/image/public/photos/",
+    );
+    expect(img?.getAttribute("src")).toContain("width=400");
   });
 });
 

--- a/src/lib/jobs/cover-photo.test.ts
+++ b/src/lib/jobs/cover-photo.test.ts
@@ -1,10 +1,17 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { resolveCoverPhotoUrl } from "./cover-photo";
 
 const SUPABASE_URL = "https://proj.supabase.co";
 
-describe("resolveCoverPhotoUrl — cover with annotation", () => {
+afterEach(() => vi.unstubAllEnvs());
+
+// The two URL-asserting cases pin the resize flag OFF explicitly: they are
+// the "no regression when transformation is disabled" guard (#420 acceptance),
+// so they must not depend on ambient env — once the flag is flipped on at
+// go-live (ADR 0008) an unpinned test would flip to the render URL and fail.
+describe("resolveCoverPhotoUrl — cover with annotation, resize off", () => {
   it("prefers the annotated image over the original", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "");
     const url = resolveCoverPhotoUrl(
       {
         annotated_path: "annotated/abc.jpg",
@@ -18,8 +25,9 @@ describe("resolveCoverPhotoUrl — cover with annotation", () => {
   });
 });
 
-describe("resolveCoverPhotoUrl — cover without annotation", () => {
+describe("resolveCoverPhotoUrl — cover without annotation, resize off", () => {
   it("falls back to the original image when there is no annotation", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "");
     const url = resolveCoverPhotoUrl(
       {
         annotated_path: null,
@@ -44,5 +52,33 @@ describe("resolveCoverPhotoUrl — cover photo row absent", () => {
   // cover_photo_id and the join yields no embedded row at all (undefined).
   it("returns null when the joined cover photo row is missing", () => {
     expect(resolveCoverPhotoUrl(undefined, SUPABASE_URL)).toBeNull();
+  });
+});
+
+describe("resolveCoverPhotoUrl — resized preview (#420)", () => {
+  // The cover thumbnail in the Comfortable rows and the squares in the cover
+  // picker are small images that shouldn't pull multi-MB originals. Like the
+  // Job Photos grid (#391, ADR 0008), the cover routes through the "grid"
+  // variant: when image transformation is enabled it serves a resized preview.
+  it("returns the resized grid preview when image transformation is enabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = resolveCoverPhotoUrl(
+      { annotated_path: null, storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+
+  it("previews the resized annotated image when an annotated cover is enabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = resolveCoverPhotoUrl(
+      { annotated_path: "annotated/abc.jpg", storage_path: "originals/abc.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+    );
   });
 });

--- a/src/lib/jobs/cover-photo.ts
+++ b/src/lib/jobs/cover-photo.ts
@@ -1,26 +1,29 @@
+import { photoUrl } from "./photo-url";
+
 // The subset of a photo row the cover-photo resolver reads.
 export interface CoverPhotoSource {
   annotated_path: string | null;
   storage_path: string;
 }
 
-const PHOTOS_BUCKET_PREFIX = "/storage/v1/object/public/photos/";
-
 /**
- * Resolve the public image URL for a job's cover photo.
+ * Resolve the preview image URL for a job's cover photo.
  *
- * Given the job's joined cover-photo row, returns the URL to display,
- * preferring the annotated image and falling back to the original
- * full-size image. Returns null when the job has no cover — either none
- * was ever set (cover_photo_id IS NULL), or the referenced photo was
- * deleted (the FK is ON DELETE SET NULL, so the join yields no row). The
- * app never auto-selects a cover.
+ * Given the job's joined cover-photo row, returns the URL to display in the
+ * cover thumbnail (Jobs tab Comfortable rows) and the cover-picker grid —
+ * both small squares that shouldn't download multi-MB originals. Delegates to
+ * the shared {@link photoUrl} resolver's "grid" variant (ADR 0008), so the
+ * cover gets a resized preview when image transformation is enabled and the
+ * untouched original when it is off (no regression). Prefers the annotated
+ * image over the original. Returns null when the job has no cover — either
+ * none was ever set (cover_photo_id IS NULL), or the referenced photo was
+ * deleted (the FK is ON DELETE SET NULL, so the join yields no row). The app
+ * never auto-selects a cover.
  */
 export function resolveCoverPhotoUrl(
   coverPhoto: CoverPhotoSource | null | undefined,
   supabaseUrl: string,
 ): string | null {
   if (!coverPhoto) return null;
-  const path = coverPhoto.annotated_path ?? coverPhoto.storage_path;
-  return `${supabaseUrl}${PHOTOS_BUCKET_PREFIX}${path}`;
+  return photoUrl(coverPhoto, supabaseUrl, "grid");
 }


### PR DESCRIPTION
## What & why

Issue #420 (follow-on of #391, ADR 0008). The Job cover image is a small
square in the Jobs tab Comfortable rows and the cover-picker grid, but both
fetched the full-resolution original (multi-MB). This routes the cover through
the shared `photoUrl` resolver's `"grid"` variant so the thumbnails get resized
previews when image transformation is enabled, with an unchanged original
fallback when it's off.

## Change

- `resolveCoverPhotoUrl` is now a thin wrapper: keeps its `null`/`undefined`
  handling and delegates URL building to `photoUrl(coverPhoto, supabaseUrl, "grid")`
  (ADR 0008's single seam).
- Both call sites (`job-comfortable-row.tsx`, `job-cover-picker.tsx`) are
  untouched - they already call the resolver, so they inherit the grid variant.

## Acceptance

- [x] Cover images in the Comfortable rows and the cover picker request the
      `"grid"` variant (pinned by unit + component tests).
- [x] Null/empty cover still handled (returns `null` as before).
- [x] Flag-off behavior identical to today (explicitly pinned; verified under a
      forced `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED=true` env - the flag-off tests
      stay green because they pin the flag off internally).

## Tests

- `cover-photo.test.ts`: flag-off cases now pin the flag off explicitly (no
  ambient-env luck), paired with flag-on tests asserting the resized render URL
  for plain and annotated covers.
- `job-comfortable-row.test.tsx` / `job-cover-picker.test.tsx`: added
  component-boundary assertions that the cover `<img>` src is the `render/image`
  (grid) URL when resize is enabled.
- `tsc --noEmit`: no new errors. Two pre-existing failures in unrelated files
  (`template-drag-end.test.tsx`, `sync-folder-incremental.test.ts`) predate this
  branch and are untouched here.

Verified via a 3-lens adversarial review (contract-correctness, completeness/
scope, test-quality); all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
