### PR TITLE
test: fix two stale red tests — jobs/[id]/reports + settings/templates (#475)

### DIFF
--- a/src/app/api/jobs/[id]/reports/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/route.test.ts
@@ -178,6 +178,9 @@ describe("POST /api/jobs/[id]/reports", () => {
           grants: ["edit_jobs"],
           extraTables: {
             user_profiles: [{ id: "user-1", full_name: "   " }],
+            // #446: the route now 404s unless the URL job is visible to the
+            // caller's org, so this preparer-name test must seed the job.
+            jobs: [{ id: "job-1", organization_id: "org-1" }],
           },
         }),
       }) as never,
@@ -202,6 +205,9 @@ describe("POST /api/jobs/[id]/reports", () => {
           grants: ["edit_jobs"],
           extraTables: {
             user_profiles: [{ id: "user-1", full_name: "" }],
+            // #446: the route now 404s unless the URL job is visible to the
+            // caller's org, so this preparer-name test must seed the job.
+            jobs: [{ id: "job-1", organization_id: "org-1" }],
           },
         }),
       }) as never,

--- a/src/app/settings/templates/page.test.tsx
+++ b/src/app/settings/templates/page.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 
 // #232 — smoke test for the combined /settings/templates shell. Each tab
 // body has its own behavior covered elsewhere; this test only verifies
-// that the shell wires up the four expected tabs in the right order and
+// that the shell wires up the five expected tabs in the right order and
 // renders without crashing.
 
 vi.mock("next/navigation", () => ({
@@ -24,11 +24,14 @@ vi.mock("./item-library-tab", () => ({
 vi.mock("./photo-report-defaults-tab", () => ({
   PhotoReportDefaultsTab: () => <div>photo-report-defaults-tab-marker</div>,
 }));
+vi.mock("./photo-report-templates-tab", () => ({
+  PhotoReportTemplatesTab: () => <div>photo-report-templates-tab-marker</div>,
+}));
 
 import TemplatesSettingsPage from "./page";
 
 describe("/settings/templates shell", () => {
-  it("renders the four expected tab labels in order", () => {
+  it("renders the five expected tab labels in order", () => {
     render(<TemplatesSettingsPage />);
 
     const tabs = screen.getAllByRole("tab");
@@ -36,6 +39,7 @@ describe("/settings/templates shell", () => {
       "Estimates",
       "Contracts",
       "Item Library",
+      "Photo Report Templates",
       "Photo Report Defaults",
     ]);
   });


### PR DESCRIPTION
## What

Fixes the two **install-independent** red tests from the #413 follow-up tracked in #475. Both are **stale tests against correct, intended production code** — there is no production change in this PR.

### `jobs/[id]/reports/route.test.ts` (2 tests: 404 → 201)

The *"falls back to the caller's email"* and *"uses a placeholder"* preparer-name tests build their Supabase fake with a `user_profiles` row but **no `jobs` row**. Since #446 the route validates that the URL's job is visible to the caller's org *before* doing any work, so these two tests 404'd before ever reaching the preparer-name fallback they exist to exercise.

Fix: seed the visible `jobs` row — matching the shared `authedClient()` that the already-passing 201 tests use. The route is correct; these tests simply predated the #446 visibility guard.

### `settings/templates/page.test.tsx` (1 test)

A fifth **"Photo Report Templates"** tab was added to the `/settings/templates` shell, but the #232 smoke test still asserted four tabs (and didn't mock the new tab body). Fix: add the tab-body mock and the expected label, in page order.

## Verification

- `npx vitest run` on both files: **9 passed** (was 3 failed / 6 passed).
- `tsc --noEmit`: **no new errors** in either touched file.

## Scope — what this does *not* fix

Intentionally does **not** close #475. The remaining reds tracked there are environmental, not repo bugs:

- a broken local `node_modules` install (empty `@react-pdf/renderer` / `imapflow` / `sharp` dirs → ~26 tsc errors + 17 import-failure test files) — cleared by a clean `npm ci`, not by code;
- the Node-25 `localStorage` artifact (dev box runs Node 25; the project targets Node 20).

Refs #475, #413, #446.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
