### PR TITLE
fix(photo-report-builder): flush pending edit on unmount (#443)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -527,6 +527,73 @@ describe("PhotoReportBuilder write-up fit counter", () => {
   });
 });
 
+describe("PhotoReportBuilder unmount flush (#443)", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    vi.useFakeTimers();
+  });
+
+  it("flushes the pending edit when the builder unmounts within the debounce window", () => {
+    const { unmount } = renderBuilder();
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Roof damage report" },
+      });
+    });
+
+    // Unmount BEFORE the 2s debounce elapses — the autosave timer has not fired,
+    // so nothing has been written yet (this is the lost-edit window in #443).
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+
+    // The pending dirty edit is flushed on unmount, persisting the last edit.
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    expect(h.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Roof damage report" }),
+    );
+  });
+
+  it("does not flush when the builder was never edited", () => {
+    const { unmount } = renderBuilder();
+
+    // No edit happened, so the report is not dirty — unmounting must not write.
+    act(() => {
+      unmount();
+    });
+
+    expect(h.updateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not flush an over-limit write-up on unmount", () => {
+    const { unmount } = renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: { value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>` },
+      });
+    });
+
+    // The write-up overflows its one-page intro, so the report is dirty but
+    // blocked. The flush must honour the same save-time guard (#404) as the
+    // debounced save and refuse to persist the over-limit content.
+    act(() => {
+      unmount();
+    });
+
+    expect(h.updateMock).not.toHaveBeenCalled();
+  });
+});
+
 describe("PhotoReportBuilder save-time guard", () => {
   beforeEach(() => {
     h.updateMock.mockClear();

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -49,6 +49,13 @@ const DEBOUNCE_MS = 2000;
 
 type SaveStatus = "idle" | "saving" | "saved" | "error" | "blocked";
 
+// A report can't be persisted while any Section's write-up overflows its
+// one-page intro (issue #404). Both save paths gate on this one rule — the
+// debounced auto-save and the unmount flush (#443) — so it lives in one place.
+function hasOverLimitSection(sections: ReportSection[]): boolean {
+  return sections.some((s) => !measureWriteupFit(s.description).fits);
+}
+
 interface PhotoReportBuilderProps {
   jobId: string;
   report: PhotoReport;
@@ -93,13 +100,10 @@ export default function PhotoReportBuilder({
     revisionRef.current = state.revision;
     if (!state.dirty) return;
     const savedRevision = state.revision;
-    // Save-time guard (issue #404): a write-up that overflows its one-page
-    // intro must not be persisted. The whole report write is held back while any
-    // Section is over the limit — the same measureWriteupFit the live counter
-    // uses — so the report stays dirty and saves itself once trimmed back under.
-    const overLimit = state.sections.some(
-      (s) => !measureWriteupFit(s.description).fits,
-    );
+    // Save-time guard (issue #404): the whole report write is held back while
+    // any Section is over the limit, so the report stays dirty and saves itself
+    // once trimmed back under.
+    const overLimit = hasOverLimitSection(state.sections);
     const timer = setTimeout(async () => {
       if (overLimit) {
         setSaveStatus("blocked");
@@ -136,6 +140,32 @@ export default function PhotoReportBuilder({
     state.revision,
     report.id,
   ]);
+
+  // Flush a pending edit when the builder unmounts (issue #443). The auto-save
+  // above only persists on a 2s debounce and its cleanup merely clears the
+  // timer, so navigating away (e.g. tapping "Back to job", easy on a tablet)
+  // within that window would otherwise silently drop the last edit. We mirror
+  // the latest savable snapshot into a ref and write it on unmount, reusing the
+  // same update path. The ref is rewritten every render so the cleanup reads the
+  // freshest snapshot, not the stale closure captured at mount.
+  const flushOnUnmountRef = useRef<() => void>(() => {});
+  flushOnUnmountRef.current = () => {
+    if (!state.dirty) return;
+    // Honour the same save-time over-limit guard (#404) as the debounced save:
+    // a flush must never sneak an over-limit write-up past it on unmount.
+    if (hasOverLimitSection(state.sections)) return;
+    const supabase = createClient();
+    void supabase
+      .from("photo_reports")
+      .update({
+        title: state.title,
+        report_date: state.reportDate,
+        sections: state.sections,
+      })
+      .eq("id", report.id);
+  };
+  // Empty deps: the cleanup runs only on unmount.
+  useEffect(() => () => flushOnUnmountRef.current(), []);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),


### PR DESCRIPTION
## Summary

Fixes #443. The Photo Report builder persisted only through a 2s debounced autosave whose effect cleanup just cleared the pending timer (no flush, no `beforeunload`). Editing a field and then leaving the builder within that window — e.g. tapping **Back to job**, easy on a touch tablet — silently dropped the last edit, undercutting the "auto-saved draft" guarantee.

- **Flush on unmount:** a mount-only effect whose cleanup persists the latest dirty snapshot when the builder unmounts/navigates away, reusing the same Supabase write as autosave.
- **Respects the over-limit guard:** the flush gates on the same `#404` rule as the debounced save, so it never sneaks an over-limit write-up past on unmount.
- **No stale closure:** the savable snapshot is mirrored into a ref each render, so the cleanup writes the *freshest* state rather than the mount-time closure.
- **DRY:** extracted `hasOverLimitSection` so the debounced save and the flush share one over-limit rule.

Per the issue, the optional `beforeunload` prompt was intentionally **out of scope** — the unmount flush already covers in-app navigation ("Back to job"), which is the reported scenario.

## Test Plan

Built test-first (red→green per behavior). New regression tests in `photo-report-builder.test.tsx`:

- [x] A save fires on unmount **within** the debounce window, persisting the edited value (the core acceptance criterion).
- [x] **No** save fires when the report was never edited (not dirty).
- [x] **No** save fires when a write-up is over the one-page limit (honors `#404`).

Verification:
- [x] `vitest run src/components/photo-report-builder.test.tsx` → 24/24 pass (21 prior + 3 new).
- [x] `eslint` on the two touched files → 0 errors (only pre-existing `<img>` warnings).
- [x] `tsc --noEmit` → touched files add 0 new errors (remaining baseline errors are pre-existing, clustered in the unrelated PDF stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)