### PR TITLE
fix(job-overview): Photo Report date shows the previous day in US timezones

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -10,6 +10,7 @@ import { pickPreloadUrls } from "@/lib/jobs/photo-preload";
 import { partitionPhotoReportsByTrash } from "@/lib/photo-report-trash";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
+import { parseDateOnly } from "@/lib/date-field";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
 import { Badge } from "@/components/ui/badge";
@@ -760,7 +761,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                 </p>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   {[
-                    job.date_of_loss ? `DOL: ${format(new Date(job.date_of_loss), "MMM d, yyyy")}` : null,
+                    job.date_of_loss ? `DOL: ${format(parseDateOnly(job.date_of_loss), "MMM d, yyyy")}` : null,
                     job.deductible != null ? `Deductible: $${Number(job.deductible).toLocaleString()}` : null,
                   ].filter(Boolean).join(" \u00b7 ")}
                 </p>
@@ -1138,7 +1139,7 @@ function ReportRowContent({ report }: { report: PhotoReport }) {
             {report.title}
           </p>
           <p className="text-xs text-muted-foreground/60">
-            {format(new Date(report.report_date), "MMM d, yyyy")}
+            {format(parseDateOnly(report.report_date), "MMM d, yyyy")}
           </p>
         </div>
       </div>

--- a/src/components/report-pdf/page-header.tsx
+++ b/src/components/report-pdf/page-header.tsx
@@ -3,6 +3,8 @@
 import { StyleSheet, Text, View } from "@react-pdf/renderer";
 import { format } from "date-fns";
 
+import { parseDateOnly } from "@/lib/date-field";
+
 const colors = {
   text: "#1A1A1A",
   muted: "#666666",
@@ -47,12 +49,9 @@ interface PageHeaderProps {
 }
 
 function formatReportDate(reportDate: string): string {
-  // report_date is a Postgres `date` (YYYY-MM-DD). Parse as a local
-  // calendar date so it does not shift across timezones.
-  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(reportDate);
-  const d = m
-    ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
-    : new Date(reportDate);
+  // report_date is a Postgres `date` (YYYY-MM-DD); parse it as a local calendar
+  // date so it does not shift across timezones (issue #444).
+  const d = parseDateOnly(reportDate);
   if (Number.isNaN(d.getTime())) return reportDate;
   return format(d, "MMM d, yyyy");
 }

--- a/src/lib/date-field.test.ts
+++ b/src/lib/date-field.test.ts
@@ -1,6 +1,24 @@
+import { format } from "date-fns";
 import { describe, expect, it } from "vitest";
 
-import { isValidPastDate, maskDateInput, parseMaskedDate } from "./date-field";
+import {
+  isValidPastDate,
+  maskDateInput,
+  parseDateOnly,
+  parseMaskedDate,
+} from "./date-field";
+
+/** Run `fn` with `process.env.TZ` pinned, then restore it. Node reads TZ per
+ *  Date operation, so this lets one test assert behavior in a specific zone. */
+function withTimeZone<T>(tz: string, fn: () => T): T {
+  const previous = process.env.TZ;
+  process.env.TZ = tz;
+  try {
+    return fn();
+  } finally {
+    process.env.TZ = previous;
+  }
+}
 
 describe("maskDateInput", () => {
   it("formats eight digits into MM/DD/YYYY", () => {
@@ -47,6 +65,44 @@ describe("parseMaskedDate", () => {
   it("returns null for a non-existent calendar date", () => {
     expect(parseMaskedDate("02/30/2024")).toBeNull();
     expect(parseMaskedDate("13/01/2024")).toBeNull();
+  });
+});
+
+describe("parseDateOnly", () => {
+  // Regression for issue #444: `new Date("2026-06-05")` parses as UTC midnight,
+  // which date-fns then renders as the previous day in negative-UTC (US) zones.
+  it("renders the literal calendar day in US/Eastern", () => {
+    withTimeZone("America/New_York", () => {
+      expect(format(parseDateOnly("2026-06-05"), "MMM d, yyyy")).toBe(
+        "Jun 5, 2026",
+      );
+    });
+  });
+
+  it("renders the literal calendar day in US/Pacific", () => {
+    withTimeZone("America/Los_Angeles", () => {
+      expect(format(parseDateOnly("2026-06-05"), "MMM d, yyyy")).toBe(
+        "Jun 5, 2026",
+      );
+    });
+  });
+
+  it("pins the parts to the local calendar day regardless of zone", () => {
+    withTimeZone("America/Los_Angeles", () => {
+      const date = parseDateOnly("2026-06-05");
+      expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([
+        2026, 5, 5,
+      ]);
+    });
+  });
+
+  it("keeps the local calendar day when a time component is present", () => {
+    withTimeZone("America/Los_Angeles", () => {
+      const date = parseDateOnly("2026-06-05T23:30:00");
+      expect([date.getFullYear(), date.getMonth(), date.getDate()]).toEqual([
+        2026, 5, 5,
+      ]);
+    });
   });
 });
 

--- a/src/lib/date-field.ts
+++ b/src/lib/date-field.ts
@@ -21,6 +21,21 @@ export function parseMaskedDate(input: string): Date | null {
   return date;
 }
 
+/**
+ * Parse a date-only string (`YYYY-MM-DD`, e.g. a Postgres `date` column) into a
+ * local-midnight Date. `new Date("YYYY-MM-DD")` parses as UTC midnight, which
+ * renders as the previous calendar day in negative-UTC (US) timezones; building
+ * the Date from its parts pins it to the user's local day (issue #444). Any
+ * trailing time component is ignored; non-date input falls back to `Date`'s own
+ * parsing (yielding an Invalid Date that callers can detect).
+ */
+export function parseDateOnly(input: string): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(input);
+  return m
+    ? new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]))
+    : new Date(input);
+}
+
 /** True when input is a complete, real `MM/DD/YYYY` date that is not in the future. */
 export function isValidPastDate(input: string): boolean {
   const date = parseMaskedDate(input);


### PR DESCRIPTION
## Summary

The Job Overview rendered `report_date` and the sibling `date_of_loss` via `new Date("YYYY-MM-DD")`, which JavaScript parses as **UTC midnight** and then formats in the host's local zone — yielding the **previous calendar day** in any UTC-minus (US) timezone, disagreeing with the builder's native date input. Closes #444.

- Add `parseDateOnly()` to `src/lib/date-field.ts` — builds a local-midnight `Date` from the `YYYY-MM-DD` parts (ignores any trailing time; falls back to `Date` parsing for non-date input).
- Use it at both Job Overview sites (`report_date` row + `date_of_loss` insurance line) in `job-detail.tsx`.
- Consolidate the identical inline local-parse in `report-pdf/page-header.tsx` onto the shared helper (removes duplication of the same fix pattern).

## Test plan

New `parseDateOnly` tests in `src/lib/date-field.test.ts` (timezone pinned via `process.env.TZ`):

- [x] `2026-06-05` renders **"Jun 5, 2026"** in `America/New_York`
- [x] `2026-06-05` renders **"Jun 5, 2026"** in `America/Los_Angeles`
- [x] Local parts stay `2026/Jun/5` regardless of zone (matches the builder's literal date)
- [x] A trailing time component is ignored (keeps the local calendar day)
- [x] Reverting the helper to `new Date(input)` makes the new tests fail with `'Jun 4, 2026'` — confirms they catch the regression

date-field suite: 18/18 pass. `tsc`/`lint` add no new failures over the known-red baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)