### PR TITLE
test(photo-report): guard against the global Reports area returning (#406)

### DIFF
--- a/src/components/nav.test.tsx
+++ b/src/components/nav.test.tsx
@@ -108,3 +108,37 @@ describe("Sidebar — Phone item visibility (PRD #304 / #306)", () => {
     expect(emailIdx).toBeGreaterThan(phoneIdx);
   });
 });
+
+// Issue #406 / ADR 0009 — the standalone global Reports area (the /reports
+// list, the /reports/new wizard, /reports/[id], and /reports/templates) was
+// removed; Photo Reports are reached only through their Job now. The removal
+// itself shipped incrementally with #400 and #405; these tests are the
+// regression guard that pins it at the Sidebar render level so the item — and
+// any link into the old global area — cannot silently come back.
+//
+// Admin is used deliberately: an admin sees every gated nav item, so a
+// re-added Reports entry could not hide behind a role/permission gate.
+describe("Sidebar — no standalone global Reports area (#406 / ADR 0009)", () => {
+  it("renders no link into the removed global /reports area", () => {
+    setAuth({ role: "admin", grants: {} });
+    render(<Sidebar />);
+    const hrefs = Array.from(document.querySelectorAll("a[href]")).map(
+      (a) => a.getAttribute("href") ?? "",
+    );
+    // A standalone "/reports" or "/reports/<anything>" href is the removed
+    // global area. In-Job reports live under /jobs/<id>/reports/... and
+    // Settings links never start with "/reports", so this anchored match
+    // flags only a genuine regression, not the retained in-Job flow.
+    const globalReportsLinks = hrefs.filter((h) => /^\/reports(\/|$)/.test(h));
+    expect(globalReportsLinks).toEqual([]);
+  });
+
+  it("shows no Reports nav item label", () => {
+    setAuth({ role: "admin", grants: {} });
+    render(<Sidebar />);
+    // The Sidebar renders both the mobile bar and the desktop aside, so a
+    // re-added item could appear more than once — assert zero occurrences.
+    expect(screen.queryAllByText("Reports")).toHaveLength(0);
+    expect(screen.queryAllByText("Report Templates")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #406 asked to **remove the standalone global Reports area** (the `/reports` list, the `/reports/new` wizard + its test, `/reports/[id]`, `/reports/templates`, and the Reports nav item) now that everything lives in-Job.

That removal **already shipped incrementally**:
- **#400** removed `/reports`, `/reports/new` (and its wizard test), and `/reports/[id]`, and dropped the Reports nav item.
- **#405** removed `/reports/templates` and moved Photo Report templates into Settings (`/settings/templates?tab=photo-report-defaults`).

So on `main` there was **no functional code left to remove**. I verified this with a 6-agent adversarial sweep across routes, links/redirects, menus/command-palette, framework config (`next.config.ts` / middleware), and tests — **all 5 acceptance criteria met, zero live remnants**. Every surviving `/reports` reference is legitimate and explicitly retained: in-Job routes (`/jobs/[id]/reports/...`, `/api/jobs/[id]/reports/**`), the `reports` storage bucket + existing PDFs, the Settings templates UI, and comments/ADRs/historical migrations.

## What this PR adds

The one thing that was missing: a **regression guard** for the invariant, so the global area can't silently come back.

- Renders the real `<Sidebar>` as an **admin** (who sees every gated item) and asserts:
  - no link into a standalone `/reports*` route exists, and
  - no `Reports` / `Report Templates` nav label renders.
- **Proven to have teeth:** temporarily re-adding a `{ href: "/reports" }` nav item fails *exactly* these two tests; reverting restores green.

## Acceptance criteria (verified)

- [x] `/reports`, `/reports/new`, `/reports/[id]`, `/reports/templates` removed (wizard test removed with it)
- [x] Reports item removed from the nav
- [x] No remaining link or redirect to the old global area; reports reachable only via the Job
- [x] `reports` bucket + existing PDFs untouched; an existing report still opens/generates from within its Job
- [x] Photos-per-page behavior unchanged (`resolve-photos-per-page.ts` untouched)

## Testing

- `vitest run src/components/nav.test.tsx` → **6/6 pass** (4 existing + 2 new guards)
- `eslint src/components/nav.test.tsx` → clean
- `tsc --noEmit` → only the 2 pre-existing repo errors; none in the touched file

Closes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)