### PR TITLE
feat(photos): route the all-Photos grid through the Photo URL resolver (#418)

### DIFF
--- a/src/app/photos/page.test.tsx
+++ b/src/app/photos/page.test.tsx
@@ -1,0 +1,106 @@
+// All-Photos page — grid thumbnails go through the Photo URL resolver (#418).
+//
+// The all-Photos grid used to hand-build the full-resolution object URL for
+// every square (the same full-res-in-a-thumbnail problem #392 fixed for the
+// Job Photos grid). These tests mount the page and assert the grid <img> src
+// is whatever photoUrl(photo, supabaseUrl, "grid") resolves to: a resized
+// render/image preview when the resize flag is on, the untouched original when
+// it's off (ADR 0008).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: vi.fn(),
+}));
+
+import PhotosPage from "./page";
+import { createClient } from "@/lib/supabase";
+
+const SUPABASE_URL = "https://proj.supabase.co";
+
+type Row = Record<string, unknown>;
+
+// Minimal thenable query builder: the page only chains .select().order() and
+// then awaits the result, reading `.data`.
+function fakeQueryBuilder(rows: Row[]) {
+  const builder = {
+    select: () => builder,
+    order: () => builder,
+    then(resolve: (v: { data: Row[]; error: null }) => unknown) {
+      return resolve({ data: rows, error: null });
+    },
+  };
+  return builder;
+}
+
+function useTables(tables: Record<string, Row[]>) {
+  vi.mocked(createClient).mockReturnValue({
+    from(table: string) {
+      return fakeQueryBuilder(tables[table] ?? []);
+    },
+  } as never);
+}
+
+function photoRow(overrides: Row = {}): Row {
+  return {
+    id: "p-1",
+    job_id: "j-1",
+    annotated_path: null,
+    storage_path: "originals/abc.jpg",
+    caption: "Kitchen before",
+    before_after_role: null,
+    created_at: "2026-05-01T00:00:00Z",
+    job: { id: "j-1", job_number: "J-100", property_address: "1 Main St" },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", SUPABASE_URL);
+});
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("/photos — grid thumbnails request the grid variant (#418)", () => {
+  it("serves a resized render/image preview when the resize flag is on", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    useTables({ photos: [photoRow()], photo_tags: [], jobs: [] });
+
+    render(<PhotosPage />);
+
+    const img = (await screen.findByAltText("Kitchen before")) as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+
+  it("serves the untouched original when the resize flag is off (no change vs today)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "");
+    useTables({ photos: [photoRow()], photo_tags: [], jobs: [] });
+
+    render(<PhotosPage />);
+
+    const img = (await screen.findByAltText("Kitchen before")) as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/abc.jpg",
+    );
+  });
+
+  it("previews the annotated copy when a photo has one (resize on)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    useTables({
+      photos: [photoRow({ annotated_path: "annotated/abc.jpg" })],
+      photo_tags: [],
+      jobs: [],
+    });
+
+    render(<PhotosPage />);
+
+    const img = (await screen.findByAltText("Kitchen before")) as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+    );
+  });
+});

--- a/src/app/photos/page.tsx
+++ b/src/app/photos/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { createClient } from "@/lib/supabase";
+import { photoUrl } from "@/lib/jobs/photo-url";
 import { Photo, PhotoTag, Job } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -55,10 +56,6 @@ export default function PhotosPage() {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
-
-  function getPublicUrl(storagePath: string) {
-    return `${supabaseUrl}/storage/v1/object/public/photos/${storagePath}`;
-  }
 
   const filtered = photos.filter((p) => {
     if (selectedJob && p.job_id !== selectedJob) return false;
@@ -220,7 +217,7 @@ export default function PhotosPage() {
             >
               <div className="aspect-square bg-muted relative overflow-hidden">
                 <img
-                  src={getPublicUrl(photo.annotated_path || photo.storage_path)}
+                  src={photoUrl(photo, supabaseUrl, "grid")}
                   alt={photo.caption || "Job photo"}
                   className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-200"
                 />


### PR DESCRIPTION
Closes #418.

## What & why

The all-Photos page (`src/app/photos/page.tsx`) hand-built the full-resolution `object` URL for every grid square — the same full-res-in-a-thumbnail problem #392 fixed for the Job Photos grid. This routes the grid through the existing `photoUrl` resolver asking for the `"grid"` variant, so it gets resized previews plus the flag-gated original fallback for free ([ADR 0008](docs/adr/0008-resize-grid-photos-at-the-storage-layer.md)). Mirrors the wiring at `job-photos-tab.tsx:566`.

## Changes

- `src/app/photos/page.tsx` — grid thumbnail now uses `photoUrl(photo, supabaseUrl, "grid")`; dropped the now-dead `getPublicUrl` helper (its only caller was the grid).
- `src/app/photos/page.test.tsx` — new page render tests (TDD).

Single-photo open stays full-res: on this page "open" is a `<Link>` to the job detail, so only the thumbnail URL changes.

## Acceptance criteria

- [x] All-Photos grid squares request the `"grid"` variant (resized when the flag is on, original when off)
- [x] Opening a photo still shows full resolution (only the thumbnail changed)
- [x] No extra query; behavior identical when the flag is off

## Tests

Built test-first (red → green). `vitest run src/app/photos/page.test.tsx src/lib/jobs/photo-url.test.ts` → **14/14 pass**:
- Resize flag on → grid serves the resized `render/image` preview
- Resize flag off → grid serves the untouched `object` original
- Annotated photo → preview built from `annotated_path`

🤖 Generated with [Claude Code](https://claude.com/claude-code)