### PR TITLE
feat(viewer): slim page-picker rail governed by pure computePaneWidths (#465)

### DIFF
--- a/src/components/documents/pdf-document-viewer.test.tsx
+++ b/src/components/documents/pdf-document-viewer.test.tsx
@@ -47,8 +47,50 @@ vi.mock("react-pdf", async () => {
         </div>
       );
     },
-    Page: (props: { pageNumber: number; width?: number }) => (
-      <div data-testid={`pdf-page-${props.pageNumber}`} data-width={props.width} />
+    Page: (props: {
+      pageNumber: number;
+      width?: number;
+      inputRef?: (el: HTMLDivElement | null) => void;
+      children?: React.ReactNode;
+    }) => (
+      <div
+        ref={props.inputRef}
+        data-testid={`pdf-page-${props.pageNumber}`}
+        data-page-number={props.pageNumber}
+        data-width={props.width}
+      >
+        {props.children}
+      </div>
+    ),
+    // Faithful to react-pdf 10's <Thumbnail>: a clickable <a> that fires
+    // onItemClick({ pageIndex, pageNumber }) and wraps the page plus any
+    // children. We forward an sr-only label as children, so the link picks up an
+    // accessible name from its content (Page itself drops aria-label).
+    Thumbnail: (props: {
+      pageNumber: number;
+      width?: number;
+      className?: string;
+      children?: React.ReactNode;
+      onItemClick?: (e: { pageIndex: number; pageNumber: number }) => void;
+    }) => (
+      <a
+        href="#"
+        className={`react-pdf__Thumbnail ${props.className ?? ""}`.trim()}
+        data-testid={`pdf-thumb-${props.pageNumber}`}
+        onClick={(e) => {
+          e.preventDefault();
+          props.onItemClick?.({
+            pageIndex: props.pageNumber - 1,
+            pageNumber: props.pageNumber,
+          });
+        }}
+      >
+        <span
+          data-testid={`pdf-thumb-page-${props.pageNumber}`}
+          data-width={props.width}
+        />
+        {props.children}
+      </a>
     ),
     pdfjs: { GlobalWorkerOptions: {} },
   };
@@ -115,8 +157,10 @@ describe("PdfDocumentViewer", () => {
   });
 
   it("fits each page to the measured container width so the document is never cropped or tiny", () => {
-    // Container measures 800px (stubbed above); pages render at width minus the
-    // 16px horizontal gutter — mirroring the contracts viewer's fit-to-width.
+    // Container measures 800px (stubbed above). #465 split the viewer into a
+    // ~¼ rail + page pane, so a multi-page document's pages now render at
+    // 800 - 200 rail - 16 gutter = 584px (down from the pre-rail 784px). The
+    // dedicated rail test below pins the rail width itself.
     render(
       <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
     );
@@ -125,8 +169,161 @@ describe("PdfDocumentViewer", () => {
       pdf.resolve(2);
     });
 
+    expect(screen.getByTestId("pdf-page-1").getAttribute("data-width")).toBe("584");
+    expect(screen.getByTestId("pdf-page-2").getAttribute("data-width")).toBe("584");
+  });
+
+  it("renders a thumbnail rail at ~a quarter of the width with the document pane filling the rest", () => {
+    // #465: the multi-page document now splits into a slim rail (~¼) and a page
+    // pane. At the 800px stubbed container, computePaneWidths gives a 200px rail,
+    // leaving 800 - 200 - 16 gutter = 584px for the pages.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    const rail = screen.getByRole("navigation", { name: /page thumbnails/i });
+    expect(rail.style.width).toBe("200px");
+
+    // One thumbnail per page, each sized to the rail minus its inner padding
+    // (200px rail - 24px padding = 176px) so it never butts against the edges.
+    expect(screen.getByTestId("pdf-thumb-1")).toBeDefined();
+    expect(screen.getByTestId("pdf-thumb-2")).toBeDefined();
+    expect(screen.getByTestId("pdf-thumb-3")).toBeDefined();
+    expect(
+      screen.getByTestId("pdf-thumb-page-1").getAttribute("data-width"),
+    ).toBe("176");
+
+    // Document pane fills the remaining width.
+    expect(screen.getByTestId("pdf-page-1").getAttribute("data-width")).toBe("584");
+  });
+
+  it("scrolls the document pane to the matching page when its thumbnail is clicked", () => {
+    // #465: clicking a thumbnail jumps the page pane to that page. The viewer
+    // captures each Page's DOM node and calls scrollIntoView on the one whose
+    // number matches the clicked thumbnail. (Active-page highlight + scroll-sync
+    // are explicitly out of scope here — deferred to slice #4.) jsdom has no
+    // layout engine, so scrollIntoView is undefined: stub it with a spy that
+    // records which page node it was called on.
+    const scrolledPages: Array<string | null> = [];
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: function (this: HTMLElement) {
+        scrolledPages.push(this.getAttribute("data-page-number"));
+      },
+    });
+
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("pdf-thumb-2"));
+    });
+
+    expect(scrolledPages).toEqual(["2"]);
+  });
+
+  it("omits the picker rail for a single-page document — there is nothing to pick", () => {
+    // #465: a one-page document has no pages to pick between, so the rail
+    // collapses and the lone page reclaims the full width.
+    render(
+      <PdfDocumentViewer src="/api/invoices/xyz/preview" title="Invoice JOB-1" />,
+    );
+    act(() => {
+      pdf.resolve(1);
+    });
+
+    expect(
+      screen.queryByRole("navigation", { name: /page thumbnails/i }),
+    ).toBeNull();
+    expect(screen.queryByTestId("pdf-thumb-1")).toBeNull();
     expect(screen.getByTestId("pdf-page-1").getAttribute("data-width")).toBe("784");
-    expect(screen.getByTestId("pdf-page-2").getAttribute("data-width")).toBe("784");
+  });
+
+  it("auto-hides the rail when the container is narrower than the two-pane breakpoint", () => {
+    // #465: on a phone-width container the rail would crowd out the document, so
+    // it collapses below the breakpoint and the pages fill the narrow width.
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 500,
+    });
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    expect(
+      screen.queryByRole("navigation", { name: /page thumbnails/i }),
+    ).toBeNull();
+    expect(screen.getByTestId("pdf-page-1").getAttribute("data-width")).toBe("484");
+  });
+
+  it("lets the reader hide and reopen the rail with a toggle control", () => {
+    // #465: the rail is collapsible so the reader can reclaim the full width for
+    // reading, then bring the picker back.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    expect(
+      screen.getByRole("navigation", { name: /page thumbnails/i }),
+    ).toBeDefined();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /hide thumbnails/i }));
+    });
+    expect(
+      screen.queryByRole("navigation", { name: /page thumbnails/i }),
+    ).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /show thumbnails/i }));
+    });
+    expect(
+      screen.getByRole("navigation", { name: /page thumbnails/i }),
+    ).toBeDefined();
+  });
+
+  it("labels each thumbnail with its page position for screen readers", () => {
+    // #465: react-pdf's Page drops aria-label, so the accessible name has to
+    // come from the Thumbnail's content — an sr-only "Page N of M" label.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(7);
+    });
+
+    expect(screen.getByRole("link", { name: "Page 1 of 7" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Page 3 of 7" })).toBeDefined();
+    expect(screen.getByRole("link", { name: "Page 7 of 7" })).toBeDefined();
+  });
+
+  it("gives the rail its own bounded scroll region so it scrolls independently of the pages", () => {
+    // #465: a long document's rail must not stretch the whole frame — it owns a
+    // height-bounded, scrollable column distinct from the page pane.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(12);
+    });
+
+    const rail = screen.getByRole("navigation", { name: /page thumbnails/i });
+    expect(rail.style.overflowY).toBe("auto");
+    expect(rail.style.maxHeight).not.toBe("");
   });
 
   it("shows a clear loading message before the document resolves, never a blank frame", () => {

--- a/src/components/documents/pdf-document-viewer.tsx
+++ b/src/components/documents/pdf-document-viewer.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { Document, Page } from "react-pdf";
+import { Document, Page, Thumbnail } from "react-pdf";
 import { configurePdfjs } from "@/lib/pdf/configure-pdfjs";
+import { computePaneWidths } from "@/lib/pdf/compute-pane-widths";
 
 // ADR 0013 constraint 1: the /preview routes stream a whole-buffer 200 with no
 // Accept-Ranges, so the viewer disables Range/stream negotiation — otherwise
@@ -10,10 +11,14 @@ import { configurePdfjs } from "@/lib/pdf/configure-pdfjs";
 // so react-pdf does not re-fetch the document on every render.
 const DOCUMENT_OPTIONS = { disableStream: true, disableRange: true } as const;
 
-// Mirror the contracts viewer: each page renders at the measured container
-// width minus a small gutter, so the document fits without a horizontal
-// scrollbar regardless of viewport size.
-const HORIZONTAL_GUTTER_PX = 16;
+// Inner padding inside the rail, subtracted from the rail width so the
+// thumbnail itself never butts against the rail's edges.
+const RAIL_PADDING_PX = 24;
+
+// Below this container width the rail auto-hides (phone / narrow). Shared with
+// computePaneWidths so the collapse math and the toggle's visibility agree on
+// the same breakpoint.
+const RAIL_COLLAPSE_BELOW_PX = 640;
 
 interface PdfDocumentViewerProps {
   src: string;
@@ -23,7 +28,14 @@ interface PdfDocumentViewerProps {
 export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
   const [numPages, setNumPages] = useState(0);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Each rendered Page registers its DOM node here keyed by page number, so a
+  // thumbnail click can scroll straight to it (react-pdf's Page drops refs
+  // through inputRef, not a plain ref).
+  const pageNodes = useRef(new Map<number, HTMLDivElement>());
   const [containerWidth, setContainerWidth] = useState(0);
+  // Reader's manual collapse of the rail (defaults open). The rail also hides
+  // for single-page docs and narrow containers regardless of this flag.
+  const [railOpen, setRailOpen] = useState(true);
   // Bumped by Retry: re-keying <Document> forces a full remount, which clears
   // the error slot and re-fetches the /preview bytes from scratch.
   const [reloadKey, setReloadKey] = useState(0);
@@ -42,10 +54,40 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
     return () => ro.disconnect();
   }, []);
 
-  const pageWidth = Math.max(1, containerWidth - HORIZONTAL_GUTTER_PX);
+  // #465: the viewer splits into a slim page-picker rail (~¼) and a page pane
+  // that fills the rest. The rail collapses when the reader closes it, for a
+  // single-page document (nothing to pick), or below the narrow breakpoint.
+  const isMultiPage = numPages > 1;
+  const { railWidth, pageWidth } = computePaneWidths(containerWidth, {
+    collapseBelow: RAIL_COLLAPSE_BELOW_PX,
+    collapsed: !railOpen || !isMultiPage,
+  });
+  const thumbnailWidth = Math.max(1, railWidth - RAIL_PADDING_PX);
+  // The toggle only makes sense when the container is wide enough to host a rail
+  // and there is more than one page to pick between.
+  const canHostRail =
+    isMultiPage && containerWidth >= RAIL_COLLAPSE_BELOW_PX;
+
+  const scrollToPage = (pageNumber: number) => {
+    pageNodes.current
+      .get(pageNumber)
+      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
 
   return (
-    <div ref={containerRef} className="flex flex-col items-center gap-6 py-6">
+    <div ref={containerRef} className="flex w-full flex-col gap-3 py-6">
+      {canHostRail && (
+        <div className="flex justify-end px-2">
+          <button
+            type="button"
+            aria-expanded={railOpen}
+            className="rounded-md border border-border px-3 py-1.5 text-sm"
+            onClick={() => setRailOpen((open) => !open)}
+          >
+            {railOpen ? "Hide thumbnails" : "Show thumbnails"}
+          </button>
+        </div>
+      )}
       <Document
         key={reloadKey}
         file={src}
@@ -69,15 +111,46 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
           </div>
         }
       >
-        {Array.from({ length: numPages }, (_, i) => (
-          <Page
-            key={i + 1}
-            pageNumber={i + 1}
-            width={pageWidth}
-            renderAnnotationLayer={false}
-            renderTextLayer={false}
-          />
-        ))}
+        <div className="flex w-full gap-4">
+          {railWidth > 0 && (
+            <nav
+              aria-label="Page thumbnails"
+              style={{
+                width: `${railWidth}px`,
+                maxHeight: "80vh",
+                overflowY: "auto",
+              }}
+              className="sticky top-0 flex shrink-0 flex-col items-center gap-3 px-2"
+            >
+              {Array.from({ length: numPages }, (_, i) => (
+                <Thumbnail
+                  key={i + 1}
+                  pageNumber={i + 1}
+                  width={thumbnailWidth}
+                  className="rounded border border-border"
+                  onItemClick={({ pageNumber }) => scrollToPage(pageNumber)}
+                >
+                  <span className="sr-only">{`Page ${i + 1} of ${numPages}`}</span>
+                </Thumbnail>
+              ))}
+            </nav>
+          )}
+          <div className="flex min-w-0 flex-1 flex-col items-center gap-6">
+            {Array.from({ length: numPages }, (_, i) => (
+              <Page
+                key={i + 1}
+                pageNumber={i + 1}
+                width={pageWidth}
+                inputRef={(el) => {
+                  if (el) pageNodes.current.set(i + 1, el);
+                  else pageNodes.current.delete(i + 1);
+                }}
+                renderAnnotationLayer={false}
+                renderTextLayer={false}
+              />
+            ))}
+          </div>
+        </div>
       </Document>
     </div>
   );

--- a/src/lib/pdf/compute-pane-widths.test.ts
+++ b/src/lib/pdf/compute-pane-widths.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { computePaneWidths } from "./compute-pane-widths";
+
+describe("computePaneWidths", () => {
+  it("sizes the rail to about a quarter of a normal container width", () => {
+    const { railWidth } = computePaneWidths(1000);
+
+    expect(railWidth).toBeGreaterThan(0);
+    expect(Math.abs(railWidth - 1000 / 4)).toBeLessThanOrEqual(1000 * 0.02);
+  });
+
+  it("subtracts the inter-pane gutter from the page width", () => {
+    // rail + gutter + page exactly tile the container — the gutter is the gap
+    // between the two panes, taken out of the page (not the rail).
+    const { railWidth, pageWidth } = computePaneWidths(1000, { gutter: 24 });
+
+    expect(railWidth + pageWidth).toBe(1000 - 24);
+  });
+
+  it("caps the rail width on very wide containers so it stays slim (max clamp)", () => {
+    // A literal quarter of 4000 would be 1000px — far too wide for a thumbnail
+    // rail. The max clamp keeps it slim.
+    const { railWidth } = computePaneWidths(4000, { maxRailWidth: 280 });
+
+    expect(railWidth).toBe(280);
+  });
+
+  it("floors the rail width just above the breakpoint so it stays usable (min clamp)", () => {
+    // A quarter of 680 is 170px; the min clamp keeps the rail wide enough to be
+    // a usable thumbnail column.
+    const { railWidth } = computePaneWidths(680, {
+      minRailWidth: 180,
+      collapseBelow: 640,
+    });
+
+    expect(railWidth).toBe(180);
+  });
+
+  it("collapses the rail to zero below the narrow/mobile breakpoint", () => {
+    const { railWidth, pageWidth } = computePaneWidths(500, {
+      collapseBelow: 640,
+    });
+
+    expect(railWidth).toBe(0);
+    // The document still gets a usable width (minus the gutter for breathing room).
+    expect(pageWidth).toBe(500 - 16);
+  });
+
+  it("forces the rail closed at any width when explicitly collapsed", () => {
+    // The manual collapse toggle and single-page documents both ask the rail to
+    // close regardless of how wide the container is.
+    const { railWidth, pageWidth } = computePaneWidths(1200, {
+      collapsed: true,
+    });
+
+    expect(railWidth).toBe(0);
+    expect(pageWidth).toBe(1200 - 16);
+  });
+
+  it("returns zero widths before the container has been measured", () => {
+    expect(computePaneWidths(0)).toEqual({ railWidth: 0, pageWidth: 0 });
+  });
+
+  it("never reports a negative page width when a measured container is narrower than the gutter", () => {
+    // A measured container thinner than the gutter would otherwise yield a
+    // negative page width (8 - 16 = -8), which react-pdf turns into a negative
+    // render scale. A measured container always renders at least 1px.
+    const { railWidth, pageWidth } = computePaneWidths(8);
+
+    expect(railWidth).toBe(0);
+    expect(pageWidth).toBe(1);
+  });
+});

--- a/src/lib/pdf/compute-pane-widths.ts
+++ b/src/lib/pdf/compute-pane-widths.ts
@@ -1,0 +1,46 @@
+export interface ComputePaneWidthsOptions {
+  /** Fraction of the container the rail aims for. Default ~a quarter. */
+  railRatio?: number;
+  /** Gap between the rail and the page pane, subtracted from the page width. */
+  gutter?: number;
+  /** Lower bound so the rail stays a usable thumbnail column. */
+  minRailWidth?: number;
+  /** Upper bound so the rail stays slim on very wide viewports. */
+  maxRailWidth?: number;
+  /** Below this container width the rail collapses to zero (phone / narrow). */
+  collapseBelow?: number;
+  /** Force the rail closed regardless of width (manual toggle / single page). */
+  collapsed?: boolean;
+}
+
+export function computePaneWidths(
+  containerWidth: number,
+  options: ComputePaneWidthsOptions = {},
+) {
+  const {
+    railRatio = 0.25,
+    gutter = 16,
+    minRailWidth = 180,
+    maxRailWidth = 280,
+    collapseBelow = 640,
+    collapsed = false,
+  } = options;
+
+  if (containerWidth <= 0) {
+    return { railWidth: 0, pageWidth: 0 };
+  }
+
+  if (collapsed || containerWidth < collapseBelow) {
+    // A measured container always renders at least 1px: below the gutter width
+    // the raw subtraction goes negative, which react-pdf turns into a negative
+    // render scale. (The unmeasured containerWidth <= 0 case returned {0,0} above.)
+    return { railWidth: 0, pageWidth: Math.max(1, containerWidth - gutter) };
+  }
+
+  const railWidth = Math.min(
+    maxRailWidth,
+    Math.max(minRailWidth, containerWidth * railRatio),
+  );
+  const pageWidth = Math.max(1, containerWidth - railWidth - gutter);
+  return { railWidth, pageWidth };
+}


### PR DESCRIPTION
## What & why

Closes #465 (parent #462). Adds the **page picker** to the in-app document
viewer as a two-pane layout: a slim thumbnail rail (~a quarter of the width)
on the left, document pane filling the rest. The split is governed by a
single **pure module**, `computePaneWidths`, so "about a quarter" is encoded
once and unit-tested rather than scattered through layout code.

Both the Estimate and Invoice views get the rail with **no consumer
changes** — they already render through the shared `PdfPreviewFrame`.

## Acceptance criteria

- [x] Rail renders at ~¼ of viewer width, document pane fills the rest, on both Estimate & Invoice views
- [x] `computePaneWidths` is a pure function, unit-tested for the ¼ ratio, gutter subtraction, min/max clamps, and narrow-breakpoint collapse-to-zero
- [x] Clicking a thumbnail scrolls the document pane to that page
- [x] Rail can be collapsed/hidden to give the document full width
- [x] Rail auto-hides on a phone / narrow window
- [x] Single-page document shows no picker (no wasteful one-item rail)
- [x] Rail scrolls independently (own bounded, sticky scroll region)
- [x] Thumbnails carry an accessible label ("Page N of M", sr-only)
- [x] New unit tests green; touched files add no new failures beyond baseline

**Out of scope, by design (slice #4):** active-page highlighting and
scroll-driven sync. Clicking a thumbnail scrolls, but the rail does **not**
track scroll position — verified absent by the review below.

## How it's built (TDD)

Strict red→green per behavior:

- `src/lib/pdf/compute-pane-widths.ts` — pure `computePaneWidths(containerWidth, options) -> { railWidth, pageWidth }`; **8** unit tests
- `src/components/documents/pdf-document-viewer.tsx` — two-pane layout, click-to-scroll (page nodes captured via `inputRef`), collapse toggle, auto-hide, single-page handling, sr-only labels, independent scroll region; **7** new component tests on top of the #464 suite

## Verification

- `vitest`: 24/24 green across the touched + adjacent files (15 viewer, 8 `computePaneWidths`, 1 unchanged `PdfPreviewFrame`)
- `tsc --noEmit`: 0 errors
- `eslint` on all touched files: clean

Ran a multi-agent adversarial review of the diff against the acceptance
criteria (4 dimensions, each finding independently re-verified). Two minor
findings were confirmed and fixed in this PR:

1. `computePaneWidths` could return a negative `pageWidth` for a measured
   container narrower than the gutter (the pre-#465 `Math.max(1, …)` floor was
   dropped in the move to the pure module) — restored as a positive floor in
   both branches, with a regression test.
2. The padding-adjusted thumbnail width was computed but unasserted — added
   coverage so dropping the padding subtraction now fails a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
