### PR TITLE
test(photo-report): backfill coverage gaps from #397 review (#448)

### DIFF
--- a/src/app/api/jobs/[id]/reports/[reportId]/delete/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/delete/route.test.ts
@@ -122,4 +122,28 @@ describe("POST /api/jobs/[id]/reports/[reportId]/delete", () => {
 
     expect(res.status).toBe(404);
   });
+
+  it("returns 404 (a no-op) for an active report that belongs to a different Job", async () => {
+    // The report exists and is active, but it lives under job-2. job-1's delete
+    // route must not reach it: `.eq("job_id", jobId)` scopes the write to the
+    // report's own Job, so a caller cannot trash another Job's report by id
+    // alone. Drop that filter and the row leaks through — 200 instead of 404 —
+    // which an empty-table 404 test cannot catch (it 404s either way).
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [{ id: "r-1", job_id: "job-2", deleted_at: null }],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(404);
+  });
 });

--- a/src/app/api/jobs/[id]/reports/[reportId]/restore/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/restore/route.test.ts
@@ -123,6 +123,32 @@ describe("POST /api/jobs/[id]/reports/[reportId]/restore", () => {
     expect(res.status).toBe(404);
   });
 
+  it("returns 404 (a no-op) for a trashed report that belongs to a different Job", async () => {
+    // The report is trashed (so the `.not("deleted_at", "is", null)` guard would
+    // admit it on its own), but it lives under job-2. job-1's restore route must
+    // not reach it: `.eq("job_id", jobId)` scopes the write to the report's own
+    // Job, so a caller cannot revive another Job's report by id alone. Drop that
+    // filter and the trashed row leaks through — 200 instead of 404.
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [
+            { id: "r-1", job_id: "job-2", deleted_at: "2026-01-01T00:00:00Z" },
+          ],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(new Request("http://test"), paramsFor("job-1", "r-1"));
+
+    expect(res.status).toBe(404);
+  });
+
   it("returns 409 when restoring collides with an active report number", async () => {
     // Pre-existing duplicate left from before the partial unique index shipped:
     // restoring the trashed copy re-adds a second active row with the same

--- a/src/components/report-pdf/before-after-pair-page.test.tsx
+++ b/src/components/report-pdf/before-after-pair-page.test.tsx
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import BeforeAfterPairPage from "./before-after-pair-page";
-import type { PhotoPageSlot } from "./photo-page";
-import { collectText, expandTree, findAll } from "./test-helpers";
+import { PHOTO_CORNER_RADIUS, type PhotoPageSlot } from "./photo-page";
+import {
+  collectText,
+  expandTree,
+  findAll,
+  flattenStyle,
+  photoFrames,
+} from "./test-helpers";
 
 function makeSlot(overrides: Partial<PhotoPageSlot> = {}): PhotoPageSlot {
   return {
@@ -118,5 +124,28 @@ describe("BeforeAfterPairPage", () => {
     expect(text).toContain("Fully dried");
     expect(text).toContain("May 19, 2026, 11:03 AM");
     expect(text).toContain("May 21, 2026, 10:00 AM");
+  });
+
+  it("applies the shared corner radius to both the before and after photo frames", () => {
+    const tree = expandTree(
+      <BeforeAfterPairPage
+        before={makeSlot({ photoId: "before", number: 7 })}
+        after={makeSlot({ photoId: "after", number: 8 })}
+        sectionTitle="Living Room"
+        customerName="Jane Doe"
+        reportDate="2026-05-19"
+      />,
+    );
+
+    // One clipping frame per photo — before and after — each rounded with the
+    // single shared constant, so the pair page can never drift from the radius
+    // the rest of the report uses.
+    const frames = photoFrames(tree);
+    expect(frames).toHaveLength(2);
+    for (const frame of frames) {
+      expect(flattenStyle(frame.props.style).borderRadius).toBe(
+        PHOTO_CORNER_RADIUS,
+      );
+    }
   });
 });

--- a/src/components/report-pdf/cover-page.test.tsx
+++ b/src/components/report-pdf/cover-page.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import CoverPage from "./cover-page";
 import type { CoverPageData } from "@/lib/cover-page-data";
-import { collectText, expandTree, findAll } from "./test-helpers";
+import { PHOTO_CORNER_RADIUS } from "./photo-page";
+import { collectText, expandTree, findAll, flattenStyle } from "./test-helpers";
 
 function makeData(overrides: Partial<CoverPageData> = {}): CoverPageData {
   return {
@@ -144,5 +145,48 @@ describe("CoverPage", () => {
       (n) => n.props.src as string,
     );
     expect(imageUrls).toContain("https://cdn.example/logo.png");
+  });
+
+  it("applies the shared corner radius to the cover photo", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData()}
+        title="Site Report"
+        coverPhotoUrl="https://cdn.example/cover.jpg"
+        logoUrl={null}
+      />,
+    );
+
+    // The cover photo is a bare IMAGE (no clipping frame), so the radius lives
+    // on the image's own style — assert it directly rather than via photoFrames.
+    const cover = findAll(tree, (n) => n.type === "IMAGE").find(
+      (n) => n.props.src === "https://cdn.example/cover.jpg",
+    );
+    expect(cover).toBeDefined();
+    expect(flattenStyle(cover!.props.style).borderRadius).toBe(
+      PHOTO_CORNER_RADIUS,
+    );
+  });
+
+  it("rounds the cover-photo placeholder with the same shared radius", () => {
+    const tree = expandTree(
+      <CoverPage
+        data={makeData()}
+        title="Site Report"
+        coverPhotoUrl={null}
+        logoUrl={null}
+      />,
+    );
+
+    // When no cover photo is selected the placeholder fills the same slot, so it
+    // must carry the same rounded corners. It is the only VIEW on the cover page
+    // with a borderRadius.
+    const rounded = findAll(
+      tree,
+      (n) =>
+        n.type === "VIEW" &&
+        flattenStyle(n.props.style).borderRadius === PHOTO_CORNER_RADIUS,
+    );
+    expect(rounded).toHaveLength(1);
   });
 });

--- a/src/components/report-pdf/photo-page.test.tsx
+++ b/src/components/report-pdf/photo-page.test.tsx
@@ -4,7 +4,13 @@ import PhotoPage, {
   PHOTO_CORNER_RADIUS,
   type PhotoPageSlot,
 } from "./photo-page";
-import { collectText, expandTree, findAll } from "./test-helpers";
+import {
+  collectText,
+  expandTree,
+  findAll,
+  flattenStyle,
+  photoFrames,
+} from "./test-helpers";
 
 function makeSlot(overrides: Partial<PhotoPageSlot> = {}): PhotoPageSlot {
   return {
@@ -19,35 +25,7 @@ function makeSlot(overrides: Partial<PhotoPageSlot> = {}): PhotoPageSlot {
   };
 }
 
-function flattenStyle(style: unknown): Record<string, unknown> {
-  if (Array.isArray(style)) {
-    return style.reduce<Record<string, unknown>>(
-      (acc, s) => ({ ...acc, ...flattenStyle(s) }),
-      {},
-    );
-  }
-  if (style && typeof style === "object") return style as Record<string, unknown>;
-  return {};
-}
-
 describe("PhotoPage (photo corner radius)", () => {
-  // Every photo frame is a clipping VIEW (overflow:'hidden') that directly
-  // wraps the photo IMAGE. There is exactly one such frame per photo, in all
-  // three layouts.
-  function photoFrames(tree: ReturnType<typeof expandTree>) {
-    return findAll(tree, (n) => {
-      if (n.type !== "VIEW") return false;
-      const s = flattenStyle(n.props.style);
-      if (s.overflow !== "hidden") return false;
-      const children = Array.isArray(n.props.children)
-        ? n.props.children
-        : [n.props.children];
-      return children.some(
-        (c) => c && typeof c === "object" && !Array.isArray(c) && c.type === "IMAGE",
-      );
-    });
-  }
-
   it("is more pronounced than the previous radius of 4", () => {
     expect(PHOTO_CORNER_RADIUS).toBeGreaterThan(4);
   });

--- a/src/components/report-pdf/test-helpers.ts
+++ b/src/components/report-pdf/test-helpers.ts
@@ -64,3 +64,44 @@ export function findAll(
   visit(node);
   return out;
 }
+
+/**
+ * Flatten an @react-pdf `style` prop — a single style object, or an array of
+ * them (possibly nested) that the renderer merges left-to-right — into one
+ * resolved object, so a test can read a final style value without caring how
+ * the component composed it.
+ */
+export function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return style.reduce<Record<string, unknown>>(
+      (acc, s) => ({ ...acc, ...flattenStyle(s) }),
+      {},
+    );
+  }
+  if (style && typeof style === "object") return style as Record<string, unknown>;
+  return {};
+}
+
+/**
+ * Every rounded photo frame in the report PDF is a clipping VIEW
+ * (`overflow: 'hidden'`) that directly wraps the photo IMAGE — the shape that
+ * carries `PHOTO_CORNER_RADIUS`. Returns one entry per such frame, so a test
+ * can hold every photo across any page layout to the shared radius. (The cover
+ * photo is the lone exception: a bare IMAGE with the radius on the image
+ * itself, not a wrapping frame, so it is asserted directly.)
+ */
+export function photoFrames(
+  tree: Expanded,
+): Array<Exclude<Expanded, string | number | null | unknown[]>> {
+  return findAll(tree, (n) => {
+    if (n.type !== "VIEW") return false;
+    if (flattenStyle(n.props.style).overflow !== "hidden") return false;
+    const children = Array.isArray(n.props.children)
+      ? n.props.children
+      : [n.props.children];
+    return children.some(
+      (c) =>
+        c && typeof c === "object" && !Array.isArray(c) && c.type === "IMAGE",
+    );
+  });
+}

--- a/src/lib/section-writeup-fit.test.ts
+++ b/src/lib/section-writeup-fit.test.ts
@@ -54,6 +54,41 @@ describe("measureWriteupFit", () => {
     ).toBe("Soakeddrywall".length);
   });
 
+  it("does not count <br> hard breaks toward the budget (characters, not lines)", () => {
+    // The budget is deliberately character-based, not line-based (ADR 0009): a
+    // write-up can stack many hard breaks and still measure only its visible
+    // text. A <br> is dropped like any other tag — it adds no character and is
+    // NOT turned into a space — so three visual lines count exactly as the same
+    // text on one line. The budget errs lax: it never blocks on break-driven
+    // height even though such a write-up could spill to a second page.
+    expect(measureWriteupFit("<p>aaa<br>bbb<br>ccc</p>").used).toBe(9);
+    expect(measureWriteupFit("<p>aaa<br>bbb<br>ccc</p>").used).toBe(
+      measureWriteupFit("<p>aaabbbccc</p>").used,
+    );
+  });
+
+  it("collapses a run of &nbsp; entities to a single space, mirroring HTML layout", () => {
+    // HTML renders a run of non-breaking spaces as one space gap, and the budget
+    // mirrors that (whitespace runs collapse to one space). Padding a write-up
+    // with extra &nbsp; therefore never pads the count, regardless of how many
+    // entities the run holds.
+    expect(measureWriteupFit("<p>a&nbsp;&nbsp;&nbsp;b</p>").used).toBe(3); // "a b"
+    expect(measureWriteupFit("<p>a&nbsp;&nbsp;&nbsp;b</p>").used).toBe(
+      measureWriteupFit("<p>a&nbsp;b</p>").used,
+    );
+  });
+
+  it("counts multi-paragraph text continuously, ignoring <p> block structure", () => {
+    // Each paragraph adds vertical margin (height) in the PDF, but the budget
+    // counts characters, not blocks: three short paragraphs measure exactly as
+    // the same characters in a single paragraph. The block boundaries are
+    // weightless, so a write-up of many short paragraphs can still run long.
+    expect(measureWriteupFit("<p>AAA</p><p>BBB</p><p>CCC</p>").used).toBe(9);
+    expect(measureWriteupFit("<p>AAA</p><p>BBB</p><p>CCC</p>").used).toBe(
+      measureWriteupFit("<p>AAABBBCCC</p>").used,
+    );
+  });
+
   it("measures legacy plain text the way the PDF renders it, not as stray markup", () => {
     // A pre-rework one-line subtitle has no HTML tags. The PDF escapes it via
     // normalizeSectionWriteup and renders every character, so the fit module


### PR DESCRIPTION
Closes #448.

Regression tests only — every behavior already shipped via merged bug fixes from the Photo Report Rework build. This backfills the characterization tests that the #397 review flagged as missing. **Zero production-source changes**; the diff is entirely test + test-infra.

Each new test is **mutation-verified**: the source contract it pins was deliberately broken, the test confirmed RED, then the source was restored. An independent adversarial review (3 lenses + synthesis) re-ran the mutations and returned **ship, no blockers**.

## Gaps covered

**Gap #3 — delete/restore job-scoping** (`delete/route.test.ts`, `restore/route.test.ts`)
Cross-job 404 no-op test for each route: a report belonging to a *different* Job must not be reachable. Dropping `.eq("job_id", jobId)` from either handler flips its test 404→200, which an empty-table 404 test cannot catch.

**Gap #4 — write-up fit counter** (`section-writeup-fit.test.ts`)
Pins the documented lax behavior (ADR 0009) the counter relies on:
- `<br>` hard breaks count as characters, not lines
- a run of `&nbsp;` entities collapses to a single space
- multi-paragraph text counts continuously, ignoring `<p>` block structure

**Gap #5 — shared corner radius** (`before-after-pair-page.test.tsx`, `cover-page.test.tsx`, `photo-page.test.tsx`, `test-helpers.ts`)
Extends the corner-radius contract beyond `PhotoPage`: both frames of the before/after pair page, the cover photo `Image`, and the cover placeholder `View` all assert the shared `PHOTO_CORNER_RADIUS`. Extracts `flattenStyle` / `photoFrames` into the shared `report-pdf/test-helpers.ts` and rewires `photo-page.test.tsx` to use them (no net test loss).

## Out of scope (already covered)

Gaps **#1 (Generate-PDF action)** and **#2 (edit-loss on unmount)** were already covered by tests that shipped alongside their respective bug fixes — exactly as the issue's "(Lands with the fix.)" notes predicted. No redundant tests added.

## Verification

- 61 tests pass across the 6 target files (53 baseline → +8)
- `tsc`: matches the pre-existing baseline (no new errors in touched files)
- `eslint`: clean on all 7 changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)