### PR TITLE
chore(email): sync email schema snapshot + types to prod multi-tenancy

### DIFF
--- a/src/components/email/build-quoted-reply.test.ts
+++ b/src/components/email/build-quoted-reply.test.ts
@@ -29,6 +29,7 @@ function makeEmail(overrides: Partial<Email> = {}): Email {
     uid: null,
     received_at: "2024-03-15T14:30:00",
     created_at: "2024-03-15T14:30:00",
+    organization_id: "org-1",
     ...overrides,
   };
 }

--- a/src/components/email/job-email-row.test.tsx
+++ b/src/components/email/job-email-row.test.tsx
@@ -52,6 +52,7 @@ function fixtureEmail(overrides: Partial<Email> = {}): Email {
     uid: null,
     received_at: "2024-03-15T14:30:00",
     created_at: "2024-03-15T14:30:00",
+    organization_id: "org-1",
     ...overrides,
   };
 }

--- a/src/lib/email-schema-drift.test.ts
+++ b/src/lib/email-schema-drift.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Drift guard for the email-system schema snapshot (issue #430).
+ *
+ * Production's email family was reshaped by the Build 42–58 multi-tenancy work
+ * and the later email builds: `job_emails` became `emails`, three sibling
+ * tables joined it (`email_attachments`, `email_folder_state`,
+ * `email_signatures`), every table gained an `organization_id` (uuid NOT NULL,
+ * FK -> organizations), and the transitional open RLS policies were replaced by
+ * real per-tenant, shared-vs-personal, and parent-tracking policies.
+ *
+ * The snapshot in `supabase/schema-email.sql` had drifted to the pre-tenancy
+ * shape (only `email_accounts` + `job_emails`, both open RLS). These tests fail
+ * if the snapshot regresses back toward that shape, catching a future re-drift
+ * before it ships. They assert the snapshot's text — the column-for-column
+ * reconciliation against the live DB was done by hand in #430.
+ *
+ * Vitest runs with the repo root as cwd, so the snapshot resolves relative to
+ * `process.cwd()`.
+ */
+const SCHEMA_PATH = path.join(process.cwd(), "supabase", "schema-email.sql");
+
+const EMAIL_TABLES = [
+  "email_accounts",
+  "emails",
+  "email_attachments",
+  "email_folder_state",
+  "email_signatures",
+] as const;
+
+/**
+ * Return the body of `CREATE TABLE <table> ( ... );` from the snapshot. The
+ * statement terminator is a line-leading `);`; mid-column parens
+ * (`gen_random_uuid()`, `CHECK (... )`) never sit at the start of a line, so a
+ * non-greedy match stops at the real table terminator. The trailing `\\s*\\(`
+ * keeps `emails` from matching the `email_accounts`/`email_attachments` prefix.
+ */
+function createTableBlock(sql: string, table: string): string {
+  const match = sql.match(
+    new RegExp(`CREATE TABLE ${table}\\s*\\(([\\s\\S]*?)\\n\\);`),
+  );
+  if (!match) {
+    throw new Error(
+      `No CREATE TABLE block found for "${table}" in schema-email.sql`,
+    );
+  }
+  return match[1];
+}
+
+describe("schema-email.sql multi-tenant drift guard", () => {
+  const sql = readFileSync(SCHEMA_PATH, "utf8");
+
+  it.each(EMAIL_TABLES)("defines the %s table", (table) => {
+    expect(() => createTableBlock(sql, table)).not.toThrow();
+  });
+
+  it.each(EMAIL_TABLES)(
+    "declares organization_id on the %s table",
+    (table) => {
+      const block = createTableBlock(sql, table);
+      expect(block).toMatch(/\borganization_id\b/);
+    },
+  );
+
+  it("no longer defines the renamed-away job_emails table", () => {
+    expect(sql).not.toMatch(/CREATE TABLE job_emails\b/);
+  });
+
+  it("does not fall back to transitional open RLS policies", () => {
+    expect(sql).not.toMatch(/Allow all/);
+  });
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -280,6 +280,7 @@ export interface Email {
   uid: number | null;
   received_at: string;
   created_at: string;
+  organization_id: string;
   // Joined fields
   job?: Job;
   account?: EmailAccount;
@@ -294,6 +295,7 @@ export interface EmailAttachment {
   file_size: number | null;
   storage_path: string | null;
   created_at: string;
+  organization_id: string;
 }
 
 export interface JobFile {
@@ -326,6 +328,11 @@ export interface EmailAccount {
   last_synced_uid: number | null;
   created_at: string;
   updated_at: string;
+  organization_id: string;
+  /** Owner of a Personal account; null for a Shared account (migration-140). */
+  user_id: string | null;
+  /** One-time inbox-categorization backfill marker; null until it has run. */
+  category_backfill_completed_at: string | null;
 }
 
 export interface JobStatus {

--- a/supabase/schema-email.sql
+++ b/supabase/schema-email.sql
@@ -2,10 +2,31 @@
 -- AAA Disaster Recovery — Email System Schema
 -- Run this in the Supabase SQL Editor
 -- ============================================
+--
+-- Multi-tenancy note: every table below carries `organization_id`
+-- (uuid NOT NULL, FK -> organizations) for per-tenant isolation, added by the
+-- Build 42–58 multi-tenancy work. These objects assume the core multi-tenant
+-- schema already exists — the `organizations` and `user_organizations` tables
+-- and the `nookleus.active_organization_id()` / `nookleus.is_member_of()`
+-- helpers — plus `jobs`, `auth.users`, and `update_updated_at()`. Run the core
+-- schema first.
+--
+-- RLS note: unlike the photo tables, the email family does NOT use one uniform
+-- `tenant_isolation_*` policy. Each table mirrors what production actually
+-- enforces today:
+--   • email_accounts     — shared-vs-personal (ADR 0001 / migration-140,
+--                          tightened to admin-only shared INSERT in #222)
+--   • emails             — visibility tracks the parent email_account
+--   • email_attachments  — visibility tracks the parent email
+--   • email_folder_state — straight per-tenant isolation
+--   • email_signatures   — straight per-tenant isolation
+-- The CREATE POLICY blocks near the bottom reproduce each one faithfully.
 
 -- ============================================
 -- 1. EMAIL ACCOUNTS
--- Stores IMAP/SMTP connection settings
+-- IMAP/SMTP connection settings. A Shared account has user_id IS NULL and is
+-- visible to Org members who hold the email permission; a Personal account is
+-- owned by user_id (migration-140).
 -- ============================================
 CREATE TABLE email_accounts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -21,56 +42,249 @@ CREATE TABLE email_accounts (
   last_synced_at timestamptz,
   last_synced_uid integer,
   created_at timestamptz NOT NULL DEFAULT now(),
-  updated_at timestamptz NOT NULL DEFAULT now()
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  display_name text NOT NULL DEFAULT 'AAA Disaster Recovery',
+  provider text NOT NULL DEFAULT 'hostinger',
+  is_default boolean NOT NULL DEFAULT false,
+  signature text,
+  category_backfill_completed_at timestamptz,                   -- one-time inbox-categorization backfill marker
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  color text,                                                   -- per-account accent color (migration-build69)
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE      -- NULL = Shared account; set = Personal owner (migration-140)
 );
 
 -- ============================================
--- 2. JOB EMAILS
--- Stores synced emails matched to jobs
+-- 2. EMAILS
+-- Synced mail (renamed from job_emails). job_id is now nullable — an email need
+-- not be matched to a Job — and mail is organized by `folder` rather than the
+-- old inbound/outbound `direction`. Recipients are jsonb arrays of
+-- {email, name?} (the EmailAddress shape in src/lib/types.ts).
 -- ============================================
-CREATE TABLE job_emails (
+CREATE TABLE emails (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  job_id uuid NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
-  email_account_id uuid NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  account_id uuid NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  job_id uuid REFERENCES jobs(id) ON DELETE SET NULL,
   message_id text NOT NULL,
   thread_id text,
+  folder text NOT NULL DEFAULT 'inbox'
+    CHECK (folder IN ('inbox', 'sent', 'drafts', 'trash', 'archive', 'spam', 'other')),
   from_address text NOT NULL,
   from_name text,
-  to_address text NOT NULL,
+  to_addresses jsonb NOT NULL DEFAULT '[]',
+  cc_addresses jsonb NOT NULL DEFAULT '[]',
+  bcc_addresses jsonb NOT NULL DEFAULT '[]',
   subject text NOT NULL DEFAULT '',
   body_text text,
   body_html text,
   snippet text,
-  direction text NOT NULL DEFAULT 'inbound'
-    CHECK (direction IN ('inbound', 'outbound')),
+  is_read boolean NOT NULL DEFAULT false,
+  is_starred boolean NOT NULL DEFAULT false,
   has_attachments boolean NOT NULL DEFAULT false,
-  matched_by text NOT NULL DEFAULT 'manual'
+  matched_by text
     CHECK (matched_by IN ('contact', 'claim_number', 'address', 'job_id', 'manual')),
   uid integer,
   received_at timestamptz NOT NULL,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  category text DEFAULT 'general',                              -- inbox categorization; free text in prod (no CHECK)
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT
+);
+
+-- ============================================
+-- 3. EMAIL ATTACHMENTS
+-- ============================================
+CREATE TABLE email_attachments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email_id uuid NOT NULL REFERENCES emails(id) ON DELETE CASCADE,
+  filename text NOT NULL,
+  content_type text,
+  file_size integer,
+  storage_path text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT
+);
+
+-- ============================================
+-- 4. EMAIL FOLDER STATE
+-- Per-account IMAP sync cursor (one row per account + folder). No surrogate
+-- key — the natural key (account_id, folder) is the primary key.
+-- ============================================
+CREATE TABLE email_folder_state (
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  account_id uuid NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  folder text NOT NULL,
+  imap_path text NOT NULL,
+  uid_validity bigint NOT NULL,
+  last_uid_seen bigint NOT NULL,
+  last_synced_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (account_id, folder)
+);
+
+-- ============================================
+-- 5. EMAIL SIGNATURES
+-- One signature per account (UNIQUE account_id).
+-- ============================================
+CREATE TABLE email_signatures (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id uuid NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+  signature_html text NOT NULL DEFAULT '',
+  include_logo boolean NOT NULL DEFAULT true,
+  auto_insert boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE RESTRICT,
+  UNIQUE (account_id)
 );
 
 -- ============================================
 -- AUTO-UPDATE updated_at TIMESTAMPS
+-- (Only email_accounts and email_signatures carry an updated_at column.)
 -- ============================================
 CREATE TRIGGER trg_email_accounts_updated_at
   BEFORE UPDATE ON email_accounts FOR EACH ROW EXECUTE FUNCTION update_updated_at();
 
+CREATE TRIGGER trg_email_signatures_updated_at
+  BEFORE UPDATE ON email_signatures FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
 -- ============================================
--- ROW LEVEL SECURITY (open for now)
+-- ROW LEVEL SECURITY (multi-tenant isolation)
+-- See the RLS note in the header: the five policies below are NOT uniform.
+-- Each reproduces what production enforces today.
 -- ============================================
 ALTER TABLE email_accounts ENABLE ROW LEVEL SECURITY;
-ALTER TABLE job_emails ENABLE ROW LEVEL SECURITY;
+ALTER TABLE emails ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_attachments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_folder_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE email_signatures ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY "Allow all on email_accounts" ON email_accounts FOR ALL USING (true) WITH CHECK (true);
-CREATE POLICY "Allow all on job_emails" ON job_emails FOR ALL USING (true) WITH CHECK (true);
+-- email_accounts — Shared vs Personal (ADR 0001 / migration-140; shared INSERT
+-- tightened to admins in #222). A row is visible/editable when it is in the
+-- caller's active Organization AND either it is Shared (user_id IS NULL) and
+-- the caller belongs to that Org, or it is the caller's own Personal account.
+-- Creating or updating a Shared account additionally requires the caller be an
+-- admin of the Org.
+CREATE POLICY email_accounts_shared_or_personal ON email_accounts
+  FOR ALL
+  USING (
+    organization_id = nookleus.active_organization_id()
+    AND (
+      (user_id IS NULL AND nookleus.is_member_of(organization_id))
+      OR user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    organization_id = nookleus.active_organization_id()
+    AND (
+      (
+        user_id IS NULL
+        AND nookleus.is_member_of(organization_id)
+        AND EXISTS (
+          SELECT 1 FROM user_organizations uo
+          WHERE uo.user_id = auth.uid()
+            AND uo.organization_id = email_accounts.organization_id
+            AND uo.role = 'admin'
+        )
+      )
+      OR user_id = auth.uid()
+    )
+  );
+
+-- emails — visibility tracks the parent email_account: a row is reachable when
+-- its account is. The account policy above is what scopes to the tenant; emails
+-- ride on it.
+CREATE POLICY emails_track_parent_account ON emails
+  FOR ALL
+  USING (
+    EXISTS (SELECT 1 FROM email_accounts ea WHERE ea.id = emails.account_id)
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM email_accounts ea WHERE ea.id = emails.account_id)
+  );
+
+-- email_attachments — visibility tracks the parent email (which in turn tracks
+-- its account).
+CREATE POLICY email_attachments_track_parent_email ON email_attachments
+  FOR ALL
+  USING (
+    EXISTS (SELECT 1 FROM emails e WHERE e.id = email_attachments.email_id)
+  )
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM emails e WHERE e.id = email_attachments.email_id)
+  );
+
+-- email_folder_state — straight per-tenant isolation.
+CREATE POLICY tenant_isolation_email_folder_state ON email_folder_state
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid()
+        AND uo.organization_id = email_folder_state.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid()
+        AND uo.organization_id = email_folder_state.organization_id
+    )
+  );
+
+-- email_signatures — straight per-tenant isolation.
+CREATE POLICY tenant_isolation_email_signatures ON email_signatures
+  FOR ALL
+  USING (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid()
+        AND uo.organization_id = email_signatures.organization_id
+    )
+  )
+  WITH CHECK (
+    organization_id IS NOT NULL
+    AND organization_id = nookleus.active_organization_id()
+    AND EXISTS (
+      SELECT 1 FROM user_organizations uo
+      WHERE uo.user_id = auth.uid()
+        AND uo.organization_id = email_signatures.organization_id
+    )
+  );
 
 -- ============================================
 -- INDEXES
 -- ============================================
-CREATE INDEX idx_job_emails_job_id ON job_emails(job_id);
-CREATE INDEX idx_job_emails_email_account_id ON job_emails(email_account_id);
-CREATE INDEX idx_job_emails_message_id ON job_emails(message_id);
-CREATE INDEX idx_job_emails_received_at ON job_emails(received_at DESC);
-CREATE INDEX idx_job_emails_direction ON job_emails(direction);
+-- email_accounts
+CREATE INDEX idx_email_accounts_organization_id ON email_accounts(organization_id);
+CREATE INDEX idx_email_accounts_user_id ON email_accounts(user_id) WHERE user_id IS NOT NULL;
+
+-- emails
+CREATE INDEX idx_emails_account_id ON emails(account_id);
+CREATE INDEX idx_emails_category ON emails(category);
+CREATE INDEX idx_emails_folder ON emails(folder);
+CREATE INDEX idx_emails_is_read ON emails(is_read) WHERE is_read = false;
+CREATE INDEX idx_emails_is_starred ON emails(is_starred) WHERE is_starred = true;
+CREATE INDEX idx_emails_job_id ON emails(job_id);
+CREATE INDEX idx_emails_message_id ON emails(message_id);
+CREATE INDEX idx_emails_organization_id ON emails(organization_id);
+CREATE INDEX idx_emails_received_at ON emails(received_at DESC);
+CREATE INDEX idx_emails_thread_id ON emails(thread_id);
+
+-- Per-tenant dedup: one stored copy of a message per (org, message, account, folder)
+CREATE UNIQUE INDEX emails_org_dedup_key ON emails(organization_id, message_id, account_id, folder);
+
+-- email_attachments
+CREATE INDEX idx_email_attachments_email_id ON email_attachments(email_id);
+CREATE INDEX idx_email_attachments_organization_id ON email_attachments(organization_id);
+
+-- email_folder_state
+CREATE INDEX idx_email_folder_state_org ON email_folder_state(organization_id);
+
+-- email_signatures (idx_email_signatures_account_id is redundant with the
+-- UNIQUE(account_id) constraint but is present in prod, so it is kept here too)
+CREATE INDEX idx_email_signatures_account_id ON email_signatures(account_id);
+CREATE INDEX idx_email_signatures_organization_id ON email_signatures(organization_id);


### PR DESCRIPTION
## Summary
Reconciles the email schema snapshot and the `Email*` types to mirror production exactly — the same multi-tenancy drift class fixed for photos in #412. **No DB migration** (prod already has all of this; this is a snapshot/types sync).

- `supabase/schema-email.sql` rewritten to prod's real shape: `job_emails` → `emails` (24 cols), the three sibling tables the snapshot never had (`email_attachments`, `email_folder_state` with a composite PK, `email_signatures`), `organization_id` (uuid NOT NULL, FK → organizations) on every table with a per-tenant index, the exact FK `ON DELETE` actions, CHECKs, indexes (incl. the dedup unique + partial is_read/is_starred), and triggers.
- RLS is **not** uniform `tenant_isolation` (as the issue text assumed) — prod's real policies are reproduced faithfully: `email_accounts_shared_or_personal` (ADR 0001 / migration-140; admin-only shared INSERT per #222), parent-tracking on `emails`/`email_attachments`, and `tenant_isolation_*` on `email_folder_state`/`email_signatures`. A header note explains the heterogeneity.
- `src/lib/types.ts`: `organization_id` added to `Email`/`EmailAttachment`/`EmailAccount`; `user_id` + `category_backfill_completed_at` added to `EmailAccount`.
- New `src/lib/email-schema-drift.test.ts` guards against future re-drift (modeled on #412's `photos-schema-drift.test.ts`).

## Test plan
- [x] New drift-guard test green (12/12)
- [x] `tsc --noEmit`: **zero new errors** vs the `main` baseline
- [x] ESLint clean on all touched files
- [x] Email test suites pass — the only failing files are pre-existing `imapflow` broken-install errors present on `main` too (untouched here)
- [x] Snapshot + types verified **column-for-column against the live DB** by 6 independent verifiers (all 5 tables + the types) — zero discrepancies

Closes #430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)