### PR TITLE
docs(adr-0013): drop dead vault-handoff link

### DIFF
--- a/docs/adr/0013-in-app-document-viewer-replaces-native-pdf-iframe.md
+++ b/docs/adr/0013-in-app-document-viewer-replaces-native-pdf-iframe.md
@@ -54,8 +54,7 @@ committing, that reputation had to be root-caused.
 
 **Reliability finding — the root cause, written down for slice #464.** The Chrome hang
 was *not* a react-pdf / pdf.js / worker defect. It was **email-iframe sandbox
-inheritance**, diagnosed and fixed on 2026-05-08 (build 15h-followup, prod-verified —
-see [`2026-05-08-build-15h-followup-chrome-sign-sandbox.md`](../vault/handoffs/2026-05-08-build-15h-followup-chrome-sign-sandbox.md)).
+inheritance**, diagnosed and fixed on 2026-05-08 (build 15h-followup, prod-verified).
 The in-app `/email` inbox renders the email body inside
 `<iframe sandbox="allow-same-origin allow-popups">` with `<base target="_blank">`
 injected, so a popup opened by clicking the contract link inherited the parent's


### PR DESCRIPTION
The `2026-05-08-build-15h-followup-chrome-sign-sandbox.md` handoff referenced in ADR 0013 was removed from `main` by the knowledge-vault retirement (ADR 0010), leaving a dead link.

Drops the `— see [...]` reference; the surrounding **prod-verified** claim stands on its own. Docs-only, no other content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)