### PR TITLE
feat(reports-api): keepalive-capable PUT route for Photo Report hard-unload flush (#478)

### DIFF
--- a/src/app/api/jobs/[id]/reports/[reportId]/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/route.test.ts
@@ -1,0 +1,196 @@
+// PUT /api/jobs/[id]/reports/[reportId] — keepalive-capable content write path
+// for the Photo Report builder (#478). Lets a pending autosave edit flush during
+// a hard page-unload (tab close / refresh / app-background) via a plain
+// `keepalive: true` PUT, instead of the Supabase JS client (which can't ride a
+// keepalive request and won't survive page teardown). Persists title /
+// report_date / sections with the same `edit_jobs` gate and (id, job_id, active)
+// tenancy scoping as the delete/restore siblings — server-side, never relying on
+// client-assembled auth. The builder trigger that fires this lives in #479.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PUT } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../__test-utils__/request-context-fakes";
+
+function paramsFor(id: string, reportId: string) {
+  return { params: Promise.resolve({ id, reportId }) };
+}
+
+function putRequest(body: unknown) {
+  return new Request("http://test", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("PUT /api/jobs/[id]/reports/[reportId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await PUT(
+      putRequest({ title: "x", report_date: "2026-06-06", sections: [] }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a member without the edit_jobs grant", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+
+    const res = await PUT(
+      putRequest({ title: "x", report_date: "2026-06-06", sections: [] }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("persists title/report_date/sections for a caller holding edit_jobs", async () => {
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [{ id: "r-1", job_id: "job-1", deleted_at: null }],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await PUT(
+      putRequest({
+        title: "Roof Inspection",
+        report_date: "2026-06-06",
+        sections: [{ id: "s-1" }],
+      }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(client.__mutations).toContainEqual(
+      expect.objectContaining({
+        table: "photo_reports",
+        op: "update",
+        payload: {
+          title: "Roof Inspection",
+          report_date: "2026-06-06",
+          sections: [{ id: "s-1" }],
+        },
+      }),
+    );
+  });
+
+  it("rejects a cross-tenant write (report reached through the wrong Job) with 404", async () => {
+    // The report exists, but it belongs to a different Job — a caller must not be
+    // able to write to it by guessing its id through their own Job. The
+    // `.eq("job_id", jobId)` scoping (RLS in prod) excludes it, so the write
+    // matches no active row and 404s rather than silently editing another
+    // tenant's report.
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [{ id: "r-1", job_id: "other-job", deleted_at: null }],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await PUT(
+      putRequest({ title: "x", report_date: "2026-06-06", sections: [] }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the report is trashed (a soft-deleted report is not editable)", async () => {
+    // A late flush must not resurrect content onto a report the user already
+    // trashed. The `.is("deleted_at", null)` guard excludes soft-deleted rows, so
+    // the write matches nothing and 404s.
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [
+            { id: "r-1", job_id: "job-1", deleted_at: "2026-01-01T00:00:00Z" },
+          ],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await PUT(
+      putRequest({ title: "x", report_date: "2026-06-06", sections: [] }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("surfaces a DB write error as a 500, not a false success", async () => {
+    // If the UPDATE itself errors, the route must not 404 (which would read as
+    // "report gone") or 200 (a false flush). `.maybeSingle()` returns the error
+    // and the route routes it through apiDbError → 500.
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [{ id: "r-1", job_id: "job-1", deleted_at: null }],
+        },
+      }),
+      errorsByTable: {
+        photo_reports: { message: "connection reset" },
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await PUT(
+      putRequest({ title: "x", report_date: "2026-06-06", sections: [] }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/jobs/[id]/reports/[reportId]/route.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/route.ts
@@ -1,0 +1,71 @@
+// PUT /api/jobs/[id]/reports/[reportId] — keepalive-capable content write path
+// for the Photo Report builder (#478). The builder autosaves on a debounce; when
+// the page goes away "the hard way" (tab close / refresh / app-background) a
+// pending edit must still flush. The Supabase JS client can't ride a
+// `keepalive: true` request, so the builder fires a plain keepalive PUT at this
+// route instead (#479 wires the trigger). Persists title / report_date /
+// sections with the same `edit_jobs` gate and (id, job_id, active) tenancy
+// scoping as the delete/restore siblings — validated server-side, never trusting
+// client-assembled auth.
+//
+// Architectural decision (#478, HITL): a server route via `withRequestContext`
+// was chosen over a direct PostgREST keepalive fetch so tenancy/permission
+// gating stays server-side and unit-testable, mirroring the Estimate/Invoice
+// flush path (#477). See the issue thread for the recorded rationale.
+
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+
+interface UpdatePayload {
+  title?: string;
+  report_date?: string;
+  sections?: unknown[];
+}
+
+export const PUT = withRequestContext(
+  { permission: "edit_jobs" },
+  async (
+    request,
+    ctx,
+    { params }: { params: Promise<{ id: string; reportId: string }> },
+  ) => {
+    const { id: jobId, reportId } = await params;
+    const body = (await request.json()) as UpdatePayload;
+
+    // Whitelist the three editable content columns; only keys actually present
+    // in the body are written, so a partial flush never clobbers a field the
+    // client didn't send.
+    const update: Record<string, unknown> = {};
+    for (const k of ["title", "report_date", "sections"] as const) {
+      if (k in body && body[k] !== undefined) update[k] = body[k];
+    }
+
+    // Scope by job_id as well as id so a report is only writable through its own
+    // Job, and `.is("deleted_at", null)` keeps the write to active rows (a
+    // trashed report is not editable). `.select().maybeSingle()` tells a real DB
+    // error apart from "no row matched" — the latter 404s instead of falsely
+    // reporting success. Mirrors the delete/restore sibling shape.
+    const { data, error } = await ctx.supabase
+      .from("photo_reports")
+      .update(update)
+      .eq("id", reportId)
+      .eq("job_id", jobId)
+      .is("deleted_at", null)
+      .select("id")
+      .maybeSingle();
+    if (error) {
+      return apiDbError(
+        error.message,
+        "PUT /api/jobs/[id]/reports/[reportId]",
+      );
+    }
+    if (!data) {
+      return NextResponse.json(
+        { error: "Photo Report not found" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  },
+);


### PR DESCRIPTION
## What

Adds `PUT /api/jobs/[id]/reports/[reportId]` — a keepalive-capable content write path for the Photo Report builder. Slice **B1** of PRD #476 (hard-unload flush); unblocks the builder trigger in #479.

The Photo Report builder autosaves on a 2s debounce. When the page goes away "the hard way" (tab close / refresh / app-background-then-kill), a pending edit must still flush. Today the builder writes via the Supabase JS client, whose `fetch` can't carry `keepalive: true`, so that write is cancelled on a true hard unload. This route gives the flush a plain `keepalive` PUT to aim at.

## Architectural decision (the HITL fork in PRD #476)

Chose **option (a): a server route via `withRequestContext`** over **(b) a direct PostgREST keepalive fetch**.

**Rationale:** keeps tenancy/permission gating server-side and unit-testable, and mirrors the Estimate/Invoice flush path shipped in #477 — one consistent shape across money documents and field reports, rather than assembling auth client-side and leaning entirely on RLS. Recorded on the issue thread per the acceptance criteria.

## Behavior

- Persists `title` / `report_date` / `sections` only (whitelisted; keys absent from the body aren't written, so a partial flush never clobbers an unsent field).
- Same `edit_jobs` permission gate and `(id, job_id, deleted_at IS NULL)` scoping as the delete/restore siblings.
- A cross-tenant write (report reached through the wrong Job) or a write to a trashed report matches no row → **404**, never a silent edit of another tenant's report or a resurrection of trashed content.

## Tests

6 tests, all passing — through the public HTTP surface (real `withRequestContext`, gated by the shared request-context fakes):

- 401 unauthenticated
- 403 member without `edit_jobs`
- happy path persists `title`/`report_date`/`sections` (asserts the recorded update payload)
- cross-tenant write → 404
- trashed (soft-deleted) report → 404

## Acceptance criteria (#478)

- [x] Decision recorded (route handler vs. PostgREST) with rationale
- [x] Authorized update to title/report_date/sections persists
- [x] Tenancy/RLS enforced — cross-tenant/unauthorized rejected
- [x] Reachable with a plain `keepalive` PUT, not the Supabase JS client
- [x] Test covers happy-path + rejection, without importing the `@react-pdf` stack
- [x] Touched files add no new vitest/tsc/lint failures vs. the known-red baseline

## Verification

- `vitest` on the new test file: **6/6 pass**
- ESLint on both touched files: **clean**
- `tsc --noEmit`: **no new errors** in the touched files (baseline's pre-existing tsc errors are elsewhere)

## Not in this slice

The builder trigger (`pagehide` + `visibilitychange → hidden`) that fires this route, and routing the existing flush through it, is **#479** (blocked on this).

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)