### PR TITLE
fix(photo-report): stable Section id so reorder keeps input focus (#467)

### DIFF
--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -104,6 +104,25 @@ vi.mock("@dnd-kit/core", async () => {
   };
 });
 
+// Record the id each SortableSection registers with dnd-kit, so a test can assert
+// sections are keyed off their stable `section.id` (not the array index) — the
+// mechanism behind smooth reorder animation (#467, AC2). The wrapper delegates to
+// the real hook, so rendering behaves exactly as in production.
+let capturedSortableIds: string[] = [];
+vi.mock("@dnd-kit/sortable", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/sortable")>(
+      "@dnd-kit/sortable",
+    );
+  return {
+    ...actual,
+    useSortable: (args: { id: string }) => {
+      capturedSortableIds.push(args.id);
+      return actual.useSortable(args);
+    },
+  };
+});
+
 import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
 import { WRITEUP_CHARACTER_LIMIT } from "@/lib/section-writeup-fit";
@@ -496,6 +515,97 @@ describe("PhotoReportBuilder section + photo management", () => {
         el?.tagName === "P" && (el.textContent ?? "").startsWith("1 photo"),
     );
     expect(label).toBeTruthy();
+  });
+});
+
+// Issue #467 — Sections used to be keyed by array index (React key + dnd-kit
+// sortable id). On reorder, React reconciles by key, so the DOM node the user
+// was focused in stayed put at its old position and had a *different* section's
+// content swapped into it — the caret jumped to the wrong section mid-edit.
+// Keying both off each section's stable `id` instead makes React move the
+// focused node with its section, so focus/caret follows the section the user
+// was editing.
+describe("PhotoReportBuilder section reorder focus (#467)", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    capturedOnDragEnd = null;
+    vi.useFakeTimers();
+  });
+
+  it("keeps focus in the edited section's heading after that section is reordered", () => {
+    renderBuilder(
+      makeReport({
+        sections: [
+          { title: "Alpha", description: "", photo_ids: [] },
+          { title: "Beta", description: "", photo_ids: [] },
+        ],
+      }),
+    );
+
+    // The user edits the first section's heading and leaves the caret in it.
+    const alphaInput = screen
+      .getAllByLabelText("Section heading")
+      .find(
+        (el) => (el as HTMLInputElement).value === "Alpha",
+      ) as HTMLInputElement;
+    act(() => {
+      alphaInput.focus();
+      fireEvent.change(alphaInput, { target: { value: "Alpha edited" } });
+    });
+
+    // …then drags that same (edited) section from the top to the bottom.
+    // resolvePhotoReportDragEnd maps the drop by `data.current.index` (the
+    // active/over `id` is immaterial here — see photo-report-drag.ts), so this
+    // drives the real reorder path without a pointer.
+    act(() => {
+      capturedOnDragEnd?.({
+        active: {
+          id: "section-0",
+          data: { current: { type: "section", index: 0 } },
+        },
+        over: {
+          id: "section-1",
+          data: { current: { type: "section", index: 1 } },
+        },
+      });
+    });
+
+    // The reorder really happened — Beta is now first. Asserting this guards the
+    // focus check below from passing vacuously (i.e. by the section never moving).
+    expect(
+      screen
+        .getAllByLabelText("Section heading")
+        .map((el) => (el as HTMLInputElement).value),
+    ).toEqual(["Beta", "Alpha edited"]);
+
+    // …and focus stayed in the field the user was editing — not stranded on
+    // whatever section slid into its old position. With index keys this is
+    // "Beta" (the wrong section); with stable `section.id` keys it follows.
+    expect((document.activeElement as HTMLInputElement).value).toBe(
+      "Alpha edited",
+    );
+  });
+
+  it("keys each section's sortable identity off its stable id, never its array position (#467, AC2)", () => {
+    // Smooth reorder animation (AC2) depends on dnd-kit seeing a *stable* sortable
+    // id per section, so the dragged node keeps its identity as positions shift.
+    // The DndContext is stubbed in these tests, so a revert of `useSortable({ id })`
+    // back to a positional `section-${index}` would not surface through the focus
+    // test above — this asserts it directly. Sections loaded with explicit ids keep
+    // them (ensureSectionIds), making the expected ids deterministic.
+    capturedSortableIds = [];
+    renderBuilder(
+      makeReport({
+        sections: [
+          { id: "sec-a", title: "A", description: "", photo_ids: [] },
+          { id: "sec-b", title: "B", description: "", photo_ids: [] },
+        ],
+      }),
+    );
+
+    expect(capturedSortableIds).toEqual(["sec-a", "sec-b"]);
   });
 });
 

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -41,7 +41,11 @@ import {
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
 import { measureWriteupFit } from "@/lib/section-writeup-fit";
-import type { ReportSection } from "@/lib/build-initial-sections";
+import {
+  newSectionId,
+  type ReportSection,
+  type StoredReportSection,
+} from "@/lib/build-initial-sections";
 import type { Photo, PhotoReport } from "@/lib/types";
 
 // How long to wait after the last edit before persisting (mirrors the
@@ -89,7 +93,7 @@ export default function PhotoReportBuilder({
     {
       title: report.title,
       report_date: report.report_date,
-      sections: report.sections as ReportSection[],
+      sections: report.sections as StoredReportSection[],
     },
     initBuilderState,
   );
@@ -371,18 +375,14 @@ export default function PhotoReportBuilder({
           </div>
 
           {/*
-            Slice-2b drag wiring. Two known low-severity follow-ups, left for a
-            later slice (no data impact here, controlled inputs keep displayed
-            values correct):
-              - Sections are addressed by array index (React key + sortable id),
-                because ReportSection has no stable id. A stable per-section id
-                would smooth dnd reorder animations and keep input focus/caret
-                pinned to a section across a reorder; it also touches the
-                persisted sections shape, so it is deferred.
-              - closestCenter targets the nearest section *center*; on very tall
-                section cards a photo dropped near an edge can land in the
-                neighbouring section. A pointer-based strategy would be more
-                precise.
+            Slice-2b drag wiring. Sections are keyed (React key + dnd-kit
+            sortable id) off their stable `id` (#467), so editing a Section then
+            reordering it keeps input focus/caret pinned to that Section and the
+            reorder animates smoothly. One known low-severity follow-up remains,
+            left for a later slice: closestCenter targets the nearest section
+            *center*, so on very tall section cards a photo dropped near an edge
+            can land in the neighbouring section; a pointer-based strategy would
+            be more precise.
           */}
           <DndContext
             sensors={sensors}
@@ -391,13 +391,13 @@ export default function PhotoReportBuilder({
           >
             {/* Sections */}
             <SortableContext
-              items={state.sections.map((_, i) => `section-${i}`)}
+              items={state.sections.map((s) => s.id)}
               strategy={verticalListSortingStrategy}
             >
               <div className="space-y-4">
                 {state.sections.map((section, index) => (
                   <SortableSection
-                    key={index}
+                    key={section.id}
                     index={index}
                     section={section}
                     photosById={photosById}
@@ -410,7 +410,7 @@ export default function PhotoReportBuilder({
 
             <button
               type="button"
-              onClick={() => dispatch({ type: "addSection" })}
+              onClick={() => dispatch({ type: "addSection", id: newSectionId() })}
               className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
             >
               <Plus size={15} />
@@ -453,7 +453,7 @@ function SortableSection({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: `section-${index}`, data: { type: "section", index } });
+  } = useSortable({ id: section.id, data: { type: "section", index } });
 
   const style = {
     transform: CSS.Transform.toString(transform),

--- a/src/lib/build-initial-sections.test.ts
+++ b/src/lib/build-initial-sections.test.ts
@@ -9,7 +9,10 @@
 // (rich-text HTML); both are copied verbatim into the new report's Sections.
 
 import { describe, expect, it } from "vitest";
-import { buildInitialSections } from "./build-initial-sections";
+import {
+  buildInitialSections,
+  ensureSectionIds,
+} from "./build-initial-sections";
 import type { PhotoReportTemplate } from "@/lib/types";
 
 function makeTemplate(
@@ -40,8 +43,16 @@ describe("buildInitialSections", () => {
     ]);
 
     expect(buildInitialSections(template)).toEqual([
-      { title: "Exterior", description: "Roof and siding", photo_ids: [] },
-      { title: "Interior", description: "Water damage", photo_ids: [] },
+      expect.objectContaining({
+        title: "Exterior",
+        description: "Roof and siding",
+        photo_ids: [],
+      }),
+      expect.objectContaining({
+        title: "Interior",
+        description: "Water damage",
+        photo_ids: [],
+      }),
     ]);
   });
 
@@ -55,12 +66,12 @@ describe("buildInitialSections", () => {
     ]);
 
     expect(buildInitialSections(template)).toEqual([
-      {
+      expect.objectContaining({
         title: "Findings",
         description:
           "<p>Our inspection found the following:</p><ul><li>Damaged drywall</li></ul>",
         photo_ids: [],
-      },
+      }),
     ]);
   });
 
@@ -68,11 +79,57 @@ describe("buildInitialSections", () => {
     const template = makeTemplate([{ title: "Overview" }]);
 
     expect(buildInitialSections(template)).toEqual([
-      { title: "Overview", description: "", photo_ids: [] },
+      expect.objectContaining({ title: "Overview", description: "", photo_ids: [] }),
     ]);
   });
 
   it("returns an empty array for a template that has no Sections", () => {
     expect(buildInitialSections(makeTemplate([]))).toEqual([]);
+  });
+
+  it("stamps each Section with an id from the injected id factory", () => {
+    const template = makeTemplate([
+      { title: "Exterior", description: "Roof" },
+      { title: "Interior", description: "Walls" },
+    ]);
+    let n = 0;
+    const sections = buildInitialSections(template, () => `sec-${++n}`);
+    expect(sections.map((s) => s.id)).toEqual(["sec-1", "sec-2"]);
+  });
+
+  it("assigns a distinct, non-empty id to each Section by default", () => {
+    const template = makeTemplate([
+      { title: "A", description: "" },
+      { title: "B", description: "" },
+    ]);
+    const ids = buildInitialSections(template).map((s) => s.id);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});
+
+describe("ensureSectionIds", () => {
+  it("keeps a Section's existing id and backfills one onto a Section that lacks it", () => {
+    const out = ensureSectionIds(
+      [
+        { id: "keep", title: "A", description: "", photo_ids: ["p1"] },
+        { title: "B", description: "", photo_ids: [] },
+      ],
+      () => "new-1",
+    );
+    expect(out).toEqual([
+      { id: "keep", title: "A", description: "", photo_ids: ["p1"] },
+      { id: "new-1", title: "B", description: "", photo_ids: [] },
+    ]);
+  });
+
+  it("backfills a distinct, non-empty id by default for legacy sections", () => {
+    const out = ensureSectionIds([
+      { title: "A", description: "", photo_ids: [] },
+      { title: "B", description: "", photo_ids: [] },
+    ]);
+    const ids = out.map((s) => s.id);
+    expect(ids.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });

--- a/src/lib/build-initial-sections.ts
+++ b/src/lib/build-initial-sections.ts
@@ -17,13 +17,54 @@
 import type { PhotoReportTemplate } from "@/lib/types";
 
 export interface ReportSection {
+  /**
+   * Stable identity for a Section, independent of its position in the report
+   * (#467). The builder keys its React list and dnd-kit sortable off this id
+   * (not the array index) so editing a Section then reordering it keeps input
+   * focus/caret pinned to the same Section and the reorder animates smoothly.
+   */
+  id: string;
   title: string;
   description: string;
   photo_ids: string[];
 }
 
+/**
+ * A Section as it may come off disk. Reports created before #467 persisted their
+ * Sections without an `id`, so the loaded shape makes `id` optional; the builder
+ * backfills any missing id on load via `ensureSectionIds`, keeping old saved
+ * reports openable and reorderable without a data migration.
+ */
+export type StoredReportSection = Omit<ReportSection, "id"> & { id?: string };
+
+/** Mint a fresh, unique Section id. The one place a real id is generated. */
+export const newSectionId = (): string => crypto.randomUUID();
+
+/**
+ * Backfill a stable `id` onto any Section that lacks one (a pre-#467 saved
+ * report), leaving Sections that already have an id untouched. This is the
+ * migration-safe load step: legacy rows become fully-identified `ReportSection`s
+ * in memory without rewriting what is on disk until the next save.
+ *
+ * The `||` (not `??`) is deliberate: it heals an *empty-string* id as well as a
+ * missing one. This helper's whole job is to guarantee every Section has a
+ * usable, non-empty identity — an `id: ""` that ever slipped onto disk would
+ * otherwise become an empty (and duplicate) React/dnd key, the exact failure
+ * #467 set out to remove. A real id from `newSectionId` is a UUID, never falsy.
+ */
+export function ensureSectionIds(
+  sections: StoredReportSection[],
+  makeId: () => string = newSectionId,
+): ReportSection[] {
+  return sections.map((section) => ({
+    ...section,
+    id: section.id || makeId(),
+  }));
+}
+
 export function buildInitialSections(
   template?: PhotoReportTemplate | null,
+  makeId: () => string = newSectionId,
 ): ReportSection[] {
   if (!template) return [];
   const templateSections = (template.sections ?? []) as {
@@ -31,6 +72,7 @@ export function buildInitialSections(
     description?: string;
   }[];
   return templateSections.map((section) => ({
+    id: makeId(),
     title: section.title ?? "",
     description: section.description ?? "",
     photo_ids: [],

--- a/src/lib/photo-report-builder.test.ts
+++ b/src/lib/photo-report-builder.test.ts
@@ -24,13 +24,17 @@ function loaded() {
 describe("buildDefaultReportSections", () => {
   it("puts every selected photo into a single default section, in order", () => {
     expect(buildDefaultReportSections(["p1", "p2", "p3"])).toEqual([
-      { title: "Photos", description: "", photo_ids: ["p1", "p2", "p3"] },
+      expect.objectContaining({
+        title: "Photos",
+        description: "",
+        photo_ids: ["p1", "p2", "p3"],
+      }),
     ]);
   });
 
   it("still returns one (empty) section when nothing was selected", () => {
     expect(buildDefaultReportSections([])).toEqual([
-      { title: "Photos", description: "", photo_ids: [] },
+      expect.objectContaining({ title: "Photos", description: "", photo_ids: [] }),
     ]);
   });
 
@@ -39,6 +43,18 @@ describe("buildDefaultReportSections", () => {
     const sections = buildDefaultReportSections(selection);
     sections[0].photo_ids.push("p2");
     expect(selection).toEqual(["p1"]);
+  });
+
+  it("stamps the default section with an id from the injected id factory", () => {
+    expect(buildDefaultReportSections(["p1"], () => "sec-1")).toEqual([
+      { id: "sec-1", title: "Photos", description: "", photo_ids: ["p1"] },
+    ]);
+  });
+
+  it("gives the default section a non-empty id by default", () => {
+    const [section] = buildDefaultReportSections([]);
+    expect(typeof section.id).toBe("string");
+    expect(section.id.length).toBeGreaterThan(0);
   });
 });
 
@@ -133,7 +149,10 @@ describe("photoReportBuilderReducer", () => {
 
   it("adds a new empty section to the end and marks the report dirty", () => {
     const before = loaded();
-    const next = photoReportBuilderReducer(before, { type: "addSection" });
+    const next = photoReportBuilderReducer(before, {
+      type: "addSection",
+      id: "new-sec",
+    });
     expect(next.sections).toHaveLength(before.sections.length + 1);
     const added = next.sections[next.sections.length - 1];
     expect(added.title).toBe("New section");
@@ -144,9 +163,21 @@ describe("photoReportBuilderReducer", () => {
     expect(next.dirty).toBe(true);
   });
 
+  it("gives the added section the stable id carried by the action", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "addSection",
+      id: "added-1",
+    });
+    expect(next.sections[next.sections.length - 1].id).toBe("added-1");
+  });
+
   it("removes the section at the given index, dropping its photos from the report, and marks dirty", () => {
     // A two-section report: [ Photos(p1,p2), New section() ].
-    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    const before = photoReportBuilderReducer(loaded(), {
+      type: "addSection",
+      id: "s2",
+    });
     const next = photoReportBuilderReducer(before, {
       type: "removeSection",
       index: 0,
@@ -208,7 +239,10 @@ describe("photoReportBuilderReducer", () => {
 
   it("assigns a photo into a section, appending it and marking dirty", () => {
     // [ Photos(p1,p2), New section() ].
-    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    const before = photoReportBuilderReducer(loaded(), {
+      type: "addSection",
+      id: "s2",
+    });
     // Add a photo that is not yet anywhere in the report (add-to-report).
     const next = photoReportBuilderReducer(before, {
       type: "assignPhotoToSection",
@@ -222,7 +256,10 @@ describe("photoReportBuilderReducer", () => {
 
   it("moving a photo to another section removes it from the section it was in", () => {
     // [ Photos(p1,p2), New section() ]; move p1 into section 1.
-    const before = photoReportBuilderReducer(loaded(), { type: "addSection" });
+    const before = photoReportBuilderReducer(loaded(), {
+      type: "addSection",
+      id: "s2",
+    });
     const next = photoReportBuilderReducer(before, {
       type: "assignPhotoToSection",
       photoId: "p1",
@@ -277,7 +314,8 @@ describe("photoReportBuilderReducer", () => {
   it("bumps the revision on a section edit so an in-flight save cannot strand it", () => {
     const before = loaded();
     expect(
-      photoReportBuilderReducer(before, { type: "addSection" }).revision,
+      photoReportBuilderReducer(before, { type: "addSection", id: "s2" })
+        .revision,
     ).toBeGreaterThan(before.revision);
     expect(
       photoReportBuilderReducer(before, {
@@ -309,5 +347,69 @@ describe("photoReportBuilderReducer", () => {
       heading: "Nowhere",
     });
     expect(next).toBe(before);
+  });
+});
+
+describe("initBuilderState section ids (#467)", () => {
+  it("backfills a stable id onto a loaded section that has none (legacy report)", () => {
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      // A report saved before #467: its section has no id.
+      sections: [{ title: "Photos", description: "", photo_ids: [] }],
+    });
+    expect(typeof state.sections[0].id).toBe("string");
+    expect(state.sections[0].id.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a loaded section's existing id", () => {
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [
+        { id: "kept", title: "Photos", description: "", photo_ids: [] },
+      ],
+    });
+    expect(state.sections[0].id).toBe("kept");
+  });
+
+  it("gives distinct ids to multiple legacy sections so they reorder cleanly", () => {
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [
+        { title: "A", description: "", photo_ids: [] },
+        { title: "B", description: "", photo_ids: [] },
+      ],
+    });
+    const ids = state.sections.map((s) => s.id);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("keeps each backfilled id with its section across a reorder of a legacy report (AC3)", () => {
+    // The full legacy path end to end: a pre-#467 report (no ids) loads, gets
+    // distinct ids backfilled, then is reordered. Each section must carry its own
+    // backfilled id to the new position — that stable identity riding with the
+    // section is exactly what keeps React/dnd keys (and thus the caret) pinned.
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [
+        { title: "A", description: "", photo_ids: [] },
+        { title: "B", description: "", photo_ids: [] },
+      ],
+    });
+    const [idA, idB] = state.sections.map((s) => s.id);
+    expect(idA).not.toBe(idB);
+
+    const next = photoReportBuilderReducer(state, {
+      type: "reorderSection",
+      from: 0,
+      to: 1,
+    });
+
+    expect(next.sections.map((s) => s.title)).toEqual(["B", "A"]);
+    // The id rides with the section, not the slot: B's id is now first, A's last.
+    expect(next.sections.map((s) => s.id)).toEqual([idB, idA]);
   });
 });

--- a/src/lib/photo-report-builder.ts
+++ b/src/lib/photo-report-builder.ts
@@ -15,7 +15,12 @@
 // `photo-report-drag.ts` for the dnd-kit drag-end → action mapping. Photos live
 // only inside Sections (no holding pool); a photo lives in at most one Section.
 
-import type { ReportSection } from "./build-initial-sections";
+import {
+  ensureSectionIds,
+  newSectionId,
+  type ReportSection,
+  type StoredReportSection,
+} from "./build-initial-sections";
 
 /** Heading the lone starter Section gets until the user renames it. */
 const DEFAULT_SECTION_TITLE = "Photos";
@@ -28,9 +33,17 @@ const NEW_SECTION_TITLE = "New section";
  * ("init from selection"). Always returns exactly one Section so the builder
  * has an invariant section to edit, even if the selection was empty.
  */
-export function buildDefaultReportSections(photoIds: string[]): ReportSection[] {
+export function buildDefaultReportSections(
+  photoIds: string[],
+  makeId: () => string = newSectionId,
+): ReportSection[] {
   return [
-    { title: DEFAULT_SECTION_TITLE, description: "", photo_ids: [...photoIds] },
+    {
+      id: makeId(),
+      title: DEFAULT_SECTION_TITLE,
+      description: "",
+      photo_ids: [...photoIds],
+    },
   ];
 }
 
@@ -57,7 +70,13 @@ export interface PhotoReportBuilderState {
 export interface LoadedPhotoReport {
   title: string;
   report_date: string;
-  sections: ReportSection[];
+  /**
+   * Sections as they come off disk: a report saved before #467 has Sections
+   * without an `id`, so the loaded shape allows a missing id. `initBuilderState`
+   * backfills any missing id (see `ensureSectionIds`) so the in-memory state is
+   * always fully identified.
+   */
+  sections: StoredReportSection[];
 }
 
 export type PhotoReportBuilderAction =
@@ -65,7 +84,7 @@ export type PhotoReportBuilderAction =
   | { type: "setReportDate"; reportDate: string }
   | { type: "setSectionHeading"; index: number; heading: string }
   | { type: "setSectionWriteup"; index: number; writeup: string }
-  | { type: "addSection" }
+  | { type: "addSection"; id: string }
   | { type: "removeSection"; index: number }
   | { type: "reorderSection"; from: number; to: number }
   | { type: "assignPhotoToSection"; photoId: string; sectionIndex: number }
@@ -82,7 +101,7 @@ export function initBuilderState(
   return {
     title: report.title,
     reportDate: report.report_date,
-    sections: report.sections,
+    sections: ensureSectionIds(report.sections),
     dirty: false,
     revision: 0,
   };
@@ -141,7 +160,12 @@ export function photoReportBuilderReducer(
         ...state,
         sections: [
           ...state.sections,
-          { title: NEW_SECTION_TITLE, description: "", photo_ids: [] },
+          {
+            id: action.id,
+            title: NEW_SECTION_TITLE,
+            description: "",
+            photo_ids: [],
+          },
         ],
         dirty: true,
         revision: state.revision + 1,

--- a/src/lib/photo-reports.test.ts
+++ b/src/lib/photo-reports.test.ts
@@ -177,7 +177,11 @@ describe("createPhotoReportDraft", () => {
     });
 
     expect(supabase.inserted?.sections).toEqual([
-      { title: "Photos", description: "", photo_ids: ["p1", "p2", "p3"] },
+      expect.objectContaining({
+        title: "Photos",
+        description: "",
+        photo_ids: ["p1", "p2", "p3"],
+      }),
     ]);
   });
 
@@ -195,7 +199,11 @@ describe("createPhotoReportDraft", () => {
     });
 
     expect(supabase.inserted?.sections).toEqual([
-      { title: "Photos", description: "", photo_ids: ["p1", "p3"] },
+      expect.objectContaining({
+        title: "Photos",
+        description: "",
+        photo_ids: ["p1", "p3"],
+      }),
     ]);
   });
 
@@ -237,17 +245,21 @@ describe("createPhotoReportDraft", () => {
     // separate, appended Photos section the user can redistribute.
     expect(supabase.inserted?.template_id).toBe("tmpl-1");
     expect(supabase.inserted?.sections).toEqual([
-      {
+      expect.objectContaining({
         title: "Findings",
         description: "<p>Findings boilerplate</p>",
         photo_ids: [],
-      },
-      {
+      }),
+      expect.objectContaining({
         title: "Work Performed",
         description: "<p>Work boilerplate</p>",
         photo_ids: [],
-      },
-      { title: "Photos", description: "", photo_ids: ["p1", "p2"] },
+      }),
+      expect.objectContaining({
+        title: "Photos",
+        description: "",
+        photo_ids: ["p1", "p2"],
+      }),
     ]);
   });
 
@@ -292,7 +304,11 @@ describe("createPhotoReportDraft", () => {
     });
 
     expect(supabase.inserted?.sections).toEqual([
-      { title: "Findings", description: "<p>x</p>", photo_ids: [] },
+      expect.objectContaining({
+        title: "Findings",
+        description: "<p>x</p>",
+        photo_ids: [],
+      }),
     ]);
   });
 
@@ -332,7 +348,43 @@ describe("createPhotoReportDraft", () => {
 
     expect(supabase.inserted?.template_id).toBeNull();
     expect(supabase.inserted?.sections).toEqual([
-      { title: "Photos", description: "", photo_ids: ["p1"] },
+      expect.objectContaining({
+        title: "Photos",
+        description: "",
+        photo_ids: ["p1"],
+      }),
     ]);
+  });
+
+  it("stamps each seeded Section with a stable id from the injected id factory (#467)", async () => {
+    // Every Section the create step seeds — template boilerplate Sections and the
+    // appended Photos section alike — gets a stable id so the builder can key its
+    // list/dnd off it and old reports never need a backfill on first open. The
+    // injected factory makes the ids deterministic to assert (default is a UUID).
+    const supabase = fakeSupabase([], {
+      template: {
+        id: "tmpl-1",
+        sections: [
+          { title: "Findings", description: "<p>x</p>" },
+          { title: "Work Performed", description: "<p>y</p>" },
+        ],
+      },
+    });
+
+    let n = 0;
+    await createPhotoReportDraft(
+      supabase,
+      {
+        organizationId: "org-1",
+        jobId: "job-1",
+        preparerName: "Eric Daniels",
+        photoIds: ["p1"],
+        templateId: "tmpl-1",
+      },
+      () => `sec-${++n}`,
+    );
+
+    const sections = supabase.inserted?.sections as Array<{ id: string }>;
+    expect(sections.map((s) => s.id)).toEqual(["sec-1", "sec-2", "sec-3"]);
   });
 });

--- a/src/lib/photo-reports.ts
+++ b/src/lib/photo-reports.ts
@@ -16,7 +16,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import type { PhotoReport, PhotoReportTemplate } from "@/lib/types";
 import { nextReportNumber } from "./next-report-number";
 import { buildDefaultReportSections } from "./photo-report-builder";
-import { buildInitialSections } from "./build-initial-sections";
+import { buildInitialSections, newSectionId } from "./build-initial-sections";
 
 export interface CreatePhotoReportDraftInput {
   organizationId: string;
@@ -50,6 +50,9 @@ const MAX_REPORT_NUMBER_ATTEMPTS = 3;
 export async function createPhotoReportDraft(
   supabase: SupabaseClient,
   input: CreatePhotoReportDraftInput,
+  // Stable-id factory for the seeded Sections (#467). Defaulted so the route
+  // calls this with two args; injectable so tests can assert deterministic ids.
+  makeId: () => string = newSectionId,
 ): Promise<PhotoReport> {
   // Trust nothing about the client-supplied selection: keep only photo ids that
   // actually belong to this Job (the query runs under the caller's RLS, so this
@@ -69,10 +72,12 @@ export async function createPhotoReportDraft(
       // they can redistribute in the builder. With nothing selected there is no
       // Photos section to append.
       [
-        ...buildInitialSections(template),
-        ...(photoIds.length > 0 ? buildDefaultReportSections(photoIds) : []),
+        ...buildInitialSections(template, makeId),
+        ...(photoIds.length > 0
+          ? buildDefaultReportSections(photoIds, makeId)
+          : []),
       ]
-    : buildDefaultReportSections(photoIds);
+    : buildDefaultReportSections(photoIds, makeId);
 
   // Per-Job numbering is read-then-insert with no DB-side serialization, so two
   // near-simultaneous "Create report" clicks on the same Job can read the same


### PR DESCRIPTION
## What & why

Fixes #467. In the in-Job Photo Report builder, Sections were keyed — both the React list **and** the dnd-kit sortable — off their **array index**. Reordering a Section the user was editing reused the focused DOM node for a *different* Section, so the caret jumped to (and would edit) the wrong Section mid-drag.

Now every `ReportSection` carries a stable `id`, and the React list, `SortableContext`, and `useSortable` all key off `section.id` instead of the index. React moves the focused node *with* its Section (caret follows) and dnd-kit animates the reorder smoothly. The drag resolver already maps drops by `data.current.index`, so no reducer/resolver change was needed.

## Migration safety (no DB migration)

Reports saved before #467 have Sections with no `id`:

- `StoredReportSection` models the persisted, id-optional shape.
- `ensureSectionIds` backfills any missing id on load (`initBuilderState`). The `||` (not `??`) is deliberate — it also heals an empty-string id, which would otherwise be an empty/duplicate React key.
- Seed/create paths (`buildInitialSections`, `buildDefaultReportSections`, `createPhotoReportDraft`) stamp ids via an injectable `makeId` factory (default `crypto.randomUUID`) — pure and deterministic in tests.
- The reducer stays pure: `addSection` carries the new id in its action payload.

Backfilled ids persist on the next normal auto-save; no separate data migration.

## Acceptance criteria

- **AC1** — editing a Section field then dragging it keeps the caret in the edited field ✅
- **AC2** — reorder animates smoothly (stable sortable id) ✅
- **AC3** — existing saved reports (sections without ids) load and reorder without error ✅

Out of scope (unchanged, per the issue): `closestCenter` drop-precision follow-up; PDF layout redesign.

## Tests (TDD, red→green)

- **Caret retention across a reorder** — asserts the reorder actually happened *and* focus follows the edited field (went red with index keys: `expected 'Beta' to be 'Alpha edited'`).
- **Sortable identity keyed off `section.id`** — guards the AC2 animation mechanism under a stubbed `DndContext`, where a revert of just `useSortable({id})` wouldn't otherwise surface.
- **Legacy backfill → reorder** — backfilled ids ride with their Section through a reorder.
- **Create path** — seeds Section ids deterministically via injected `makeId`.

## Verification

- 110/110 tests pass across all touched + adjacent files (incl. the create routes).
- `tsc --noEmit`: 0 errors. `eslint` on touched files: 0 errors (2 pre-existing `<img>` warnings in untouched photo-grid code).
- Rebased onto current `main` (which landed the #479 hard-unload flush in the same component); integrated tree re-verified green.

## Review

A multi-agent adversarial review (5 lenses × per-finding verification) ran against this change; its real findings on test robustness were folded in (the order-assertion and sortable-id guard above). Two flagged items were intentionally **not** taken — switching `||`→`??` (would un-heal empty-string ids) and re-keying the `writeup-counter` test-id off the UUID (the counter is positional UI; out of scope) — with reasoning captured in the code/commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
