### PR TITLE
chore(schema): sync core schema snapshot (schema.sql) to prod multi-tenancy (#429)

### DIFF
--- a/src/components/insurance-company-picker.test.tsx
+++ b/src/components/insurance-company-picker.test.tsx
@@ -49,6 +49,7 @@ import InsuranceCompanyPicker from "./insurance-company-picker";
 function makeContact(overrides: Partial<Contact> = {}): Contact {
   return {
     id: "c-1",
+    organization_id: "org-1",
     full_name: "State Farm",
     phone: null,
     email: "claims@statefarm.com",

--- a/src/components/intake-form.test.tsx
+++ b/src/components/intake-form.test.tsx
@@ -78,6 +78,7 @@ import IntakeForm from "./intake-form";
 function makeContact(overrides: Partial<Contact> = {}): Contact {
   return {
     id: "c-1",
+    organization_id: "org-1",
     full_name: "State Farm",
     phone: null,
     email: "claims@statefarm.com",

--- a/src/components/job-comfortable-row.test.tsx
+++ b/src/components/job-comfortable-row.test.tsx
@@ -86,6 +86,7 @@ function makePhoto(overrides: Partial<Photo> = {}): Photo {
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
     id: "job-1",
+    organization_id: "org-1",
     job_number: "JOB-1001",
     contact_id: "c-1",
     status: "in_progress",
@@ -117,6 +118,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
     updated_at: "2026-05-01T00:00:00Z",
     contact: {
       id: "c-1",
+      organization_id: "org-1",
       full_name: "Jane Homeowner",
       phone: null,
       email: null,

--- a/src/components/job-list-row.test.tsx
+++ b/src/components/job-list-row.test.tsx
@@ -21,6 +21,7 @@ import JobListRow, { JobListHeader } from "./job-list-row";
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
     id: "job-1",
+    organization_id: "org-1",
     job_number: "JOB-1001",
     contact_id: "c-1",
     status: "in_progress",
@@ -51,6 +52,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
     updated_at: "2026-05-01T00:00:00Z",
     contact: {
       id: "c-1",
+      organization_id: "org-1",
       full_name: "Jane Homeowner",
       phone: null,
       email: null,

--- a/src/lib/cover-page-data.test.ts
+++ b/src/lib/cover-page-data.test.ts
@@ -6,6 +6,7 @@ import type { CompanySettings, Contact, Job } from "./types";
 function makeJob(overrides: Partial<Job> = {}): Job {
   return {
     id: "job-1",
+    organization_id: "org-1",
     job_number: "J-0001",
     contact_id: "c-1",
     status: "active",
@@ -41,6 +42,7 @@ function makeJob(overrides: Partial<Job> = {}): Job {
 function makeContact(overrides: Partial<Contact> = {}): Contact {
   return {
     id: "c-1",
+    organization_id: "org-1",
     full_name: "Jane Customer",
     phone: null,
     email: null,

--- a/src/lib/schema-drift.test.ts
+++ b/src/lib/schema-drift.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Drift guard for the core schema snapshot (issue #429).
+ *
+ * Every core-domain table in production carries an `organization_id`
+ * (uuid NOT NULL, FK -> organizations) for multi-tenant isolation, added
+ * platform-wide by the Build 42–58 migrations. The snapshot in
+ * `supabase/schema.sql` was a single-tenant "v1.0" file that omitted it on
+ * every table. This test fails if any core table's CREATE TABLE block stops
+ * declaring `organization_id`, catching a future re-drift before it ships.
+ *
+ * Vitest runs with the repo root as cwd, so the snapshot resolves relative to
+ * `process.cwd()`.
+ */
+const SCHEMA_PATH = path.join(process.cwd(), "supabase", "schema.sql");
+
+const CORE_TABLES = [
+  "contacts",
+  "jobs",
+  "job_activities",
+  "invoices",
+  "payments",
+  "invoice_line_items",
+] as const;
+
+/**
+ * Return the body of `CREATE TABLE <table> ( ... );` from the snapshot. The
+ * statement terminator is a line-leading `);`; mid-column parens
+ * (`gen_random_uuid()`, `CHECK (... )`) never sit at the start of a line, so a
+ * non-greedy match stops at the real table terminator.
+ */
+function createTableBlock(sql: string, table: string): string {
+  const match = sql.match(
+    new RegExp(`CREATE TABLE ${table}\\s*\\(([\\s\\S]*?)\\n\\);`)
+  );
+  if (!match) {
+    throw new Error(`No CREATE TABLE block found for "${table}" in schema.sql`);
+  }
+  return match[1];
+}
+
+describe("schema.sql multi-tenant drift guard", () => {
+  const sql = readFileSync(SCHEMA_PATH, "utf8");
+
+  it.each(CORE_TABLES)("declares organization_id on the %s table", (table) => {
+    const block = createTableBlock(sql, table);
+    expect(block).toMatch(/\borganization_id\b/);
+  });
+
+  it("keeps no single-tenant \"Allow all\" policy", () => {
+    expect(sql).not.toMatch(/Allow all/);
+  });
+
+  it.each(CORE_TABLES)(
+    "guards the %s table with a tenant_isolation policy",
+    (table) => {
+      expect(sql).toMatch(
+        new RegExp(`CREATE POLICY tenant_isolation_${table}\\b`)
+      );
+    }
+  );
+});
+
+describe("schema.sql line-item table split (#429)", () => {
+  const sql = readFileSync(SCHEMA_PATH, "utf8");
+
+  it("replaces the single-tenant line_items table with invoice_line_items", () => {
+    // The old invoice-scoped `line_items` table was split out in prod; the
+    // core file now defines `invoice_line_items`. Guard against the stale name
+    // creeping back in any statement (CREATE TABLE, ALTER, index, policy).
+    expect(sql).not.toMatch(/\bline_items\b(?<!invoice_line_items)/);
+    expect(sql).toMatch(/CREATE TABLE invoice_line_items\b/);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,7 @@
 export interface Contact {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   /** Canonical customer name — the sole name column on `contacts` (PRD #109). */
   full_name: string;
   phone: string | null;
@@ -28,6 +30,8 @@ export interface Contact {
 
 export interface Job {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   job_number: string;
   contact_id: string;
   status: string;
@@ -89,6 +93,8 @@ export interface JobAdjuster {
 
 export interface JobActivity {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   job_id: string;
   activity_type: "note" | "photo" | "milestone" | "insurance" | "equipment" | "expense";
   title: string;
@@ -139,6 +145,8 @@ export interface Invoice {
 
 export interface Payment {
   id: string;
+  /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
+  organization_id: string;
   job_id: string;
   invoice_id: string | null;
   source: "insurance" | "homeowner" | "other";

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2,21 +2,47 @@
 -- AAA Disaster Recovery — Database Schema v1.0
 -- Run this in the Supabase SQL Editor
 -- ============================================
+--
+-- Multi-tenancy note: every table below carries `organization_id`
+-- (uuid NOT NULL, FK -> organizations ON DELETE RESTRICT) and is guarded by a
+-- per-tenant `tenant_isolation_<table>` RLS policy granted to `authenticated`.
+-- Those objects assume the core multi-tenant schema already exists — the
+-- `organizations` and `user_organizations` tables and the
+-- `nookleus.active_organization_id()` helper (added Build 42–58). Several
+-- columns/FKs also reference later-domain tables not defined here
+-- (`referral_partners`, `photos`, `user_profiles`, `estimates`,
+-- `invoice_sections`, `item_library`, `payment_requests`); run those domains'
+-- schemas alongside this one.
+--
+-- Scope: this snapshot mirrors prod's table/column shape, constraints, indexes,
+-- and RLS column-for-column. It deliberately does NOT reproduce the
+-- cross-domain application triggers prod layers onto these tables (QuickBooks
+-- sync, Stripe payment + invoice-status recompute, payer-type recompute,
+-- referral-partner eligibility) — those are defined in their own build
+-- migrations, not the core schema.
 
 -- ============================================
 -- 1. CONTACTS
 -- ============================================
+-- Columns are listed in production ordinal order so a fresh run mirrors prod
+-- exactly. `full_name` sits late because the name-collapse migrations
+-- (#109–#115) dropped the original first_name/last_name and added it then.
 CREATE TABLE contacts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  full_name text NOT NULL,
   phone text,
   email text,
   role text NOT NULL DEFAULT 'homeowner'
-    CHECK (role IN ('homeowner', 'tenant', 'property_manager', 'adjuster', 'insurance')),
+    CHECK (role IN ('homeowner', 'tenant', 'property_manager', 'adjuster', 'insurance', 'referral_contact')),
   company text,
   notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  title text,
+  qb_customer_id text,                           -- QuickBooks customer link (#37)
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  full_name text NOT NULL,                        -- canonical customer name (#109)
+  -- FK to a referral_partners row when role = 'referral_contact' (#250).
+  referral_partner_id uuid REFERENCES referral_partners(id) ON DELETE SET NULL
 );
 
 -- ============================================
@@ -64,16 +90,19 @@ $$ LANGUAGE plpgsql;
 -- ============================================
 -- 3. JOBS
 -- ============================================
+-- job_number is unique per Organization (see jobs_org_job_number_key below),
+-- not globally. The original status/damage_type CHECK constraints were dropped
+-- in prod as those vocabularies grew; both are now free text validated by the
+-- app. The legacy single-tenant adjuster_contact_id was replaced by
+-- insurance_contact_id (#47) plus the job_adjusters join table.
 CREATE TABLE jobs (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  job_number text UNIQUE NOT NULL,
+  job_number text NOT NULL,
   contact_id uuid NOT NULL REFERENCES contacts(id),
-  status text NOT NULL DEFAULT 'new'
-    CHECK (status IN ('new', 'in_progress', 'pending_invoice', 'completed', 'cancelled')),
+  status text NOT NULL DEFAULT 'new',
   urgency text NOT NULL DEFAULT 'scheduled'
     CHECK (urgency IN ('emergency', 'urgent', 'scheduled')),
-  damage_type text NOT NULL
-    CHECK (damage_type IN ('water', 'fire', 'mold', 'storm', 'biohazard', 'contents', 'rebuild', 'other')),
+  damage_type text NOT NULL,
   damage_source text,
   property_address text NOT NULL,
   property_type text
@@ -83,10 +112,28 @@ CREATE TABLE jobs (
   affected_areas text,
   insurance_company text,
   claim_number text,
-  adjuster_contact_id uuid REFERENCES contacts(id),
   access_notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  policy_number text,
+  date_of_loss date,
+  deductible numeric(10,2),
+  hoa_name text,
+  hoa_contact_name text,
+  hoa_contact_phone text,
+  hoa_contact_email text,
+  has_signed_contract boolean NOT NULL DEFAULT false,
+  has_pending_contract boolean NOT NULL DEFAULT false,
+  estimated_crew_labor_cost numeric(10,2),
+  payer_type text
+    CHECK (payer_type IN ('insurance', 'homeowner', 'mixed')),
+  qb_subcustomer_id text,                          -- QuickBooks sub-customer link (#37)
+  has_pending_payment_request boolean NOT NULL DEFAULT false,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  deleted_at timestamptz,                          -- soft-delete (#66); NULL = live
+  cover_photo_id uuid REFERENCES photos(id) ON DELETE SET NULL,
+  insurance_contact_id uuid REFERENCES contacts(id) ON DELETE SET NULL,
+  referral_partner_id uuid REFERENCES referral_partners(id) ON DELETE SET NULL
 );
 
 -- Auto-generate job_number on insert using a trigger
@@ -112,27 +159,65 @@ CREATE TABLE job_activities (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
   activity_type text NOT NULL
-    CHECK (activity_type IN ('note', 'photo', 'milestone', 'insurance', 'equipment')),
+    CHECK (activity_type IN ('note', 'photo', 'milestone', 'insurance', 'equipment', 'expense')),
   title text NOT NULL,
   description text,
   author text NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT
 );
 
 -- ============================================
 -- 5. INVOICES
 -- ============================================
+-- invoice_number is unique per Organization (invoices_org_invoice_number_key
+-- below), not globally. `voided_by`/`created_by` reference user_profiles and
+-- `converted_from_estimate_id` references estimates — both from later domains
+-- (see the multi-tenancy / dependency note at the top of this file).
 CREATE TABLE invoices (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-  invoice_number text UNIQUE NOT NULL,
+  invoice_number text NOT NULL,
   total_amount numeric(10,2) NOT NULL DEFAULT 0,
   status text NOT NULL DEFAULT 'draft'
-    CHECK (status IN ('draft', 'sent', 'partial', 'paid')),
+    CHECK (status IN ('draft', 'sent', 'partial', 'paid', 'voided')),
   issued_date date,
   notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  qb_invoice_id text,                              -- QuickBooks invoice link (#37)
+  sent_at timestamptz,
+  voided_at timestamptz,
+  voided_by uuid REFERENCES user_profiles(id) ON DELETE SET NULL,
+  due_date timestamptz,
+  subtotal numeric(10,2) NOT NULL DEFAULT 0,
+  tax_rate numeric(6,4) NOT NULL DEFAULT 0,
+  tax_amount numeric(10,2) NOT NULL DEFAULT 0,
+  po_number text,
+  memo text,
+  has_payment_request boolean NOT NULL DEFAULT false,
+  stripe_balance_remaining numeric(10,2),          -- Stripe partial-payment tracking (#39)
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  sequence_number integer NOT NULL,                -- per-job display sequence
+  title text NOT NULL,
+  opening_statement text,
+  closing_statement text,
+  markup_type text NOT NULL DEFAULT 'none'
+    CHECK (markup_type IN ('percent', 'amount', 'none')),
+  markup_value numeric(10,2) NOT NULL DEFAULT 0,
+  markup_amount numeric(10,2) NOT NULL DEFAULT 0,
+  discount_type text NOT NULL DEFAULT 'none'
+    CHECK (discount_type IN ('percent', 'amount', 'none')),
+  discount_value numeric(10,2) NOT NULL DEFAULT 0,
+  discount_amount numeric(10,2) NOT NULL DEFAULT 0,
+  adjusted_subtotal numeric(10,2) NOT NULL DEFAULT 0,
+  converted_from_estimate_id uuid REFERENCES estimates(id) ON DELETE SET NULL,
+  void_reason text,
+  created_by uuid REFERENCES user_profiles(id),
+  last_sent_at timestamptz,
+  last_sent_to_email text,
+  deleted_at timestamptz,                          -- soft-delete (#67d); NULL = live
+  delete_reason text
 );
 
 -- Auto-generate invoice numbers: INV-2026-0001
@@ -159,38 +244,65 @@ CREATE TRIGGER trg_set_invoice_number
   EXECUTE FUNCTION set_invoice_number();
 
 -- ============================================
--- 6. LINE ITEMS
+-- 6. INVOICE LINE ITEMS
 -- ============================================
-CREATE TABLE line_items (
+-- The single-tenant invoice line-item table was replaced by
+-- `invoice_line_items` (the invoice builder, #67). The old `xactimate_code` and
+-- the generated `total` column are gone; `amount` is now a plain column the app
+-- computes.
+-- `section_id`/`library_item_id` reference invoice_sections and item_library
+-- from the same invoice-builder domain (not defined in this core file).
+CREATE TABLE invoice_line_items (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   invoice_id uuid NOT NULL REFERENCES invoices(id) ON DELETE CASCADE,
+  sort_order integer NOT NULL DEFAULT 0,
   description text NOT NULL,
-  xactimate_code text,
   quantity numeric(10,2) NOT NULL DEFAULT 1,
   unit_price numeric(10,2) NOT NULL DEFAULT 0,
-  total numeric(10,2) NOT NULL GENERATED ALWAYS AS (quantity * unit_price) STORED,
-  created_at timestamptz NOT NULL DEFAULT now()
+  amount numeric(10,2) NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  section_id uuid REFERENCES invoice_sections(id) ON DELETE CASCADE,
+  library_item_id uuid REFERENCES item_library(id) ON DELETE SET NULL,
+  unit text,
+  code text,
+  name text
 );
 
 -- ============================================
 -- 7. PAYMENTS
 -- ============================================
+-- The source/method/status CHECKs were widened for Stripe payments (#39):
+-- source gains 'stripe', method gains 'stripe_card'/'stripe_ach', status gains
+-- 'refunded'. `payment_request_id` references payment_requests (Stripe domain).
 CREATE TABLE payments (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
   invoice_id uuid REFERENCES invoices(id),
   source text NOT NULL
-    CHECK (source IN ('insurance', 'homeowner', 'other')),
+    CHECK (source IN ('insurance', 'homeowner', 'other', 'stripe')),
   method text NOT NULL
-    CHECK (method IN ('check', 'ach', 'venmo_zelle', 'cash', 'credit_card')),
+    CHECK (method IN ('check', 'ach', 'venmo_zelle', 'cash', 'credit_card', 'stripe_card', 'stripe_ach')),
   amount numeric(10,2) NOT NULL,
   reference_number text,
   payer_name text,
   status text NOT NULL DEFAULT 'received'
-    CHECK (status IN ('received', 'pending', 'due')),
+    CHECK (status IN ('received', 'pending', 'due', 'refunded')),
   notes text,
   received_date date,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  qb_payment_id text,                              -- QuickBooks payment link (#37)
+  stripe_payment_intent_id text,
+  payment_request_id uuid REFERENCES payment_requests(id) ON DELETE SET NULL,
+  stripe_charge_id text,
+  stripe_fee_amount numeric(10,2),
+  net_amount numeric(10,2),
+  quickbooks_sync_status text
+    CHECK (quickbooks_sync_status IN ('pending', 'synced', 'failed', 'not_applicable')),
+  quickbooks_sync_attempted_at timestamptz,
+  quickbooks_sync_error text,
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT
 );
 
 -- ============================================
@@ -213,31 +325,187 @@ CREATE TRIGGER trg_jobs_updated_at
 CREATE TRIGGER trg_invoices_updated_at
   BEFORE UPDATE ON invoices FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
+CREATE TRIGGER trg_invoice_line_items_updated_at
+  BEFORE UPDATE ON invoice_line_items FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
 -- ============================================
--- ROW LEVEL SECURITY (open for now, lock down later)
+-- ROW LEVEL SECURITY (multi-tenant isolation)
 -- ============================================
 ALTER TABLE contacts ENABLE ROW LEVEL SECURITY;
 ALTER TABLE jobs ENABLE ROW LEVEL SECURITY;
 ALTER TABLE job_activities ENABLE ROW LEVEL SECURITY;
 ALTER TABLE invoices ENABLE ROW LEVEL SECURITY;
-ALTER TABLE line_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE invoice_line_items ENABLE ROW LEVEL SECURITY;
 ALTER TABLE payments ENABLE ROW LEVEL SECURITY;
 
--- Allow all operations for now (will restrict with auth later)
-CREATE POLICY "Allow all on contacts" ON contacts FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on jobs" ON jobs FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on job_activities" ON job_activities FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on invoices" ON invoices FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on line_items" ON line_items FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on payments" ON payments FOR ALL USING (true) WITH CHECK (true);
+-- Each core table is scoped to the caller's active Organization: the row's
+-- organization_id must be non-null, equal to nookleus.active_organization_id(),
+-- and the caller must belong to that Organization (user_organizations). USING
+-- and WITH CHECK are identical so the same predicate gates reads, writes, and
+-- inserts. Granted to the authenticated role, matching prod.
+CREATE POLICY tenant_isolation_contacts ON contacts
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = contacts.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = contacts.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_jobs ON jobs
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = jobs.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = jobs.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_job_activities ON job_activities
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = job_activities.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = job_activities.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_invoices ON invoices
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = invoices.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = invoices.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_invoice_line_items ON invoice_line_items
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = invoice_line_items.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = invoice_line_items.organization_id
+    )
+  );
+
+CREATE POLICY tenant_isolation_payments ON payments
+  FOR ALL
+  TO authenticated
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = payments.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid() AND uo.organization_id = payments.organization_id
+    )
+  );
 
 -- ============================================
 -- INDEXES for common queries
 -- ============================================
+-- contacts
+CREATE INDEX idx_contacts_organization_id ON contacts(organization_id);
+CREATE INDEX idx_contacts_referral_partner_id ON contacts(referral_partner_id)
+  WHERE referral_partner_id IS NOT NULL;
+
+-- jobs (job_number is unique per Organization, not globally)
+CREATE UNIQUE INDEX jobs_org_job_number_key ON jobs(organization_id, job_number);
 CREATE INDEX idx_jobs_status ON jobs(status);
 CREATE INDEX idx_jobs_contact_id ON jobs(contact_id);
 CREATE INDEX idx_jobs_created_at ON jobs(created_at DESC);
+CREATE INDEX idx_jobs_insurance_contact_id ON jobs(insurance_contact_id);
+CREATE INDEX idx_jobs_organization_id ON jobs(organization_id);
+CREATE INDEX idx_jobs_org_deleted_at ON jobs(organization_id, deleted_at);
+CREATE INDEX idx_jobs_referral_partner_id_live ON jobs(referral_partner_id)
+  WHERE deleted_at IS NULL;
+
+-- job_activities
 CREATE INDEX idx_job_activities_job_id ON job_activities(job_id);
+CREATE INDEX idx_job_activities_organization_id ON job_activities(organization_id);
+
+-- invoices (invoice_number is unique per Organization; sequence_number per job)
+CREATE UNIQUE INDEX invoices_org_invoice_number_key ON invoices(organization_id, invoice_number);
+CREATE UNIQUE INDEX invoices_job_seq_unique ON invoices(job_id, sequence_number);
 CREATE INDEX idx_invoices_job_id ON invoices(job_id);
+CREATE INDEX idx_invoices_organization_id ON invoices(organization_id);
+CREATE INDEX idx_invoices_org_deleted_at ON invoices(organization_id, deleted_at);
+
+-- invoice_line_items
+CREATE INDEX idx_invoice_line_items_invoice ON invoice_line_items(invoice_id, sort_order);
+CREATE INDEX idx_invoice_line_items_organization_id ON invoice_line_items(organization_id);
+CREATE INDEX idx_invoice_line_items_section_id ON invoice_line_items(section_id);
+CREATE INDEX idx_invoice_line_items_library_item_id ON invoice_line_items(library_item_id);
+
+-- payments (one Stripe PaymentIntent maps to at most one payment per Org)
+CREATE UNIQUE INDEX payments_org_stripe_payment_intent_key
+  ON payments(organization_id, stripe_payment_intent_id)
+  WHERE stripe_payment_intent_id IS NOT NULL;
 CREATE INDEX idx_payments_job_id ON payments(job_id);
-CREATE INDEX idx_line_items_invoice_id ON line_items(invoice_id);
+CREATE INDEX idx_payments_invoice_id ON payments(invoice_id) WHERE invoice_id IS NOT NULL;
+CREATE INDEX idx_payments_organization_id ON payments(organization_id);
+CREATE INDEX idx_payments_payment_request_id ON payments(payment_request_id);
+CREATE INDEX idx_payments_stripe_charge_id ON payments(stripe_charge_id);
+CREATE INDEX idx_payments_stripe_payment_intent_id ON payments(stripe_payment_intent_id);


### PR DESCRIPTION
Closes #429. Follow-up to #412 (which reconciled `schema-photos.sql`).

The core schema snapshot `supabase/schema.sql` was still the single-tenant "v1.0" file. This reconciles it **column-for-column** to production across all six core tables and syncs the matching `types.ts` interfaces. **No DB migration** — prod already has everything; this is a snapshot/types sync.

## schema.sql
- **`organization_id`** (uuid NOT NULL, FK→organizations `ON DELETE RESTRICT`) on `contacts`, `jobs`, `job_activities`, `invoices`, `payments`, `invoice_line_items`, each with a per-tenant index
- **RLS**: every `"Allow all"` policy → prod's `tenant_isolation_<table>` (`FOR ALL TO authenticated`, org-scoped via `nookleus.active_organization_id()` + `user_organizations`)
- **line-item split**: stale `line_items` → `invoice_line_items` (drops `xactimate_code` + generated `total`; adds `amount`, `sort_order`, `section_id`, `library_item_id`, `unit`, `code`, `name`)
- **full reconciliation**: invoices 10→40 cols, jobs +16 (drops legacy `adjuster_contact_id`), payments +10 qb/stripe cols; widened CHECKs (payments stripe/refunded, invoices `voided`, job_activities `expense`, contacts `referral_contact`); per-org unique + partial indexes; `invoice_line_items` `updated_at` trigger
- header note documenting the multi-tenant dependency and the **deliberate exclusion** of cross-domain triggers (QuickBooks, Stripe, payer-type recompute, referral eligibility) that live in their own build migrations

## types.ts
- required `organization_id` added to `Contact`, `Job`, `JobActivity`, `Payment` (Invoice already had it); fixed the five test fixtures the new required field broke

## Tests
- new `src/lib/schema-drift.test.ts` (14 tests) guards against re-drift: `organization_id` per table, no `"Allow all"` survives, `tenant_isolation` present, `line_items` split

## Verification
- drift-guard suite 14/14 · all touched tests 63/63 · `tsc` clean (only 2 pre-existing unrelated errors) · eslint clean on touched files
- **column-for-column vs live DB: 6/6 tables match, 0 discrepancies** — verified by six independent introspection passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)