### PR TITLE
feat(photo-report): one-page write-up cap — live counter + save guard (#404)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -101,6 +101,7 @@ vi.mock("@dnd-kit/core", async () => {
 
 import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
+import { WRITEUP_CHARACTER_LIMIT } from "@/lib/section-writeup-fit";
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
   return {
@@ -446,5 +447,250 @@ describe("PhotoReportBuilder section + photo management", () => {
         el?.tagName === "P" && (el.textContent ?? "").startsWith("1 photo"),
     );
     expect(label).toBeTruthy();
+  });
+});
+
+describe("PhotoReportBuilder write-up fit counter", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+  });
+
+  it("shows a live write-up character counter per section", () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          { title: "Findings", description: "<p>Hello</p>", photo_ids: [] },
+        ],
+      }),
+    );
+
+    const counter = screen.getByTestId("writeup-counter-0");
+    // "Hello" is 5 visible characters, measured against the one-page limit.
+    // Assert against the delimiter so the "5" can't be satisfied by the "5" in
+    // "1500" (a tautology if we only checked toContain("5")).
+    expect(counter.textContent).toContain(`5 / ${WRITEUP_CHARACTER_LIMIT}`);
+  });
+
+  it("updates the counter live as the write-up is edited", () => {
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    expect(screen.getByTestId("writeup-counter-0").textContent).toContain(
+      `0 / ${WRITEUP_CHARACTER_LIMIT}`,
+    );
+
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: { value: "<p>abcd</p>" },
+      });
+    });
+
+    expect(screen.getByTestId("writeup-counter-0").textContent).toContain(
+      `4 / ${WRITEUP_CHARACTER_LIMIT}`,
+    );
+  });
+
+  it("gives each section its own independent counter", () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          { title: "A", description: "<p>Hello</p>", photo_ids: [] },
+          { title: "B", description: "<p>Hi</p>", photo_ids: [] },
+        ],
+      }),
+    );
+
+    expect(screen.getByTestId("writeup-counter-0").textContent).toContain(
+      `5 / ${WRITEUP_CHARACTER_LIMIT}`,
+    );
+    expect(screen.getByTestId("writeup-counter-1").textContent).toContain(
+      `2 / ${WRITEUP_CHARACTER_LIMIT}`,
+    );
+  });
+
+  it("flags a write-up that is over the one-page limit, with the overflow amount", () => {
+    const tooLong = `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 50)}</p>`;
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: tooLong, photo_ids: [] }],
+      }),
+    );
+
+    const counter = screen.getByTestId("writeup-counter-0");
+    // Pin the magnitude, not just the presence of the word "over".
+    expect(counter.textContent).toContain("50 over");
+  });
+});
+
+describe("PhotoReportBuilder save-time guard", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    vi.useFakeTimers();
+  });
+
+  it("does not persist a write-up that is over the one-page limit", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: {
+          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/can't save/i)).toBeTruthy();
+  });
+
+  it("resumes saving once an over-limit write-up is trimmed back under", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+    const editor = screen.getByTestId("tiptap-stub");
+
+    // Over the limit → blocked, nothing written.
+    act(() => {
+      fireEvent.change(editor, {
+        target: {
+          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    // Trimmed back under → the next debounce persists it.
+    act(() => {
+      fireEvent.change(editor, { target: { value: "<p>short</p>" } });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: { description: string }[];
+    };
+    expect(payload.sections[0].description).toBe("<p>short</p>");
+    expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("blocks the whole save when any one section is over the limit", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          { title: "A", description: "<p>fine</p>", photo_ids: [] },
+          {
+            title: "B",
+            description: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
+            photo_ids: [],
+          },
+        ],
+      }),
+    );
+
+    // Edit an unrelated field (the title) to make the report dirty without
+    // touching the overflowing section: the save is still held back.
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Renamed report" },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/can't save/i)).toBeTruthy();
+  });
+
+  it("persists a write-up that is exactly at the limit", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    const atLimit = `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT)}</p>`;
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: { value: atLimit },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: { description: string }[];
+    };
+    expect(payload.sections[0].description).toBe(atLimit);
+    expect(screen.getByText("Saved")).toBeTruthy();
+  });
+
+  it("keeps the blocked status when a stale in-flight save resolves after an over-limit edit", async () => {
+    h.manual = true;
+    renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    // A valid edit goes in flight and is held open ("Saving…").
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Valid title" },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    expect(h.resolvers).toHaveLength(1);
+    expect(screen.getByText(/saving/i)).toBeTruthy();
+
+    // Before it resolves, the write-up goes over the limit → next debounce blocks
+    // and writes nothing new.
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: {
+          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
+        },
+      });
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.getByText(/can't save/i)).toBeTruthy();
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+
+    // The stale valid save now resolves. It must NOT flip the badge to "Saved" —
+    // the over-limit content was never persisted.
+    await act(async () => {
+      h.resolvers[0]();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.queryByText("Saved")).toBeNull();
+    expect(screen.getByText(/can't save/i)).toBeTruthy();
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import Link from "next/link";
 import {
   DndContext,
@@ -39,6 +39,7 @@ import {
   photoReportBuilderReducer,
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
+import { measureWriteupFit } from "@/lib/section-writeup-fit";
 import type { ReportSection } from "@/lib/build-initial-sections";
 import type { Photo, PhotoReport } from "@/lib/types";
 
@@ -46,7 +47,7 @@ import type { Photo, PhotoReport } from "@/lib/types";
 // estimate builder's auto-save debounce).
 const DEBOUNCE_MS = 2000;
 
-type SaveStatus = "idle" | "saving" | "saved" | "error";
+type SaveStatus = "idle" | "saving" | "saved" | "error" | "blocked";
 
 interface PhotoReportBuilderProps {
   jobId: string;
@@ -74,6 +75,12 @@ export default function PhotoReportBuilder({
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [generating, setGenerating] = useState(false);
 
+  // The latest edit revision, mirrored into a ref so the async save tail can
+  // tell whether a newer edit landed while it was in flight (its own captured
+  // `state` is stale by then). Without this, a slow valid save resolving after a
+  // newer over-limit edit would flip the badge from "blocked" back to "Saved".
+  const revisionRef = useRef(state.revision);
+
   const photosById = new Map(photos.map((p) => [p.id, p]));
 
   // Auto-save: a debounced write whenever the builder is dirty. The closure
@@ -83,9 +90,21 @@ export default function PhotoReportBuilder({
   // revision and reschedules its own save; `markSaved` then declines to clear
   // dirty for the older revision, so the newer edit is never lost.
   useEffect(() => {
+    revisionRef.current = state.revision;
     if (!state.dirty) return;
     const savedRevision = state.revision;
+    // Save-time guard (issue #404): a write-up that overflows its one-page
+    // intro must not be persisted. The whole report write is held back while any
+    // Section is over the limit — the same measureWriteupFit the live counter
+    // uses — so the report stays dirty and saves itself once trimmed back under.
+    const overLimit = state.sections.some(
+      (s) => !measureWriteupFit(s.description).fits,
+    );
     const timer = setTimeout(async () => {
+      if (overLimit) {
+        setSaveStatus("blocked");
+        return;
+      }
       setSaveStatus("saving");
       const supabase = createClient();
       const { error } = await supabase
@@ -101,7 +120,12 @@ export default function PhotoReportBuilder({
         return;
       }
       dispatch({ type: "markSaved", revision: savedRevision });
-      setSaveStatus("saved");
+      // Only claim "Saved" if no newer edit landed while this write was in
+      // flight. If one did, its own effect run owns the status (e.g. it may have
+      // set "blocked"), so we must not overwrite it with a stale success.
+      if (savedRevision === revisionRef.current) {
+        setSaveStatus("saved");
+      }
     }, DEBOUNCE_MS);
     return () => clearTimeout(timer);
   }, [
@@ -157,10 +181,17 @@ export default function PhotoReportBuilder({
           Back to job
         </Link>
         <div className="flex-1" />
-        <span className="text-xs text-muted-foreground min-w-[64px] text-right">
+        <span
+          className={`text-xs text-right ${
+            saveStatus === "blocked" || saveStatus === "error"
+              ? "text-destructive"
+              : "text-muted-foreground"
+          }`}
+        >
           {saveStatus === "saving" && "Saving…"}
           {saveStatus === "saved" && "Saved"}
           {saveStatus === "error" && "Save failed"}
+          {saveStatus === "blocked" && "Can't save — write-up too long"}
         </span>
         <button
           type="button"
@@ -330,6 +361,10 @@ function SortableSection({
     photosById.has(id),
   ).length;
 
+  // The write-up is capped to one PDF intro page (ADR 0009). measureWriteupFit
+  // is the single source of truth shared with the save-time guard.
+  const fit = measureWriteupFit(section.description);
+
   return (
     <section
       ref={setNodeRef}
@@ -384,6 +419,17 @@ function SortableSection({
         }
         placeholder="Write-up — what you found, what you did…"
       />
+
+      {/* Live one-page fit counter (issue #404), driven by measureWriteupFit. */}
+      <p
+        data-testid={`writeup-counter-${index}`}
+        className={`text-xs ${
+          fit.fits ? "text-muted-foreground" : "font-medium text-destructive"
+        }`}
+      >
+        {fit.used} / {fit.limit} characters
+        {!fit.fits && ` · ${-fit.remaining} over the limit`}
+      </p>
 
       <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
         {section.photo_ids.map((photoId) => {

--- a/src/lib/section-writeup-fit.test.ts
+++ b/src/lib/section-writeup-fit.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  measureWriteupFit,
+  WRITEUP_CHARACTER_LIMIT,
+} from "./section-writeup-fit";
+
+describe("measureWriteupFit", () => {
+  it("counts the visible characters of a simple write-up", () => {
+    const fit = measureWriteupFit("<p>Hello</p>");
+    expect(fit.used).toBe(5); // "Hello", not the surrounding <p> tags
+    expect(fit.fits).toBe(true);
+    expect(fit.remaining).toBe(fit.limit - 5);
+  });
+
+  it("treats a missing, empty, or whitespace-only write-up as zero used", () => {
+    for (const empty of [
+      null,
+      undefined,
+      "",
+      "   ",
+      "\n\t  ",
+      "<p></p>",
+      "<p>   </p>",
+      "<ul><li></li></ul>",
+    ]) {
+      const fit = measureWriteupFit(empty);
+      expect(fit.used).toBe(0);
+      expect(fit.fits).toBe(true);
+      expect(fit.remaining).toBe(fit.limit);
+    }
+  });
+
+  it("counts decoded entities as one visible character each, not their source", () => {
+    // "Mold & mildew" is 13 visible characters; the &amp; source is 5.
+    expect(measureWriteupFit("<p>Mold &amp; mildew</p>").used).toBe(13);
+    // < > " ' and a non-breaking space each render as a single character.
+    expect(measureWriteupFit("<p>a &lt; b &gt; c</p>").used).toBe(
+      "a < b > c".length,
+    );
+    expect(measureWriteupFit("<p>&quot;hi&quot;</p>").used).toBe('"hi"'.length);
+    expect(measureWriteupFit("<p>it&#39;s</p>").used).toBe("it's".length);
+    expect(measureWriteupFit("<p>a&nbsp;b</p>").used).toBe("a b".length);
+  });
+
+  it("counts only the visible text of inline and list markup, never the tags", () => {
+    // Inline <strong>/<em> are weightless: "Soaked drywall" is 14 chars.
+    expect(measureWriteupFit("<p>Soaked <strong>drywall</strong></p>").used).toBe(
+      "Soaked drywall".length,
+    );
+    // Bullet text is counted; the <ul>/<li> scaffolding is not.
+    expect(
+      measureWriteupFit("<ul><li>Soaked</li><li>drywall</li></ul>").used,
+    ).toBe("Soakeddrywall".length);
+  });
+
+  it("measures legacy plain text the way the PDF renders it, not as stray markup", () => {
+    // A pre-rework one-line subtitle has no HTML tags. The PDF escapes it via
+    // normalizeSectionWriteup and renders every character, so the fit module
+    // must count all of them rather than delete "< 40F and humidity >" as if it
+    // were a tag (the old greedy /<[^>]+>/ strip did exactly that).
+    const legacy = "Temp < 40F and humidity > 80% in the basement";
+    expect(measureWriteupFit(legacy).used).toBe(legacy.length);
+  });
+
+  it("keeps a stray '<' inside HTML, matching the renderer's tokenizer", () => {
+    // Hand-authored / boilerplate HTML can carry a literal '<' that is not a
+    // tag. The renderer's tokenizer keeps it as text; the count must too.
+    expect(measureWriteupFit("<p>gap was < 2 inches</p>").used).toBe(
+      "gap was < 2 inches".length,
+    );
+  });
+
+  it("reports a write-up over the limit as not fitting, with negative remaining", () => {
+    const fit = measureWriteupFit(`<p>${"a".repeat(20)}</p>`, 10);
+    expect(fit.used).toBe(20);
+    expect(fit.limit).toBe(10);
+    expect(fit.fits).toBe(false);
+    expect(fit.remaining).toBe(-10);
+  });
+
+  it("treats exactly the limit as fitting and one character over as not", () => {
+    const at = measureWriteupFit(`<p>${"a".repeat(10)}</p>`, 10);
+    expect(at.used).toBe(10);
+    expect(at.fits).toBe(true);
+    expect(at.remaining).toBe(0);
+
+    const over = measureWriteupFit(`<p>${"a".repeat(11)}</p>`, 10);
+    expect(over.used).toBe(11);
+    expect(over.fits).toBe(false);
+    expect(over.remaining).toBe(-1);
+  });
+
+  it("exposes a positive default one-page character limit in the result", () => {
+    expect(WRITEUP_CHARACTER_LIMIT).toBeGreaterThan(0);
+    expect(measureWriteupFit("<p>x</p>").limit).toBe(WRITEUP_CHARACTER_LIMIT);
+  });
+});

--- a/src/lib/section-writeup-fit.ts
+++ b/src/lib/section-writeup-fit.ts
@@ -1,0 +1,80 @@
+/**
+ * The one-page fit check for a Photo Report Section write-up.
+ *
+ * A Section's write-up renders as a single PDF intro page (see ADR 0009 and
+ * `src/components/report-pdf/section-divider-page.tsx`). Rather than measure the
+ * PDF live — the on-screen editor and `@react-pdf` lay text out differently — the
+ * cap is a conservatively tuned character budget over the write-up's *visible*
+ * text. This module is the single source of truth for that budget: the builder's
+ * live per-Section counter and its save-time guard both read it.
+ *
+ * It measures the SAME string the PDF renders — `normalizeSectionWriteup(html)`,
+ * the exact value `section-divider-page` feeds `htmlToPdfNodes` — so a legacy
+ * one-line plain-text subtitle (which the normalizer escapes and wraps) is
+ * counted as the characters it actually renders, not mistaken for markup. Tags
+ * are dropped with the same pattern the renderer's tokenizer recognizes (a bare
+ * "<" that is not a real tag is kept, as the PDF keeps it), and entities decode
+ * to the single glyph they render.
+ *
+ * Deliberate imprecision (accepted per ADR 0009, "a conservatively tuned
+ * character limit … not pixel-exact"):
+ *   - It counts characters, not lines. A write-up made of many short bullets or
+ *     hard breaks can still spill onto a second page well under the character
+ *     cap; the budget errs lax (it never wrongly blocks content that fits)
+ *     rather than risk blocking a write-up that would actually fit.
+ *   - Whitespace runs collapse to one space (mirroring HTML layout), whereas
+ *     @react-pdf keeps them verbatim. This only ever under-counts, so it cannot
+ *     wrongly block, and intra-line whitespace wraps rather than adding height.
+ */
+
+import { normalizeSectionWriteup } from "./section-writeup";
+
+/** Visible characters that comfortably fit on one Section intro page. */
+export const WRITEUP_CHARACTER_LIMIT = 1500;
+
+// Match real tags the same way `html-to-pdf`'s tokenizer does: "<" (optionally
+// "/") immediately followed by a letter. A stray "<" in prose ("gap was < 2in")
+// is left intact, exactly as the renderer leaves it, so the count never eats
+// visible text the way a greedy `/<[^>]+>/` would.
+const HTML_TAG = /<\/?[a-z][a-z0-9]*\b[^>]*>/gi;
+
+export interface WriteupFit {
+  /** Visible characters the write-up uses (markup and entities excluded). */
+  used: number;
+  /** The one-page budget the write-up is measured against. */
+  limit: number;
+  /** True while the write-up fits within the budget (`used <= limit`). */
+  fits: boolean;
+  /** Characters left before the cap; goes negative once over. */
+  remaining: number;
+}
+
+/** Count the visible text characters of normalized write-up HTML. */
+function visibleLength(html: string): number {
+  const text = html
+    .replace(HTML_TAG, "") // drop real tags; a stray "<" is kept, as the PDF keeps it
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\s+/g, " ") // HTML collapses whitespace runs to one space
+    .trim();
+  return text.length;
+}
+
+/**
+ * Measure how full a Section write-up is against the one-page character budget.
+ * `limit` defaults to {@link WRITEUP_CHARACTER_LIMIT} but is overridable so the
+ * counter, the guard, and tests all share one calculation. The write-up is run
+ * through {@link normalizeSectionWriteup} first, so it is measured as exactly the
+ * string the PDF renderer receives.
+ */
+export function measureWriteupFit(
+  writeup: string | null | undefined,
+  limit: number = WRITEUP_CHARACTER_LIMIT,
+): WriteupFit {
+  const used = visibleLength(normalizeSectionWriteup(writeup));
+  return { used, limit, fits: used <= limit, remaining: limit - used };
+}


### PR DESCRIPTION
Closes #404. Part of the Photo Report rework (PRD #397, ADR 0009); builds on #403.

## What

A Section's write-up renders as a single PDF intro page, so it must not overflow. This adds the **fit module** that backs both a **live counter** and a **save-time guard**.

- **`src/lib/section-writeup-fit.ts`** — pure `measureWriteupFit(writeup, limit?)` → `{ used, limit, fits, remaining }`, plus `WRITEUP_CHARACTER_LIMIT` (1500), a conservatively tuned one-page character budget. `used` = visible characters measured on the **same string the PDF renders** (`normalizeSectionWriteup(html)`), using the renderer's own tag pattern so a legacy plain-text subtitle is counted as the characters it renders, not mistaken for markup.
- **Live per-Section counter** in the builder, driven by the module — shows `used / limit characters` and turns destructive with `· N over the limit` once over.
- **Save-time guard** — the debounced auto-save write is held back while any Section is over the limit (status: *Can't save — write-up too long*) and resumes automatically once trimmed back under.

## Acceptance criteria

- [x] Pure fit module returns at least `{ used, limit, fits, remaining }`.
- [x] Builder shows a live counter per Section driven by that module.
- [x] A write-up over the limit cannot be saved (guard uses the same module).
- [x] Empty/whitespace counts as zero; the boundary at the limit behaves correctly.
- [x] Fit module covered by tests (fits, over-limit, empty, boundary) — prior art: `resolve-photos-per-page` test style.

## How it was built

TDD throughout (RED→GREEN vertical slices). After the green implementation, an adversarial multi-lens review (fit-math, save-guard, test-quality, regression) ran with per-finding verification; confirmed in-scope findings were fixed:

- Measure the **normalized** string (not the raw `description`) with the renderer's stricter tag pattern, so the counter/guard agree with the PDF for legacy/`<`-containing text (was a silent undercount).
- **Revision-guard the save success branch** so a slow in-flight valid save resolving *after* a newer over-limit edit can no longer flip `blocked` → `Saved` (false success badge).
- Test hardening: kill a tautological assertion, pin the overflow magnitude, add a second-section counter test, add an at-limit-saves boundary test, add the stale-save race regression.

### Known, accepted imprecision (per ADR 0009)
The cap is a deliberately conservative **character** proxy, **not pixel-exact**: it does not account for line/bullet geometry, so a write-up of many very short bullets can still spill to a second page well under the character cap. The budget intentionally errs **lax** (it never wrongly blocks content that fits). This is documented in the module. A line-aware weight (or auto-shrink / live page-fill meter) was considered and rejected in ADR 0009.

## Tests

`section-writeup-fit.test.ts` (9) + `photo-report-builder.test.tsx` (21, incl. all prior behaviors); 72 green across the touched area (fit module, builder, html-to-pdf, section-divider-page, section-writeup, resolve-photos-per-page). tsc clean for changed files; eslint 0 errors (2 pre-existing `<img>` warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)