### PR TITLE
feat(estimate-builder): pure planUnmountFlush planner for pending autosave writes

### DIFF
--- a/src/components/estimate-builder/use-auto-save.plan-unmount-flush.test.ts
+++ b/src/components/estimate-builder/use-auto-save.plan-unmount-flush.test.ts
@@ -1,0 +1,225 @@
+// Guards planUnmountFlush (#460) — the PURE planner that decides which PUTs the
+// unmount flush should fire to persist a builder's pending (dirty) edits.
+// No React, no fetch, no timers: it is exercised here as a plain function.
+// Slice 2 (#461) wires this into useAutoSave's unmount cleanup.
+
+import { describe, it, expect } from "vitest";
+
+import { planUnmountFlush, pickLineItemFields } from "./use-auto-save";
+import type { AutoSaveConfig } from "@/lib/types";
+
+// ── Test fixtures ────────────────────────────────────────────────────────────
+
+// An index signature (not an interface) so items satisfy pickLineItemFields's
+// `{ id: string } & Record<string, unknown>` parameter, matching the runtime
+// shape of estimate/invoice line items.
+type TestItem = { id: string } & Record<string, unknown>;
+
+interface TestEntity {
+  id: string;
+  updated_at?: string | null;
+  title: string;
+  sections: Array<{
+    items: TestItem[];
+    subsections: Array<{ items: TestItem[] }>;
+  }>;
+}
+
+function makeConfig(
+  overrides: Partial<AutoSaveConfig<TestEntity>> = {},
+): AutoSaveConfig<TestEntity> {
+  return {
+    entityKind: "estimate",
+    entityId: "est-1",
+    paths: {
+      rootPut: "/api/estimates/est-1",
+      sectionsReorder: "/api/estimates/est-1/sections/reorder",
+      sectionRoute: (sectionId: string) =>
+        `/api/estimates/est-1/sections/${sectionId}`,
+      lineItemsReorder: "/api/estimates/est-1/line-items/reorder",
+      lineItemRoute: (itemId: string) =>
+        `/api/estimates/est-1/line-items/${itemId}`,
+    },
+    serializeRootPut: (e: TestEntity) => ({ title: e.title }),
+    hasSnapshotConcurrency: true,
+    ...overrides,
+  };
+}
+
+function makeItem(id: string, overrides: Record<string, unknown> = {}): TestItem {
+  return {
+    id,
+    description: "Replace shingles",
+    note: null,
+    code: null,
+    quantity: 1,
+    unit: "sq",
+    unit_price: 100,
+    section_id: "sec-1",
+    sort_order: 0,
+    ...overrides,
+  };
+}
+
+function makeEntity(overrides: Partial<TestEntity> = {}): TestEntity {
+  return {
+    id: "est-1",
+    updated_at: "2026-06-05T00:00:00Z",
+    title: "Roof repair",
+    sections: [],
+    ...overrides,
+  };
+}
+
+describe("planUnmountFlush (#460)", () => {
+  it("plans a root PUT when the entity's root fields are dirty", () => {
+    const config = makeConfig();
+    const entity = makeEntity({ title: "Roof repair — edited" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T00:00:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan.rootPut).not.toBeNull();
+    expect(plan.rootPut?.path).toBe("/api/estimates/est-1");
+    expect(plan.rootPut?.body).toMatchObject({ title: "Roof repair — edited" });
+  });
+
+  it("plans nothing when the entity is clean (root matches snapshot, no items)", () => {
+    const config = makeConfig();
+    const entity = makeEntity({ title: "Roof repair" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T00:00:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan).toEqual({ rootPut: null, lineItemPuts: [] });
+  });
+
+  it("plans nothing when a stale conflict is active, even if dirty", () => {
+    const config = makeConfig();
+    const entity = makeEntity({ title: "Roof repair — edited" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T00:00:00Z",
+      staleConflict: true,
+    });
+
+    expect(plan).toEqual({ rootPut: null, lineItemPuts: [] });
+  });
+
+  it("plans nothing when the root snapshot is not yet initialized (null)", () => {
+    const config = makeConfig();
+    const entity = makeEntity({ title: "Roof repair" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: null,
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T00:00:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan).toEqual({ rootPut: null, lineItemPuts: [] });
+  });
+
+  it("attaches updated_at_snapshot to the body when concurrency is enabled", () => {
+    const config = makeConfig({ hasSnapshotConcurrency: true });
+    const entity = makeEntity({ title: "Roof repair — edited" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T12:30:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan.rootPut?.body).toMatchObject({
+      title: "Roof repair — edited",
+      updated_at_snapshot: "2026-06-05T12:30:00Z",
+    });
+  });
+
+  it("omits updated_at_snapshot from the body when concurrency is disabled", () => {
+    const config = makeConfig({ hasSnapshotConcurrency: false });
+    const entity = makeEntity({ title: "Roof repair — edited" });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map(),
+      updatedAt: "2026-06-05T12:30:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan.rootPut?.body).not.toHaveProperty("updated_at_snapshot");
+  });
+
+  it("plans exactly one line-item PUT for a single dirty item (ignoring unchanged ones)", () => {
+    const config = makeConfig({ hasSnapshotConcurrency: true });
+
+    const savedItem1 = makeItem("li-1", { description: "Replace shingles" });
+    const savedItem2 = makeItem("li-2", { description: "Tarp roof" });
+    const dirtyItem1 = makeItem("li-1", { description: "Replace shingles — 30yr" });
+    const cleanItem2 = makeItem("li-2", { description: "Tarp roof" });
+
+    const entity = makeEntity({
+      title: "Roof repair", // root clean — only the line item is dirty
+      sections: [
+        { items: [dirtyItem1], subsections: [{ items: [cleanItem2] }] },
+      ],
+    });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof repair" },
+      lineItems: new Map([
+        ["li-1", pickLineItemFields(savedItem1)],
+        ["li-2", pickLineItemFields(savedItem2)],
+      ]),
+      updatedAt: "2026-06-05T12:30:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan.rootPut).toBeNull();
+    expect(plan.lineItemPuts).toHaveLength(1);
+    expect(plan.lineItemPuts[0].path).toBe(
+      "/api/estimates/est-1/line-items/li-1",
+    );
+    expect(plan.lineItemPuts[0].body).toMatchObject({
+      description: "Replace shingles — 30yr",
+      updated_at_snapshot: "2026-06-05T12:30:00Z",
+    });
+  });
+
+  it("plans no line-item PUTs for templates, even when items differ", () => {
+    // Templates have no live DB rows behind their line items, so per-item saves
+    // are gated off in the hook; the planner must match that.
+    const config = makeConfig({
+      entityKind: "template",
+      hasSnapshotConcurrency: false,
+    });
+
+    const savedItem = makeItem("li-1", { description: "Replace shingles" });
+    const dirtyItem = makeItem("li-1", { description: "Replace shingles — edited" });
+
+    const entity = makeEntity({
+      title: "Roof template",
+      sections: [{ items: [dirtyItem], subsections: [] }],
+    });
+
+    const plan = planUnmountFlush(config, entity, {
+      rootSnapshot: { title: "Roof template" }, // root clean
+      lineItems: new Map([["li-1", pickLineItemFields(savedItem)]]),
+      updatedAt: "2026-06-05T12:30:00Z",
+      staleConflict: false,
+    });
+
+    expect(plan.lineItemPuts).toEqual([]);
+  });
+});

--- a/src/components/estimate-builder/use-auto-save.ts
+++ b/src/components/estimate-builder/use-auto-save.ts
@@ -56,7 +56,7 @@ const LINE_ITEM_FIELDS = [
 ] as const;
 
 type LineItemFieldKey = typeof LINE_ITEM_FIELDS[number];
-type LineItemSubset = Record<LineItemFieldKey, unknown>;
+export type LineItemSubset = Record<LineItemFieldKey, unknown>;
 
 // Minimal internal shape used for sections traversal — all three entity kinds
 // (EstimateWithContents, InvoiceWithContents, TemplateWithContents) share this
@@ -116,6 +116,83 @@ function diffSubset<T extends Record<string, unknown>>(a: T, b: T): boolean {
     if (a[k] !== b[k]) return true;
   }
   return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// planUnmountFlush — pure planner (#460)
+//
+// Decides which PUTs an unmount flush must fire to persist a builder's pending
+// (dirty) edits. PURE: no React, no fetch, no timers — given the config, the
+// current entity, and a snapshot bundle, it returns the exact set of writes.
+// Slice 2 (#461) wires this into useAutoSave's unmount cleanup.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface PlannedWrite {
+  path: string;
+  body: unknown;
+}
+
+export interface UnmountFlushPlan {
+  rootPut: PlannedWrite | null;
+  lineItemPuts: PlannedWrite[];
+}
+
+export function planUnmountFlush<T extends { id: string; updated_at?: string | null }>(
+  config: AutoSaveConfig<T>,
+  entity: T,
+  snapshots: {
+    rootSnapshot: unknown | null;
+    lineItems: Map<string, LineItemSubset>;
+    updatedAt: string;
+    staleConflict: boolean;
+  },
+): UnmountFlushPlan {
+  // A stale conflict suppresses all saves; a null root snapshot means the hook
+  // never initialized (nothing to compare against) — both flush nothing.
+  if (snapshots.staleConflict || snapshots.rootSnapshot === null) {
+    return { rootPut: null, lineItemPuts: [] };
+  }
+
+  // Attach the optimistic-concurrency token to a body only when the entity kind
+  // uses snapshot concurrency (estimates/invoices), matching performEntitySave /
+  // performLineItemSave. Templates send the bare body.
+  const withToken = (body: Record<string, unknown>): unknown =>
+    config.hasSnapshotConcurrency
+      ? { ...body, updated_at_snapshot: snapshots.updatedAt }
+      : body;
+
+  let rootPut: PlannedWrite | null = null;
+
+  const current = config.serializeRootPut(entity);
+  if (
+    diffSubset(
+      current as Record<string, unknown>,
+      snapshots.rootSnapshot as Record<string, unknown>,
+    )
+  ) {
+    rootPut = {
+      path: config.paths.rootPut,
+      body: withToken(current as Record<string, unknown>),
+    };
+  }
+
+  // Templates have no live DB rows backing their line items, so per-item saves
+  // are gated off (mirrors the watch effect in useAutoSave).
+  const lineItemPuts: PlannedWrite[] = [];
+  if (config.entityKind !== "template") {
+    for (const item of getAllLineItems(entity as unknown as EntityWithSections)) {
+      const saved = snapshots.lineItems.get(item.id);
+      if (!saved) continue; // not yet baselined — the debounced flow records, never saves
+      const currentSubset = pickLineItemFields(item);
+      if (!diffSubset(currentSubset, saved)) continue; // unchanged
+      lineItemPuts.push({
+        path: config.paths.lineItemRoute(item.id),
+        body: withToken(currentSubset),
+      });
+    }
+  }
+
+  return { rootPut, lineItemPuts };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds `planUnmountFlush`, a pure planner returning the exact set of PUTs an unmount flush must fire to persist a builder's pending (dirty) edits — no React, fetch, or timers.
- Factors the "is it dirty / what body do I send" logic (currently duplicated in `performEntitySave` / `performLineItemSave`) into one isolated, table-testable unit, reusing the existing helpers.
- Hook runtime is unchanged. This is Slice 1 of PRD #458; Slice 2 (#461) wires it into `useAutoSave`'s unmount cleanup.

Implements #460 (parent PRD #458).

## Test plan

- [x] 8 unit tests: dirty root → rootPut; clean → empty plan; staleConflict → empty plan; null snapshot → empty plan; concurrency token on/off; single dirty line item → one PUT (subsection-nested, ignores unchanged); template → no line-item PUTs.
- [x] Existing `use-auto-save.line-item-fields.test.ts` still passes (9 tests total across both files).
- [x] `tsc --noEmit` adds no new errors in touched files (baseline 34, clustered in the PDF stack per the known-red baseline).
- [x] `eslint` output is identical to main's untouched copy (0 errors, same 6 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
