### PR TITLE
fix(photo-report-builder): persistent Open-PDF link, drop blocked window.open (#442)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -100,8 +100,12 @@ vi.mock("@dnd-kit/core", async () => {
 });
 
 import React from "react";
+import { toast } from "sonner";
 import PhotoReportBuilder from "./photo-report-builder";
+import { generateReportPDF } from "@/lib/generate-report-pdf";
 import { WRITEUP_CHARACTER_LIMIT } from "@/lib/section-writeup-fit";
+
+const mockGenerate = vi.mocked(generateReportPDF);
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
   return {
@@ -692,5 +696,112 @@ describe("PhotoReportBuilder save-time guard", () => {
     });
     expect(screen.queryByText("Saved")).toBeNull();
     expect(screen.getByText(/can't save/i)).toBeTruthy();
+  });
+});
+
+// Issue #442 — on iPad / iOS WebView the post-`await` window.open is blocked, so
+// the generated PDF was a dead-end that still showed a success toast. The fix is
+// a persistent "Open PDF" anchor the user taps (a real user gesture), bound to
+// the report's pdf_path. These drive the generate flow through the DOM. No fake
+// timers here: generation is promise-based, not debounce/timer-based.
+describe("PhotoReportBuilder generate + retrieve PDF", () => {
+  beforeEach(() => {
+    // Generation is promise-based, and findByRole polls on real timers. Earlier
+    // describes enable fake timers without restoring them, so reset to real
+    // timers here or findByRole would stall.
+    vi.useRealTimers();
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    // Reset the generator to a clean default so per-call overrides
+    // (mockResolvedValueOnce / mockRejectedValueOnce) can't leak between tests.
+    mockGenerate.mockReset();
+    mockGenerate.mockResolvedValue("job-1/report-1.pdf");
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.error).mockClear();
+  });
+
+  it("shows a tappable Open-PDF link after generating, bound to the report PDF path", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+
+    const link = await screen.findByRole("link", { name: /open pdf/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1.pdf",
+    );
+    expect(link.getAttribute("target")).toBe("_blank");
+  });
+
+  it("delivers the PDF via the link, not a programmatic popup (the iPad/WebView regression)", async () => {
+    // The original bug: window.open ran after `await`, so iOS had already
+    // consumed the tap's user-gesture allowance and silently blocked the popup.
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+
+    // Retrieval works — the persistent link is there ...
+    await screen.findByRole("link", { name: /open pdf/i });
+    // ... and it does not depend on a blockable post-await window.open.
+    expect(openSpy).not.toHaveBeenCalled();
+
+    openSpy.mockRestore();
+  });
+
+  it("updates the link to the latest PDF when regenerated", async () => {
+    mockGenerate
+      .mockResolvedValueOnce("job-1/report-1.pdf")
+      .mockResolvedValueOnce("job-1/report-1-v2.pdf");
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+    const first = await screen.findByRole("link", { name: /open pdf/i });
+    expect(first.getAttribute("href")).toBe(
+      "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1.pdf",
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+    const second = await screen.findByRole("link", { name: /open pdf/i });
+    expect(second.getAttribute("href")).toBe(
+      "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1-v2.pdf",
+    );
+  });
+
+  it("shows no link and reports an error when generation fails", async () => {
+    mockGenerate.mockRejectedValueOnce(new Error("boom"));
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /generate pdf/i }));
+    });
+
+    // No false success: no retrieval affordance, an error is surfaced, and the
+    // success toast never fires.
+    expect(screen.queryByRole("link", { name: /open pdf/i })).toBeNull();
+    expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled();
+  });
+
+  it("shows the Open-PDF link on load for an already-generated report", () => {
+    // A report generated in a previous session persists its pdf_path; the user
+    // can retrieve that PDF without regenerating (the removed global /reports
+    // detail page used to provide this Download anchor).
+    renderBuilder(
+      makeReport({ pdf_path: "job-1/report-1.pdf", status: "generated" }),
+    );
+
+    const link = screen.getByRole("link", { name: /open pdf/i });
+    expect(link.getAttribute("href")).toBe(
+      "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1.pdf",
+    );
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -74,6 +74,11 @@ export default function PhotoReportBuilder({
   );
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [generating, setGenerating] = useState(false);
+  // The path of the most recently generated PDF, surfaced as a persistent
+  // "Open PDF" link the user taps (issue #442). Seeded from the report so a
+  // PDF generated in an earlier session is retrievable on load without
+  // regenerating.
+  const [pdfPath, setPdfPath] = useState<string | null>(report.pdf_path);
 
   // The latest edit revision, mirrored into a ref so the async save tail can
   // tell whether a newer edit landed while it was in flight (its own captured
@@ -155,12 +160,9 @@ export default function PhotoReportBuilder({
   const handleGenerate = async () => {
     setGenerating(true);
     try {
-      const pdfPath = await generateReportPDF(report.id);
+      const generatedPath = await generateReportPDF(report.id);
+      setPdfPath(generatedPath);
       toast.success("PDF generated.");
-      window.open(
-        `${supabaseUrl}/storage/v1/object/public/reports/${pdfPath}`,
-        "_blank",
-      );
     } catch {
       toast.error("Failed to generate PDF.");
     } finally {
@@ -206,6 +208,17 @@ export default function PhotoReportBuilder({
           )}
           Generate PDF
         </button>
+        {pdfPath && (
+          <a
+            href={`${supabaseUrl}/storage/v1/object/public/reports/${pdfPath}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-[#2B5EA7] px-4 py-1.5 text-sm font-semibold text-[#2B5EA7] hover:bg-[#2B5EA7]/10 transition-colors"
+          >
+            <FileDown size={14} />
+            Open PDF
+          </a>
+        )}
       </header>
 
       {/* Body */}


### PR DESCRIPTION
## Summary

On iPad / iOS WebView the generated PDF never opened and the builder offered no other way to retrieve it, yet a "PDF generated." success toast still showed — a dead end that looked like success.

`handleGenerate` `await`ed PDF generation + upload and **then** called `window.open(publicUrl, "_blank")`. On iOS Safari / WKWebView the user-gesture allowance is consumed after the `await`, so the popup is silently blocked.

## Fix

Replace the fragile post-`await` `window.open` with a **persistent "Open PDF" anchor** (`<a href target="_blank" rel="noopener noreferrer">`) bound to the report's `pdf_path`:

- Tracked in component state, **seeded from `report.pdf_path`** so a PDF generated in an earlier session is retrievable on load without regenerating (restores the Download affordance the removed global `/reports` detail page used to provide).
- The tap on a real anchor is itself the user gesture → opens reliably on iPad and desktop.
- On failure, no link is shown and the success toast does not fire.
- Re-generating updates the link to the latest PDF.

Out of scope (unchanged): server-side PDF generation, the `reports` bucket's public/private visibility.

## Acceptance criteria

- [x] After generating on iPad/WebView, the user has a tappable element that opens/downloads the PDF.
- [x] The same works on desktop browsers.
- [x] The "generated" success state is not shown when the PDF cannot be presented (failure path shows no link + error toast, no success).
- [x] Re-generating updates the link to the latest PDF.

## Tests (TDD)

Added 5 cases to `photo-report-builder.test.tsx` (now **26/26 pass**), each driven red→green:

1. Open-PDF link appears after generate, with correct `href` + `target="_blank"`
2. Generating does **not** call `window.open` (the iPad/WebView regression guard)
3. Re-generating updates the link to the latest PDF
4. Failure → no link, error toast, no success state
5. Already-generated report shows the link on load

Also restored real timers in the new `describe` block — earlier blocks enable fake timers without restoring them, which would stall `findByRole`.

## Verification

- `photo-report-builder.test.tsx`: **26/26 pass**
- ESLint on touched files: **0 errors** (pre-existing `<img>` warnings on untouched lines only)
- `tsc --noEmit`: touched files contribute **0 errors** (consistent with the repo's known-red baseline)

Fixes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
