### PR TITLE
feat(photo-report): flush pending edit on hard page-unload (#479)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -10,7 +10,7 @@
 // estimate-drag-end.test.tsx.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
 
 import type { Photo, PhotoReport } from "@/lib/types";
 
@@ -151,6 +151,48 @@ function renderBuilder(report = makeReport(), photos: Photo[] = noPhotos) {
     />,
   );
 }
+
+// The teardown flush (unmount #443 and hard-unload #479) can't ride the Supabase
+// JS client — its fetch is cancelled when the page goes away "the hard way" — so
+// it fires a plain `keepalive: true` PUT at the #478 route instead. Only those
+// PUTs carry keepalive:true, so isolate them: an assertion can't then be fooled
+// by an unrelated debounced/in-flight Supabase write.
+function keepalivePuts(mock: ReturnType<typeof vi.fn>): unknown[][] {
+  return mock.mock.calls.filter(
+    ([, init]) => (init as RequestInit | undefined)?.keepalive === true,
+  );
+}
+
+// jsdom's document.visibilityState is a read-only getter; override it so a
+// visibilitychange event can simulate the page being backgrounded/hidden.
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => state,
+  });
+}
+
+// The teardown flush is a keepalive `fetch` PUT, not a Supabase call. Stub fetch
+// inert for every test so the flush is harmless where it isn't asserted, and so
+// the flush tests can inspect what it sent. A fresh mock per test prevents bleed.
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  // Unmount now, while `fetch` is still stubbed, so a teardown flush from a
+  // component a test left mounted-and-dirty hits the inert mock instead of the
+  // real undici fetch (which rejects on the route's relative URL). Runs before
+  // RTL's own auto-cleanup either way, so that becomes a no-op.
+  cleanup();
+  vi.unstubAllGlobals();
+  setVisibility("visible"); // reset so a hidden value can't leak to the next test
+});
 
 describe("PhotoReportBuilder auto-save", () => {
   beforeEach(() => {
@@ -542,7 +584,7 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
     vi.useFakeTimers();
   });
 
-  it("flushes the pending edit when the builder unmounts within the debounce window", () => {
+  it("flushes the pending edit as a keepalive PUT when the builder unmounts within the debounce window", () => {
     const { unmount } = renderBuilder();
 
     act(() => {
@@ -553,17 +595,23 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
 
     // Unmount BEFORE the 2s debounce elapses — the autosave timer has not fired,
     // so nothing has been written yet (this is the lost-edit window in #443).
-    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
 
     act(() => {
       unmount();
     });
 
-    // The pending dirty edit is flushed on unmount, persisting the last edit.
-    expect(h.updateMock).toHaveBeenCalledTimes(1);
-    expect(h.updateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Roof damage report" }),
-    );
+    // The pending dirty edit is flushed on unmount via a keepalive PUT to the
+    // #478 route (not the Supabase client, whose fetch can't survive teardown).
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/jobs/job-1/reports/report-1");
+    const init = puts[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(init.keepalive).toBe(true);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: "Roof damage report",
+    });
   });
 
   it("does not flush when the builder was never edited", () => {
@@ -574,7 +622,7 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
       unmount();
     });
 
-    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
   });
 
   it("does not flush an over-limit write-up on unmount", () => {
@@ -597,7 +645,185 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
       unmount();
     });
 
-    expect(h.updateMock).not.toHaveBeenCalled();
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+  });
+});
+
+// Hard unload (#479): a real tab-close / refresh / app-background does NOT run
+// React cleanup, so the unmount flush (#443) above never fires. These tests keep
+// the builder MOUNTED and dispatch the browser page-lifecycle events it now
+// listens for — proving the flush is driven by the listeners, not by unmount.
+// Mirrors the Estimate/Invoice hard-unload trigger (slice A / #477).
+describe("PhotoReportBuilder hard-unload flush (#479)", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    vi.useFakeTimers();
+  });
+
+  it("flushes a dirty edit as a keepalive PUT on a pagehide event (still mounted)", () => {
+    const { unmount } = renderBuilder();
+
+    // Edit the title, staying inside the 2s debounce window (no timer flush).
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Roof damage report" },
+      });
+    });
+
+    // The page is torn down the hard way — React cleanup never runs.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/jobs/job-1/reports/report-1");
+    const init = puts[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(init.keepalive).toBe(true);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: "Roof damage report",
+    });
+
+    // Tidy up while fetch is still stubbed (the test left the node mounted).
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("flushes a dirty edit as a keepalive PUT on visibilitychange when the page becomes hidden", () => {
+    const { unmount } = renderBuilder();
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Roof damage report" },
+      });
+    });
+
+    // The tab/app is backgrounded — the common iOS exit path.
+    act(() => {
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(puts[0][0]).toBe("/api/jobs/job-1/reports/report-1");
+    const init = puts[0][1] as RequestInit;
+    expect(init.method).toBe("PUT");
+    expect(init.keepalive).toBe(true);
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      title: "Roof damage report",
+    });
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("flushes on visibilitychange only when hidden, not when the page becomes visible", () => {
+    const { unmount } = renderBuilder();
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Roof damage report" },
+      });
+    });
+
+    // Returning to the foreground is not a teardown — no flush. The report is
+    // dirty and savable here (proven below), so a missing hidden-guard would
+    // fire a PUT and fail this assertion; it isn't the dirty guard masking it.
+    act(() => {
+      setVisibility("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    // Same dirty edit, now the page genuinely hides → the flush fires. Holding
+    // the dirty state constant across both branches isolates the visibility
+    // guard: only document.visibilityState gates the difference.
+    act(() => {
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(keepalivePuts(fetchMock)).toHaveLength(1);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("does not flush an over-limit write-up on pagehide or visibilitychange (#404)", () => {
+    const { unmount } = renderBuilder(
+      makeReport({
+        sections: [{ title: "Findings", description: "", photo_ids: [] }],
+      }),
+    );
+
+    // Dirty, but the write-up overflows its one-page intro — the same save-time
+    // guard (#404) that holds back the debounced save must hold back the flush.
+    act(() => {
+      fireEvent.change(screen.getByTestId("tiptap-stub"), {
+        target: { value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>` },
+      });
+    });
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("fires no PUT on pagehide or visibilitychange when the report is clean", () => {
+    const { unmount } = renderBuilder();
+
+    // No edit — both events must be no-ops (the report is not dirty).
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+
+    act(() => {
+      unmount();
+    });
+  });
+
+  it("removes its listeners on unmount — a later pagehide or visibilitychange fires no further PUT", () => {
+    const { unmount } = renderBuilder();
+
+    act(() => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Roof damage report" },
+      });
+    });
+
+    // In-app unmount flushes once via the #443 cleanup.
+    act(() => {
+      unmount();
+    });
+    const afterUnmount = keepalivePuts(fetchMock).length;
+    expect(afterUnmount).toBe(1);
+
+    // The listeners must be gone: were they leaked, this would fire a 2nd PUT.
+    act(() => {
+      window.dispatchEvent(new Event("pagehide"));
+      setVisibility("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(keepalivePuts(fetchMock)).toHaveLength(afterUnmount);
   });
 });
 

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -172,31 +172,59 @@ export default function PhotoReportBuilder({
     // on each edit; `report.id` is covered transitively through `writeReport`.
   }, [state, writeReport]);
 
-  // Flush a pending edit when the builder unmounts (issue #443). The auto-save
-  // above only persists on a 2s debounce and its cleanup merely clears the
-  // timer, so navigating away (e.g. tapping "Back to job", easy on a tablet)
-  // within that window would otherwise silently drop the last edit. We mirror
-  // the latest savable snapshot into a ref and write it on unmount, reusing the
-  // same update path. The ref is rewritten every render so the cleanup reads the
-  // freshest snapshot, not the stale closure captured at mount.
+  // Flush a pending edit when the page goes away. Two triggers share this one
+  // function: an in-app unmount (#443, e.g. tapping "Back to job", easy on a
+  // tablet) and a hard page-unload (#479: tab close / refresh / app-background).
+  // The debounced auto-save above only persists on a 2s timer and its cleanup
+  // merely clears that timer, so leaving within the window would otherwise drop
+  // the last edit. The Supabase JS client can't ride a teardown — its fetch is
+  // cancelled — so the flush fires a plain `keepalive: true` PUT at the #478
+  // route, whose server-side `edit_jobs` + tenancy gating mirrors the debounced
+  // write. The ref is rewritten every render so a trigger reads the freshest
+  // snapshot, not the stale closure captured at mount.
   const flushOnUnmountRef = useRef<() => void>(() => {});
   flushOnUnmountRef.current = () => {
     if (!state.dirty) return;
     // Honour the same save-time over-limit guard (#404) as the debounced save:
-    // a flush must never sneak an over-limit write-up past it on unmount.
+    // a flush must never sneak an over-limit write-up past it on teardown.
     if (hasOverLimitSection(state.sections)) return;
-    const supabase = createClient();
-    void supabase
-      .from("photo_reports")
-      .update({
+    void fetch(`/api/jobs/${jobId}/reports/${report.id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
         title: state.title,
         report_date: state.reportDate,
         sections: state.sections,
-      })
-      .eq("id", report.id);
+      }),
+      keepalive: true,
+    });
   };
-  // Empty deps: the cleanup runs only on unmount.
+  // Empty deps: the cleanup runs only on unmount (#443).
   useEffect(() => () => flushOnUnmountRef.current(), []);
+
+  // Hard page-unload (#479): a real tab close / refresh / app-background tears
+  // the page down without running React cleanup, so the unmount flush above
+  // never fires. `pagehide` covers tab-close / refresh; `visibilitychange` to
+  // "hidden" covers app-backgrounding (the common iOS exit, where pagehide is
+  // unreliable). We flush only when the page is actually hidden — a change *to*
+  // visible is the user returning, not leaving. The same flush ref is reused, so
+  // the over-limit (#404) and dirty guards still apply. Listeners are removed on
+  // unmount so a torn-down builder can't keep flushing. iOS can fire both
+  // visibilitychange→hidden AND pagehide in one teardown, re-running the flush;
+  // the #478 PUT is idempotent and the flush no-ops once clean, so — as in #477
+  // — no "already-flushed" guard is needed.
+  useEffect(() => {
+    const onPageHide = () => flushOnUnmountRef.current();
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flushOnUnmountRef.current();
+    };
+    window.addEventListener("pagehide", onPageHide);
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.removeEventListener("pagehide", onPageHide);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),


### PR DESCRIPTION
Closes #479.

Wires the hard-unload trigger into the Photo Report builder so an edit made inside the 2s autosave debounce isn't silently dropped when the page goes away "the hard way" (tab close / refresh / iOS app-background) — paths that never run React cleanup, so the existing #443 unmount flush never fires.

## What changed
- **Reroute the teardown flush to a keepalive PUT.** The single shared flush now fires a `keepalive: true` `fetch` PUT at the #478 route `/api/jobs/[id]/reports/[reportId]` (body `{ title, report_date, sections }`) instead of the Supabase JS client, whose underlying fetch is cancelled on a hard teardown. Both the dirty guard and the #404 `hasOverLimitSection` guard are preserved.
- **Register page-lifecycle listeners.** `pagehide` (window) + `visibilitychange` (document, hidden-only) reuse that flush and are removed on unmount. Mirrors the Estimate/Invoice trigger (#477). iOS can fire both events in one teardown — that's safe, the #478 PUT is idempotent (documented in-code, matching #477's rationale).
- **Tests.** Migrated the three #443 unmount-flush tests to the keepalive transport and added a `#479 hard-unload` describe: pagehide flushes once, visibilitychange→hidden flushes once, visible→no flush (guard isolated by holding dirty state constant), over-limit→no flush (#404), clean→no flush, and listeners-removed-on-unmount.

## Acceptance criteria — all met
1. dirty + `pagehide` → one keepalive write ✅
2. dirty + `visibilitychange`→hidden → one keepalive write ✅
3. over-limit + dirty + either event → no write (#404) ✅
4. clean + either event → no write ✅
5. after unmount, either event → no write (listeners removed) ✅
6. builder test does not import the `@react-pdf` stack (`generate-report-pdf` mocked) ✅
7. no new vitest/tsc/lint failures vs baseline ✅

## Verification
- `photo-report-builder.test.tsx`: **37 passed**, 0 errors.
- Full unit suite: 2053 passed; the only 4 failures are the pre-existing `estimate-drag-end` localStorage failures (untouched file).
- `tsc --noEmit`: 13 errors = baseline (all pg-integration); 0 in touched files.
- `eslint` touched files: 0 errors (2 pre-existing `<img>` warnings).

Built test-first (vertical RED→GREEN slices) and adversarially reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)