### PR TITLE
fix(photo-report-builder): Generate PDF from latest edits, not last-saved state (#441)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -9,7 +9,7 @@
 // sonner, and the PDF generator. Follows the RTL pattern in
 // estimate-drag-end.test.tsx.
 
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 
 import type { Photo, PhotoReport } from "@/lib/types";
@@ -22,6 +22,9 @@ const h = vi.hoisted(() => ({
   updateMock: vi.fn<(payload: Record<string, unknown>) => void>(),
   manual: false,
   resolvers: [] as Array<() => void>,
+  // When true, every save resolves with a Supabase error, so a test can drive
+  // the failed-save path (issue #441: a failed flush must not yield a PDF).
+  errorOnSave: false,
 }));
 
 vi.mock("@/lib/supabase", () => ({
@@ -31,11 +34,13 @@ vi.mock("@/lib/supabase", () => ({
         h.updateMock(payload);
         return {
           eq: () =>
-            h.manual
-              ? new Promise<{ error: null }>((resolve) =>
-                  h.resolvers.push(() => resolve({ error: null })),
-                )
-              : Promise.resolve({ error: null }),
+            h.errorOnSave
+              ? Promise.resolve({ error: { message: "save failed" } })
+              : h.manual
+                ? new Promise<{ error: null }>((resolve) =>
+                    h.resolvers.push(() => resolve({ error: null })),
+                  )
+                : Promise.resolve({ error: null }),
         };
       },
     }),
@@ -102,6 +107,8 @@ vi.mock("@dnd-kit/core", async () => {
 import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
 import { WRITEUP_CHARACTER_LIMIT } from "@/lib/section-writeup-fit";
+import { generateReportPDF } from "@/lib/generate-report-pdf";
+import { toast } from "sonner";
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
   return {
@@ -759,5 +766,118 @@ describe("PhotoReportBuilder save-time guard", () => {
     });
     expect(screen.queryByText("Saved")).toBeNull();
     expect(screen.getByText(/can't save/i)).toBeTruthy();
+  });
+});
+
+// Issue #441 — Generating the PDF must reflect what is on screen, not the
+// last-saved row. The generator (`generateReportPDF`) re-reads the persisted row
+// and is mocked here, so these tests assert what the builder does *before* it
+// calls the generator: it flushes pending edits, and it refuses to generate a
+// stale PDF when the report is over the one-page limit.
+describe("PhotoReportBuilder generate", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    h.errorOnSave = false;
+    vi.mocked(generateReportPDF).mockClear();
+    vi.mocked(generateReportPDF).mockResolvedValue("job-1/report-1.pdf");
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+    vi.spyOn(window, "open").mockImplementation(() => null);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.mocked(window.open).mockRestore();
+  });
+
+  function clickGenerate() {
+    return act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+  }
+
+  it("flushes a pending edit to the database before generating, so the PDF reflects it", async () => {
+    renderBuilder();
+
+    // Edit the title but do NOT let the 2s auto-save debounce elapse.
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Latest title" },
+      });
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    // Clicking Generate now must first persist the edit, then generate.
+    await clickGenerate();
+
+    // The latest on-screen content was written…
+    expect(h.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Latest title" }),
+    );
+    // …and it was written BEFORE the generator (which reads the persisted row) ran.
+    expect(h.updateMock.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(generateReportPDF).mock.invocationCallOrder[0],
+    );
+    expect(vi.mocked(generateReportPDF)).toHaveBeenCalledWith("report-1");
+  });
+
+  it("refuses to generate when a section write-up is over the one-page limit, producing no PDF", async () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          {
+            title: "Findings",
+            description: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
+            photo_ids: [],
+          },
+        ],
+      }),
+    );
+
+    await clickGenerate();
+
+    // No stale PDF: the generator (which would render the persisted, shorter
+    // row) is never invoked.
+    expect(vi.mocked(generateReportPDF)).not.toHaveBeenCalled();
+    // The user is told why, in plain terms.
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      expect.stringMatching(/too long|shorten/i),
+    );
+  });
+
+  it("does not generate a PDF when flushing the pending edit fails", async () => {
+    h.errorOnSave = true;
+    renderBuilder();
+
+    // A pending edit makes the report dirty; the debounce has not elapsed.
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Latest title" },
+      });
+    });
+
+    await clickGenerate();
+
+    // The flush failed, so the generator (which would read the older persisted
+    // row) must not run — better no PDF than a stale one.
+    expect(vi.mocked(generateReportPDF)).not.toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+  });
+
+  it("generates and opens the PDF for a fitting report with no pending edits", async () => {
+    renderBuilder();
+
+    await clickGenerate();
+
+    // A clean, fitting report needs no flush, generates, and opens in a new tab.
+    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(vi.mocked(generateReportPDF)).toHaveBeenCalledWith("report-1");
+    expect(vi.mocked(toast.success)).toHaveBeenCalled();
+    expect(vi.mocked(window.open)).toHaveBeenCalledWith(
+      "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1.pdf",
+      "_blank",
+    );
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import Link from "next/link";
 import {
   DndContext,
@@ -37,6 +37,7 @@ import TiptapEditor from "@/components/tiptap-editor";
 import {
   initBuilderState,
   photoReportBuilderReducer,
+  type PhotoReportBuilderState,
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
 import { measureWriteupFit } from "@/lib/section-writeup-fit";
@@ -50,10 +51,23 @@ const DEBOUNCE_MS = 2000;
 type SaveStatus = "idle" | "saving" | "saved" | "error" | "blocked";
 
 // A report can't be persisted while any Section's write-up overflows its
-// one-page intro (issue #404). Both save paths gate on this one rule — the
-// debounced auto-save and the unmount flush (#443) — so it lives in one place.
+// one-page intro (issue #404). Every save path gates on this one rule — the
+// debounced auto-save, the unmount flush (#443), and the Generate flush (#441)
+// — so it lives in one place.
 function hasOverLimitSection(sections: ReportSection[]): boolean {
   return sections.some((s) => !measureWriteupFit(s.description).fits);
+}
+
+// The fields a save persists, plus the revision that snapshot belongs to. Built
+// in one place so the debounced auto-save and the Generate flush always persist
+// exactly the same shape. (issue #441)
+function snapshotOf(state: PhotoReportBuilderState) {
+  return {
+    title: state.title,
+    reportDate: state.reportDate,
+    sections: state.sections,
+    revision: state.revision,
+  };
 }
 
 interface PhotoReportBuilderProps {
@@ -87,59 +101,71 @@ export default function PhotoReportBuilder({
   // `state` is stale by then). Without this, a slow valid save resolving after a
   // newer over-limit edit would flip the badge from "blocked" back to "Saved".
   const revisionRef = useRef(state.revision);
+  // Holds the pending auto-save debounce timer so the Generate flush can cancel
+  // it and write immediately, rather than racing the debounce. (issue #441)
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const photosById = new Map(photos.map((p) => [p.id, p]));
 
-  // Auto-save: a debounced write whenever the builder is dirty. The closure
-  // captures the state (and its `revision`) as of the last edit, so we persist
-  // exactly that snapshot and tell `markSaved` which revision it was. If the
-  // user edits again while this write is in flight, that edit bumps the
-  // revision and reschedules its own save; `markSaved` then declines to clear
-  // dirty for the older revision, so the newer edit is never lost.
-  useEffect(() => {
-    revisionRef.current = state.revision;
-    if (!state.dirty) return;
-    const savedRevision = state.revision;
-    // Save-time guard (issue #404): the whole report write is held back while
-    // any Section is over the limit, so the report stays dirty and saves itself
-    // once trimmed back under.
-    const overLimit = hasOverLimitSection(state.sections);
-    const timer = setTimeout(async () => {
-      if (overLimit) {
-        setSaveStatus("blocked");
-        return;
-      }
+  // Persist a builder snapshot. Shared by the debounced auto-save and the
+  // Generate flush so both write the same way and report status the same way.
+  // The snapshot is passed in (not closed over) so this function is stable and
+  // always writes exactly what the caller decided to persist. Returns whether
+  // the write succeeded, so a caller (Generate) can avoid producing a stale PDF
+  // when the flush failed. (issue #441)
+  const writeReport = useCallback(
+    async (snapshot: ReturnType<typeof snapshotOf>): Promise<boolean> => {
       setSaveStatus("saving");
       const supabase = createClient();
       const { error } = await supabase
         .from("photo_reports")
         .update({
-          title: state.title,
-          report_date: state.reportDate,
-          sections: state.sections,
+          title: snapshot.title,
+          report_date: snapshot.reportDate,
+          sections: snapshot.sections,
         })
         .eq("id", report.id);
       if (error) {
         setSaveStatus("error");
-        return;
+        return false;
       }
-      dispatch({ type: "markSaved", revision: savedRevision });
+      dispatch({ type: "markSaved", revision: snapshot.revision });
       // Only claim "Saved" if no newer edit landed while this write was in
       // flight. If one did, its own effect run owns the status (e.g. it may have
       // set "blocked"), so we must not overwrite it with a stale success.
-      if (savedRevision === revisionRef.current) {
+      if (snapshot.revision === revisionRef.current) {
         setSaveStatus("saved");
       }
+      return true;
+    },
+    [report.id],
+  );
+
+  // Auto-save: a debounced write whenever the builder is dirty. The effect
+  // captures the state (and its `revision`) as of the last edit and hands that
+  // snapshot to `writeReport`, so we persist exactly that snapshot. If the user
+  // edits again while this write is in flight, that edit bumps the revision and
+  // reschedules its own save; `markSaved` then declines to clear dirty for the
+  // older revision, so the newer edit is never lost.
+  useEffect(() => {
+    revisionRef.current = state.revision;
+    if (!state.dirty) return;
+    // Save-time guard (issue #404): the whole report write is held back while
+    // any Section is over the limit, so the report stays dirty and saves itself
+    // once trimmed back under.
+    const overLimit = hasOverLimitSection(state.sections);
+    const timer = setTimeout(() => {
+      if (overLimit) {
+        setSaveStatus("blocked");
+        return;
+      }
+      void writeReport(snapshotOf(state));
     }, DEBOUNCE_MS);
+    saveTimerRef.current = timer;
     return () => clearTimeout(timer);
-  }, [
-    state.dirty,
-    state.title,
-    state.reportDate,
-    state.sections,
-    state.revision,
-    report.id,
-  ]);
+    // `state` is a fresh object on every dispatch, so this re-arms the debounce
+    // on each edit; `report.id` is covered transitively through `writeReport`.
+  }, [state, writeReport]);
 
   // Flush a pending edit when the builder unmounts (issue #443). The auto-save
   // above only persists on a 2s debounce and its cleanup merely clears the
@@ -183,8 +209,30 @@ export default function PhotoReportBuilder({
   const availablePhotos = photos.filter((p) => !assignedIds.has(p.id));
 
   const handleGenerate = async () => {
+    // A write-up over the one-page limit was never persisted (the save guard
+    // holds it back), so generating now would render a stale, shorter PDF.
+    // Refuse with a clear message instead of silently producing it. (issue #441)
+    if (hasOverLimitSection(state.sections)) {
+      setSaveStatus("blocked");
+      toast.error("Write-up too long — shorten it before generating.");
+      return;
+    }
+
     setGenerating(true);
     try {
+      // The PDF is rendered from the persisted row and auto-save is debounced,
+      // so a just-made edit may not be on disk yet. Flush it first (cancelling
+      // the pending debounce) so the PDF reflects what is on screen. (issue #441)
+      if (state.dirty) {
+        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+        const saved = await writeReport(snapshotOf(state));
+        // If the flush failed, the persisted row is still the old one. Better to
+        // produce no PDF than a stale one — bail with a message. (issue #441)
+        if (!saved) {
+          toast.error("Couldn't save your latest edits — try again.");
+          return;
+        }
+      }
       const pdfPath = await generateReportPDF(report.id);
       toast.success("PDF generated.");
       window.open(


### PR DESCRIPTION
Closes #441.

## Problem
The builder's **Generate PDF** renders from the **persisted report row**, but auto-save is debounced (~2s) and the handler never flushed it or checked save status. Two failure modes, both with a misleading success toast:

1. **Pending-edit race** — an edit made inside the debounce window isn't on disk yet, so the PDF omits it.
2. **Blocked save** — when a section write-up exceeds the one-page limit, the save guard sets `blocked` and persists nothing, so Generate renders the older/shorter row.

## Fix
`handleGenerate` now (keeping the button enabled — flush-then-generate, the issue's "Desired behavior"):

- **Over the one-page limit** → refuse with a clear toast (*"Write-up too long — shorten it before generating."*) and produce **no PDF**.
- **Pending edits** → flush them (cancelling the pending debounce) and **await** the write before generating, so the PDF reflects what's on screen.
- **Flush fails** → bail with a message instead of generating a stale PDF.

The DB write is extracted into a shared `writeReport(snapshot)` helper used by both auto-save and the flush, so the two paths can't drift. No changes to `generateReportPDF` (it correctly reads the persisted row) or the reducer.

## Acceptance criteria
- [x] Edit a title/write-up/photo placement then immediately Generate → PDF includes the edits (persisted first).
- [x] Generate short-circuits with a message while dirty/blocked (flushes when dirty, blocks when over-limit).
- [x] An over-limit section cannot be generated until it fits.
- [x] Tests cover generate-after-edit and generate-while-blocked (the generate path was previously unclicked/untested).

## Test plan
- `src/components/photo-report-builder.test.tsx`: **25 pass** (21 pre-existing + 4 new: flush-before-generate, over-limit-refused, failed-flush-aborts, happy-path).
- All photo-report-related test files together: **64 pass**.
- `eslint` on touched files: 0 errors (2 pre-existing `<img>` warnings only).
- `tsc --noEmit`: no errors in touched files. (Pre-existing, unrelated `@react-pdf/renderer`/`sharp` module-resolution errors come from an incomplete `node_modules` install on `main`, not this change.)

Built test-first (red→green per behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)