### PR TITLE
fix(api/reports): create route does not verify the job belongs to the caller's org

### DIFF
--- a/src/app/api/jobs/[id]/reports/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/route.test.ts
@@ -41,8 +41,10 @@ function postBody(body: unknown) {
   });
 }
 
-// A caller who is a member with edit_jobs and whose user_profiles row carries a
-// display name (the route stamps this into the report's "Prepared by").
+// A caller who is a member with edit_jobs, whose user_profiles row carries a
+// display name (the route stamps this into the report's "Prepared by"), and for
+// whom the URL's Job (`job-1`) is visible in their Organization — the route now
+// verifies job visibility before creating a report (#446).
 function authedClient() {
   return fakeUserClient({
     user: { id: "user-1" },
@@ -52,6 +54,7 @@ function authedClient() {
       grants: ["edit_jobs"],
       extraTables: {
         user_profiles: [{ id: "user-1", full_name: "Eric Daniels" }],
+        jobs: [{ id: "job-1", organization_id: "org-1" }],
       },
     }),
   });
@@ -78,6 +81,54 @@ describe("POST /api/jobs/[id]/reports", () => {
 
     expect(res.status).toBe(403);
     expect(createPhotoReportDraft).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 without creating a report when the Job is not visible to the caller's organization", async () => {
+    // Issue #446: the URL job id was used unvalidated, so a caller in org A
+    // could create a report referencing org B's job (or a bogus id). Under the
+    // caller's RLS-scoped client a cross-org or nonexistent job simply isn't
+    // visible, so the route must 404 *before* any report is created — and the
+    // cross-org and nonexistent cases must look identical (no existence oracle
+    // distinguishing a real-but-foreign id from a fake one).
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "member",
+          grants: ["edit_jobs"],
+          extraTables: {
+            user_profiles: [{ id: "user-1", full_name: "Eric Daniels" }],
+            // No `jobs` row: the job is not visible to this caller's org.
+          },
+        }),
+      }) as never,
+    );
+
+    const res = await POST(postBody({ photoIds: ["p1"] }), paramsFor("job-1"));
+
+    expect(res.status).toBe(404);
+    expect(createPhotoReportDraft).not.toHaveBeenCalled();
+  });
+
+  it("creates the report (201) when the Job is visible to the caller's organization", async () => {
+    // AC #3 (#446): the visibility guard must reject only foreign/nonexistent
+    // jobs — a job the caller can legitimately see still creates normally and
+    // forwards the URL job id to the create step.
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      authedClient() as never,
+    );
+
+    const res = await POST(
+      postBody({ photoIds: ["p1", "p2"] }),
+      paramsFor("job-1"),
+    );
+
+    expect(res.status).toBe(201);
+    expect(createPhotoReportDraft).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ jobId: "job-1", organizationId: "org-1" }),
+    );
   });
 
   it("forwards an explicit templateId to the create step", async () => {

--- a/src/app/api/jobs/[id]/reports/route.ts
+++ b/src/app/api/jobs/[id]/reports/route.ts
@@ -26,6 +26,24 @@ export const POST = withRequestContext(
       );
     }
 
+    // Verify the URL's Job is visible to the caller's Organization before doing
+    // any work for it (#446). `ctx.supabase` is RLS-scoped, so a cross-org or
+    // nonexistent job id resolves to no row — both 404 identically, leaking no
+    // existence oracle. Without this, the create step would stamp a report with
+    // the caller's org_id but a foreign job_id (a cross-org dangling reference),
+    // since the report-row RLS WITH CHECK validates only organization_id.
+    const { data: job, error: jobError } = await ctx.supabase
+      .from("jobs")
+      .select("id")
+      .eq("id", jobId)
+      .maybeSingle<{ id: string }>();
+    if (jobError) {
+      return apiDbError(jobError.message, "POST /api/jobs/[id]/reports");
+    }
+    if (!job) {
+      return NextResponse.json({ error: "Job not found" }, { status: 404 });
+    }
+
     const { data: profile } = await ctx.supabase
       .from("user_profiles")
       .select("full_name")


### PR DESCRIPTION
## Summary

`POST /api/jobs/[id]/reports` stamped the new `photo_reports` row with the caller's active `organization_id` but used the URL's `job_id` **unvalidated**. The report-row RLS `WITH CHECK` validates only `organization_id`, and no FK enforces job/org consistency — so an authenticated user in org A could create a report referencing org B's job (`organization_id = A`, `job_id = B's`). That is a cross-org dangling reference **and** a job-UUID existence oracle (real id → 201, bogus id → error). No photo data leaks (photos stay RLS-blocked), but it violates the Job-scoped integrity guarantee.

**Fix:** under the caller's RLS-scoped client (`ctx.supabase`), look the Job up by id **before any report-number allocation or insert**. A cross-org or nonexistent job resolves to no row and **404s identically** (no existence oracle); a genuine DB error still redacts to 500 via `apiDbError`. An in-org job creates normally. This mirrors the sibling `jobs/[id]` route's fetch-by-id → 404 idiom and the create route's own `user_profiles` lookup.

## Acceptance criteria

- [x] Creating a report for a job in another organization returns **404** and inserts no row.
- [x] Creating a report for a job that does not exist returns **404** (no existence oracle via 500 vs 201).
- [x] Creating a report for an in-org job still **succeeds (201)**.
- [x] A test covers the cross-org / nonexistent-job rejection — the previous create test mocked the data layer entirely; the route test now exercises the **real** `jobs` lookup on `ctx.supabase`.

## Test plan (TDD)

- **RED** → new route test for an invisible job failed with `expected 201 to be 404` (the route had created a report for a job the caller can't see).
- **GREEN** → added the route guard; seeded the happy-path fixture with a visible job.
- **Finalize** → explicit in-org-success (AC #3) acceptance lock.
- `vitest run` on the two related suites: **14/14 green** (5 route + 9 lib).
- `tsc --noEmit`: 34 errors = the pre-existing baseline, **0 in the touched paths**. ESLint on both touched files: **clean**.

## Notes / out of scope

- The issue's **optional** DB-level CHECK/trigger (defense-in-depth asserting a report's `organization_id` matches its job's) is intentionally left as a follow-up: it needs a Supabase migration and can't be exercised by this unit suite. The application-level guard fully satisfies the stated acceptance criteria.
- No change to report read/delete/restore scoping, the RLS model, or `created_by` (all out of scope per the issue).

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)