### PR TITLE
feat: live single-toggle layout panel on the Estimate View (#483) + per-document PDF layout foundation (#482)

### DIFF
--- a/src/app/api/estimates/[id]/layout/route.test.ts
+++ b/src/app/api/estimates/[id]/layout/route.test.ts
@@ -1,0 +1,211 @@
+// Route test for PATCH /api/estimates/[id]/layout (#483) — persisting a
+// document's own PDF layout snapshot (ADR 0012). The route gates on
+// edit_estimates, refuses a frozen (converted) estimate, validates the body
+// into a complete DocumentPdfLayout, and writes it to the `pdf_layout` column.
+//
+// Mirrors the withRequestContext route-test pattern from
+// estimates/[id]/status/route.test.ts: mock the server client + active-org
+// resolver, drive the exported handler, assert status + recorded __mutations.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../__test-utils__/request-context-fakes";
+
+const routeCtx = { params: Promise.resolve({ id: "est-1" }) };
+
+// A complete DocumentPdfLayout — exactly what the panel sends: the effective
+// look with one switch (show_markup) flipped off.
+const COMPLETE_LAYOUT = {
+  document_title: "Estimate",
+  show_document_title: true,
+  show_markup: false,
+  show_discount: true,
+  show_tax: true,
+  show_opening_statement: true,
+  show_closing_statement: true,
+  show_category_subtotals: false,
+  show_code_column: true,
+  show_item_notes: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// Bind a fake User client and hand it back so the test can read __mutations.
+function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
+  const client = fakeUserClient(opts);
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+  return client;
+}
+
+function patchRequest(body: unknown) {
+  return new Request("http://test/api/estimates/est-1/layout", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/estimates/[id]/layout", () => {
+  // The edit-document gate is enforced by withRequestContext; these guard that
+  // this route is wired to it (#483: "gated by edit-document permission").
+  it("returns 401 when unauthenticated", async () => {
+    const client = useUser({ user: null });
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+    expect(res.status).toBe(401);
+    expect(client.__mutations).toHaveLength(0);
+  });
+
+  it("returns 403 when the caller lacks edit_estimates", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+    });
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+    expect(res.status).toBe(403);
+    expect(client.__mutations).toHaveLength(0);
+  });
+
+  it("persists the complete layout snapshot onto the estimate's pdf_layout column", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: {
+          estimates: [
+            { id: "est-1", status: "draft", deleted_at: null, pdf_layout: null },
+          ],
+        },
+      }),
+    });
+
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+
+    expect(res.status).toBe(200);
+    const update = client.__mutations.find(
+      (m) => m.table === "estimates" && m.op === "update",
+    );
+    expect(update).toBeDefined();
+    expect((update!.payload as { pdf_layout: unknown }).pdf_layout).toEqual(
+      COMPLETE_LAYOUT,
+    );
+  });
+
+  it("refuses to persist a layout on a frozen (converted) estimate", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: {
+          estimates: [
+            { id: "est-1", status: "converted", deleted_at: null, pdf_layout: null },
+          ],
+        },
+      }),
+    });
+
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+
+    expect(res.status).toBe(409);
+    // Nothing was written — the frozen document keeps its look.
+    const update = client.__mutations.find(
+      (m) => m.table === "estimates" && m.op === "update",
+    );
+    expect(update).toBeUndefined();
+  });
+
+  it("rejects a malformed (incomplete) layout payload without writing", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: {
+          estimates: [
+            { id: "est-1", status: "draft", deleted_at: null, pdf_layout: null },
+          ],
+        },
+      }),
+    });
+
+    // Missing the eight other boolean toggles — not a complete DocumentPdfLayout.
+    const res = await PATCH(
+      patchRequest({ document_title: "Estimate", show_document_title: true }),
+      routeCtx,
+    );
+
+    expect(res.status).toBe(400);
+    const update = client.__mutations.find(
+      (m) => m.table === "estimates" && m.op === "update",
+    );
+    expect(update).toBeUndefined();
+  });
+
+  it("returns 404 for a missing estimate without writing", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: { estimates: [] },
+      }),
+    });
+
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+
+    expect(res.status).toBe(404);
+    const update = client.__mutations.find(
+      (m) => m.table === "estimates" && m.op === "update",
+    );
+    expect(update).toBeUndefined();
+  });
+
+  it("returns 404 for a trashed estimate without writing", async () => {
+    const client = useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: {
+          estimates: [
+            {
+              id: "est-1",
+              status: "draft",
+              deleted_at: "2026-01-01T00:00:00Z",
+              pdf_layout: null,
+            },
+          ],
+        },
+      }),
+    });
+
+    const res = await PATCH(patchRequest(COMPLETE_LAYOUT), routeCtx);
+
+    expect(res.status).toBe(404);
+    const update = client.__mutations.find(
+      (m) => m.table === "estimates" && m.op === "update",
+    );
+    expect(update).toBeUndefined();
+  });
+});

--- a/src/app/api/estimates/[id]/layout/route.ts
+++ b/src/app/api/estimates/[id]/layout/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import { assertNotTrashed } from "@/lib/api/assert-not-trashed";
+import { isLayoutLocked, parseLayoutPayload } from "@/lib/pdf-layout";
+
+// PATCH /api/estimates/[id]/layout — persist a document's own PDF layout
+// snapshot (ADR 0012, #483). The panel sends a complete DocumentPdfLayout (the
+// effective look with switches flipped); this route writes it to the estimate's
+// `pdf_layout` JSONB column.
+export const PATCH = withRequestContext(
+  { permission: "edit_estimates" },
+  async (request, { supabase }, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const body = await request.json().catch(() => null);
+
+    // The panel always sends a complete DocumentPdfLayout (the effective look
+    // with switches flipped). Reject anything that is not the canonical shape so
+    // only a well-formed snapshot reaches the JSONB column.
+    const layout = parseLayoutPayload(body);
+    if (!layout) {
+      return NextResponse.json({ error: "invalid_layout" }, { status: 400 });
+    }
+
+    const { data: cur } = await supabase
+      .from("estimates")
+      .select("status, deleted_at")
+      .eq("id", id)
+      .maybeSingle<{ status: string; deleted_at: string | null }>();
+
+    // The document must exist and be live (not soft-deleted) — 404 otherwise.
+    const trashed = assertNotTrashed(cur);
+    if (trashed) return trashed;
+
+    // A frozen document (estimate once converted, ADR 0007/0012) can no longer
+    // change its look. Refuse with 409 — the request conflicts with state.
+    if (cur && isLayoutLocked("estimate", cur.status)) {
+      return NextResponse.json({ error: "layout_locked" }, { status: 409 });
+    }
+
+    const { error } = await supabase
+      .from("estimates")
+      .update({ pdf_layout: layout })
+      .eq("id", id);
+    if (error) {
+      return apiDbError(error.message, "PATCH /api/estimates/[id]/layout");
+    }
+    return NextResponse.json({ pdf_layout: layout });
+  },
+);

--- a/src/app/estimates/[id]/live-layout-panel.test.tsx
+++ b/src/app/estimates/[id]/live-layout-panel.test.tsx
@@ -1,0 +1,252 @@
+// Component test for the live single-toggle layout panel on the Estimate View
+// (#483). The panel renders one "Show markup" switch over a live PDF preview:
+// flipping the switch optimistically updates, debounce-saves the *complete*
+// layout snapshot (ADR 0012) to PATCH /api/estimates/[id]/layout, and on success
+// reloads the preview iframe (cache-busting query param + key remount). It is
+// read-only on a frozen (converted) estimate.
+//
+// Mirrors the fetch-mock + fake-timer pattern from
+// use-auto-save.flush-on-unmount.test.tsx and photo-report-defaults-tab.test.tsx.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { LiveLayoutPanel } from "./live-layout-panel";
+import { toast } from "sonner";
+import type { DocumentPdfLayout } from "@/lib/types";
+
+// A complete effective layout, as the server resolves and passes in.
+const EFFECTIVE_LAYOUT: DocumentPdfLayout = {
+  document_title: "Estimate",
+  show_document_title: true,
+  show_markup: true,
+  show_discount: true,
+  show_tax: true,
+  show_opening_statement: true,
+  show_closing_statement: true,
+  show_category_subtotals: false,
+  show_code_column: true,
+  show_item_notes: true,
+};
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  fetchMock = vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+function renderPanel(over: Partial<Parameters<typeof LiveLayoutPanel>[0]> = {}) {
+  return render(
+    <LiveLayoutPanel
+      estimateId="est-1"
+      previewSrc="/api/estimates/est-1/preview"
+      previewTitle="Estimate EST-1"
+      layout={{ ...EFFECTIVE_LAYOUT }}
+      canEdit
+      locked={false}
+      {...over}
+    />,
+  );
+}
+
+describe("LiveLayoutPanel", () => {
+  it("renders the markup toggle reflecting the effective layout (reopening restores state)", () => {
+    renderPanel({ layout: { ...EFFECTIVE_LAYOUT, show_markup: false } });
+
+    const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByText(/show markup/i)).toBeDefined();
+  });
+
+  it("autosaves the complete layout snapshot (markup flipped) via a debounced PATCH", async () => {
+    renderPanel({ layout: { ...EFFECTIVE_LAYOUT, show_markup: true } });
+
+    fireEvent.click(screen.getByRole("switch"));
+
+    // Debounced — no request has gone out yet.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/estimates/est-1/layout");
+    expect((init as RequestInit).method).toBe("PATCH");
+    // The whole snapshot is sent (seeded from the effective look) with only
+    // show_markup flipped — ADR 0012 snapshot, not a partial overlay.
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ ...EFFECTIVE_LAYOUT, show_markup: false });
+  });
+
+  it("coalesces rapid toggles into a single trailing PATCH carrying the final state", async () => {
+    renderPanel({ layout: { ...EFFECTIVE_LAYOUT, show_markup: true } });
+
+    const sw = screen.getByRole("switch");
+    fireEvent.click(sw); // → false
+    fireEvent.click(sw); // → true   (both within the debounce window)
+
+    // Still nothing sent — the second click cancels the first's pending timer.
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // Exactly one request, carrying the FINAL state (last-write-wins) — proves
+    // the debounce coalesces rather than firing one PATCH per click.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ ...EFFECTIVE_LAYOUT, show_markup: true });
+  });
+
+  it("reloads the live preview after a successful save (cache-busting query param)", async () => {
+    renderPanel();
+
+    const before = (
+      screen.getByTitle("Estimate EST-1") as HTMLIFrameElement
+    ).getAttribute("src");
+    expect(before).toBe("/api/estimates/est-1/preview");
+
+    fireEvent.click(screen.getByRole("switch"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    const after = (
+      screen.getByTitle("Estimate EST-1") as HTMLIFrameElement
+    ).getAttribute("src");
+    expect(after).not.toBe(before);
+    expect(after).toMatch(/[?&]v=/);
+  });
+
+  it("is read-only on a frozen (converted) estimate — switch disabled, no save", async () => {
+    renderPanel({ locked: true });
+
+    const sw = screen.getByRole("switch") as HTMLButtonElement;
+    expect(sw.disabled).toBe(true);
+
+    fireEvent.click(sw);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("is read-only without the edit grant — switch disabled, no save", async () => {
+    renderPanel({ canEdit: false });
+
+    const sw = screen.getByRole("switch") as HTMLButtonElement;
+    expect(sw.disabled).toBe(true);
+
+    fireEvent.click(sw);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("toasts and leaves the preview untouched when the save fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "boom" }),
+    } as Response);
+    renderPanel();
+
+    const before = (
+      screen.getByTitle("Estimate EST-1") as HTMLIFrameElement
+    ).getAttribute("src");
+
+    fireEvent.click(screen.getByRole("switch"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // No live reload on failure — the iframe keeps the last good render.
+    const after = (
+      screen.getByTitle("Estimate EST-1") as HTMLIFrameElement
+    ).getAttribute("src");
+    expect(after).toBe(before);
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("rolls the toggle back to the saved look when the save fails", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "boom" }),
+    } as Response);
+    renderPanel({ layout: { ...EFFECTIVE_LAYOUT, show_markup: true } });
+
+    const sw = screen.getByRole("switch");
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+
+    fireEvent.click(sw); // optimistic flip → false
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("false");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // Save failed: the switch reverts to the persisted look so it agrees with
+    // the (un-reloaded) preview instead of asserting an unsaved state.
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it("flushes the pending save with keepalive when unmounted mid-debounce", () => {
+    const { unmount } = renderPanel({
+      layout: { ...EFFECTIVE_LAYOUT, show_markup: true },
+    });
+
+    fireEvent.click(screen.getByRole("switch")); // schedules a debounced save
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    unmount(); // navigate away within the 600ms debounce window
+
+    // The trailing edit is flushed (keepalive) rather than silently dropped.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/estimates/est-1/layout");
+    expect((init as RequestInit & { keepalive?: boolean }).keepalive).toBe(true);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({ ...EFFECTIVE_LAYOUT, show_markup: false });
+  });
+
+  it("flushes the pending save with keepalive on a hard page-unload (pagehide)", () => {
+    renderPanel({ layout: { ...EFFECTIVE_LAYOUT, show_markup: true } });
+
+    fireEvent.click(screen.getByRole("switch")); // schedules a debounced save
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    act(() => {
+      window.dispatchEvent(new Event("pagehide")); // tab close / refresh / nav away
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0][1] as RequestInit & {
+      keepalive?: boolean;
+    };
+    expect(init.keepalive).toBe(true);
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({ ...EFFECTIVE_LAYOUT, show_markup: false });
+  });
+});

--- a/src/app/estimates/[id]/live-layout-panel.tsx
+++ b/src/app/estimates/[id]/live-layout-panel.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { PdfPreviewFrame } from "@/components/documents/pdf-preview-frame";
+import { toast } from "sonner";
+import type { DocumentPdfLayout } from "@/lib/types";
+
+const SAVE_DELAY_MS = 600;
+
+interface LiveLayoutPanelProps {
+  estimateId: string;
+  previewSrc: string;
+  previewTitle: string;
+  /** The document's effective layout (server-resolved), so the toggle restores state. */
+  layout: DocumentPdfLayout;
+  /** Caller holds edit_estimates. */
+  canEdit: boolean;
+  /** The document is frozen (converted) — layout is read-only. */
+  locked: boolean;
+}
+
+// Live single-toggle layout panel on the Estimate View (#483).
+export function LiveLayoutPanel({
+  estimateId,
+  previewSrc,
+  previewTitle,
+  layout: initialLayout,
+  canEdit,
+  locked,
+}: LiveLayoutPanelProps) {
+  // A frozen document, or a caller without the edit grant, sees the look but
+  // cannot change it (ADR 0012 reuses the edit-document boundary + freeze).
+  const readOnly = !canEdit || locked;
+  const [layout, setLayout] = useState<DocumentPdfLayout>(initialLayout);
+  const [version, setVersion] = useState(0);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // The edit currently waiting on the debounce timer — flushed on teardown so a
+  // fast navigate-away inside the window doesn't silently drop it.
+  const pending = useRef<DocumentPdfLayout | null>(null);
+  // The last look the server actually has (what the preview renders), so a
+  // failed save can roll the optimistic switch back to a state that agrees with
+  // the preview instead of leaving the two silently desynced.
+  const savedLayout = useRef<DocumentPdfLayout>(initialLayout);
+
+  const sendLayout = useCallback(
+    (next: DocumentPdfLayout, keepalive = false) =>
+      fetch(`/api/estimates/${estimateId}/layout`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(next),
+        keepalive,
+      }),
+    [estimateId],
+  );
+
+  // Flush the pending edit on unmount instead of merely clearing the timer: the
+  // debounce window would otherwise drop the last toggle on a fast navigate-away
+  // (easy on a tablet). Mirrors the keepalive flush in use-auto-save.ts (#461).
+  // A ref-held closure, rewritten each render, reads the freshest sendLayout.
+  const flushRef = useRef<() => void>(() => {});
+  flushRef.current = () => {
+    if (timer.current && pending.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+      const body = pending.current;
+      pending.current = null;
+      void sendLayout(body, true);
+    }
+  };
+  useEffect(() => () => flushRef.current(), []);
+
+  // The unmount cleanup above fires only on in-app navigation; a hard teardown
+  // (tab close, refresh, address-bar nav, iOS backgrounding) never runs React
+  // cleanup, so fire the same keepalive flush from the page-lifecycle event too
+  // (#477). beforeunload is intentionally avoided (unreliable in iOS WebKit).
+  useEffect(() => {
+    const flush = () => flushRef.current();
+    window.addEventListener("pagehide", flush);
+    return () => window.removeEventListener("pagehide", flush);
+  }, []);
+
+  // Debounced autosave: the panel always persists the *complete* snapshot
+  // (ADR 0012), seeded from the effective look with switches flipped. On a
+  // successful save, bump the preview version so the iframe re-renders live.
+  const save = useCallback(
+    (next: DocumentPdfLayout) => {
+      pending.current = next;
+      if (timer.current) clearTimeout(timer.current);
+      timer.current = setTimeout(async () => {
+        timer.current = null;
+        pending.current = null;
+        const res = await sendLayout(next);
+        // On success, record the persisted look and bump the preview version for
+        // a live re-render. On failure, roll the switch back to the last saved
+        // look (keeping it in sync with the un-reloaded preview) and surface it.
+        if (res.ok) {
+          savedLayout.current = next;
+          setVersion((v) => v + 1);
+        } else {
+          const { error } = await res
+            .json()
+            .catch(() => ({ error: undefined as string | undefined }));
+          setLayout(savedLayout.current);
+          toast.error(error ?? "Couldn't save layout");
+        }
+      }, SAVE_DELAY_MS);
+    },
+    [sendLayout],
+  );
+
+  const setMarkup = (show_markup: boolean) => {
+    if (readOnly) return;
+    const next = { ...layout, show_markup };
+    setLayout(next); // optimistic
+    save(next);
+  };
+
+  // version 0 is the untouched server-rendered preview; later versions append a
+  // cache-busting param so the iframe (also keyed on src) re-fetches live.
+  const src = version === 0 ? previewSrc : `${previewSrc}?v=${version}`;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-card px-5 py-4">
+        <h2 className="text-sm font-medium text-foreground mb-3">Document layout</h2>
+        <div className="flex items-start gap-3">
+          <Switch
+            id="show_markup"
+            checked={layout.show_markup}
+            disabled={readOnly}
+            onCheckedChange={setMarkup}
+          />
+          <Label htmlFor="show_markup" className="cursor-pointer">
+            Show markup row in totals
+          </Label>
+        </div>
+      </div>
+      <PdfPreviewFrame key={src} src={src} title={previewTitle} />
+    </div>
+  );
+}

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -8,7 +8,9 @@ import { STATUS_BADGE_CLASSES, formatStatusLabel } from "@/lib/estimate-status";
 import { ExportPdfButton } from "@/components/export-pdf-modal/button";
 import { SendButton } from "@/components/send-modal/button";
 import { TrashedBanner } from "@/components/trash/trashed-banner";
-import { PdfPreviewFrame } from "@/components/documents/pdf-preview-frame";
+import { getDefaultPreset } from "@/lib/pdf-presets";
+import { isLayoutLocked, resolveEffectiveLayout } from "@/lib/pdf-layout";
+import { LiveLayoutPanel } from "./live-layout-panel";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Local ErrorPage helper — mirrors the pattern in /estimates/[id]/edit/page.tsx
@@ -77,6 +79,16 @@ export default async function EstimateViewPage({
     permission: "edit_estimates",
   });
   const canEdit = editAuth.ok;
+
+  // 4. Resolve the document's effective look (ADR 0012 precedence: the
+  //    document's own snapshot → Organization default preset → field defaults)
+  //    so the layout panel's toggle restores the current state. The panel is
+  //    read-only once the estimate is frozen (converted, ADR 0007) or trashed —
+  //    matching the PATCH route's 409/404 refusals.
+  const preset = await getDefaultPreset(supabase, "estimate");
+  const effectiveLayout = resolveEffectiveLayout(estimate.pdf_layout, preset);
+  const layoutLocked =
+    isLayoutLocked("estimate", estimate.status) || Boolean(estimate.deleted_at);
 
   // ── Derived display values ─────────────────────────────────────────────────
   const isVoided = estimate.status === "voided";
@@ -166,10 +178,16 @@ export default async function EstimateViewPage({
         )}
       </div>
 
-      {/* ── INLINE PDF (the real customer-facing document) ──────────────────── */}
-      <PdfPreviewFrame
-        src={`/api/estimates/${id}/preview`}
-        title={`Estimate ${estimate.estimate_number}`}
+      {/* ── LAYOUT PANEL + INLINE PDF (the real customer-facing document) ───── */}
+      {/* The panel owns the live preview so a single shared version drives the
+          re-render: flip the markup toggle → autosave the snapshot → reload. */}
+      <LiveLayoutPanel
+        estimateId={id}
+        previewSrc={`/api/estimates/${id}/preview`}
+        previewTitle={`Estimate ${estimate.estimate_number}`}
+        layout={effectiveLayout}
+        canEdit={canEdit}
+        locked={layoutLocked}
       />
     </div>
   );

--- a/src/components/estimate-builder/estimate-drag-end.test.tsx
+++ b/src/components/estimate-builder/estimate-drag-end.test.tsx
@@ -162,6 +162,7 @@ function makeEstimateEntity(): BuilderEntity {
     last_sent_to_email: null,
     deleted_at: null,
     delete_reason: null,
+    pdf_layout: null,
     sections: [
       {
         id: "S1",

--- a/src/components/estimate-builder/invoice-drag-end.test.tsx
+++ b/src/components/estimate-builder/invoice-drag-end.test.tsx
@@ -163,6 +163,7 @@ function makeInvoiceEntity(): BuilderEntity {
     last_sent_to_email: null,
     deleted_at: null,
     delete_reason: null,
+    pdf_layout: null,
     sections: [
       {
         id: "S1",

--- a/src/lib/pdf-layout.test.ts
+++ b/src/lib/pdf-layout.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import {
+  isLayoutLocked,
+  resolveEffectiveLayout,
+  parseLayoutPayload,
+  LAYOUT_FIELD_DEFAULTS,
+} from "./pdf-layout";
+import type {
+  DocumentPdfLayout,
+  EstimateStatus,
+  Invoice,
+  PdfPreset,
+} from "./types";
+
+// A complete, deliberately non-default layout so a test that expects the
+// document's own look to win can tell it apart from preset/field defaults.
+function customLayout(): DocumentPdfLayout {
+  return {
+    document_title: "Proposal",
+    show_document_title: false,
+    show_markup: false,
+    show_discount: false,
+    show_tax: false,
+    show_opening_statement: false,
+    show_closing_statement: false,
+    show_category_subtotals: true,
+    show_code_column: false,
+    show_item_notes: false,
+  };
+}
+
+// A preset whose every toggle is the opposite of the field defaults, so a test
+// can tell "the preset supplied this" apart from "the field default did".
+function customPreset(): PdfPreset {
+  return {
+    id: "preset-1",
+    organization_id: "org-1",
+    name: "Branded",
+    document_type: "estimate",
+    document_title: "Quote",
+    show_markup: false,
+    show_discount: false,
+    show_tax: false,
+    show_opening_statement: false,
+    show_closing_statement: false,
+    show_category_subtotals: true,
+    show_code_column: false,
+    show_item_notes: false,
+    is_default: true,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+// #482 — the per-document layout is frozen exactly where ADR 0007 draws the
+// freeze boundary: an estimate locks only once it has been *converted*. Every
+// earlier state (including a *voided* estimate, which is terminal but never
+// became an invoice) stays editable.
+describe("isLayoutLocked — estimate freeze boundary (#482)", () => {
+  const ALL_ESTIMATE_STATUSES: EstimateStatus[] = [
+    "draft",
+    "sent",
+    "approved",
+    "rejected",
+    "converted",
+    "voided",
+  ];
+
+  it("locks an estimate only when it is converted", () => {
+    for (const status of ALL_ESTIMATE_STATUSES) {
+      expect(isLayoutLocked("estimate", status)).toBe(status === "converted");
+    }
+  });
+});
+
+// An invoice's money has moved (or been voided), so its layout freezes once it
+// is `paid` or `voided`. Earlier states (draft / sent / partial) stay editable.
+describe("isLayoutLocked — invoice freeze boundary (#482)", () => {
+  const ALL_INVOICE_STATUSES: Invoice["status"][] = [
+    "draft",
+    "sent",
+    "partial",
+    "paid",
+    "voided",
+  ];
+
+  it("locks an invoice when it is paid or voided", () => {
+    for (const status of ALL_INVOICE_STATUSES) {
+      const expected = status === "paid" || status === "voided";
+      expect(isLayoutLocked("invoice", status)).toBe(expected);
+    }
+  });
+});
+
+// The precedence engine: document layout > org default preset > field defaults.
+// The render path must never have "no look", so the output is always complete.
+describe("resolveEffectiveLayout — precedence (#482)", () => {
+  it("returns the document's own layout when it has one", () => {
+    const layout = customLayout();
+    // Even with a preset present, the document's own snapshot wins outright.
+    expect(resolveEffectiveLayout(layout, customPreset())).toEqual(layout);
+  });
+
+  it("falls back to the org default preset when the layout is NULL", () => {
+    const preset = customPreset();
+    // The preset carries every field except `show_document_title` (new in #482),
+    // which has no preset column — so it falls through to the field default.
+    expect(resolveEffectiveLayout(null, preset)).toEqual({
+      document_title: preset.document_title,
+      show_document_title: LAYOUT_FIELD_DEFAULTS.show_document_title,
+      show_markup: preset.show_markup,
+      show_discount: preset.show_discount,
+      show_tax: preset.show_tax,
+      show_opening_statement: preset.show_opening_statement,
+      show_closing_statement: preset.show_closing_statement,
+      show_category_subtotals: preset.show_category_subtotals,
+      show_code_column: preset.show_code_column,
+      show_item_notes: preset.show_item_notes,
+    });
+  });
+
+  it("falls back to built-in field defaults when both layout and preset are absent", () => {
+    expect(resolveEffectiveLayout(null, null)).toEqual(LAYOUT_FIELD_DEFAULTS);
+  });
+
+  it("fills a field the layout is missing from the next precedence level", () => {
+    const full = customLayout();
+    const { show_tax: _omit, ...partial } = full; // a layout written without show_tax
+    void _omit;
+    const preset = customPreset(); // preset.show_tax === false; field default is true
+    const resolved = resolveEffectiveLayout(partial as DocumentPdfLayout, preset);
+    // Fields the layout has still come from the layout.
+    expect(resolved.document_title).toBe(full.document_title);
+    expect(resolved.show_code_column).toBe(full.show_code_column);
+    // The missing field falls through to the preset (false), not "off" and not
+    // the field default (true) — proving per-field, not all-or-nothing, merge.
+    expect(resolved.show_tax).toBe(false);
+  });
+});
+
+// The payload validator guards the PATCH autosave: only a well-formed layout
+// (nine booleans + a string title) is accepted; anything else is rejected so a
+// malformed body can never reach the JSONB column. Returns the normalized layout
+// or null.
+describe("parseLayoutPayload — validation (#482)", () => {
+  it("accepts a well-formed layout and returns it normalized", () => {
+    const payload = customLayout();
+    expect(parseLayoutPayload({ ...payload })).toEqual(payload);
+  });
+
+  it("rejects non-object bodies", () => {
+    for (const bad of [null, undefined, "layout", 42, true, [customLayout()]]) {
+      expect(parseLayoutPayload(bad)).toBeNull();
+    }
+  });
+
+  it("rejects a body missing a required field", () => {
+    const { show_markup: _omit, ...partial } = customLayout();
+    void _omit;
+    expect(parseLayoutPayload(partial)).toBeNull();
+  });
+
+  it("rejects a toggle that is not a boolean", () => {
+    expect(parseLayoutPayload({ ...customLayout(), show_tax: "true" })).toBeNull();
+    expect(parseLayoutPayload({ ...customLayout(), show_markup: 1 })).toBeNull();
+  });
+
+  it("rejects a document_title that is not a string", () => {
+    expect(parseLayoutPayload({ ...customLayout(), document_title: 7 })).toBeNull();
+    const { document_title: _t, ...noTitle } = customLayout();
+    void _t;
+    expect(parseLayoutPayload(noTitle)).toBeNull();
+  });
+
+  it("strips unknown keys, returning only the canonical layout shape", () => {
+    const payload = customLayout();
+    const result = parseLayoutPayload({ ...payload, evil: "drop me", id: "x" });
+    expect(result).toEqual(payload);
+    expect(result).not.toHaveProperty("evil");
+    expect(result).not.toHaveProperty("id");
+  });
+});

--- a/src/lib/pdf-layout.ts
+++ b/src/lib/pdf-layout.ts
@@ -1,0 +1,123 @@
+// src/lib/pdf-layout.ts — the per-document PDF layout core (#482).
+//
+// A *PDF layout* is a per-document snapshot of the look a document renders with
+// (ADR 0012). This module holds the pure pieces the whole feature renders
+// through: the freeze predicate, the precedence resolver, and the payload
+// validator. No I/O — every function here is pure and unit-tested.
+
+import type { DocumentPdfLayout, DocumentType, PdfPreset } from "./types";
+
+// Built-in field defaults — the last resort when a document has neither its own
+// layout nor an Organization default preset. Mirrors the `pdf_presets` column
+// defaults (migrations build67c1 + 382a): every toggle on except
+// `show_category_subtotals`. `show_document_title` defaults on because the title
+// renders unconditionally today. `document_title` is a generic placeholder; in
+// every real render path a preset supplies the actual title.
+export const LAYOUT_FIELD_DEFAULTS: DocumentPdfLayout = {
+  document_title: "Document",
+  show_document_title: true,
+  show_markup: true,
+  show_discount: true,
+  show_tax: true,
+  show_opening_statement: true,
+  show_closing_statement: true,
+  show_category_subtotals: false,
+  show_code_column: true,
+  show_item_notes: true,
+};
+
+// Whether a document's layout is frozen, reusing the freeze boundary ADR 0007
+// draws: an estimate locks once it is `converted`; an invoice locks once it is
+// `paid` or `voided`. A *voided estimate* is terminal but never became an
+// invoice, so its layout stays editable. Pure over (kind, status).
+export function isLayoutLocked(kind: DocumentType, status: string): boolean {
+  if (kind === "estimate") return status === "converted";
+  return status === "paid" || status === "voided";
+}
+
+// Resolve a document's effective look. Precedence, per field: the document's own
+// layout wins; else the Organization's default preset; else the built-in field
+// defaults. Always returns a complete `DocumentPdfLayout` — the render path must
+// never have "no look."
+export function resolveEffectiveLayout(
+  layout: DocumentPdfLayout | null,
+  preset: PdfPreset | null,
+  defaults: DocumentPdfLayout = LAYOUT_FIELD_DEFAULTS,
+): DocumentPdfLayout {
+  // The preset is the per-field fallback below a document's own layout. It
+  // carries every layout field except `show_document_title` (new in #482, no
+  // preset column), so that one always falls through to the field default.
+  const fromPreset: Partial<DocumentPdfLayout> = preset
+    ? {
+        document_title: preset.document_title,
+        show_markup: preset.show_markup,
+        show_discount: preset.show_discount,
+        show_tax: preset.show_tax,
+        show_opening_statement: preset.show_opening_statement,
+        show_closing_statement: preset.show_closing_statement,
+        show_category_subtotals: preset.show_category_subtotals,
+        show_code_column: preset.show_code_column,
+        show_item_notes: preset.show_item_notes,
+      }
+    : {};
+
+  // Per-field precedence: document layout > preset > field default. A layout
+  // present but missing a field (`undefined`) falls through, not "off".
+  const pick = <K extends keyof DocumentPdfLayout>(key: K): DocumentPdfLayout[K] => {
+    const fromLayout = layout?.[key];
+    if (fromLayout !== undefined) return fromLayout;
+    const presetVal = fromPreset[key];
+    if (presetVal !== undefined) return presetVal;
+    return defaults[key];
+  };
+
+  return {
+    document_title: pick("document_title"),
+    show_document_title: pick("show_document_title"),
+    show_markup: pick("show_markup"),
+    show_discount: pick("show_discount"),
+    show_tax: pick("show_tax"),
+    show_opening_statement: pick("show_opening_statement"),
+    show_closing_statement: pick("show_closing_statement"),
+    show_category_subtotals: pick("show_category_subtotals"),
+    show_code_column: pick("show_code_column"),
+    show_item_notes: pick("show_item_notes"),
+  };
+}
+
+// Validate an untrusted PATCH body into a `DocumentPdfLayout`. Accepts only a
+// well-formed layout — exactly the nine boolean toggles plus a string
+// `document_title` — and returns it normalized (extra keys stripped) so only the
+// canonical shape ever reaches the JSONB column. Returns null on any violation.
+// The nine boolean toggles that, with `document_title`, make up a layout. Used
+// to validate and normalize a payload field-by-field.
+const LAYOUT_TOGGLE_KEYS = [
+  "show_document_title",
+  "show_markup",
+  "show_discount",
+  "show_tax",
+  "show_opening_statement",
+  "show_closing_statement",
+  "show_category_subtotals",
+  "show_code_column",
+  "show_item_notes",
+] as const;
+
+export function parseLayoutPayload(body: unknown): DocumentPdfLayout | null {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return null;
+  }
+  const obj = body as Record<string, unknown>;
+
+  if (typeof obj.document_title !== "string") return null;
+
+  const toggles = {} as Record<(typeof LAYOUT_TOGGLE_KEYS)[number], boolean>;
+  for (const key of LAYOUT_TOGGLE_KEYS) {
+    if (typeof obj[key] !== "boolean") return null;
+    toggles[key] = obj[key] as boolean;
+  }
+
+  // Normalize: emit exactly the canonical shape, dropping any extra keys so only
+  // a well-formed layout ever reaches the JSONB column.
+  return { document_title: obj.document_title, ...toggles };
+}

--- a/src/lib/pdf-renderer/components/page-header.test.tsx
+++ b/src/lib/pdf-renderer/components/page-header.test.tsx
@@ -1,0 +1,43 @@
+// Render-shape coverage for the document-title gate on the PDF masthead (#482).
+// `show_document_title` hides only the title text — the logo still renders, so a
+// logo-only masthead is possible. The toggle defaults on, preserving the
+// historical "title always shows" look for documents with no layout.
+
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "./page-header";
+import {
+  collectText,
+  expandTree,
+  findAll,
+} from "@/components/report-pdf/test-helpers";
+
+describe("PageHeader — document-title gate (#482)", () => {
+  it("renders the document title when show_document_title is on", () => {
+    const tree = expandTree(
+      <PageHeader documentTitle="Estimate" showDocumentTitle logoUrl={null} />,
+    );
+    expect(collectText(tree)).toContain("Estimate");
+  });
+
+  it("omits the document title when show_document_title is off", () => {
+    const tree = expandTree(
+      <PageHeader documentTitle="Estimate" showDocumentTitle={false} logoUrl={null} />,
+    );
+    expect(collectText(tree)).not.toContain("Estimate");
+  });
+
+  it("still renders the logo when the title is hidden", () => {
+    const tree = expandTree(
+      <PageHeader
+        documentTitle="Estimate"
+        showDocumentTitle={false}
+        logoUrl="https://cdn.example/logo.png"
+      />,
+    );
+    // The title text is gone, but the masthead's logo image survives — proving
+    // the gate hides the title only, not the whole header.
+    expect(collectText(tree)).not.toContain("Estimate");
+    expect(findAll(tree, (n) => n.type === "IMAGE")).toHaveLength(1);
+  });
+});

--- a/src/lib/pdf-renderer/components/page-header.tsx
+++ b/src/lib/pdf-renderer/components/page-header.tsx
@@ -1,12 +1,18 @@
 import { View, Text, Image } from "@react-pdf/renderer";
 import { styles } from "@/lib/pdf-renderer/styles";
 
-interface Props { documentTitle: string; logoUrl: string | null; }
+interface Props {
+  documentTitle: string;
+  showDocumentTitle: boolean;
+  logoUrl: string | null;
+}
 
-export function PageHeader({ documentTitle, logoUrl }: Props) {
+export function PageHeader({ documentTitle, showDocumentTitle, logoUrl }: Props) {
   return (
     <View style={styles.header}>
-      <Text style={styles.docTitle}>{documentTitle}</Text>
+      {showDocumentTitle ? (
+        <Text style={styles.docTitle}>{documentTitle}</Text>
+      ) : null}
       {/* eslint-disable-next-line jsx-a11y/alt-text */}
       {logoUrl ? <Image src={logoUrl} style={styles.logo} /> : null}
     </View>

--- a/src/lib/pdf-renderer/components/sections-table.test.tsx
+++ b/src/lib/pdf-renderer/components/sections-table.test.tsx
@@ -6,15 +6,12 @@ import { describe, expect, it } from "vitest";
 
 import { SectionsTable } from "./sections-table";
 import { expandTree, collectText } from "@/components/report-pdf/test-helpers";
-import type { EstimateSection, EstimateLineItem, PdfPreset } from "@/lib/types";
+import type { EstimateSection, EstimateLineItem, DocumentPdfLayout } from "@/lib/types";
 
-function makePreset(overrides: Partial<PdfPreset> = {}): PdfPreset {
+function makeLayout(overrides: Partial<DocumentPdfLayout> = {}): DocumentPdfLayout {
   return {
-    id: "preset-1",
-    organization_id: "org-1",
-    name: "Default",
-    document_type: "estimate",
     document_title: "Estimate",
+    show_document_title: true,
     show_markup: true,
     show_discount: true,
     show_tax: true,
@@ -23,10 +20,6 @@ function makePreset(overrides: Partial<PdfPreset> = {}): PdfPreset {
     show_category_subtotals: false,
     show_code_column: true,
     show_item_notes: true,
-    is_default: true,
-    created_by: null,
-    created_at: "",
-    updated_at: "",
     ...overrides,
   };
 }
@@ -67,7 +60,7 @@ function lineItem(overrides: Partial<EstimateLineItem> = {}): EstimateLineItem {
 describe("SectionsTable — line-item note (#382)", () => {
   it("renders the note when show_item_notes is on", () => {
     const tree = expandTree(
-      <SectionsTable sections={[section]} lineItems={[lineItem()]} preset={makePreset()} />,
+      <SectionsTable sections={[section]} lineItems={[lineItem()]} layout={makeLayout()} />,
     );
     expect(collectText(tree)).toContain("Match existing shingle color");
   });
@@ -77,7 +70,7 @@ describe("SectionsTable — line-item note (#382)", () => {
       <SectionsTable
         sections={[section]}
         lineItems={[lineItem()]}
-        preset={makePreset({ show_item_notes: false })}
+        layout={makeLayout({ show_item_notes: false })}
       />,
     );
     expect(collectText(tree)).not.toContain("Match existing shingle color");
@@ -88,7 +81,7 @@ describe("SectionsTable — line-item note (#382)", () => {
       <SectionsTable
         sections={[section]}
         lineItems={[lineItem({ note: null })]}
-        preset={makePreset()}
+        layout={makeLayout()}
       />,
     );
     // Description still renders; there's simply no note sub-line.
@@ -97,7 +90,7 @@ describe("SectionsTable — line-item note (#382)", () => {
 
   it("does not render a 'Notes' column header (note is a sub-line, not a column)", () => {
     const tree = expandTree(
-      <SectionsTable sections={[section]} lineItems={[lineItem()]} preset={makePreset()} />,
+      <SectionsTable sections={[section]} lineItems={[lineItem()]} layout={makeLayout()} />,
     );
     expect(collectText(tree)).not.toContain("Notes");
   });

--- a/src/lib/pdf-renderer/components/sections-table.tsx
+++ b/src/lib/pdf-renderer/components/sections-table.tsx
@@ -1,11 +1,11 @@
 // src/lib/pdf-renderer/components/sections-table.tsx
 // Renders the hierarchical sections + subsections + line items for both estimates and invoices.
-// Pure function of (sections, lineItems, preset) — no DB access.
+// Pure function of (sections, lineItems, layout) — no DB access.
 
 import { View, Text } from "@react-pdf/renderer";
 import { styles } from "@/lib/pdf-renderer/styles";
 import type {
-  PdfPreset, EstimateSection, EstimateLineItem, InvoiceSection, InvoiceLineItem,
+  DocumentPdfLayout, EstimateSection, EstimateLineItem, InvoiceSection, InvoiceLineItem,
 } from "@/lib/types";
 
 type Section = EstimateSection | InvoiceSection;
@@ -14,7 +14,7 @@ type LineItem = EstimateLineItem | InvoiceLineItem;
 interface Props {
   sections: Section[];
   lineItems: LineItem[];
-  preset: PdfPreset;
+  layout: DocumentPdfLayout;
 }
 
 function fmt(n: number): string {
@@ -52,7 +52,7 @@ function sectionSubtotal(items: LineItem[]): number {
   return items.reduce((s, i) => s + lineTotal(i), 0);
 }
 
-export function SectionsTable({ sections, lineItems, preset }: Props) {
+export function SectionsTable({ sections, lineItems, layout }: Props) {
   const { tops, childrenOf } = groupSections(sections);
 
   function renderItemRow(item: LineItem, key: string) {
@@ -60,11 +60,11 @@ export function SectionsTable({ sections, lineItems, preset }: Props) {
     const itemName = item.name ?? null;
     return (
       <View key={key} style={styles.tr} wrap={false}>
-        {preset.show_code_column && <Text style={styles.tdCode}>{item.code ?? ""}</Text>}
+        {layout.show_code_column && <Text style={styles.tdCode}>{item.code ?? ""}</Text>}
         <View style={styles.tdDesc}>
           {itemName && <Text style={styles.tdName}>{itemName}</Text>}
           <Text>{item.description}</Text>
-          {preset.show_item_notes && item.note && (
+          {layout.show_item_notes && item.note && (
             <Text style={styles.tdNoteSub}>{item.note}</Text>
           )}
         </View>
@@ -89,7 +89,7 @@ export function SectionsTable({ sections, lineItems, preset }: Props) {
         </View>
         {directItems.map((it, i) => renderItemRow(it, `${sectionKey}-it-${i}`))}
         {subs.map((sub, i) => renderSection(sub, depth + 1, `${sectionKey}-sub-${i}`))}
-        {preset.show_category_subtotals && depth === 0 && (
+        {layout.show_category_subtotals && depth === 0 && (
           <View style={styles.sectionSubtotal} wrap={false}>
             <Text>Section subtotal: {fmt(sectionTot)}</Text>
           </View>
@@ -104,7 +104,7 @@ export function SectionsTable({ sections, lineItems, preset }: Props) {
     <View style={styles.table}>
       {/* Header row */}
       <View style={styles.thRow} wrap={false}>
-        {preset.show_code_column && <Text style={styles.tdCode}>Code</Text>}
+        {layout.show_code_column && <Text style={styles.tdCode}>Code</Text>}
         <Text style={styles.tdDesc}>Description</Text>
         <Text style={styles.tdQty}>Qty</Text>
         <Text style={styles.tdUnit}>Unit</Text>

--- a/src/lib/pdf-renderer/components/totals-block.tsx
+++ b/src/lib/pdf-renderer/components/totals-block.tsx
@@ -3,18 +3,18 @@
 
 import { View, Text } from "@react-pdf/renderer";
 import { styles } from "@/lib/pdf-renderer/styles";
-import type { PdfPreset, Estimate, Invoice } from "@/lib/types";
+import type { DocumentPdfLayout, Estimate, Invoice } from "@/lib/types";
 
 interface Props {
   document: Estimate | Invoice;
-  preset: PdfPreset;
+  layout: DocumentPdfLayout;
 }
 
 function fmt(n: number): string {
   return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
 }
 
-export function TotalsBlock({ document: doc, preset }: Props) {
+export function TotalsBlock({ document: doc, layout }: Props) {
   const subtotal = Number(doc.subtotal);
   const markupAmt = Number(doc.markup_amount);
   const discountAmt = Number(doc.discount_amount);
@@ -30,25 +30,25 @@ export function TotalsBlock({ document: doc, preset }: Props) {
         <Text>Subtotal</Text>
         <Text>{fmt(subtotal)}</Text>
       </View>
-      {preset.show_markup && markupAmt !== 0 && (
+      {layout.show_markup && markupAmt !== 0 && (
         <View style={styles.totalsRow}>
           <Text>Markup</Text>
           <Text>{fmt(markupAmt)}</Text>
         </View>
       )}
-      {preset.show_discount && discountAmt !== 0 && (
+      {layout.show_discount && discountAmt !== 0 && (
         <View style={styles.totalsRow}>
           <Text>Discount</Text>
           <Text>−{fmt(Math.abs(discountAmt))}</Text>
         </View>
       )}
-      {(preset.show_markup && markupAmt !== 0) || (preset.show_discount && discountAmt !== 0) ? (
+      {(layout.show_markup && markupAmt !== 0) || (layout.show_discount && discountAmt !== 0) ? (
         <View style={styles.totalsRow}>
           <Text>Adjusted Subtotal</Text>
           <Text>{fmt(adjusted)}</Text>
         </View>
       ) : null}
-      {preset.show_tax && (
+      {layout.show_tax && (
         <View style={styles.totalsRow}>
           <Text>Tax ({taxRate.toFixed(2)}%)</Text>
           <Text>{fmt(taxAmt)}</Text>

--- a/src/lib/pdf-renderer/estimate-pdf.tsx
+++ b/src/lib/pdf-renderer/estimate-pdf.tsx
@@ -14,22 +14,26 @@ import type { RenderInput } from "@/lib/pdf-renderer/types";
 type Input = Extract<RenderInput, { kind: "estimate" }>;
 
 export function EstimatePdf(input: Input) {
-  const { document, sections, lineItems, preset, company, recipient, jobNumber } = input;
+  const { document, sections, lineItems, layout, company, recipient, jobNumber } = input;
   return (
     <Document>
       <Page size="LETTER" style={styles.page}>
-        <PageHeader documentTitle={preset.document_title} logoUrl={company.logo_url} />
+        <PageHeader
+          documentTitle={layout.document_title}
+          showDocumentTitle={layout.show_document_title}
+          logoUrl={company.logo_url}
+        />
         <View style={styles.twoCol}>
           <CompanyBlock company={company} />
           <RecipientBlock recipient={recipient} />
         </View>
         <DocumentDetails document={document} kind="estimate" />
-        {preset.show_opening_statement && (
+        {layout.show_opening_statement && (
           <StatementBlock html={document.opening_statement} />
         )}
-        <SectionsTable sections={sections} lineItems={lineItems} preset={preset} />
-        <TotalsBlock document={document} preset={preset} />
-        {preset.show_closing_statement && (
+        <SectionsTable sections={sections} lineItems={lineItems} layout={layout} />
+        <TotalsBlock document={document} layout={layout} />
+        {layout.show_closing_statement && (
           <StatementBlock html={document.closing_statement} />
         )}
         <PageFooter jobNumber={jobNumber} />

--- a/src/lib/pdf-renderer/invoice-pdf.tsx
+++ b/src/lib/pdf-renderer/invoice-pdf.tsx
@@ -14,22 +14,26 @@ import type { RenderInput } from "@/lib/pdf-renderer/types";
 type Input = Extract<RenderInput, { kind: "invoice" }>;
 
 export function InvoicePdf(input: Input) {
-  const { document, sections, lineItems, preset, company, recipient, jobNumber } = input;
+  const { document, sections, lineItems, layout, company, recipient, jobNumber } = input;
   return (
     <Document>
       <Page size="LETTER" style={styles.page}>
-        <PageHeader documentTitle={preset.document_title} logoUrl={company.logo_url} />
+        <PageHeader
+          documentTitle={layout.document_title}
+          showDocumentTitle={layout.show_document_title}
+          logoUrl={company.logo_url}
+        />
         <View style={styles.twoCol}>
           <CompanyBlock company={company} />
           <RecipientBlock recipient={recipient} />
         </View>
         <DocumentDetails document={document} kind="invoice" />
-        {preset.show_opening_statement && (
+        {layout.show_opening_statement && (
           <StatementBlock html={document.opening_statement} />
         )}
-        <SectionsTable sections={sections} lineItems={lineItems} preset={preset} />
-        <TotalsBlock document={document} preset={preset} />
-        {preset.show_closing_statement && (
+        <SectionsTable sections={sections} lineItems={lineItems} layout={layout} />
+        <TotalsBlock document={document} layout={layout} />
+        {layout.show_closing_statement && (
           <StatementBlock html={document.closing_statement} />
         )}
         <PageFooter jobNumber={jobNumber} />

--- a/src/lib/pdf-renderer/render-and-upload.ts
+++ b/src/lib/pdf-renderer/render-and-upload.ts
@@ -9,6 +9,7 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServiceClient } from "@/lib/supabase-api";
 import { getPreset } from "@/lib/pdf-presets";
+import { resolveEffectiveLayout } from "@/lib/pdf-layout";
 import { renderPdf } from "@/lib/pdf-renderer/render";
 import { estimatePdfPath, invoicePdfPath } from "@/lib/storage/paths";
 import type {
@@ -159,6 +160,11 @@ export async function renderEstimatePdfBuffer(
     throw new PdfRenderInputError("preset document_type mismatch", 400);
   }
 
+  // Per-document look (ADR 0012): the document's own snapshot wins; else this
+  // org-default preset; else field defaults. A document with no layout resolves
+  // every field from the preset, so its output stays byte-identical (#482).
+  const layout = resolveEffectiveLayout(doc.pdf_layout, preset);
+
   const service = createServiceClient();
   const company = await loadCompany(service, orgId);
   const { recipient, jobNumber } = await loadRecipient(service, doc.job_id);
@@ -168,7 +174,7 @@ export async function renderEstimatePdfBuffer(
     document: doc,
     sections: (sections ?? []) as EstimateSection[],
     lineItems: (lineItems ?? []) as EstimateLineItem[],
-    preset,
+    layout,
     company,
     recipient,
     jobNumber,
@@ -239,6 +245,11 @@ export async function renderInvoicePdfBuffer(
     throw new PdfRenderInputError("preset document_type mismatch", 400);
   }
 
+  // Per-document look (ADR 0012): the document's own snapshot wins; else this
+  // org-default preset; else field defaults. A document with no layout resolves
+  // every field from the preset, so its output stays byte-identical (#482).
+  const layout = resolveEffectiveLayout(doc.pdf_layout, preset);
+
   const service = createServiceClient();
   const company = await loadCompany(service, orgId);
   const { recipient, jobNumber } = await loadRecipient(service, doc.job_id);
@@ -248,7 +259,7 @@ export async function renderInvoicePdfBuffer(
     document: doc,
     sections: (sections ?? []) as InvoiceSection[],
     lineItems: (lineItems ?? []) as InvoiceLineItem[],
-    preset,
+    layout,
     company,
     recipient,
     jobNumber,

--- a/src/lib/pdf-renderer/types.ts
+++ b/src/lib/pdf-renderer/types.ts
@@ -1,7 +1,7 @@
 // src/lib/pdf-renderer/types.ts — typed inputs for the renderer.
 
 import type {
-  PdfPreset, Estimate, Invoice, EstimateSection, EstimateLineItem,
+  DocumentPdfLayout, Estimate, Invoice, EstimateSection, EstimateLineItem,
   InvoiceSection, InvoiceLineItem,
 } from "@/lib/types";
 
@@ -27,7 +27,7 @@ export type RenderInput =
       document: Estimate;
       sections: EstimateSection[];
       lineItems: EstimateLineItem[];
-      preset: PdfPreset;
+      layout: DocumentPdfLayout;
       company: PdfCompany;
       recipient: PdfRecipient;
       jobNumber: string;
@@ -37,7 +37,7 @@ export type RenderInput =
       document: Invoice;
       sections: InvoiceSection[];
       lineItems: InvoiceLineItem[];
-      preset: PdfPreset;
+      layout: DocumentPdfLayout;
       company: PdfCompany;
       recipient: PdfRecipient;
       jobNumber: string;

--- a/src/lib/sample-pdf-data.ts
+++ b/src/lib/sample-pdf-data.ts
@@ -5,6 +5,7 @@ import type {
   Invoice, InvoiceSection, InvoiceLineItem,
 } from "@/lib/types";
 import type { PdfCompany, PdfRecipient } from "@/lib/pdf-renderer/types";
+import { resolveEffectiveLayout } from "@/lib/pdf-layout";
 
 export const SAMPLE_COMPANY: PdfCompany = {
   name: "Sample Company LLC",
@@ -68,6 +69,7 @@ export function buildSampleEstimate(orgId: string): {
     last_sent_to_email: null,
     deleted_at: null,
     delete_reason: null,
+    pdf_layout: null,
   };
   const sections: EstimateSection[] = [{
     id: secId,
@@ -166,6 +168,7 @@ export function buildSampleInvoice(orgId: string): {
     last_sent_to_email: null,
     deleted_at: null,
     delete_reason: null,
+    pdf_layout: null,
   };
   const sections: InvoiceSection[] = [{
     id: secId,
@@ -219,12 +222,15 @@ export function buildSampleInvoice(orgId: string): {
 }
 
 export function buildSampleInput(preset: PdfPreset, orgId: string) {
+  // The preset preview shows the preset's own look: resolve it as the effective
+  // layout with no per-document override (preset → field defaults).
+  const layout = resolveEffectiveLayout(null, preset);
   if (preset.document_type === "estimate") {
     const sample = buildSampleEstimate(orgId);
     return {
       kind: "estimate" as const,
       ...sample,
-      preset,
+      layout,
       company: SAMPLE_COMPANY,
       recipient: SAMPLE_RECIPIENT,
       jobNumber: SAMPLE_JOB_NUMBER,
@@ -234,7 +240,7 @@ export function buildSampleInput(preset: PdfPreset, orgId: string) {
   return {
     kind: "invoice" as const,
     ...sample,
-    preset,
+    layout,
     company: SAMPLE_COMPANY,
     recipient: SAMPLE_RECIPIENT,
     jobNumber: SAMPLE_JOB_NUMBER,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -141,6 +141,8 @@ export interface Invoice {
   last_sent_to_email: string | null;
   deleted_at: string | null;
   delete_reason: string | null;
+  /** Per-document PDF layout snapshot; NULL = fall back to the org default preset (#482). */
+  pdf_layout: DocumentPdfLayout | null;
 }
 
 export interface Payment {
@@ -657,6 +659,8 @@ export interface Estimate {
   last_sent_to_email: string | null;
   deleted_at: string | null;
   delete_reason: string | null;
+  /** Per-document PDF layout snapshot; NULL = fall back to the org default preset (#482). */
+  pdf_layout: DocumentPdfLayout | null;
 }
 
 export interface EstimateSection {
@@ -769,6 +773,29 @@ export type PdfPresetCreatePayload = Pick<
 export type PdfPresetUpdatePayload = Partial<Omit<PdfPreset,
   "id" | "organization_id" | "created_by" | "created_at" | "updated_at" | "document_type"
 >>;
+
+// ─── PDF layout (per-document snapshot) — #482 / ADR 0012 ──────────────────
+//
+// A document's *PDF layout* is a self-contained snapshot of the look it renders
+// with — a snapshot, NOT a reference to a preset (ADR 0012). It carries the
+// same eight toggles a PdfPreset does, plus `show_document_title`: the ninth
+// toggle, new in #482 (today the title renders unconditionally). `show_item_notes`
+// reuses #382's field name rather than adding a parallel flag.
+//
+// A NULL `pdf_layout` column means "no layout of its own; fall back to the
+// Organization's default preset" — see `resolveEffectiveLayout` in pdf-layout.ts.
+export interface DocumentPdfLayout {
+  document_title: string;
+  show_document_title: boolean;
+  show_markup: boolean;
+  show_discount: boolean;
+  show_tax: boolean;
+  show_opening_statement: boolean;
+  show_closing_statement: boolean;
+  show_category_subtotals: boolean;
+  show_code_column: boolean;
+  show_item_notes: boolean;
+}
 
 // =============================================================================
 // 67b — invoices, templates, builder entity union

--- a/supabase/migration-482-pdf-layout-column.sql
+++ b/supabase/migration-482-pdf-layout-column.sql
@@ -1,0 +1,20 @@
+-- Issue #482 — Per-document PDF layout snapshot column.
+--
+-- ADR 0012 (a document's PDF layout is a per-document snapshot, resolved by
+-- precedence): each of `estimates` and `invoices` gains a nullable `pdf_layout`
+-- JSONB column holding the document's own complete look — all nine show/hide
+-- switches plus the editable document-title text.
+--
+--   NULL  = "this document has no layout of its own; render from the
+--            Organization's default preset" (the precedence fallback in
+--            src/lib/pdf-layout.ts → resolveEffectiveLayout).
+--   {...} = a complete DocumentPdfLayout snapshot, seeded from the effective
+--            look the first time a switch is flipped, and from then on the
+--            document follows only itself (snapshot, not a preset_id reference).
+--
+-- Both changes are additive and safe: a new nullable column with no default, so
+-- every existing document keeps NULL and renders byte-identically from the
+-- default preset (parity preserved — no backfill, no data rewrite).
+
+ALTER TABLE estimates ADD COLUMN IF NOT EXISTS pdf_layout jsonb;
+ALTER TABLE invoices  ADD COLUMN IF NOT EXISTS pdf_layout jsonb;


### PR DESCRIPTION
## What

A live single-toggle layout panel on the Estimate View (#483), sitting on the per-document PDF layout snapshot foundation (#482, ADR 0012).

Closes #483. Implements the #482 foundation it depends on.

## #482 — per-document PDF layout snapshot + precedence (ADR 0012)

Documents carry their own **complete** `pdf_layout` snapshot (not a reference to the org preset), resolved per-field at render time.

- `pdf-layout.ts`: `isLayoutLocked` predicate, `resolveEffectiveLayout` precedence engine (document snapshot › org preset › field default), `parseLayoutPayload` validator (complete `DocumentPdfLayout` or `null`)
- `DocumentPdfLayout` type + nullable `pdf_layout` on `Estimate`/`Invoice`
- PDF renderer rewired (page-header, sections-table, totals-block, estimate-pdf, invoice-pdf, render-and-upload) to the resolved layout
- Migration: additive, idempotent, nullable `pdf_layout jsonb` on `estimates` + `invoices`

## #483 — live layout panel (tracer bullet)

A minimal panel with just the **Show markup** switch over the live PDF preview.

- `PATCH /api/estimates/[id]/layout`: gated by `edit_estimates`; refuses a frozen (converted) estimate (409) or trashed/missing one (404); validates the body into a complete `DocumentPdfLayout` (400); writes `pdf_layout`
- `LiveLayoutPanel`: owns the toggle + preview behind one shared `version` so a successful save drives the live iframe re-render (cache-bust param + key remount). Reopening restores toggle state. Read-only when frozen or without the edit grant. Debounced autosave (no save button) with **optimistic rollback on failure** and **keepalive flush on unmount + `pagehide`** (mirrors #461/#477).
- Wired into the Estimate View, resolving the effective layout server-side (ADR 0012 precedence) and locking on converted/trashed.

Estimates-only by design.

## Migration — already applied to AAA prod

```sql
ALTER TABLE estimates ADD COLUMN IF NOT EXISTS pdf_layout jsonb;
ALTER TABLE invoices  ADD COLUMN IF NOT EXISTS pdf_layout jsonb;
```

Applied + verified live on `rzzprgidqbnqcdupmpfe` (both columns `jsonb`, `nullable`). Additive — existing rows stay `NULL` and render identically from the default preset.

## Testing

Strict TDD (red→green per vertical slice).

- Slice tests: **29 passed** — 10 panel + 7 route + 12 pdf-layout core
- `tsc --noEmit`: **0 new errors**; holds at the pre-existing 13-error `tests/integration/*.pg.test.ts` baseline
- Adversarial review (15-agent workflow, refute-by-default): 3 confirmed findings, all fixed via TDD (rollback-on-failure, unmount/`pagehide` keepalive flush, coalescing regression lock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)