### PR TITLE
chore(vault): remove dead docs/superpowers links left by #225

### DIFF
--- a/docs/vault/_templates/agent.md
+++ b/docs/vault/_templates/agent.md
@@ -1,6 +1,6 @@
 <!--
 Templater stub for agents/{agent-name}.md.
-Authored in Build 66b. See docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md §66b.
+Authored in Build 66b.
 -->
 
 # Agent card template — placeholder

--- a/docs/vault/_templates/build.md
+++ b/docs/vault/_templates/build.md
@@ -1,6 +1,6 @@
 <!--
 Templater stub for builds/build-{id}.md.
-Authored in Build 66b / 66c. See docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md.
+Authored in Build 66b / 66c.
 -->
 
 # Build card template — placeholder

--- a/docs/vault/_templates/decision.md
+++ b/docs/vault/_templates/decision.md
@@ -1,6 +1,6 @@
 <!--
 Templater stub for decisions/{YYYY-MM-DD}-{slug}.md.
-Authored in Build 66b / 66c. See docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md.
+Authored in Build 66b / 66c.
 -->
 
 # Decision template — placeholder

--- a/docs/vault/_templates/platform-skill.md
+++ b/docs/vault/_templates/platform-skill.md
@@ -1,6 +1,6 @@
 <!--
 Templater stub for platform-skills/{skill-name}.md.
-Authored in Build 66b. See docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md §66b.
+Authored in Build 66b.
 -->
 
 # Platform skill template — placeholder

--- a/docs/vault/agents/jarvis.md
+++ b/docs/vault/agents/jarvis.md
@@ -91,5 +91,4 @@ Digital marketing content. Built [[build-26b]] (commit `99fde06`, with Build 2.6
 ## Source
 
 - Build cards: [[build-21]] (Jarvis Chat UI + Claude API), [[build-23]] (R&D), [[build-25a]] (Knowledge + Field Ops), [[build-26b]] (Marketing).
-- Plan: [docs/superpowers/plans/2026-04-09-agent-architecture-map.md](../../../docs/superpowers/plans/2026-04-09-agent-architecture-map.md).
 - Code: [src/app/jarvis/page.tsx](../../../src/app/jarvis/page.tsx), [src/app/api/jarvis/](../../../src/app/api/jarvis/), [src/components/jarvis/](../../../src/components/jarvis/), [src/lib/jarvis/](../../../src/lib/jarvis/).

--- a/docs/vault/builds/README.md
+++ b/docs/vault/builds/README.md
@@ -16,7 +16,6 @@ One card per build. Builds are the unit of work in the Nookleus repo — every s
   started: 2026-04-26
   shipped: 2026-04-28
   guide_doc: null              # or "v1.7 §Build 17" if specced in a docx
-  plan_file: docs/superpowers/plans/2026-04-26-build-65a-scaffold.md
   handoff: null                # retired with the continuity loop — see ADR 0010
   related: ["[[build-65b]]", "[[build-18c]]"]
   ```

--- a/docs/vault/builds/build-16a.md
+++ b/docs/vault/builds/build-16a.md
@@ -6,7 +6,6 @@ phase: accounting
 started: null
 shipped: 2026-04-18
 guide_doc: "v1.6 §Build 16 (summary of v1.5)"
-plan_file: docs/superpowers/plans/2026-04-18-build-16a-expenses.md
 handoff: null
 related: ["[[build-16b]]", "[[build-16c]]", "[[build-16d]]"]
 ---
@@ -24,6 +23,5 @@ Per-job expense logging with vendor catalog and receipt photo capture (compresse
 ## Source
 
 - Commit range: `23a7701` (spec) → `18c68e5` (final fix), through PR #14
-- Plan: [docs/superpowers/plans/2026-04-18-build-16a-expenses.md](../../../docs/superpowers/plans/2026-04-18-build-16a-expenses.md)
 - Migration: [supabase/migration-build35-expenses.sql](../../../supabase/migration-build35-expenses.sql)
 - Guide: v1.6 §Build 16 (v1.5 referenced; not in repo)

--- a/docs/vault/builds/build-16b.md
+++ b/docs/vault/builds/build-16b.md
@@ -6,7 +6,6 @@ phase: accounting
 started: null
 shipped: 2026-04-19
 guide_doc: "v1.6 §Build 16"
-plan_file: docs/superpowers/plans/2026-04-19-build-16b-accounting.md
 handoff: null
 related: ["[[build-16a]]", "[[build-16c]]", "[[build-16d]]"]
 ---
@@ -26,6 +25,5 @@ related: ["[[build-16a]]", "[[build-16c]]", "[[build-16d]]"]
 ## Source
 
 - Commit range: `6b53e1b` (spec) → `6640084` (final fix split)
-- Plan: [docs/superpowers/plans/2026-04-19-build-16b-accounting.md](../../../docs/superpowers/plans/2026-04-19-build-16b-accounting.md)
 - Migration: [supabase/migration-build36-accounting.sql](../../../supabase/migration-build36-accounting.sql)
 - Guide: v1.6 §Build 16

--- a/docs/vault/builds/build-16d.md
+++ b/docs/vault/builds/build-16d.md
@@ -6,7 +6,6 @@ phase: accounting
 started: null
 shipped: 2026-04-19
 guide_doc: "v1.6 §Build 16"
-plan_file: docs/superpowers/plans/2026-04-19-build-16d-invoice-payment-sync.md
 handoff: null
 related: ["[[build-16b]]", "[[build-16c]]", "[[build-17a]]", "[[build-17c]]"]
 ---
@@ -25,6 +24,5 @@ Invoices, manual payments, and bidirectional sync to QuickBooks. Invoice PDF gen
 ## Source
 
 - Commit range: `d2975fb` (migration) → `70be0b3` (cents fix), through PR #18
-- Plan: [docs/superpowers/plans/2026-04-19-build-16d-invoice-payment-sync.md](../../../docs/superpowers/plans/2026-04-19-build-16d-invoice-payment-sync.md)
 - Migration: [supabase/migration-build38-invoice-payment-sync.sql](../../../supabase/migration-build38-invoice-payment-sync.sql)
 - Guide: v1.6 §Build 16

--- a/docs/vault/builds/build-17a.md
+++ b/docs/vault/builds/build-17a.md
@@ -6,7 +6,6 @@ phase: payments
 started: null
 shipped: 2026-04-20
 guide_doc: "v1.7 §Build 17"
-plan_file: docs/superpowers/plans/2026-04-20-build-17a-stripe.md
 handoff: null
 related: ["[[build-17b]]", "[[build-17c]]", "[[build-16d]]"]
 ---
@@ -25,6 +24,5 @@ Stripe Connect (Standard) flow: connect/disconnect, signed OAuth state, settings
 ## Source
 
 - Commit range: `86fa608` (install) → `e627939` (settings polish), through PR #19
-- Plan: [docs/superpowers/plans/2026-04-20-build-17a-stripe.md](../../../docs/superpowers/plans/2026-04-20-build-17a-stripe.md)
 - Migration: [supabase/migration-build39-stripe-payments.sql](../../../supabase/migration-build39-stripe-payments.sql)
 - Guide: v1.7 §Build 17

--- a/docs/vault/builds/build-17b.md
+++ b/docs/vault/builds/build-17b.md
@@ -6,7 +6,6 @@ phase: payments
 started: null
 shipped: 2026-04-20
 guide_doc: "v1.7 §Build 17"
-plan_file: docs/superpowers/plans/2026-04-20-build-17b-payment-page-email.md
 handoff: null
 related: ["[[build-17a]]", "[[build-17c]]"]
 ---
@@ -24,6 +23,5 @@ Customer-facing `/pay/[token]` page with method selector (card vs ACH), success 
 ## Source
 
 - Commit range: `362da6b` (migration) → `0a84f32` (AppShell /pay public-route bypass), through PR #20 + hotfix PR #21
-- Plan: [docs/superpowers/plans/2026-04-20-build-17b-payment-page-email.md](../../../docs/superpowers/plans/2026-04-20-build-17b-payment-page-email.md)
 - Migration: [supabase/migration-build40-payment-emails.sql](../../../supabase/migration-build40-payment-emails.sql)
 - Guide: v1.7 §Build 17

--- a/docs/vault/builds/build-17c.md
+++ b/docs/vault/builds/build-17c.md
@@ -6,7 +6,6 @@ phase: payments
 started: null
 shipped: 2026-04-21
 guide_doc: "v1.7 §Build 17"
-plan_file: docs/superpowers/plans/2026-04-21-build-17c-webhook-receipts-refunds-qb.md
 handoff: null
 related: ["[[build-17a]]", "[[build-17b]]", "[[build-16c]]", "[[build-14g]]"]
 ---
@@ -28,8 +27,5 @@ Full Stripe webhook handler, branded PDF receipts, refund flow, dispute tracking
 ## Source
 
 - Commit range: `eb64bb9` (migration) → `cc50bec` (E2E hardening) → `f97bdf5` (receipt_email fix)
-- Plan: [docs/superpowers/plans/2026-04-21-build-17c-webhook-receipts-refunds-qb.md](../../../docs/superpowers/plans/2026-04-21-build-17c-webhook-receipts-refunds-qb.md)
-- Briefing: [docs/superpowers/plans/2026-04-21-build-17c-briefing.md](../../../docs/superpowers/plans/2026-04-21-build-17c-briefing.md)
-- Post-briefing: [docs/superpowers/plans/2026-04-22-post-17c-briefing.md](../../../docs/superpowers/plans/2026-04-22-post-17c-briefing.md)
 - Migration: [supabase/migration-build41-webhook-receipts-refunds.sql](../../../supabase/migration-build41-webhook-receipts-refunds.sql)
 - Guide: v1.7 §Build 17

--- a/docs/vault/builds/build-18a.md
+++ b/docs/vault/builds/build-18a.md
@@ -6,7 +6,6 @@ phase: multi-tenant
 started: null
 shipped: 2026-04-22
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-21-build-18a-schema-backfill.md
 handoff: null
 related: ["[[build-18b]]", "[[build-18c]]", "[[build-64]]", "[[2026-04-22-build52-null-tokens-lesson]]"]
 ---
@@ -38,8 +37,6 @@ Shipped over **9 migrations** — build42 through build50 — with three follow-
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-21-build-18a-schema-backfill.md](../../../docs/superpowers/plans/2026-04-21-build-18a-schema-backfill.md), [docs/superpowers/plans/build-18a-briefing.md](../../../docs/superpowers/plans/build-18a-briefing.md)
-- Handoffs (older paths, pre-vault): [docs/build-18a-handoff.md](../../../docs/build-18a-handoff.md), [docs/build-18a-complete-handoff.md](../../../docs/build-18a-complete-handoff.md)
 - Migration files: build42–build50, plus build51, build52, build53, build54
 - Commit range: `d64f17d` (briefing/prompts) → `1b4004c` (Build 18a complete) → `c19278a` (build53/54 fixes)
 - Guide: none (post-Build 17)

--- a/docs/vault/builds/build-18b.md
+++ b/docs/vault/builds/build-18b.md
@@ -6,7 +6,6 @@ phase: multi-tenant
 started: null
 shipped: 2026-04-23
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-23-build-18b-rls-enforcement.md
 handoff: null
 related: ["[[build-18a]]", "[[build-18c]]", "[[build-64]]"]
 ---
@@ -28,8 +27,6 @@ Flips the multi-tenant infrastructure from "RLS written" to "RLS enforced." Drop
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-23-build-18b-rls-enforcement.md](../../../docs/superpowers/plans/2026-04-23-build-18b-rls-enforcement.md)
-- Source artifacts: [docs/superpowers/build-18b/session-a-handoff.md](../../../docs/superpowers/build-18b/session-a-handoff.md), [docs/superpowers/build-18b/session-c-handoff.md](../../../docs/superpowers/build-18b/session-c-handoff.md), [docs/superpowers/build-18b/code-sweep-report.md](../../../docs/superpowers/build-18b/code-sweep-report.md), [docs/superpowers/build-18b/session-b-rehearsal-report.md](../../../docs/superpowers/build-18b/session-b-rehearsal-report.md), [docs/superpowers/build-18b/session-c-run-log.md](../../../docs/superpowers/build-18b/session-c-run-log.md)
 - Migration files: build55–build60
 - Commit range: `c70abd5` (plan) → `2240df6` (session-c apply)
 - Guide: none

--- a/docs/vault/builds/build-18c.md
+++ b/docs/vault/builds/build-18c.md
@@ -6,7 +6,6 @@ phase: multi-tenant
 started: null
 shipped: 2026-04-26
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-25-build-18c-workspace-switcher.md
 handoff: null
 related: ["[[build-18a]]", "[[build-18b]]", "[[build-64]]"]
 ---
@@ -22,12 +21,10 @@ The workspace switcher UI for users with memberships in multiple orgs, plus publ
   - build62b — `set_active_organization()` RPC that swaps the active flag and refreshes the JWT claim.
   - build63 — `user_profiles` SELECT policy fix (admins reading other users' profiles).
 - **Code:** [src/components/workspace-switcher.tsx](../../../src/components/workspace-switcher.tsx) (moved into sidebar by `96ba027`); RLS-broken API routes fixed to use cookie-aware SSR client (`90d7405`); public-route audit.
-- **Public route audit** lived in [docs/superpowers/build-18c/public-route-audit.md](../../../docs/superpowers/build-18c/public-route-audit.md) — surfaced [[build-64]] (missing `handle_new_user` trigger) as a follow-on.
+- **Public route audit** surfaced [[build-64]] (missing `handle_new_user` trigger) as a follow-on.
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-25-build-18c-workspace-switcher.md](../../../docs/superpowers/plans/2026-04-25-build-18c-workspace-switcher.md)
-- Source artifacts: [docs/superpowers/build-18c/session-a-handoff.md](../../../docs/superpowers/build-18c/session-a-handoff.md), [docs/superpowers/build-18c/session-b-handoff.md](../../../docs/superpowers/build-18c/session-b-handoff.md), [docs/superpowers/build-18c/session-c-handoff.md](../../../docs/superpowers/build-18c/session-c-handoff.md), [docs/superpowers/build-18c/session-b-run-log.md](../../../docs/superpowers/build-18c/session-b-run-log.md), [docs/superpowers/build-18c/session-c-run-log.md](../../../docs/superpowers/build-18c/session-c-run-log.md), [docs/superpowers/build-18c/public-route-audit.md](../../../docs/superpowers/build-18c/public-route-audit.md)
 - Migration files: build62, build62b, build63
 - Commit range: `c84f652` (plan) → `dcf4127` (merge) → `90d7405` (SSR fix) → `9e986b2` (PR #39 JWT decode)
 - Guide: none

--- a/docs/vault/builds/build-21.md
+++ b/docs/vault/builds/build-21.md
@@ -6,7 +6,6 @@ phase: jarvis-ecosystem
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-09-agent-architecture-map.md
 handoff: null
 related: ["[[build-23]]", "[[build-25a]]", "[[build-26b]]", "[[jarvis]]"]
 ---
@@ -27,6 +26,5 @@ Jarvis Core — the orchestrator AI assistant. Chat UI + Claude API backend with
 ## Source
 
 - Commits: `f97e4d6 Build 2.1: Jarvis Chat UI`, `4384bb8 Add Jarvis Claude API backend`, `3cd0d9b Bold & vibrant design overhaul + Jarvis UX improvements`
-- Plan: [docs/superpowers/plans/2026-04-09-agent-architecture-map.md](../../../docs/superpowers/plans/2026-04-09-agent-architecture-map.md)
 - Migration: [supabase/migration-build21-jarvis.sql](../../../supabase/migration-build21-jarvis.sql)
 - Guide: none

--- a/docs/vault/builds/build-27.md
+++ b/docs/vault/builds/build-27.md
@@ -6,7 +6,6 @@ phase: email
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-10-email-categories.md
 handoff: null
 related: ["[[build-12]]", "[[build-13]]", "[[build-28]]"]
 ---
@@ -24,6 +23,5 @@ Configurable inbox categories (Promotions, Social, etc.) driven by rules: `sende
 ## Source
 
 - Commits: `e914f1c feat(db): add category column, rules table, and default seed` → `41a5253 integrate IconRail and CategoryTabs into EmailInbox`
-- Plan/spec: [docs/superpowers/specs/2026-04-10-email-categories-design.md](../../../docs/superpowers/specs/2026-04-10-email-categories-design.md), [docs/superpowers/plans/2026-04-10-email-categories.md](../../../docs/superpowers/plans/2026-04-10-email-categories.md)
 - Migration: [supabase/migration-build27-categories.sql](../../../supabase/migration-build27-categories.sql)
 - Guide: none

--- a/docs/vault/builds/build-28.md
+++ b/docs/vault/builds/build-28.md
@@ -6,7 +6,6 @@ phase: email
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-09-email-improvements.md
 handoff: null
 related: ["[[build-12]]", "[[build-27]]"]
 ---
@@ -23,6 +22,5 @@ Rule engine extension for `body_pattern` matches (in addition to sender/subject 
 ## Source
 
 - Commit: `194a107 feat(email): body_pattern rules + IMAP header re-fetch for backfill`
-- Plan/spec: [docs/superpowers/specs/2026-04-09-email-improvements-design.md](../../../docs/superpowers/specs/2026-04-09-email-improvements-design.md), [docs/superpowers/plans/2026-04-09-email-improvements.md](../../../docs/superpowers/plans/2026-04-09-email-improvements.md)
 - Migration: [supabase/migration-build28-body-patterns.sql](../../../supabase/migration-build28-body-patterns.sql)
 - Guide: none

--- a/docs/vault/builds/build-29.md
+++ b/docs/vault/builds/build-29.md
@@ -6,7 +6,6 @@ phase: settings
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-10-navbar-reorder.md
 handoff: null
 related: ["[[build-14a]]"]
 ---
@@ -25,6 +24,5 @@ Admin-configurable sidebar navigation order persisted to DB. Builds on the stati
 ## Source
 
 - Commits: `f9a4050` (migration) through `cd20d41` (per-call snapshot fix), PR #2
-- Plan/spec: [docs/superpowers/specs/2026-04-10-navbar-reorder-design.md](../../../docs/superpowers/specs/2026-04-10-navbar-reorder-design.md), [docs/superpowers/plans/2026-04-10-navbar-reorder.md](../../../docs/superpowers/plans/2026-04-10-navbar-reorder.md)
 - Migration: [supabase/migration-build29-nav-order.sql](../../../supabase/migration-build29-nav-order.sql) — note the rename from build27 to build29 to avoid the email-categories collision (commit `b74d774`)
 - Guide: none

--- a/docs/vault/builds/build-30.md
+++ b/docs/vault/builds/build-30.md
@@ -6,7 +6,6 @@ phase: jobs
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-10-job-files-section.md
 handoff: null
 related: ["[[build-1-10]]", "[[build-31]]"]
 ---
@@ -25,6 +24,5 @@ A "Files" section on the job-detail page — sibling to Photos, but for arbitrar
 ## Source
 
 - Commit range: `7bf0ed6` (db) → `9d0a0e4` (UI mount)
-- Plan/spec: [docs/superpowers/specs/2026-04-10-job-files-section-design.md](../../../docs/superpowers/specs/2026-04-10-job-files-section-design.md), [docs/superpowers/plans/2026-04-10-job-files-section.md](../../../docs/superpowers/plans/2026-04-10-job-files-section.md)
 - Migration: [supabase/migration-build30-job-files.sql](../../../supabase/migration-build30-job-files.sql)
 - Guide: none

--- a/docs/vault/builds/build-31.md
+++ b/docs/vault/builds/build-31.md
@@ -6,7 +6,6 @@ phase: jobs
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-12-job-detail-insurance-redesign.md
 handoff: null
 related: ["[[build-30]]", "[[build-11]]"]
 ---
@@ -28,6 +27,5 @@ Two coordinated job-detail redesigns shipped under the build31 migration:
 
 - Commit range (insurance): `dbc4a3b` (spec) → `b37f4ba` (3-column redesign)
 - Commit range (photos): `3aeb08d` (spec) → `280c4ed` (remove old preview)
-- Plans: [docs/superpowers/plans/2026-04-12-job-detail-insurance-redesign.md](../../../docs/superpowers/plans/2026-04-12-job-detail-insurance-redesign.md), [docs/superpowers/plans/2026-04-12-job-photos-tab.md](../../../docs/superpowers/plans/2026-04-12-job-photos-tab.md)
 - Migration: [supabase/migration-build31-insurance-redesign.sql](../../../supabase/migration-build31-insurance-redesign.sql)
 - Guide: none

--- a/docs/vault/builds/build-64.md
+++ b/docs/vault/builds/build-64.md
@@ -6,7 +6,6 @@ phase: multi-tenant
 started: 2026-04-26
 shipped: 2026-04-26
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-26-build-64-handle-new-user-trigger.md
 handoff: null
 related: ["[[build-18a]]", "[[build-18b]]", "[[build-18c]]", "[[build-14d]]"]
 ---
@@ -25,7 +24,5 @@ The fix is one idempotent `CREATE OR REPLACE TRIGGER` plus deletion of one orpha
 ## Source
 
 - Commit: `1b287a4 build64: restore on_auth_user_created trigger on auth.users (#24)`
-- Plan: [docs/superpowers/plans/2026-04-26-build-64-handle-new-user-trigger.md](../../../docs/superpowers/plans/2026-04-26-build-64-handle-new-user-trigger.md)
-- Handoff: [docs/superpowers/build-64/handoff.md](../../../docs/superpowers/build-64/handoff.md)
 - Migration: [supabase/migration-build64-recreate-handle-new-user-trigger.sql](../../../supabase/migration-build64-recreate-handle-new-user-trigger.sql)
 - Guide: none

--- a/docs/vault/builds/build-65a.md
+++ b/docs/vault/builds/build-65a.md
@@ -6,7 +6,6 @@ phase: mobile
 started: 2026-04-26
 shipped: 2026-04-28
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-26-build-65-mobile-platform.md
 handoff: null
 related: ["[[2026-04-21-rename-to-nookleus]]"]
 ---
@@ -35,7 +34,5 @@ The follow-on Nookleus rename ([[2026-04-21-rename-to-nookleus]]) updated `Info.
 ## Source
 
 - Commits: `a2ae498 build65a: Capacitor iOS scaffolding (#25)` → `1d48859 rename ios app display name to Nookleus (#28)` → `57c1c67 65a: rename app to Nookleus (Info.plist, capacitor.config, build 2) (#38)`
-- Plan: [docs/superpowers/plans/2026-04-26-build-65-mobile-platform.md](../../../docs/superpowers/plans/2026-04-26-build-65-mobile-platform.md) §5.1, §11.1
-- Handoffs: [docs/superpowers/build-65/65a-handoff.md](../../../docs/superpowers/build-65/65a-handoff.md), [docs/superpowers/build-65/65a-windows-handoff.md](../../../docs/superpowers/build-65/65a-windows-handoff.md)
 - Tag: `mobile-v0.1.0`
 - Guide: none

--- a/docs/vault/builds/build-65b.2.md
+++ b/docs/vault/builds/build-65b.2.md
@@ -6,7 +6,6 @@ phase: mobile
 started: 2026-05-11
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-05-11-build-65b.2-camera-ui-redesign.md
 pr: null
 handoff: null
 related: ["[[build-65a]]", "[[build-65c]]"]
@@ -92,6 +91,5 @@ Driven by Vanessa's request after the 65c smoke tests: "I want the UI to look mo
 ## Source
 
 - Spec: embedded in this card (no separate file)
-- Plan: [docs/superpowers/plans/2026-05-11-build-65b.2-camera-ui-redesign.md](../../../docs/superpowers/plans/2026-05-11-build-65b.2-camera-ui-redesign.md)
 - Predecessors: [[build-65c]] (just shipped — upload pipeline, the foundation this UI sits on)
 - Grilling session: 2026-05-11 (this conversation)

--- a/docs/vault/builds/build-65c.md
+++ b/docs/vault/builds/build-65c.md
@@ -6,8 +6,6 @@ phase: mobile
 started: 2026-05-08
 shipped: null
 guide_doc: null
-spec_file: docs/superpowers/specs/2026-05-08-build-65c-upload-pipeline-design.md
-plan_file: docs/superpowers/plans/2026-05-08-build-65c-upload-pipeline.md
 pr: https://github.com/ericdaniels22/Nookleus/pull/52
 handoff: null
 related: ["[[build-65a]]", "[[build-65b]]"]
@@ -134,8 +132,6 @@ Implication: 87 captures on disk are invisible to the worker because `s.upload_s
 
 ## Source
 
-- Spec: [docs/superpowers/specs/2026-05-08-build-65c-upload-pipeline-design.md](../../../docs/superpowers/specs/2026-05-08-build-65c-upload-pipeline-design.md)
-- Plan: [docs/superpowers/plans/2026-05-08-build-65c-upload-pipeline.md](../../../docs/superpowers/plans/2026-05-08-build-65c-upload-pipeline.md)
 - PR #52: https://github.com/ericdaniels22/Nookleus/pull/52
 - Branch: `build-65c-upload-pipeline`
 - Last commit (pre-finding-investigation): `3ece2b1` (vault handoff for Test 2 findings)

--- a/docs/vault/builds/build-66a.md
+++ b/docs/vault/builds/build-66a.md
@@ -6,7 +6,6 @@ phase: knowledge-vault
 started: 2026-04-29
 shipped: 2026-04-29
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md
 handoff: null
 related: ["[[build-66b]]", "[[build-66c]]", "[[build-66d]]"]
 ---
@@ -26,5 +25,4 @@ The empty-but-structured `docs/vault/` tree: subfolders for builds, handoffs, de
 ## Source
 
 - Commit: `298a072 tooling: vault scaffolding (build 66a)`
-- Plan: [docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md](../../../docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md)
 - Guide: none

--- a/docs/vault/builds/build-66b.md
+++ b/docs/vault/builds/build-66b.md
@@ -6,7 +6,6 @@ phase: knowledge-vault
 started: 2026-04-29
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md
 handoff: null
 related: ["[[build-66a]]", "[[build-66c]]", "[[build-66d]]"]
 ---
@@ -30,6 +29,5 @@ The non-negotiable discipline: every claim is repo-grounded. The four guide docx
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md](../../../docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md) §66b
 - Predecessor: [[build-66a]]
 - Guide: none (this build is itself the audit-first backfill)

--- a/docs/vault/builds/build-66c.md
+++ b/docs/vault/builds/build-66c.md
@@ -6,7 +6,6 @@ phase: knowledge-vault
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md
 handoff: null
 related: ["[[build-66a]]", "[[build-66b]]", "[[build-66d]]"]
 ---
@@ -25,6 +24,5 @@ Authoring the Claude Code skills that keep the vault current without willpower:
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md](../../../docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md) §66c
 - Predecessors: [[build-66a]], [[build-66b]]
 - Guide: none

--- a/docs/vault/builds/build-66d.md
+++ b/docs/vault/builds/build-66d.md
@@ -6,7 +6,6 @@ phase: knowledge-vault
 started: null
 shipped: null
 guide_doc: null
-plan_file: docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md
 handoff: null
 related: ["[[build-66a]]", "[[build-66b]]", "[[build-66c]]"]
 ---
@@ -21,6 +20,5 @@ Stage four of the knowledge-vault build series. Scope is intentionally TBD until
 
 ## Source
 
-- Plan: [docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md](../../../docs/superpowers/plans/2026-04-29-build-66-knowledge-vault.md) §66d
 - Predecessors: [[build-66a]], [[build-66b]], [[build-66c]]
 - Guide: none

--- a/docs/vault/decisions/2026-04-26-capacitor-live-bundle.md
+++ b/docs/vault/decisions/2026-04-26-capacitor-live-bundle.md
@@ -43,5 +43,4 @@ So at 65e the architectural flip happens: `webDir: 'out'` becomes the live bundl
 
 ## Related
 
-- Plan: [docs/superpowers/plans/2026-04-26-build-65-mobile-platform.md](../../../docs/superpowers/plans/2026-04-26-build-65-mobile-platform.md) §5.1, §5.5
 - Build: [[build-65a]]

--- a/supabase/migration-build67a-estimates-foundation.sql
+++ b/supabase/migration-build67a-estimates-foundation.sql
@@ -1,5 +1,4 @@
 -- Build 67a — Estimates & Invoices Foundation
--- Spec: docs/superpowers/specs/2026-04-30-build-67a-estimates-foundation-design.md
 -- Pre-flight: INV-2026-0001 + its 2 invoice_line_items rows must be deleted before this runs.
 
 -- ============================================================================

--- a/supabase/migration-build67b-cleanup.sql
+++ b/supabase/migration-build67b-cleanup.sql
@@ -1,6 +1,4 @@
 -- Build 67b cleanup — RPC fixes (I2, I4) + minor comment / variable cleanups (M3/M4/M6/M7/M8)
--- Spec: docs/superpowers/specs/2026-05-01-build-67b-cleanup-chips.md
--- Plan: docs/superpowers/plans/2026-05-02-build-67b-cleanup.md (Task 4)
 
 -- ============================================================================
 -- 1. convert_estimate_to_invoice — I2 fix: regex-safe settings cast

--- a/supabase/migration-build67b-conversion-and-template-apply.sql
+++ b/supabase/migration-build67b-conversion-and-template-apply.sql
@@ -1,5 +1,4 @@
 -- Build 67b — Estimate→Invoice conversion + Apply Template RPCs
--- Spec: docs/superpowers/specs/2026-05-01-build-67b-design.md (§5)
 
 -- ============================================================================
 -- 1. CHECK constraint: void-when-converted guard

--- a/supabase/migration-build67c1-pdf-presets-and-bucket.sql
+++ b/supabase/migration-build67c1-pdf-presets-and-bucket.sql
@@ -1,6 +1,5 @@
 -- supabase/migration-build67c1-pdf-presets-and-bucket.sql
 -- Build 67c1 — PDF Presets table, pdfs Storage bucket, default-preset seeding.
--- Spec: docs/superpowers/specs/2026-05-04-build-67c1-design.md
 
 -- ============================================================================
 -- 0. Drop placeholder table from build 67a foundation migration.

--- a/supabase/migration-build67e-line-item-name.sql
+++ b/supabase/migration-build67e-line-item-name.sql
@@ -1,5 +1,4 @@
 -- Build 67e — Line item name (title) on estimates and invoices.
--- Spec: docs/superpowers/specs/2026-05-06-build-67e-line-item-name-design.md
 --
 -- Adds a nullable `name text` column to estimate_line_items and
 -- invoice_line_items, and updates the two RPCs that INSERT into those tables


### PR DESCRIPTION
## What

Commit #225 deleted the pre-vault `docs/superpowers/` plans, specs, and per-build scratch dirs, but left dangling pointers across the frozen knowledge vault and the `build67*` migration headers. This PR removes those dead references.

**Pure link cleanup — no content or behavior changes.** 35 files, 69 deletions, 5 one-line rewrites (where the line carried real content alongside a dead link).

## Scope

- **23 build cards** — drop dead `plan_file:`/`spec_file:` frontmatter and `- Plan` / `- Spec` / `- Briefing` / `- Post-briefing` source links. Each Source section keeps its Commit/Migration/Guide lines.
- **`builds/README.md`** — drop the dead `plan_file:` line from the canonical frontmatter example.
- **4 `_templates/*.md`** — keep the "Authored in Build 66b/66c" provenance, drop only the dead "See …/plans/….md" clause.
- **`jarvis.md`, `capacitor-live-bundle.md`** — drop dead `- Plan:` links.
- **5 `supabase/migration-build67*.sql`** — drop dead `-- Spec:`/`-- Plan:` header comments (comment-only).

## Two judgment calls beyond the literal plans+specs sweep

Both are the **same #225 deletion**, so leaving them would have made this a half-cleanup. Flagging so they can be vetoed:

1. **Per-build scratch-dir links** (`docs/superpowers/build-18b|18c|64|65/…`) folded in. In `build-18c` the real insight is preserved ("public route audit surfaced build-64 as a follow-on"); only the dead link is dropped.
2. **`build-18a`'s root-orphan handoffs** (`docs/build-18a-handoff.md`, `…-complete-handoff.md`) — also #225 casualties — folded in so that card ends fully clean.

## Verification

- `grep` proves **zero** remaining `docs/superpowers/(plans|specs|build-|prompts)/` refs and zero dead root-handoff refs.
- The **3 surviving specs** and the glossary's live `docs/superpowers/` definition are untouched.
- ADR 0010 links confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
