### PR TITLE
docs(adr): per-document PDF layout snapshot + precedence (ADR 0012)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -167,6 +167,34 @@ state, and QuickBooks sync; a deposit or staged payment is a partial payment on
 the single Invoice, never a second Invoice.
 _Avoid_: bill (fine in UI copy), receipt
 
+**PDF preset**:
+A saved, reusable set of look-preferences for the customer-facing PDF of an
+Estimate or Invoice — which parts show (markup, discount, tax, opening and
+closing statements, code column, category subtotals, the document-title
+heading, and item notes) plus the title text. Belongs to one Organization and
+is the starting point a document's PDF layout is copied from. Exactly one of
+an Organization's presets is its **default preset**, the look any document
+uses until it is given a layout of its own. Distinct from a Photo Report
+template, which the photo-report UI historically also called a "preset" — see
+Flagged ambiguities; the two are always qualified by document.
+_Avoid_: template (that's the Estimate/Photo-Report feature), style, theme,
+bare "preset" outside the billing-PDF context
+
+**PDF layout**:
+The set of show/hide choices a single specific Estimate or Invoice is
+rendered with — its own copy of the preferences, stored on that document. A
+document with no layout falls back to its Organization's **default preset**;
+the moment its look is changed it takes a complete layout of its own and stops
+following the default (it never half-follows). A layout sticks to its
+document and is frozen along with it — once the Estimate is converted or the
+Invoice is paid or voided, the look is locked, so the record keeps exactly the
+look it was approved or billed with. The look a document actually renders with
+is resolved by a pure precedence rule: the document's own layout wins over the
+default preset; absent a layout, the default applies. See
+[ADR 0012](docs/adr/0012-pdf-layout-is-a-per-document-snapshot.md).
+_Avoid_: format, theme, bare "layout" outside the billing-PDF context, View
+(that's the screen a layout is edited on, not the layout itself)
+
 **Target**:
 A row on the Referral Partners call list whose Lifecycle status is still
 Uncontacted (grey) or In progress (yellow) — i.e. someone we want to call
@@ -206,6 +234,7 @@ _Avoid_: stage, pipeline status, partner status
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 - A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).
+- An **Estimate** or **Invoice** has zero or one **PDF layout** of its own; with none it renders using its Organization's **default preset**. A document's own layout always wins over the default, resolved by a pure precedence rule, and is locked once the document is frozen (Estimate converted, Invoice paid or voided). A **PDF preset** belongs to one **Organization** and seeds a document's layout; applying one copies its preferences in, it is not a binding link.
 - A **Job** has zero or more **Photo Reports**; each Photo Report belongs to exactly one Job, gathers that Job's **Photos** into ordered **Sections**, and is created and edited only from within the Job. Reports are numbered per Job (Report #1, #2, …).
 - A **Photo Report template** belongs to one **Organization** and seeds a new Photo Report's **Sections**; applying one is a starting point, not a binding link.
 
@@ -219,4 +248,5 @@ _Avoid_: stage, pipeline status, partner status
 - "auth gate" was used for four near-identical route helpers (`requirePermission`, `requireAdmin`, `requireViewAccounting`, and an inline `requireLogExpenses`) — resolved: these collapse into the one **Request Context** wrapper.
 - "active" was being used for two unrelated concepts in `src/lib/accounting/margins.ts`: (a) a job with financial activity in a reporting period, and (b) a non-completed job (the user-facing filter pill on the Job Profitability page, which also folds cancelled jobs in with active ones). Neither matches the canonical **Active job** definition above. The dashboard rebuild adopts the canonical meaning; the accounting page is left as-is for now but is a cleanup candidate.
 - "section" is used for two unrelated concepts: an **Estimate** Section (a group of priced line items) and a **Photo Report** Section (a heading + one-page write-up + photos). Resolved: both keep the word but are always qualified by their document ("Estimate section" vs "Photo Report section"); they share no table, type, or component.
-- "template" is likewise overloaded: an **Estimate** template (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)) and a **Photo Report** template. Resolved: always qualify by document. Note the older Photo-Report builder UI also called these "presets" — the canonical term is **Photo Report template**; "preset" is an alias to retire.
+- "template" is likewise overloaded: an **Estimate** template (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)) and a **Photo Report** template. Resolved: always qualify by document. Note the older Photo-Report builder UI also called these "presets" — the canonical term is **Photo Report template**; "preset" is an alias to retire _there_.
+- "preset" and "layout" are overloaded across domains. On the **Photo Report** side both are words to avoid (canonical term: **Photo Report template**). On the **billing-PDF** side they are first-class and canonical — a **PDF preset** (reusable saved look) and a **PDF layout** (the look stuck to one Estimate/Invoice). Resolved the same way as "section"/"template": always qualify by document, so bare "preset"/"layout" never appear unqualified. The billing-PDF preset has lived in the code (`pdf_presets`) since before this was written; ADR 0007 explicitly left that system out of its scope.

--- a/docs/adr/0012-pdf-layout-is-a-per-document-snapshot.md
+++ b/docs/adr/0012-pdf-layout-is-a-per-document-snapshot.md
@@ -1,0 +1,135 @@
+# A document's PDF layout is a per-document snapshot, resolved by precedence
+
+**Status:** Accepted
+**Date:** 2026-06-06 — documents the design decisions for issue #387 (live PDF layout options panel for estimates & invoices)
+
+## Context
+
+Issue #387 adds a layout-options panel beside the live PDF View of an Estimate
+or Invoice: a set of show/hide switches (markup, discount, tax, opening
+statement, closing statement, code column, category subtotals, document title,
+item notes) plus an editable document-title text, with the preview re-rendering
+live as switches flip. The same look must apply when the PDF is exported or
+sent, not just on screen.
+
+A `PdfPreset` system already exists in code (`src/lib/pdf-presets.ts`,
+`pdf_presets`) but was explicitly left **out of scope** by
+[ADR 0007](0007-estimates-are-the-single-billing-entry-point.md) (it "belongs to
+issue #379's other two asks"). Nothing today governs how a *per-document* look
+relates to those reusable presets, what happens to that look once a document is
+frozen, or how the two are resolved at render time. Those are the questions this
+ADR settles, because the answers shape the schema (a snapshot column vs. a
+foreign key) and a behavioural guarantee (frozen documents keep their look) that
+are both costly to change after data exists.
+
+Two terms are now first-class and qualified by document to avoid the long-running
+"preset" / "template" / "layout" overload (see the **PDF preset** and **PDF
+layout** entries in [CONTEXT.md](../../CONTEXT.md)):
+
+- **PDF preset** — a saved, reusable set of look-preferences belonging to an
+  Organization. Exactly one is the Organization's **default preset**.
+- **PDF layout** — the show/hide choices one specific Estimate or Invoice
+  actually renders with, stored on that document.
+
+## Decision
+
+1. **A document's PDF layout is a snapshot, not a reference.** The moment a user
+   changes any switch on a document, that document gets its **own complete copy**
+   of the look (all switches plus the title text), stored on the document itself —
+   not a `preset_id` pointing back at a preset. Editing a preset later never
+   reaches back and changes documents already made. This follows the house
+   snapshot-over-live-reference stance set by
+   [ADR 0004](0004-template-line-items-snapshot.md): a document's appearance is a
+   user-authored fact about *that document*, not a derived view of current preset
+   state, and silent "spooky-action-at-a-distance" rewrites are exactly what we
+   avoid.
+
+2. **Taking a layout copies the whole look — never half-and-half.** A document
+   either has no layout of its own (and renders from the default preset) or has a
+   complete layout. The first switch-flip seeds the document's layout from the
+   currently-effective look and from then on the document follows only itself.
+   There is no partial overlay where some switches come from the document and the
+   rest still track the preset.
+
+3. **The look is resolved by a pure precedence rule.** A single pure function
+   resolves the effective look at render time: **the document's own layout wins;
+   absent a layout, the Organization's default preset applies.** The renderer,
+   the on-screen preview, the export path, and the send path all call the same
+   resolver, so what is sent or exported is byte-for-byte the look shown in the
+   preview.
+
+4. **A frozen document's layout is locked.** Once an Estimate is converted and
+   once an Invoice is paid or voided, its PDF layout can no longer be changed —
+   the same boundary [ADR 0007](0007-estimates-are-the-single-billing-entry-point.md)
+   draws for editing the document ("no edits once paid or voided") and the
+   record-integrity principle [ADR 0011](0011-signed-contract-pdfs-are-immutable.md)
+   sets for signed artifacts. Everything earlier in the lifecycle (a draft
+   estimate, a sent-but-unpaid invoice) stays freely editable. The layout panel
+   is read-only on a frozen document; its stored layout still drives rendering so
+   the frozen document keeps looking exactly as it did.
+
+5. **"Document title" is a switch plus editable text, carried per document.** The
+   ninth toggle turns the title on or off, and an accompanying text field edits
+   the title words. Both the on/off state and the text are part of the document's
+   layout snapshot, so a renamed title travels with the document like every other
+   choice.
+
+6. **Layout changes autosave.** There is no explicit "save layout" action on the
+   document — flipping a switch or editing the title persists to the document's
+   layout. ("Save as preset" is a separate, deliberate action; see below.)
+
+7. **Permissions reuse existing boundaries.** Changing one document's layout
+   requires the same permission as editing that document. Saving a reusable,
+   Organization-wide preset (including "Save as preset" from the panel) requires
+   the manage-presets permission.
+
+## Consequences
+
+- **Schema:** each of `estimates` and `invoices` gains a nullable `pdf_layout`
+  JSONB column holding the snapshot (`NULL` = "no layout of its own, use the
+  default preset"), plus a `show_document_title` boolean inside that shape since
+  the title is now a per-document toggle. A hand-written `DocumentPdfLayout` type
+  is added to `src/lib/types.ts` (manual migrations, no gen-types — consistent
+  with the rest of the repo).
+- **Item notes reuse #382's `show_item_notes`** rather than introducing a parallel
+  flag; the layout snapshot carries the same field name the renderer already
+  understands.
+- **Storing a snapshot, not a `preset_id`, is a deliberate denormalization.** A
+  future reader will ask "why not just store which preset this document uses?" —
+  the answer is decisions 1 and 2: a document must keep its look even as presets
+  change or are deleted, exactly as template line items keep their values when the
+  library changes (ADR 0004). The column is intentionally redundant with whatever
+  preset it was seeded from.
+- **Default-preset fallback must always resolve to *something*.** When a document
+  has no layout and the Organization has no default preset, the resolver falls
+  back to the field-level defaults (the column defaults the `pdf_presets` shape
+  already carries). The render path never has "no look."
+- **No relayout of frozen documents — and no endpoint that would allow it.** As
+  with [ADR 0011](0011-signed-contract-pdfs-are-immutable.md)'s refusal to add a
+  regenerate-signed-PDF path, a future "let me re-skin this old approved estimate"
+  request must not be answered by mutating the frozen document's layout. The
+  approved/paid record is what the customer saw; changing its look after the fact
+  would misrepresent it.
+- **One resolver, four call sites.** Centralizing the precedence rule in a single
+  pure function (testable in isolation) is what guarantees preview/export/send
+  parity; any path that renders a billing PDF without going through it is a bug.
+
+## Considered options
+
+- **Store a `preset_id` reference instead of a snapshot.** Rejected: editing or
+  deleting a preset would silently change or break the look of past documents —
+  the spooky-action-at-a-distance ADR 0004 already ruled out for templates, and
+  worse here because some of those documents are frozen legal/financial records.
+- **Partial overlay (document overrides specific switches, the rest track the
+  preset).** Rejected: it makes "what does this document actually look like?"
+  depend on live preset state, defeating the snapshot guarantee and complicating
+  both the resolver and the frozen-document lock. Whole-look copy is simpler and
+  matches user intuition ("this document looks the way I left it").
+- **Let frozen documents be re-laid-out, showing only an ephemeral preview.**
+  Rejected: it invites exactly the record-integrity problem ADR 0007 and ADR 0011
+  guard against — the on-screen look diverging from, or quietly replacing, the
+  look the customer approved or paid against.
+- **Explicit "Save layout" button on the document.** Rejected: the look *is* the
+  document's state, not a draft to be committed; autosave matches how the rest of
+  the document edits behave. The deliberate-commit affordance is reserved for the
+  cross-document action ("Save as preset").


### PR DESCRIPTION
## What

Records the design decisions resolved for the **#387** live PDF layout
options panel, before any schema/UI work starts:

- **ADR 0012** — a document's PDF layout is a per-document **snapshot** (not a
  reference to a preset), the effective look is resolved by a pure
  **precedence rule** (document layout > org default preset > field defaults),
  and a **frozen document** (converted estimate / paid-or-voided invoice) has
  its look locked.
- **CONTEXT.md** — adds the **PDF preset** and **PDF layout** glossary entries
  and links the layout entry to ADR 0012.

## Why

The #387 PRD and its seven slice issues (#482–#488) reference these docs as
the source of truth for the vocabulary and the hard-to-reverse decisions.
Landing them makes those links resolve against committed docs. Decisions are
grounded in ADR 0004 (snapshot lineage), 0007 (frozen / no-edits-once-paid),
and 0011 (record immutability).

Docs-only change — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
