### PR TITLE
fix(section-writeup): treat legacy <angle-bracket> subtitles as text, not HTML (#445)

### DIFF
--- a/src/lib/pdf-renderer/html-to-pdf.test.tsx
+++ b/src/lib/pdf-renderer/html-to-pdf.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { htmlToPdfNodes } from "./html-to-pdf";
+import { normalizeSectionWriteup } from "@/lib/section-writeup";
 import {
   collectText,
   expandTree,
@@ -209,5 +210,23 @@ describe("htmlToPdfNodes", () => {
     expect(indents[1]).toBeGreaterThan(indents[0]);
     expect(indents[2]).toBeGreaterThan(indents[0]);
     expect(indents[3]).toBe(indents[0]);
+  });
+
+  // ── A legacy plain-text subtitle containing angle brackets (a `<email>`, prose
+  // naming `<div>`) used to be misread as HTML by normalizeSectionWriteup and
+  // have the bracketed span dropped here as a phantom tag. Normalized correctly,
+  // it arrives as escaped entities and must render in full. (Issue #445.)
+
+  it("renders an angle-bracketed legacy subtitle in full, brackets included (#445)", () => {
+    expect(text(normalizeSectionWriteup("email me <john@x.com>"))).toBe(
+      "email me <john@x.com>",
+    );
+    expect(text(normalizeSectionWriteup("use <div> tags for layout"))).toBe(
+      "use <div> tags for layout",
+    );
+    // A stray closing tag in prose survives too, rather than being swallowed.
+    expect(text(normalizeSectionWriteup("see the </p> example"))).toBe(
+      "see the </p> example",
+    );
   });
 });

--- a/src/lib/section-writeup-fit.test.ts
+++ b/src/lib/section-writeup-fit.test.ts
@@ -63,6 +63,14 @@ describe("measureWriteupFit", () => {
     expect(measureWriteupFit(legacy).used).toBe(legacy.length);
   });
 
+  it("counts an angle-bracketed legacy subtitle in full, not as stray markup (#445)", () => {
+    // `<john@x.com>` looks like a tag to a loose detector, which used to drop
+    // the bracketed address from both the PDF and this counter. It is escaped
+    // legacy text now, so every character — brackets included — is counted.
+    const legacy = "email me <john@x.com>";
+    expect(measureWriteupFit(legacy).used).toBe(legacy.length);
+  });
+
   it("keeps a stray '<' inside HTML, matching the renderer's tokenizer", () => {
     // Hand-authored / boilerplate HTML can carry a literal '<' that is not a
     // tag. The renderer's tokenizer keeps it as text; the count must too.

--- a/src/lib/section-writeup.test.ts
+++ b/src/lib/section-writeup.test.ts
@@ -49,4 +49,44 @@ describe("normalizeSectionWriteup", () => {
     const html = "<pre><code>const x = 1;</code></pre>";
     expect(normalizeSectionWriteup(html)).toBe(html);
   });
+
+  it("treats a legacy subtitle with an angle-bracketed email as plain text (#445)", () => {
+    // `<john@x.com>` is not a recognized editor tag. The old loose pattern
+    // matched any letter-led `<…>` and returned it unescaped, so the PDF
+    // tokenizer then dropped the bracketed address as if it were a tag. It must
+    // be escaped and wrapped so every character survives.
+    expect(normalizeSectionWriteup("email me <john@x.com>")).toBe(
+      "<p>email me &lt;john@x.com&gt;</p>",
+    );
+  });
+
+  it("treats legacy prose with a stray closing tag as plain text (#445)", () => {
+    // `</p>` names a recognized tag, but a lone close tag is never genuine
+    // editor output — real write-ups always open a block first. Detection keys
+    // off a recognized OPENING tag, so this falls through to escape-and-wrap
+    // instead of being passed through and dropped by the tokenizer.
+    expect(normalizeSectionWriteup("see the </p> example")).toBe(
+      "<p>see the &lt;/p&gt; example</p>",
+    );
+  });
+
+  it("treats legacy prose mentioning an unknown tag as plain text (#445)", () => {
+    // `<div>` is a real HTML tag but not one the editor emits, so prose that
+    // happens to name it stays plain text rather than being passed through and
+    // having the bracketed span eaten by the tokenizer.
+    expect(normalizeSectionWriteup("use <div> tags for layout")).toBe(
+      "<p>use &lt;div&gt; tags for layout</p>",
+    );
+  });
+
+  it("still passes genuine editor HTML (list, emphasis) through richly (#445)", () => {
+    // The narrower detector must not regress real editor output: an opening
+    // recognized tag still marks the value as rich text, untouched.
+    expect(normalizeSectionWriteup("<ol><li>First</li><li>Second</li></ol>")).toBe(
+      "<ol><li>First</li><li>Second</li></ol>",
+    );
+    expect(normalizeSectionWriteup("<p>Some <em>emphasis</em> here</p>")).toBe(
+      "<p>Some <em>emphasis</em> here</p>",
+    );
+  });
 });

--- a/src/lib/section-writeup.ts
+++ b/src/lib/section-writeup.ts
@@ -14,14 +14,19 @@
  * read-tolerance foundation the narrative slices build on.
  */
 
-// A value is treated as already-rich-text when it contains ANY HTML tag — not
-// just the subset we render richly. The editor is bare StarterKit, so a write-up
-// can be made entirely of tags we fold to plain text downstream (a heading, a
-// code block); those must still reach `htmlToPdfNodes` as HTML rather than be
-// escaped and shown to the customer as literal `<h2>…</h2>` source. Anything with
-// no tag is a legacy plain-text line that gets escaped and wrapped as a single
-// paragraph. The `[a-z]` after `<` keeps stray prose like "a < b" from matching.
-const HTML_TAG = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
+// A value is treated as already-rich-text only when it OPENS one of the tags the
+// bare-StarterKit editor actually emits. Genuine editor output always opens a
+// block first, so an opening tag from this set is a reliable "this is HTML"
+// signal. Folded-to-plain tags (a heading, a code block) are included so they
+// still reach `htmlToPdfNodes` as HTML rather than be shown to the customer as
+// literal `<h2>…</h2>` source. Everything else is legacy plain text and gets
+// escaped and wrapped as a single paragraph — crucially, an unrecognized
+// `<…>` (a bracketed email `<john@x.com>`, prose like `use <div>`) or a stray
+// CLOSING tag (`</p>`) no longer masquerades as markup, so the PDF tokenizer
+// can never silently drop it (issue #445). Matching openers only — no leading
+// `/` — is what keeps `</p>` on the plain-text branch.
+const HTML_TAG =
+  /<(?:p|ul|ol|li|h[1-6]|strong|b|em|i|br|pre|code|blockquote|hr)\b[^>]*>/i;
 
 export function normalizeSectionWriteup(
   description: string | null | undefined,


### PR DESCRIPTION
## Summary
- `normalizeSectionWriteup` classified any value containing a letter-led `<…>` as rich text and returned it unescaped. A legacy plain-text subtitle like `email me <john@x.com>` reached the PDF tokenizer as raw HTML, which dropped `<john@x.com>` as a phantom tag — losing customer-facing text from both the PDF and the write-up fit counter (which normalizes through the same boundary).
- Gate "is HTML" on a recognized **opening** tag from the bare-StarterKit set (`p, ul, ol, li, h1–h6, strong, b, em, i, br, pre, code, blockquote, hr`). Genuine editor output always opens a block first, so real rich text still renders richly, while unrecognized `<…>` (a bracketed email, prose naming `<div>`) and stray closing tags (`</p>`) fall to the escape-and-wrap branch and survive intact. Matching openers only — no leading `/` — is what keeps `</p>` on the plain-text branch.
- The PDF tokenizer and fit-counter strippers keep their broad strip-all-tags patterns: once legacy text is escaped upstream they only ever see real tags, and narrowing them would leak inline tags like `<s>`/`<u>`.

Closes #445.

## Test Plan
- [x] `npx vitest run src/lib/section-writeup.test.ts src/lib/section-writeup-fit.test.ts` — 22 pass: the three legacy cases + genuine-HTML pass-through through `normalizeSectionWriteup`, plus a fit-counter regression.
- [ ] `npx vitest run src/lib/pdf-renderer/html-to-pdf.test.tsx` — end-to-end render through `htmlToPdfNodes` shows the full bracketed text. (Runs in CI; `@react-pdf/renderer` is not installed locally, so this file was verified locally via a temporary stub-aliased harness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)