### PR TITLE
fix(job-overview): render date-only fields in local time, not UTC (#444)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -9,6 +9,7 @@ import { photoUrl } from "@/lib/jobs/photo-url";
 import { pickPreloadUrls } from "@/lib/jobs/photo-preload";
 import { partitionPhotoReportsByTrash } from "@/lib/photo-report-trash";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
+import { parseDateOnly } from "@/lib/date-field";
 import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
 import FinancialsTab from "@/components/job-detail/financials-tab";
 import { EstimatesInvoicesSection } from "@/components/job-detail/estimates-invoices-section";
@@ -760,7 +761,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                 </p>
                 <p className="text-xs text-muted-foreground mt-0.5">
                   {[
-                    job.date_of_loss ? `DOL: ${format(new Date(job.date_of_loss), "MMM d, yyyy")}` : null,
+                    job.date_of_loss ? `DOL: ${format(parseDateOnly(job.date_of_loss), "MMM d, yyyy")}` : null,
                     job.deductible != null ? `Deductible: $${Number(job.deductible).toLocaleString()}` : null,
                   ].filter(Boolean).join(" \u00b7 ")}
                 </p>
@@ -1138,7 +1139,7 @@ function ReportRowContent({ report }: { report: PhotoReport }) {
             {report.title}
           </p>
           <p className="text-xs text-muted-foreground/60">
-            {format(new Date(report.report_date), "MMM d, yyyy")}
+            {format(parseDateOnly(report.report_date), "MMM d, yyyy")}
           </p>
         </div>
       </div>

--- a/src/lib/date-field.test.ts
+++ b/src/lib/date-field.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
+import { format } from "date-fns";
 
-import { isValidPastDate, maskDateInput, parseMaskedDate } from "./date-field";
+import { isValidPastDate, maskDateInput, parseDateOnly, parseMaskedDate } from "./date-field";
 
 describe("maskDateInput", () => {
   it("formats eight digits into MM/DD/YYYY", () => {
@@ -48,6 +49,37 @@ describe("parseMaskedDate", () => {
     expect(parseMaskedDate("02/30/2024")).toBeNull();
     expect(parseMaskedDate("13/01/2024")).toBeNull();
   });
+});
+
+describe("parseDateOnly", () => {
+  it("returns a Date whose local Y/M/D equal the YYYY-MM-DD parts", () => {
+    const d = parseDateOnly("2026-06-05");
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(5); // June is month index 5
+    expect(d.getDate()).toBe(5);
+  });
+});
+
+// Issue #444: the Overview rendered report_date a day early in US (UTC-minus)
+// timezones. These pin the exact acceptance criteria across both US zones named
+// in the issue. The first assertion in each case is a guard: it confirms the TZ
+// override is live and the off-by-one is genuinely reproducible here, so the
+// second assertion is a meaningful regression test rather than a no-op.
+describe("parseDateOnly across US timezones (issue #444)", () => {
+  const originalTz = process.env.TZ;
+  afterAll(() => {
+    process.env.TZ = originalTz;
+  });
+
+  for (const tz of ["America/New_York", "America/Los_Angeles"]) {
+    it(`renders "Jun 5, 2026" for 2026-06-05 in ${tz}`, () => {
+      process.env.TZ = tz;
+      // The bug: a naive UTC parse renders the previous calendar day here.
+      expect(format(new Date("2026-06-05"), "MMM d, yyyy")).toBe("Jun 4, 2026");
+      // The fix: parseDateOnly preserves the day the user set.
+      expect(format(parseDateOnly("2026-06-05"), "MMM d, yyyy")).toBe("Jun 5, 2026");
+    });
+  }
 });
 
 describe("isValidPastDate", () => {

--- a/src/lib/date-field.ts
+++ b/src/lib/date-field.ts
@@ -21,6 +21,18 @@ export function parseMaskedDate(input: string): Date | null {
   return date;
 }
 
+/**
+ * Parse a Postgres `date` string (`"YYYY-MM-DD"`) into a **local**-midnight Date.
+ *
+ * `new Date("YYYY-MM-DD")` parses as UTC midnight, so formatting it in the host's
+ * local timezone renders the previous calendar day in any UTC-minus (US) zone.
+ * Constructing from the parts keeps the calendar day the user actually set.
+ */
+export function parseDateOnly(value: string): Date {
+  const [year, month, day] = value.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
 /** True when input is a complete, real `MM/DD/YYYY` date that is not in the future. */
 export function isValidPastDate(input: string): boolean {
   const date = parseMaskedDate(input);


### PR DESCRIPTION
## Summary

The Job Overview rendered the Photo Report date **one day early** in US (UTC-minus) timezones, disagreeing with the date shown in the builder for the same report.

**Root cause:** `report_date` is a Postgres `date` column returned as a bare `"YYYY-MM-DD"` string. The Overview formatted it via `new Date("YYYY-MM-DD")`, which JS parses as **UTC midnight**; date-fns then renders it in the host's local timezone, yielding the previous calendar day in any UTC-minus zone (US Eastern/Pacific). The builder binds the raw string into a native date input and shows the correct day — so the same report displayed two different dates.

**Fix:** Add a small pure helper `parseDateOnly("YYYY-MM-DD") → local-midnight Date` to `src/lib/date-field.ts` (sibling to the existing `parseMaskedDate`) and use it at both date-only call sites in `job-detail.tsx`. Building the `Date` from the parts preserves the calendar day the user set, in any timezone.

## Scope

- ✅ `report_date` row in the Overview report list (the reported bug).
- ✅ Sibling `date_of_loss` display, which had the identical off-by-one (acceptance criterion #3).
- ⬜ Timestamp fields (`created_at`, `deleted_at`) left untouched — they're true `timestamptz` values where the UTC parse is correct (explicitly out of scope).

## Acceptance criteria

- [x] A report dated `2026-06-05` renders "Jun 5, 2026" in US/Eastern **and** US/Pacific.
- [x] The Overview date matches the builder's date input for the same report.
- [x] The `date_of_loss` display off-by-one is fixed alongside.

## Tests (TDD)

Driven red-green in `src/lib/date-field.test.ts`:

- A local-components **contract** test for `parseDateOnly`.
- **TZ-forced acceptance tests** pinning `"Jun 5, 2026"` for `2026-06-05` under `America/New_York` and `America/Los_Angeles`. Each carries a guard assertion proving the off-by-one is genuinely reproducible in-test (so the regression test isn't a no-op).
- Verified the guards by mutation: reverting `parseDateOnly` to the buggy UTC parse turns all three tests red (`Received: "Jun 4, 2026"`).

## Verification

- `vitest run src/lib/date-field.test.ts` → **17/17 passing**.
- `tsc --noEmit` → no new errors in the touched files.
- `eslint` → identical problem count to the `main` baseline for `job-detail.tsx` (no new lint issues; pre-existing ones are the repo-wide `react-hooks/set-state-in-effect`).

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
