### PR TITLE
feat(estimate-builder): flush pending autosave on hard page-unload (pagehide + visibilitychange) (#477)

### DIFF
--- a/src/components/estimate-builder/use-auto-save.flush-on-unmount.test.tsx
+++ b/src/components/estimate-builder/use-auto-save.flush-on-unmount.test.tsx
@@ -96,6 +96,15 @@ function keepalivePuts(mock: ReturnType<typeof vi.fn>): unknown[][] {
   );
 }
 
+// jsdom's document.visibilityState is a read-only getter; override it so a
+// visibilitychange event can simulate the page being backgrounded/hidden.
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
 let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
@@ -114,6 +123,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
   vi.useRealTimers();
   vi.restoreAllMocks();
+  setVisibility("visible"); // reset so a hidden value can't leak to the next test
 });
 
 describe("useAutoSave flush-on-unmount (#461)", () => {
@@ -328,5 +338,273 @@ describe("useAutoSave flush-on-unmount (#461)", () => {
     expect(puts).toHaveLength(1);
     expect(puts[0][0]).toBe("/api/estimates/est-1");
     expect(puts.some(([path]) => String(path).includes("/line-items/"))).toBe(false);
+  });
+});
+
+// Hard unload (#477): a real tab-close / refresh / address-bar nav does NOT run
+// React cleanup, so the unmount flush above never fires. These tests keep the
+// component MOUNTED and dispatch the browser page-lifecycle events the hook now
+// listens for — proving the flush is driven by the listeners, not by unmount.
+describe("useAutoSave flush-on-hard-unload (#477)", () => {
+  it("flushes a dirty root edit as a keepalive PUT on a pagehide event (still mounted)", () => {
+    const config = makeConfig();
+    const { rerender, unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    // Edit a root field, staying inside the 2s debounce window (no timer flush).
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({ title: "Roof repair — edited" })}
+      />,
+    );
+
+    // The page is torn down the hard way — React cleanup never runs.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/estimates/est-1");
+    const init = puts[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(init.keepalive).toBe(true);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: "Roof repair — edited",
+    });
+
+    // Tidy up while fetch is still stubbed (the test left the node mounted).
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("flushes a dirty root edit as a keepalive PUT on visibilitychange when the page becomes hidden", () => {
+    const config = makeConfig();
+    const { rerender, unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({ title: "Roof repair — edited" })}
+      />,
+    );
+
+    // The tab/app is backgrounded — the common iOS exit path.
+    act(() => {
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/estimates/est-1");
+    const init = puts[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(init.keepalive).toBe(true);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: "Roof repair — edited",
+    });
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("does not flush on visibilitychange when the page becomes visible", () => {
+    const config = makeConfig();
+    const { rerender, unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({ title: "Roof repair — edited" })}
+      />,
+    );
+
+    // Returning to the foreground is not a teardown — no flush.
+    act(() => {
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("fires no PUT on pagehide or visibilitychange when the document is clean", () => {
+    const config = makeConfig();
+    const { unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    // No edit — both events should be no-ops (the planner returns an empty plan).
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("suppresses the pagehide flush entirely while a stale conflict is active", async () => {
+    const config = makeConfig({ hasSnapshotConcurrency: true });
+    // The debounced save will 409 (another user modified the row), driving the
+    // hook into its stale-conflict state.
+    fetchMock.mockImplementation(() =>
+      Promise.resolve({ ok: false, status: 409, json: async () => ({}) } as Response),
+    );
+
+    const { rerender, unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({ title: "Roof repair — edited" })}
+      />,
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    // Hard unload while the conflict is active: the planner still suppresses.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("removes its listeners on unmount — a later pagehide or visibilitychange fires no further PUT", () => {
+    const config = makeConfig();
+    const { rerender, unmount } = render(
+      <Harness config={config} entity={makeEntity({ title: "Roof repair" })} />,
+    );
+
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({ title: "Roof repair — edited" })}
+      />,
+    );
+
+    // In-app unmount flushes once via the #461 cleanup.
+    act(() => {
+      unmount();
+    });
+    const afterUnmount = keepalivePuts(fetchMock).length;
+    expect(afterUnmount).toBe(1);
+
+    // The listeners must be gone: were they leaked, this would fire a 2nd PUT
+    // (the entity is still dirty relative to the un-advanced snapshot).
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(afterUnmount);
+  });
+
+  it("flushes a template's root edit but never a per-line-item PUT on pagehide", () => {
+    const config = makeConfig({
+      entityKind: "template",
+      hasSnapshotConcurrency: false,
+    });
+    const templateEntity = (title: string, description: string) =>
+      makeEntity({
+        title,
+        sections: [{ items: [makeItem("li-1", { description })], subsections: [] }],
+      });
+
+    const { rerender, unmount } = render(
+      <Harness
+        config={config}
+        entity={templateEntity("Roof template", "Replace shingles")}
+      />,
+    );
+
+    // Both the root AND the line item are dirty.
+    rerender(
+      <Harness
+        config={config}
+        entity={templateEntity("Roof template — edited", "Replace shingles — edited")}
+      />,
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/estimates/est-1");
+    expect(puts.some(([path]) => String(path).includes("/line-items/"))).toBe(false);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("stamps updated_at_snapshot on the pagehide flush when concurrency is enabled", () => {
+    const config = makeConfig({ hasSnapshotConcurrency: true });
+    const { rerender, unmount } = render(
+      <Harness
+        config={config}
+        entity={makeEntity({
+          title: "Roof repair",
+          updated_at: "2026-06-05T12:30:00Z",
+        })}
+      />,
+    );
+
+    rerender(
+      <Harness
+        config={config}
+        entity={makeEntity({
+          title: "Roof repair — edited",
+          updated_at: "2026-06-05T12:30:00Z",
+        })}
+      />,
+    );
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(JSON.parse((puts[0][1] as RequestInit).body as string)).toMatchObject({
+      title: "Roof repair — edited",
+      updated_at_snapshot: "2026-06-05T12:30:00Z",
+    });
+
+    act(() => {
+      unmount();
+    });
   });
 });

--- a/src/components/estimate-builder/use-auto-save.ts
+++ b/src/components/estimate-builder/use-auto-save.ts
@@ -325,6 +325,29 @@ export function useAutoSave<T extends { id: string; updated_at?: string | null }
   // Empty deps: the cleanup runs only on unmount, reading the latest ref.
   useEffect(() => () => flushOnUnmountRef.current(), []);
 
+  // ── Flush pending edits on hard page-unload (#477) ────────────────────────
+  // The cleanup above fires only on in-app unmount; a true page teardown (tab
+  // close, refresh, address-bar nav, or iOS backgrounding the app and the OS
+  // later killing it) never runs React cleanup, so an edit inside the debounce
+  // window would be silently dropped. Fire the same keepalive flush from the
+  // browser's page-lifecycle event so it survives the page going away.
+  // beforeunload is intentionally avoided (unreliable in iOS WebKit, can
+  // surface a "Leave site?" prompt). Safe to fire alongside the unmount cleanup:
+  // planUnmountFlush returns an empty plan on a clean/already-saved document and
+  // the PUTs are idempotent, so no "already-flushed" guard is needed.
+  useEffect(() => {
+    const flush = () => flushOnUnmountRef.current();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
+
   // ── Core save flow helpers ────────────────────────────────────────────────
 
   const transitionToSaved = useCallback(() => {


### PR DESCRIPTION
## Summary

Closes #477 (slice of PRD #476).

The unmount flush from #461 fires only on in-app navigation (React cleanup). A true page teardown — tab close, refresh, address-bar nav, or iOS backgrounding the app then the OS killing it — never runs React cleanup, so an edit made inside the ~2s autosave debounce window was silently dropped.

This adds one effect to `useAutoSave` that listens for two browser page-lifecycle events and fires the **existing** unmount flush:

- `pagehide` on `window`
- `visibilitychange` on `document` (flushes only when `document.visibilityState === "hidden"` — the common iOS backgrounding exit)

Both call the existing `flushOnUnmountRef.current()`, which reuses the pure `planUnmountFlush` planner and the `keepalive` PUT executor **verbatim** — no save logic is written or duplicated. The effect cleanup removes both listeners on unmount. `beforeunload` is intentionally not used (unreliable in iOS WebKit; can surface a "Leave site?" prompt).

Multi-fire is safe by construction: the planner returns an empty plan on a clean / stale-conflict / uninitialized document, and the PUTs are idempotent, so `pagehide` + `visibilitychange` + the unmount cleanup all firing (routine on a backgrounded tablet) needs no "already-flushed" guard.

This also ships **PRD #458's pre-agreed deferred hard-unload test**, which was gated on this guard existing.

## Test Plan

All run in an isolated worktree off clean `origin/main`:

- [x] `use-auto-save.flush-on-unmount.test.tsx` — 15/15 (7 existing + 8 new), covering: pagehide → root PUT; visibilitychange→hidden → PUT; visible → no PUT; clean doc → no PUT; stale-conflict → no PUT; template root-only (no line-item PUT); `updated_at_snapshot` stamping; listener-removal/no-leak after unmount.
- [x] All `use-auto-save*` test files — 24/24, no regressions.
- [x] `eslint` on both touched files — 0 errors (warnings all pre-existing).
- [x] `tsc --noEmit` — 0 errors in touched files (only the 2 documented baseline errors repo-wide: #408 `kind`, #64 Mock type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
