### PR TITLE
fix(photo-report-templates): Edit/Create opens with stale or empty form — reseed builder on every open (#440)

### DIFF
--- a/src/app/settings/templates/photo-report-templates-tab.test.tsx
+++ b/src/app/settings/templates/photo-report-templates-tab.test.tsx
@@ -4,6 +4,11 @@
 // owner create / edit / delete them, and seeds the Findings + Work Performed
 // defaults. These tests pin the list render and that "Add Defaults" seeds the
 // canonical defaults, each scoped to the active Organization.
+//
+// Issue #440 — the builder is mounted persistently in this tab, so the form must
+// reseed from `editingTemplate` every time the dialog opens (its useState
+// initializers run once per mount). These tests render the real builder (not a
+// stub) and exercise the Edit / New transitions, asserting the visible form.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -11,6 +16,8 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 const h = vi.hoisted(() => ({
   templates: [] as Array<Record<string, unknown>>,
   insertMock: vi.fn<(payload: unknown) => void>(),
+  updateMock: vi.fn<(payload: unknown) => void>(),
+  updateTargetId: null as string | null,
 }));
 
 vi.mock("@/lib/supabase", () => ({
@@ -25,6 +32,15 @@ vi.mock("@/lib/supabase", () => ({
         h.insertMock(payload);
         return Promise.resolve({ error: null });
       },
+      update: (payload: unknown) => {
+        h.updateMock(payload);
+        return {
+          eq: (col: string, val: string) => {
+            if (col === "id") h.updateTargetId = val;
+            return { eq: () => Promise.resolve({ error: null }) };
+          },
+        };
+      },
       delete: () => ({
         eq: () => ({ eq: () => Promise.resolve({ error: null }) }),
       }),
@@ -38,15 +54,44 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
-// The builder is a heavy TipTap/dialog component tested on its own; stub it out.
-vi.mock("@/components/report-template-builder", () => ({ default: () => null }));
+// The Section boilerplate uses the shared TipTap editor; stub it with a textarea
+// mirroring its contract (seeded from `content`, emits HTML via `onChange`).
+vi.mock("@/components/tiptap-editor", () => ({
+  default: ({
+    content,
+    onChange,
+    placeholder,
+  }: {
+    content: string;
+    onChange: (html: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="boilerplate-editor"
+      placeholder={placeholder}
+      defaultValue={content}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
 
 import React from "react";
 import { PhotoReportTemplatesTab } from "./photo-report-templates-tab";
 
+const INSPECTION = {
+  id: "t-insp",
+  name: "Inspection Report",
+  sections: [
+    { title: "Exterior", description: "<p>ext</p>" },
+    { title: "Interior", description: "<p>int</p>" },
+  ],
+  created_at: "2026-06-04T00:00:00Z",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   h.templates = [];
+  h.updateTargetId = null;
 });
 
 describe("PhotoReportTemplatesTab", () => {
@@ -92,5 +137,110 @@ describe("PhotoReportTemplatesTab", () => {
     for (const row of seeded) {
       expect(row.organization_id).toBe("org-1");
     }
+  });
+
+  it("opens the builder pre-filled with the template's name and every section on Edit", async () => {
+    h.templates = [INSPECTION];
+
+    render(<PhotoReportTemplatesTab />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /edit inspection report/i }),
+    );
+
+    // Name reseeded from the edited template.
+    expect(await screen.findByDisplayValue("Inspection Report")).toBeDefined();
+    // Every one of the template's sections is shown, not a single blank one.
+    expect(screen.getByDisplayValue("Exterior")).toBeDefined();
+    expect(screen.getByDisplayValue("Interior")).toBeDefined();
+    expect(screen.getAllByPlaceholderText("Section heading")).toHaveLength(2);
+  });
+
+  it("opens an empty form with one blank section on New right after editing", async () => {
+    h.templates = [INSPECTION];
+
+    render(<PhotoReportTemplatesTab />);
+
+    // Edit first so the builder is seeded with a template.
+    fireEvent.click(
+      await screen.findByRole("button", { name: /edit inspection report/i }),
+    );
+    expect(await screen.findByDisplayValue("Inspection Report")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    // New must not inherit the just-edited template's data.
+    fireEvent.click(screen.getByRole("button", { name: /new template/i }));
+
+    const nameInput = (await screen.findByPlaceholderText(
+      "e.g. Findings",
+    )) as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+    const headings = screen.getAllByPlaceholderText(
+      "Section heading",
+    ) as HTMLInputElement[];
+    expect(headings).toHaveLength(1);
+    expect(headings[0].value).toBe("");
+  });
+
+  it("reseeds with the template's data on Edit right after opening New", async () => {
+    h.templates = [INSPECTION];
+
+    render(<PhotoReportTemplatesTab />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new template/i }),
+    );
+    const nameInput = (await screen.findByPlaceholderText(
+      "e.g. Findings",
+    )) as HTMLInputElement;
+    expect(nameInput.value).toBe("");
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /edit inspection report/i }),
+    );
+    expect(await screen.findByDisplayValue("Inspection Report")).toBeDefined();
+    expect(screen.getByDisplayValue("Exterior")).toBeDefined();
+  });
+
+  it("does not carry a discarded New draft into the next New", async () => {
+    render(<PhotoReportTemplatesTab />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /new template/i }),
+    );
+    const draft = (await screen.findByPlaceholderText(
+      "e.g. Findings",
+    )) as HTMLInputElement;
+    fireEvent.change(draft, { target: { value: "Discarded draft" } });
+    expect(draft.value).toBe("Discarded draft");
+    fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /new template/i }));
+    const fresh = (await screen.findByPlaceholderText(
+      "e.g. Findings",
+    )) as HTMLInputElement;
+    expect(fresh.value).toBe("");
+  });
+
+  it("saves an edited template via update on the same id, not a new insert", async () => {
+    h.templates = [INSPECTION];
+
+    render(<PhotoReportTemplatesTab />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: /edit inspection report/i }),
+    );
+    const nameInput = await screen.findByDisplayValue("Inspection Report");
+    fireEvent.change(nameInput, { target: { value: "Inspection Report v2" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /update template/i }));
+
+    await waitFor(() => expect(h.updateMock).toHaveBeenCalledTimes(1));
+    expect(h.insertMock).not.toHaveBeenCalled();
+    expect(h.updateTargetId).toBe("t-insp");
+    expect(h.updateMock.mock.calls[0][0]).toMatchObject({
+      name: "Inspection Report v2",
+    });
   });
 });

--- a/src/app/settings/templates/photo-report-templates-tab.tsx
+++ b/src/app/settings/templates/photo-report-templates-tab.tsx
@@ -26,6 +26,12 @@ export function PhotoReportTemplatesTab() {
   const [builderOpen, setBuilderOpen] = useState(false);
   const [editingTemplate, setEditingTemplate] =
     useState<PhotoReportTemplate | null>(null);
+  // Bumped on every open so the builder re-mounts and its form reseeds from
+  // `editingTemplate` — the builder's useState initializers run once per mount,
+  // so a persistently-mounted builder would otherwise keep the previous (or
+  // empty) template's data (issue #440). Keying the always-mounted builder this
+  // way preserves the dialog's open/close animation and focus restoration.
+  const [builderSession, setBuilderSession] = useState(0);
   const [seeding, setSeeding] = useState(false);
 
   const fetchTemplates = useCallback(async () => {
@@ -66,11 +72,13 @@ export function PhotoReportTemplatesTab() {
   function handleEdit(template: PhotoReportTemplate) {
     setEditingTemplate(template);
     setBuilderOpen(true);
+    setBuilderSession((n) => n + 1);
   }
 
   function handleCreate() {
     setEditingTemplate(null);
     setBuilderOpen(true);
+    setBuilderSession((n) => n + 1);
   }
 
   async function handleSeedDefaults() {
@@ -229,6 +237,7 @@ export function PhotoReportTemplatesTab() {
       )}
 
       <ReportTemplateBuilder
+        key={builderSession}
         open={builderOpen}
         onOpenChange={(open) => {
           setBuilderOpen(open);


### PR DESCRIPTION
@-