### PR TITLE
feat(documents): in-app react-pdf viewer replaces native iframe on Estimate & Invoice Views (#464)

### DIFF
--- a/src/components/documents/pdf-document-viewer.test.tsx
+++ b/src/components/documents/pdf-document-viewer.test.tsx
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+// react-pdf drives pdf.js (canvas + a web worker), neither of which exists in
+// jsdom — and nothing in this repo mocks it yet, so we establish the pattern
+// here. The stand-in is a faithful-enough state machine: it shows the `loading`
+// slot until the test resolves the document, the `error` slot if the test fails
+// it, and the page `children` once loaded. `vi.hoisted` lets the hoisted
+// vi.mock factory reference these capture/control objects without a
+// temporal-dead-zone error.
+const { documentCalls, pdf } = vi.hoisted(() => {
+  // Reassigned by the latest mounted <Document> mock, so a retry remount wins.
+  // The no-op placeholders take no args (assignable to the declared signature),
+  // which keeps the typed `resolve(n)` call site honest without an unused param.
+  const pdf: { resolve: (numPages: number) => void; fail: () => void } = {
+    resolve: () => {},
+    fail: () => {},
+  };
+  return { documentCalls: [] as Array<Record<string, unknown>>, pdf };
+});
+
+vi.mock("react-pdf", async () => {
+  const React = await import("react");
+  return {
+    Document: (props: Record<string, unknown> & { children?: unknown }) => {
+      documentCalls.push(props);
+      const [status, setStatus] = React.useState<"loading" | "loaded" | "error">(
+        "loading",
+      );
+      pdf.resolve = (numPages: number) => {
+        (props.onLoadSuccess as ((e: { numPages: number }) => void) | undefined)?.({
+          numPages,
+        });
+        setStatus("loaded");
+      };
+      pdf.fail = () => {
+        (props.onLoadError as ((e: Error) => void) | undefined)?.(
+          new Error("load failed"),
+        );
+        setStatus("error");
+      };
+      if (status === "loading") return <>{props.loading as React.ReactNode}</>;
+      if (status === "error") return <>{props.error as React.ReactNode}</>;
+      return (
+        <div data-testid="pdf-document" data-file={String(props.file)}>
+          {props.children as React.ReactNode}
+        </div>
+      );
+    },
+    Page: (props: { pageNumber: number; width?: number }) => (
+      <div data-testid={`pdf-page-${props.pageNumber}`} data-width={props.width} />
+    ),
+    pdfjs: { GlobalWorkerOptions: {} },
+  };
+});
+
+vi.mock("@/lib/pdf/configure-pdfjs", () => ({ configurePdfjs: vi.fn() }));
+
+import PdfDocumentViewer from "./pdf-document-viewer";
+import { configurePdfjs } from "@/lib/pdf/configure-pdfjs";
+
+beforeEach(() => {
+  documentCalls.length = 0;
+  // jsdom has no layout engine: clientWidth is always 0 and ResizeObserver is
+  // undefined. The viewer measures its container to fit pages to width, so give
+  // it a non-zero width and a no-op observer — otherwise its measure gate would
+  // never open and no page would ever mount.
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    value: 800,
+  });
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+describe("PdfDocumentViewer", () => {
+  it("paints the streamed /preview PDF through react-pdf's <Document file={src}>", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    expect(documentCalls.length).toBeGreaterThan(0);
+    expect(documentCalls[0].file).toBe("/api/estimates/abc/preview");
+  });
+
+  it("disables Range/stream negotiation so Chrome cannot stall on the no-Accept-Ranges /preview byte stream", () => {
+    // ADR 0013 constraint 1: /preview returns a whole-buffer 200 with no
+    // Accept-Ranges, so the viewer must opt out of partial-content fetching.
+    render(
+      <PdfDocumentViewer src="/api/invoices/xyz/preview" title="Invoice JOB-1" />,
+    );
+
+    expect(documentCalls[0].options).toEqual({
+      disableStream: true,
+      disableRange: true,
+    });
+  });
+
+  it("renders every page in one continuous scroll once the document reports its page count", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    expect(screen.getByTestId("pdf-page-1")).toBeDefined();
+    expect(screen.getByTestId("pdf-page-2")).toBeDefined();
+    expect(screen.getByTestId("pdf-page-3")).toBeDefined();
+    expect(screen.queryByTestId("pdf-page-4")).toBeNull();
+  });
+
+  it("fits each page to the measured container width so the document is never cropped or tiny", () => {
+    // Container measures 800px (stubbed above); pages render at width minus the
+    // 16px horizontal gutter — mirroring the contracts viewer's fit-to-width.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    act(() => {
+      pdf.resolve(2);
+    });
+
+    expect(screen.getByTestId("pdf-page-1").getAttribute("data-width")).toBe("784");
+    expect(screen.getByTestId("pdf-page-2").getAttribute("data-width")).toBe("784");
+  });
+
+  it("shows a clear loading message before the document resolves, never a blank frame", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    // The document has not resolved yet — the user must see a placeholder.
+    expect(screen.getByText(/loading/i)).toBeDefined();
+    expect(screen.queryByTestId("pdf-page-1")).toBeNull();
+  });
+
+  it("shows a friendly message and a Retry control when the document fails to load", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    act(() => {
+      pdf.fail();
+    });
+
+    expect(screen.getByText(/we couldn.t load this document/i)).toBeDefined();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeDefined();
+  });
+
+  it("re-attempts the load when Retry is clicked, recovering to the rendered document", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    act(() => {
+      pdf.fail();
+    });
+    expect(screen.getByText(/we couldn.t load this document/i)).toBeDefined();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    });
+
+    // Retry clears the error and returns to loading — a fresh fetch attempt.
+    expect(screen.queryByText(/we couldn.t load this document/i)).toBeNull();
+    expect(screen.getByText(/loading/i)).toBeDefined();
+
+    // The fresh attempt can now succeed and paint the document.
+    act(() => {
+      pdf.resolve(1);
+    });
+    expect(screen.getByTestId("pdf-page-1")).toBeDefined();
+  });
+
+  it("configures the version-locked pdf.js worker on mount (ADR 0013 constraint 2)", () => {
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    expect(vi.mocked(configurePdfjs)).toHaveBeenCalled();
+  });
+});

--- a/src/components/documents/pdf-document-viewer.tsx
+++ b/src/components/documents/pdf-document-viewer.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { Document, Page } from "react-pdf";
+import { configurePdfjs } from "@/lib/pdf/configure-pdfjs";
+
+// ADR 0013 constraint 1: the /preview routes stream a whole-buffer 200 with no
+// Accept-Ranges, so the viewer disables Range/stream negotiation — otherwise
+// Chrome can stall on partial-content fetching. Hoisted to a stable reference
+// so react-pdf does not re-fetch the document on every render.
+const DOCUMENT_OPTIONS = { disableStream: true, disableRange: true } as const;
+
+// Mirror the contracts viewer: each page renders at the measured container
+// width minus a small gutter, so the document fits without a horizontal
+// scrollbar regardless of viewport size.
+const HORIZONTAL_GUTTER_PX = 16;
+
+interface PdfDocumentViewerProps {
+  src: string;
+  title: string;
+}
+
+export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
+  const [numPages, setNumPages] = useState(0);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  // Bumped by Retry: re-keying <Document> forces a full remount, which clears
+  // the error slot and re-fetches the /preview bytes from scratch.
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    configurePdfjs();
+  }, []);
+
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () => setContainerWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const pageWidth = Math.max(1, containerWidth - HORIZONTAL_GUTTER_PX);
+
+  return (
+    <div ref={containerRef} className="flex flex-col items-center gap-6 py-6">
+      <Document
+        key={reloadKey}
+        file={src}
+        options={DOCUMENT_OPTIONS}
+        onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+        loading={
+          <div className="text-muted-foreground py-12">Loading document…</div>
+        }
+        error={
+          <div className="flex flex-col items-center gap-3 py-12">
+            <p className="text-muted-foreground">
+              {"We couldn't load this document."}
+            </p>
+            <button
+              type="button"
+              className="rounded-md border border-border px-3 py-1.5 text-sm"
+              onClick={() => setReloadKey((k) => k + 1)}
+            >
+              Retry
+            </button>
+          </div>
+        }
+      >
+        {Array.from({ length: numPages }, (_, i) => (
+          <Page
+            key={i + 1}
+            pageNumber={i + 1}
+            width={pageWidth}
+            renderAnnotationLayer={false}
+            renderTextLayer={false}
+          />
+        ))}
+      </Document>
+    </div>
+  );
+}

--- a/src/components/documents/pdf-preview-frame.test.tsx
+++ b/src/components/documents/pdf-preview-frame.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// The seam loads the heavy react-pdf island lazily (ssr:false, because react-pdf
+// evaluates pdfjs-dist at import time and cannot be server-rendered). In jsdom we
+// stand in a lightweight stub so this test exercises the seam's pass-through
+// contract — not pdf.js — by echoing the props it receives into the DOM.
+vi.mock("./pdf-document-viewer", () => ({
+  default: ({ src, title }: { src: string; title: string }) => (
+    <div data-testid="pdf-island" data-src={src} data-title={title} />
+  ),
+}));
+
+import { PdfPreviewFrame } from "./pdf-preview-frame";
+
+describe("PdfPreviewFrame", () => {
+  it("renders the in-app document viewer island with the src and title it was given", async () => {
+    render(
+      <PdfPreviewFrame src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    // findBy* waits out the lazy dynamic import before asserting.
+    const island = await screen.findByTestId("pdf-island");
+    expect(island.getAttribute("data-src")).toBe("/api/estimates/abc/preview");
+    expect(island.getAttribute("data-title")).toBe("Estimate WTR-1");
+  });
+});

--- a/src/components/documents/pdf-preview-frame.tsx
+++ b/src/components/documents/pdf-preview-frame.tsx
@@ -1,10 +1,25 @@
-// Inline PDF preview frame (#385). Embeds a server-rendered, customer-facing
-// document PDF via the browser's native viewer, so the View surface shows the
-// real PDF — exactly what the customer receives — rather than an HTML
-// re-render. Purely presentational (no hooks/events), so it is safe to render
-// from either a Server Component (estimate View) or a Client Component
-// (invoice View). `src` points at the `/preview` route that streams the PDF
-// inline.
+"use client";
+
+// In-app document viewer seam (ADR 0013, #464). The Estimate and Invoice Views
+// both render the customer-facing PDF through this one frame — byte-for-byte the
+// `/preview` document, a pure read, never an HTML re-render (the #385 intent).
+// The mechanism is now an owned react-pdf island instead of the browser's native
+// iframe chrome, so we can ship a slim page picker (#465) the native viewer never
+// let us size. react-pdf evaluates pdfjs-dist at import time and cannot be
+// server-rendered, so the island loads client-only via dynamic ssr:false — this
+// `'use client'` wrapper is what lets a Server Component (the Estimate View) and a
+// Client Component (the Invoice View) both render the same seam unchanged. The
+// public `{ src, title }` interface is preserved exactly so neither consumer moves.
+import dynamic from "next/dynamic";
+
+const PdfDocumentViewer = dynamic(() => import("./pdf-document-viewer"), {
+  ssr: false,
+  loading: () => (
+    <div className="text-muted-foreground py-12 text-center">
+      Loading document…
+    </div>
+  ),
+});
 
 interface PdfPreviewFrameProps {
   src: string;
@@ -13,8 +28,8 @@ interface PdfPreviewFrameProps {
 
 export function PdfPreviewFrame({ src, title }: PdfPreviewFrameProps) {
   return (
-    <div className="rounded-lg border border-border bg-muted/30 overflow-hidden">
-      <iframe src={src} title={title} className="w-full h-[80vh]" />
+    <div className="rounded-lg border border-border bg-muted/30 overflow-auto h-[80vh]">
+      <PdfDocumentViewer src={src} title={title} />
     </div>
   );
 }


### PR DESCRIPTION
## What

Replaces the native browser `<iframe>` at the shared `PdfPreviewFrame` seam with an owned **react-pdf** client island, so both the **Estimate View** and the **Invoice read-only View** flip to the in-app viewer at once through the unchanged `{ src, title }` interface — neither consumer's call site moves.

This is the first tracer bullet of the in-app document viewer chain (ADR 0013).

## How

- **`pdf-document-viewer.tsx`** (new island): renders the streamed `/preview` PDF in continuous vertical scroll, fit-to-width (measured container minus a 16px gutter), mirroring the contracts `signed-pdf-viewer`.
- **`pdf-preview-frame.tsx`** (seam): converted to a `'use client'` `dynamic(ssr:false)` wrapper inside an 80vh scroll envelope, preserving the public `{ src, title }` seam so a Server Component (Estimate) and a Client Component (Invoice) both render it unchanged.

## ADR 0013 reliability constraints honored

1. `<Document options={{ disableStream, disableRange }}>` (stable ref) for the no-Accept-Ranges `/preview` whole-buffer stream.
2. Version-locked worker via the reused `configurePdfjs()` on mount.
3. Top-level (non-sandboxed) entry — Views are top-level pages.

## Product decisions

- Friendly **"We couldn't load this document"** error with a working **Retry** (remount).
- **Raster-only** pages (`renderTextLayer` / `renderAnnotationLayer` off).
- **No page picker yet** — deferred to #466.

## Testing

Built TDD: **9 co-located tests** (8 island + 1 seam) green; `tsc` and `eslint` clean on touched files; adversarial multi-agent review returned no confirmed findings.

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)
