### PR TITLE
docs(env): document NEXT_PUBLIC_PHOTO_RESIZE_ENABLED in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,3 +43,17 @@ TWILIO_AUTH_TOKEN=
 # preview needs a rebuild / dev-server restart to pick up the change.
 NOOKLEUS_PHONE_DEMO_MODE=
 NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED=
+
+# Photo grid previews — PRD #391 / ADR 0008. When 'true', the Job Photos grid
+# (and the other resolver call sites) request small resized previews from
+# Supabase's render/image endpoint instead of full-resolution originals — the
+# core speedup of #391.
+#
+# REQUIRES Supabase Pro on the *AAA Disaster Recovery* org with image
+# transformation enabled; the free plan rejects the render endpoint. Leave
+# blank/false until Pro is live. When off, the resolver falls back to full-res
+# originals, so the grid never breaks (it's just no faster than before).
+#
+# Inlined into the client bundle at build time (NEXT_PUBLIC_), so flipping it
+# needs a redeploy / dev-server restart to take effect. Go-live checklist: #391.
+NEXT_PUBLIC_PHOTO_RESIZE_ENABLED=


### PR DESCRIPTION
## What

Adds the missing `.env.example` entry for `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED` — the photo-grid resize flag from PRD #391 / [ADR 0008](docs/adr/0008-resize-grid-photos-at-the-storage-layer.md). The doc block covers:

- **What it does** — when `true`, the Job Photos grid requests small resized previews from Supabase's `render/image` endpoint instead of full-resolution originals.
- **Prerequisite** — Supabase Pro with image transformation on the *AAA Disaster Recovery* org; the free plan rejects the render endpoint.
- **Safe by default** — when off (blank/`false`), the resolver falls back to full-res originals, so the grid never breaks.
- **Build-time caveat** — it's a `NEXT_PUBLIC_` var inlined at build time, so flipping it needs a redeploy / dev-server restart.

## Why

The resolver (`src/lib/jobs/photo-url.ts`) and its 9 tests already shipped via #392–#395, but `.env.example` never documented the flag. This closes that gap so the variable is discoverable for local/preview setup.

## Scope

**Docs-only** — no code, no behavior change. The go-live itself (Supabase Pro + flag flip) was verified live under #417: org plan = `pro`, and the render endpoint serves a **~117 KB preview vs a ~5.0 MB original (43.8× / ~97.7% reduction)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
