### PR TITLE
feat(viewer): scroll-spy active-page sync + pure page-picker reducer (#466)

### DIFF
--- a/src/components/documents/pdf-document-viewer.test.tsx
+++ b/src/components/documents/pdf-document-viewer.test.tsx
@@ -8,7 +8,7 @@ import { render, screen, act, fireEvent } from "@testing-library/react";
 // it, and the page `children` once loaded. `vi.hoisted` lets the hoisted
 // vi.mock factory reference these capture/control objects without a
 // temporal-dead-zone error.
-const { documentCalls, pdf } = vi.hoisted(() => {
+const { documentCalls, pdf, io } = vi.hoisted(() => {
   // Reassigned by the latest mounted <Document> mock, so a retry remount wins.
   // The no-op placeholders take no args (assignable to the declared signature),
   // which keeps the typed `resolve(n)` call site honest without an unused param.
@@ -16,7 +16,35 @@ const { documentCalls, pdf } = vi.hoisted(() => {
     resolve: () => {},
     fail: () => {},
   };
-  return { documentCalls: [] as Array<Record<string, unknown>>, pdf };
+  // Drives the scroll-spy IntersectionObserver (#466). The viewer observes each
+  // page node; the stubbed observer records the callback + observed nodes here,
+  // and `io.fire` synthesises entries from a { pageNumber: ratio } map so a test
+  // can say "page 2 is now the most-visible" without a real layout engine.
+  const io: {
+    cb:
+      | ((
+          entries: Array<{
+            target: Element;
+            isIntersecting: boolean;
+            intersectionRatio: number;
+          }>,
+        ) => void)
+      | null;
+    observed: Element[];
+    fire: (ratios: Record<number, number>) => void;
+  } = {
+    cb: null,
+    observed: [],
+    fire: (ratios) => {
+      const entries = io.observed.map((target) => {
+        const pageNumber = Number(target.getAttribute("data-page-number"));
+        const ratio = ratios[pageNumber] ?? 0;
+        return { target, isIntersecting: ratio > 0, intersectionRatio: ratio };
+      });
+      io.cb?.(entries);
+    },
+  };
+  return { documentCalls: [] as Array<Record<string, unknown>>, pdf, io };
 });
 
 vi.mock("react-pdf", async () => {
@@ -116,6 +144,41 @@ beforeEach(() => {
     unobserve() {}
     disconnect() {}
   };
+  // jsdom has no IntersectionObserver either. Scroll-spy (#466) observes each
+  // page node and marks the most-visible one active; the stub captures the
+  // viewer's callback and observed nodes into `io` so a test can drive
+  // intersection ratios with `io.fire({ page: ratio })`.
+  io.cb = null;
+  io.observed = [];
+  globalThis.IntersectionObserver = class {
+    constructor(
+      cb: (
+        entries: Array<{
+          target: Element;
+          isIntersecting: boolean;
+          intersectionRatio: number;
+        }>,
+      ) => void,
+    ) {
+      io.cb = cb;
+      io.observed = [];
+    }
+    observe(el: Element) {
+      io.observed.push(el);
+    }
+    unobserve(el: Element) {
+      io.observed = io.observed.filter((node) => node !== el);
+    }
+    disconnect() {
+      io.observed = [];
+    }
+    takeRecords() {
+      return [];
+    }
+    root = null;
+    rootMargin = "";
+    thresholds = [];
+  } as unknown as typeof IntersectionObserver;
 });
 
 describe("PdfDocumentViewer", () => {
@@ -298,7 +361,8 @@ describe("PdfDocumentViewer", () => {
 
   it("labels each thumbnail with its page position for screen readers", () => {
     // #465: react-pdf's Page drops aria-label, so the accessible name has to
-    // come from the Thumbnail's content — an sr-only "Page N of M" label.
+    // come from the Thumbnail's content — an sr-only "Page N of M" label. #466
+    // appends ", current page" to whichever page is active (page 1 on load).
     render(
       <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
     );
@@ -306,7 +370,9 @@ describe("PdfDocumentViewer", () => {
       pdf.resolve(7);
     });
 
-    expect(screen.getByRole("link", { name: "Page 1 of 7" })).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: "Page 1 of 7, current page" }),
+    ).toBeDefined();
     expect(screen.getByRole("link", { name: "Page 3 of 7" })).toBeDefined();
     expect(screen.getByRole("link", { name: "Page 7 of 7" })).toBeDefined();
   });
@@ -380,5 +446,209 @@ describe("PdfDocumentViewer", () => {
     );
 
     expect(vi.mocked(configurePdfjs)).toHaveBeenCalled();
+  });
+
+  it("marks the first page as the active thumbnail once the document loads", () => {
+    // #466: the picker always has exactly one active page; before the reader
+    // scrolls or picks, that is page 1. Active state is exposed as aria-current
+    // on the thumbnail's wrapper so it is both visible and announced.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    expect(
+      screen.getByTestId("pdf-thumb-1").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-3").closest('[aria-current="page"]'),
+    ).toBeNull();
+  });
+
+  it("announces the active page as the current page in its accessible name", () => {
+    // #466: react-pdf forwards only className/onItemClick to the thumbnail's <a>,
+    // so aria-current on the wrapper is never inherited by the link a keyboard /
+    // screen-reader user actually focuses. The current-page state therefore has
+    // to ride the link's own accessible name, so AT users hear it too — not just
+    // sighted users who see the ring.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    // Page 1 is active on load: its link announces that it is current.
+    expect(
+      screen.getByRole("link", { name: "Page 1 of 3, current page" }),
+    ).toBeDefined();
+    // Non-active pages announce only their position.
+    expect(screen.getByRole("link", { name: "Page 2 of 3" })).toBeDefined();
+    expect(
+      screen.queryByRole("link", { name: "Page 2 of 3, current page" }),
+    ).toBeNull();
+  });
+
+  it("tracks the most-visible page as the reader scrolls, marking its thumbnail active", () => {
+    // #466 core behavior: scroll-spy is an IntersectionObserver binding that maps
+    // whichever page element is most visible in the pane to the active page. We
+    // drive the observer directly with intersection ratios — no real layout — and
+    // assert the active marker follows the dominant page.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    // Page 2 now dominates the viewport: it becomes the active thumbnail.
+    act(() => {
+      io.fire({ 1: 0.1, 2: 0.9, 3: 0 });
+    });
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-1").closest('[aria-current="page"]'),
+    ).toBeNull();
+
+    // Scrolling on so page 3 dominates moves the active marker along with it.
+    act(() => {
+      io.fire({ 1: 0, 2: 0.2, 3: 0.85 });
+    });
+    expect(
+      screen.getByTestId("pdf-thumb-3").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).toBeNull();
+  });
+
+  it("breaks an equal-visibility tie toward the lower page so the marker never jitters", () => {
+    // #466: when two pages straddle the fold equally, the active marker must
+    // settle deterministically rather than flicker between them. The lower page
+    // number wins.
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    act(() => {
+      io.fire({ 1: 0, 2: 0.5, 3: 0.5 });
+    });
+
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-3").closest('[aria-current="page"]'),
+    ).toBeNull();
+  });
+
+  it("marks a clicked thumbnail active immediately, not just after the scroll settles", () => {
+    // #466: a thumbnail click jumps to that page (smooth scroll) AND makes it the
+    // active page right away, so the highlight tracks the reader's intent without
+    // waiting for scroll-spy to catch up. jsdom has no scrollIntoView, so stub it.
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: function () {},
+    });
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByTestId("pdf-thumb-3"));
+    });
+
+    expect(
+      screen.getByTestId("pdf-thumb-3").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("pdf-thumb-1").closest('[aria-current="page"]'),
+    ).toBeNull();
+  });
+
+  it("moves the active page up and down the rail with the arrow keys, scrolling the document to each", () => {
+    // #466: the rail is keyboard-navigable — ArrowDown/ArrowUp step the active
+    // page through the document AND scroll the pane to the page they land on
+    // (criterion 4, "the document scrolls accordingly"). jsdom has no
+    // scrollIntoView, so record which page node each step scrolls to.
+    const scrolledPages: Array<string | null> = [];
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: function (this: HTMLElement) {
+        scrolledPages.push(this.getAttribute("data-page-number"));
+      },
+    });
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    const rail = screen.getByRole("navigation", { name: /page thumbnails/i });
+
+    act(() => {
+      fireEvent.keyDown(rail, { key: "ArrowDown" });
+    });
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      fireEvent.keyDown(rail, { key: "ArrowDown" });
+    });
+    expect(
+      screen.getByTestId("pdf-thumb-3").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      fireEvent.keyDown(rail, { key: "ArrowUp" });
+    });
+    expect(
+      screen.getByTestId("pdf-thumb-2").closest('[aria-current="page"]'),
+    ).not.toBeNull();
+
+    // Each arrow step scrolled the pane to the page it landed on.
+    expect(scrolledPages).toEqual(["2", "3", "2"]);
+  });
+
+  it("moves keyboard focus onto the thumbnail it steps to without a competing scroll", () => {
+    // #466: arrow-key nav must carry focus to the page it lands on, so a keyboard
+    // reader is never stranded on the thumbnail they just left. The focus call
+    // must opt out of the browser's instant focus-scroll (preventScroll) so it
+    // doesn't fight the smooth scrollIntoView that the same keypress kicks off.
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: function () {},
+    });
+    const focusSpy = vi.spyOn(HTMLElement.prototype, "focus");
+    render(
+      <PdfDocumentViewer src="/api/estimates/abc/preview" title="Estimate WTR-1" />,
+    );
+    act(() => {
+      pdf.resolve(3);
+    });
+
+    const rail = screen.getByRole("navigation", { name: /page thumbnails/i });
+    act(() => {
+      fireEvent.keyDown(rail, { key: "ArrowDown" });
+    });
+
+    expect(document.activeElement).toBe(screen.getByTestId("pdf-thumb-2"));
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    focusSpy.mockRestore();
   });
 });

--- a/src/components/documents/pdf-document-viewer.tsx
+++ b/src/components/documents/pdf-document-viewer.tsx
@@ -1,9 +1,21 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { Document, Page, Thumbnail } from "react-pdf";
 import { configurePdfjs } from "@/lib/pdf/configure-pdfjs";
 import { computePaneWidths } from "@/lib/pdf/compute-pane-widths";
+import {
+  initialPagePickerState,
+  pagePickerReducer,
+  type PagePickerAction,
+} from "@/lib/pdf/page-picker-reducer";
 
 // ADR 0013 constraint 1: the /preview routes stream a whole-buffer 200 with no
 // Accept-Ranges, so the viewer disables Range/stream negotiation — otherwise
@@ -26,8 +38,18 @@ interface PdfDocumentViewerProps {
 }
 
 export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
-  const [numPages, setNumPages] = useState(0);
+  // The page-picker reducer is the single source of truth for which page is
+  // active. Scroll-spy, thumbnail clicks, and keyboard nav all dispatch into it,
+  // so they can never disagree (#466). numPages also lives here so a Retry that
+  // reloads a shorter document re-clamps the active page in one place.
+  const [{ numPages, activePage }, dispatch] = useReducer(
+    pagePickerReducer,
+    initialPagePickerState,
+  );
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // The thumbnail rail, so keyboard nav can move focus to the newly active
+  // thumbnail (its anchors carry the react-pdf__Thumbnail class).
+  const railRef = useRef<HTMLElement | null>(null);
   // Each rendered Page registers its DOM node here keyed by page number, so a
   // thumbnail click can scroll straight to it (react-pdf's Page drops refs
   // through inputRef, not a plain ref).
@@ -54,6 +76,44 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
     return () => ro.disconnect();
   }, []);
 
+  // Scroll-spy (#466): watch every page node and keep the active page pinned to
+  // whichever one is most visible in the pane, so the rail's highlight tracks
+  // the reader's scroll position. We reverse-map each observed node back to its
+  // page via data-page-number, hold the latest visible ratio per page, and
+  // dispatch the page with the largest one (ties favour the lower page so the
+  // marker never jitters between two equally-visible pages). Keyed on numPages
+  // so the observer re-binds to the freshly mounted page nodes after a (re)load.
+  useEffect(() => {
+    if (numPages < 1) return;
+    const ratios = new Map<number, number>();
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          const pageNumber = Number(
+            entry.target.getAttribute("data-page-number"),
+          );
+          if (!pageNumber) continue;
+          ratios.set(
+            pageNumber,
+            entry.isIntersecting ? entry.intersectionRatio : 0,
+          );
+        }
+        let best = 0;
+        let bestRatio = 0;
+        for (const [pageNumber, ratio] of ratios) {
+          if (ratio > bestRatio) {
+            best = pageNumber;
+            bestRatio = ratio;
+          }
+        }
+        if (best > 0) dispatch({ type: "setActivePage", page: best });
+      },
+      { threshold: [0, 0.25, 0.5, 0.75, 1] },
+    );
+    for (const node of pageNodes.current.values()) observer.observe(node);
+    return () => observer.disconnect();
+  }, [numPages]);
+
   // #465: the viewer splits into a slim page-picker rail (~¼) and a page pane
   // that fills the rest. The rail collapses when the reader closes it, for a
   // single-page document (nothing to pick), or below the narrow breakpoint.
@@ -74,6 +134,42 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
       ?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
+  // A deliberate jump to a page (thumbnail click, keyboard nav): mark it active
+  // straight away so the highlight tracks intent, then scroll it into view.
+  // Scroll-spy will re-confirm the same page once the smooth scroll settles, so
+  // the two paths agree rather than fight.
+  const goToPage = (pageNumber: number) => {
+    dispatch({ type: "setActivePage", page: pageNumber });
+    scrollToPage(pageNumber);
+  };
+
+  // Move keyboard focus to a thumbnail's anchor so arrow-key nav lands the
+  // reader on the page they stepped to (anchors carry react-pdf__Thumbnail).
+  // preventScroll: the same keypress already runs a smooth scrollIntoView on the
+  // page; letting .focus() also scroll its ancestors (instantly) would yank the
+  // pane mid-animation, so we leave all scrolling to scrollToPage.
+  const focusThumbnail = (pageNumber: number) => {
+    railRef.current
+      ?.querySelectorAll<HTMLElement>("a.react-pdf__Thumbnail")
+      [pageNumber - 1]?.focus({ preventScroll: true });
+  };
+
+  // Arrow-key navigation within the rail. We run the same pure reducer the rest
+  // of the picker uses to predict where the move lands (so clamping at the first
+  // and last page is defined in exactly one place), then dispatch it and bring
+  // that page + its thumbnail into view/focus.
+  const onRailKeyDown = (e: ReactKeyboardEvent<HTMLElement>) => {
+    let action: PagePickerAction | null = null;
+    if (e.key === "ArrowDown") action = { type: "next" };
+    else if (e.key === "ArrowUp") action = { type: "prev" };
+    if (!action) return;
+    e.preventDefault();
+    const target = pagePickerReducer({ numPages, activePage }, action).activePage;
+    dispatch(action);
+    scrollToPage(target);
+    focusThumbnail(target);
+  };
+
   return (
     <div ref={containerRef} className="flex w-full flex-col gap-3 py-6">
       {canHostRail && (
@@ -92,7 +188,9 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
         key={reloadKey}
         file={src}
         options={DOCUMENT_OPTIONS}
-        onLoadSuccess={({ numPages }) => setNumPages(numPages)}
+        onLoadSuccess={({ numPages }) =>
+          dispatch({ type: "setNumPages", numPages })
+        }
         loading={
           <div className="text-muted-foreground py-12">Loading document…</div>
         }
@@ -114,7 +212,9 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
         <div className="flex w-full gap-4">
           {railWidth > 0 && (
             <nav
+              ref={railRef}
               aria-label="Page thumbnails"
+              onKeyDown={onRailKeyDown}
               style={{
                 width: `${railWidth}px`,
                 maxHeight: "80vh",
@@ -122,17 +222,38 @@ export default function PdfDocumentViewer({ src }: PdfDocumentViewerProps) {
               }}
               className="sticky top-0 flex shrink-0 flex-col items-center gap-3 px-2"
             >
-              {Array.from({ length: numPages }, (_, i) => (
-                <Thumbnail
-                  key={i + 1}
-                  pageNumber={i + 1}
-                  width={thumbnailWidth}
-                  className="rounded border border-border"
-                  onItemClick={({ pageNumber }) => scrollToPage(pageNumber)}
-                >
-                  <span className="sr-only">{`Page ${i + 1} of ${numPages}`}</span>
-                </Thumbnail>
-              ))}
+              {Array.from({ length: numPages }, (_, i) => {
+                const pageNumber = i + 1;
+                const isActive = pageNumber === activePage;
+                return (
+                  // The visible active ring rides a wrapper, since react-pdf
+                  // forwards only className/onItemClick to its <a>. aria-current
+                  // on a generic wrapper is not announced on the link a keyboard /
+                  // SR user focuses, so the "current page" state is also folded
+                  // into the link's own accessible name (its sr-only label) — that
+                  // is what AT actually reads when focus lands on the thumbnail.
+                  <div
+                    key={pageNumber}
+                    aria-current={isActive ? "page" : undefined}
+                    className={`rounded ${
+                      isActive ? "ring-2 ring-primary ring-offset-2" : ""
+                    }`.trim()}
+                  >
+                    <Thumbnail
+                      pageNumber={pageNumber}
+                      width={thumbnailWidth}
+                      className="rounded border border-border"
+                      onItemClick={({ pageNumber }) => goToPage(pageNumber)}
+                    >
+                      <span className="sr-only">
+                        {`Page ${pageNumber} of ${numPages}${
+                          isActive ? ", current page" : ""
+                        }`}
+                      </span>
+                    </Thumbnail>
+                  </div>
+                );
+              })}
             </nav>
           )}
           <div className="flex min-w-0 flex-1 flex-col items-center gap-6">

--- a/src/lib/pdf/page-picker-reducer.test.ts
+++ b/src/lib/pdf/page-picker-reducer.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  pagePickerReducer,
+  initialPagePickerState,
+} from "./page-picker-reducer";
+
+describe("pagePickerReducer", () => {
+  it("setActivePage moves the active page to a page inside the range", () => {
+    const state = { numPages: 5, activePage: 1 };
+
+    const next = pagePickerReducer(state, { type: "setActivePage", page: 3 });
+
+    expect(next.activePage).toBe(3);
+  });
+
+  it("setActivePage clamps a page past the end down to the last page", () => {
+    const state = { numPages: 5, activePage: 1 };
+
+    const next = pagePickerReducer(state, { type: "setActivePage", page: 9 });
+
+    expect(next.activePage).toBe(5);
+  });
+
+  it("setActivePage clamps a page before the start up to the first page", () => {
+    const state = { numPages: 5, activePage: 3 };
+
+    const next = pagePickerReducer(state, { type: "setActivePage", page: 0 });
+
+    expect(next.activePage).toBe(1);
+  });
+
+  it("next advances to the following page", () => {
+    const state = { numPages: 5, activePage: 2 };
+
+    const next = pagePickerReducer(state, { type: "next" });
+
+    expect(next.activePage).toBe(3);
+  });
+
+  it("next on the last page stays on the last page", () => {
+    const state = { numPages: 5, activePage: 5 };
+
+    const next = pagePickerReducer(state, { type: "next" });
+
+    expect(next.activePage).toBe(5);
+  });
+
+  it("prev steps back to the previous page", () => {
+    const state = { numPages: 5, activePage: 3 };
+
+    const next = pagePickerReducer(state, { type: "prev" });
+
+    expect(next.activePage).toBe(2);
+  });
+
+  it("prev on the first page stays on the first page", () => {
+    const state = { numPages: 5, activePage: 1 };
+
+    const next = pagePickerReducer(state, { type: "prev" });
+
+    expect(next.activePage).toBe(1);
+  });
+
+  describe("single-page document", () => {
+    const single = { numPages: 1, activePage: 1 };
+
+    it("next cannot leave the only page", () => {
+      expect(pagePickerReducer(single, { type: "next" }).activePage).toBe(1);
+    });
+
+    it("prev cannot leave the only page", () => {
+      expect(pagePickerReducer(single, { type: "prev" }).activePage).toBe(1);
+    });
+
+    it("setActivePage to any number resolves to the only page", () => {
+      expect(
+        pagePickerReducer(single, { type: "setActivePage", page: 4 }).activePage,
+      ).toBe(1);
+    });
+  });
+
+  describe("before the page count is known", () => {
+    // initialPagePickerState starts with numPages: 0 — the document has not
+    // reported its length yet, so there is no range to navigate within.
+    it("starts on page 1 with no known count", () => {
+      expect(initialPagePickerState).toEqual({ numPages: 0, activePage: 1 });
+    });
+
+    it("setActivePage holds on page 1 until the count is known", () => {
+      expect(
+        pagePickerReducer(initialPagePickerState, {
+          type: "setActivePage",
+          page: 5,
+        }).activePage,
+      ).toBe(1);
+    });
+
+    it("next holds on page 1 until the count is known", () => {
+      expect(
+        pagePickerReducer(initialPagePickerState, { type: "next" }).activePage,
+      ).toBe(1);
+    });
+  });
+
+  describe("setNumPages", () => {
+    it("records the page count the document reports", () => {
+      const next = pagePickerReducer(initialPagePickerState, {
+        type: "setNumPages",
+        numPages: 5,
+      });
+
+      expect(next.numPages).toBe(5);
+      expect(next.activePage).toBe(1);
+    });
+
+    it("pulls the active page back into range when the document shrinks", () => {
+      // A Retry can reload a document with fewer pages; the active page must not
+      // be left pointing past the new end.
+      const state = { numPages: 10, activePage: 8 };
+
+      const next = pagePickerReducer(state, { type: "setNumPages", numPages: 3 });
+
+      expect(next.numPages).toBe(3);
+      expect(next.activePage).toBe(3);
+    });
+  });
+});

--- a/src/lib/pdf/page-picker-reducer.ts
+++ b/src/lib/pdf/page-picker-reducer.ts
@@ -1,0 +1,63 @@
+// Issue #466 — Scroll-spy active-page sync, slice #4 of the in-app PDF viewer
+// (#462). The pure "page-picker brain": which page the viewer considers active,
+// and how that moves. It has no React in it on purpose — the viewer wraps
+// `pagePickerReducer` in `useReducer`, and scroll-spy, thumbnail clicks, and
+// keyboard nav all funnel through the same actions so they can never disagree on
+// the active page. Keeping the transitions here makes them trivially testable
+// (dispatch an action, assert the next state) without rendering pdf.js.
+
+/** Which page is active and how many pages the document has. */
+export interface PagePickerState {
+  /** Page count once the document reports it; 0 before it has loaded. */
+  numPages: number;
+  /** The page the picker currently considers active, 1-based. */
+  activePage: number;
+}
+
+export type PagePickerAction =
+  | { type: "setNumPages"; numPages: number }
+  | { type: "setActivePage"; page: number }
+  | { type: "next" }
+  | { type: "prev" };
+
+/** Before the document loads there is no count yet, and page 1 is active. */
+export const initialPagePickerState: PagePickerState = {
+  numPages: 0,
+  activePage: 1,
+};
+
+/**
+ * Pin a page into the valid `[1, numPages]` range. Before the count is known
+ * (`numPages < 1`) there is no range to land in, so every page resolves to the
+ * first — the picker can never point past a page that has not been reported yet.
+ */
+function clampPage(page: number, numPages: number): number {
+  if (numPages < 1) return 1;
+  return Math.min(numPages, Math.max(1, page));
+}
+
+export function pagePickerReducer(
+  state: PagePickerState,
+  action: PagePickerAction,
+): PagePickerState {
+  switch (action.type) {
+    case "setNumPages": {
+      // A reload can report a different (often smaller) count, so re-clamp the
+      // active page against the new range — it must never point past the end.
+      const numPages = Math.max(0, Math.floor(action.numPages));
+      return { numPages, activePage: clampPage(state.activePage, numPages) };
+    }
+    case "setActivePage":
+      return { ...state, activePage: clampPage(action.page, state.numPages) };
+    case "next":
+      return {
+        ...state,
+        activePage: clampPage(state.activePage + 1, state.numPages),
+      };
+    case "prev":
+      return {
+        ...state,
+        activePage: clampPage(state.activePage - 1, state.numPages),
+      };
+  }
+}


### PR DESCRIPTION
## What & why

Slice #4 of the in-app PDF viewer (#462). Makes the page-picker rail a **live position indicator**: as the reader scrolls the document pane, the most-visible page becomes the active page and its thumbnail is marked. Clicking a thumbnail (slice #3) and arrow-keying the rail also move the active page — so navigation works in both directions and every path stays in sync.

The active-page state is owned by a single **pure reducer** (`pagePickerReducer`), so clamping and navigation are deterministic and testable without rendering a PDF. Scroll-spy, thumbnail clicks, and keyboard nav all dispatch into it, so they can never disagree.

Closes #466. Built with `/tdd` (vertical RED→GREEN slices) and hardened by an adversarial multi-agent review (3 real findings fixed — see below).

## How it works

- **`src/lib/pdf/page-picker-reducer.ts`** — pure `{ numPages, activePage }` reducer: `setActivePage(n)` / `next()` / `prev()`, all clamped to `[1, numPages]`; `setNumPages` re-clamps the active page when a Retry reloads a shorter document. No React in it.
- **Scroll-spy** — an `IntersectionObserver` maps the most-visible page element back to its number (via `data-page-number`) and dispatches `setActivePage`. Ties favour the lower page so the marker never jitters; the observer re-binds to the freshly mounted page nodes on every (re)load.
- **Click & keyboard** — both dispatch through the reducer, then scroll the pane to the target. Keyboard (`ArrowUp`/`ArrowDown`) also moves focus onto the landed-on thumbnail, with `preventScroll` so the focus-scroll doesn't fight the smooth `scrollIntoView`.
- **Visible + announced active state** — the active thumbnail gets a `ring-2 ring-primary ring-offset-2` highlight, and ", current page" is folded into its link's accessible name (react-pdf forwards only `className` to the `<a>`, so the wrapper's `aria-current` alone isn't announced to assistive tech).
- **Both views** — inherited unchanged by the Estimate and Invoice Views through the shared `PdfPreviewFrame → PdfDocumentViewer`.

## Acceptance criteria

- [x] Scrolling updates which thumbnail is active, tracking the most-visible page, on both Estimate and Invoice views
- [x] Active thumbnail visibly distinguished (ring) **and** announced to AT
- [x] Pure reducer unit-tested: `setActivePage` clamp, `next`/`prev` range, single-page, before `numPages` is known
- [x] Keyboard user moves between pages (focus + arrow / Enter-on-link) and the document scrolls accordingly
- [x] Click-to-scroll and scroll-to-highlight stay consistent (one reducer is the source of truth)
- [x] New tests green; touched files add no new failures beyond the known-red baseline

## Tests

- `page-picker-reducer.test.ts` — 15 unit tests (clamp, next/prev, single-page, pre-count, shrink-on-reload)
- `pdf-document-viewer.test.tsx` — 22 tests (first-active, scroll-spy most-visible, tie-break, click-active, arrow-nav + scroll, focus + preventScroll, current-page announcement)
- 46/46 green across the documents + pdf-lib suites; `tsc --noEmit` and `eslint` clean on all touched files

## Review findings fixed

An adversarial review surfaced 3 confirmed issues, all fixed here:
1. **(test gap)** keyboard-nav test didn't assert the document actually scrolls — now records and asserts the scroll sequence.
2. **(a11y)** `aria-current` on a no-role wrapper isn't announced — current-page state now also rides the link's accessible name.
3. **(a11y/UX)** focus-move competed with the smooth scroll — now `focus({ preventScroll: true })`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
