### PR TITLE
feat(pdf-presets): apply preset as starting point + Save as preset (#486)

### DIFF
--- a/src/app/api/pdf-presets/route.test.ts
+++ b/src/app/api/pdf-presets/route.test.ts
@@ -14,16 +14,32 @@ vi.mock("@/lib/pdf-presets", () => ({
   createPreset: vi.fn(),
 }));
 
-import { GET } from "./route";
+import { GET, POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { listPresets } from "@/lib/pdf-presets";
+import { listPresets, createPreset } from "@/lib/pdf-presets";
 import {
   fakeUserClient,
   memberTables,
 } from "../email/__test-utils__/request-context-fakes";
+import type { PdfPreset } from "@/lib/types";
 
 const noParams = { params: Promise.resolve({}) };
+
+// A minimal valid create body — the three fields the route requires.
+const VALID_POST_BODY = {
+  name: "House Style",
+  document_type: "estimate",
+  document_title: "Estimate",
+};
+
+function postRequest(body: unknown): Request {
+  return new Request("http://test/api/pdf-presets", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -86,5 +102,74 @@ describe("GET /api/pdf-presets (converted to withRequestContext)", () => {
     const res = await GET(new Request("http://test/api/pdf-presets"), noParams);
 
     expect(res.status).toBe(200);
+  });
+});
+
+// #486 — "Save as preset" reuses this POST. Its manage_pdf_presets gate is the
+// server-side backstop for AC #4: an edit-only user is refused here even though
+// the UI also hides the control.
+describe("POST /api/pdf-presets — manage_pdf_presets gate (#486)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(postRequest(VALID_POST_BODY), noParams);
+
+    expect(res.status).toBe(401);
+    expect(createPreset).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for an edit-only user who lacks manage_pdf_presets", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["edit_estimates"],
+        }),
+      }) as never,
+    );
+
+    const res = await POST(postRequest(VALID_POST_BODY), noParams);
+
+    expect(res.status).toBe(403);
+    expect(createPreset).not.toHaveBeenCalled();
+  });
+
+  it("creates the preset for a non-admin holding manage_pdf_presets", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({
+          userId: "user-1",
+          role: "crew_member",
+          grants: ["manage_pdf_presets"],
+        }),
+      }) as never,
+    );
+    vi.mocked(createPreset).mockResolvedValue({ id: "preset-9" } as PdfPreset);
+
+    const res = await POST(postRequest(VALID_POST_BODY), noParams);
+
+    expect(res.status).toBe(201);
+    expect(createPreset).toHaveBeenCalledTimes(1);
+    expect(await res.json()).toEqual({ preset: { id: "preset-9" } });
+  });
+
+  it("allows an admin who holds no explicit grants", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "admin", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createPreset).mockResolvedValue({ id: "preset-admin" } as PdfPreset);
+
+    const res = await POST(postRequest(VALID_POST_BODY), noParams);
+
+    expect(res.status).toBe(201);
+    expect(createPreset).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -8,7 +8,7 @@ import { STATUS_BADGE_CLASSES, formatStatusLabel } from "@/lib/estimate-status";
 import { ExportPdfButton } from "@/components/export-pdf-modal/button";
 import { SendButton } from "@/components/send-modal/button";
 import { TrashedBanner } from "@/components/trash/trashed-banner";
-import { getDefaultPreset } from "@/lib/pdf-presets";
+import { listPresets } from "@/lib/pdf-presets";
 import { isLayoutLocked, resolveEffectiveLayout } from "@/lib/pdf-layout";
 import { LiveLayoutPanel } from "@/components/documents/live-layout-panel";
 
@@ -80,13 +80,23 @@ export default async function EstimateViewPage({
   });
   const canEdit = editAuth.ok;
 
+  // 3b. Manage-presets permission gates the panel's "Save as preset" action
+  //     (#486). An edit-only user can change the look but cannot save a preset.
+  const manageAuth = await requirePagePermission(supabase, {
+    permission: "manage_pdf_presets",
+  });
+  const canManagePresets = manageAuth.ok;
+
   // 4. Resolve the document's effective look (ADR 0012 precedence: the
   //    document's own snapshot → Organization default preset → field defaults)
   //    so the layout panel's toggle restores the current state. The panel is
   //    read-only once the estimate is frozen (converted, ADR 0007) or trashed —
-  //    matching the PATCH route's 409/404 refusals.
-  const preset = await getDefaultPreset(supabase, "estimate");
-  const effectiveLayout = resolveEffectiveLayout(estimate.pdf_layout, preset);
+  //    matching the PATCH route's 409/404 refusals. The same preset list also
+  //    feeds the panel's preset picker (#486), so derive the default from it
+  //    rather than issuing a second query.
+  const presets = await listPresets(supabase, "estimate");
+  const defaultPreset = presets.find((p) => p.is_default) ?? null;
+  const effectiveLayout = resolveEffectiveLayout(estimate.pdf_layout, defaultPreset);
   const layoutLocked =
     isLayoutLocked("estimate", estimate.status) || Boolean(estimate.deleted_at);
 
@@ -189,6 +199,8 @@ export default async function EstimateViewPage({
         layout={effectiveLayout}
         canEdit={canEdit}
         locked={layoutLocked}
+        presets={presets}
+        canManagePresets={canManagePresets}
       />
     </div>
   );

--- a/src/app/invoices/[id]/page.tsx
+++ b/src/app/invoices/[id]/page.tsx
@@ -4,7 +4,7 @@ import { requirePagePermission } from "@/lib/request-context/require-page-permis
 import { getInvoiceWithContents } from "@/lib/invoices";
 import { loadStripeConnection } from "@/lib/stripe";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
-import { getDefaultPreset } from "@/lib/pdf-presets";
+import { listPresets } from "@/lib/pdf-presets";
 import { isLayoutLocked, resolveEffectiveLayout } from "@/lib/pdf-layout";
 import InvoiceReadOnlyClient from "@/components/invoices/invoice-read-only-client";
 
@@ -40,12 +40,21 @@ export default async function InvoicePage({
   });
   const canEdit = editAuth.ok;
 
+  // Manage-presets permission gates the panel's "Save as preset" action (#486).
+  const manageAuth = await requirePagePermission(supabase, {
+    permission: "manage_pdf_presets",
+  });
+  const canManagePresets = manageAuth.ok;
+
   // Resolve the document's effective look (ADR 0012 precedence: the document's
   // own snapshot → Organization default preset → field defaults) so the panel's
   // toggles restore the current state. Read-only once the invoice is frozen
   // (paid or voided, ADR 0007) or trashed — matching the PATCH route's 409/404.
-  const preset = await getDefaultPreset(supabase, "invoice");
-  const effectiveLayout = resolveEffectiveLayout(inv.pdf_layout, preset);
+  // The same preset list feeds the panel's picker (#486), so derive the default
+  // from it rather than issuing a second query.
+  const presets = await listPresets(supabase, "invoice");
+  const defaultPreset = presets.find((p) => p.is_default) ?? null;
+  const effectiveLayout = resolveEffectiveLayout(inv.pdf_layout, defaultPreset);
   const layoutLocked =
     isLayoutLocked("invoice", inv.status) || Boolean(inv.deleted_at);
 
@@ -58,6 +67,8 @@ export default async function InvoicePage({
       layout={effectiveLayout}
       canEdit={canEdit}
       locked={layoutLocked}
+      presets={presets}
+      canManagePresets={canManagePresets}
     />
   );
 }

--- a/src/components/documents/live-layout-panel.test.tsx
+++ b/src/components/documents/live-layout-panel.test.tsx
@@ -29,7 +29,7 @@ vi.mock("@/components/documents/pdf-preview-frame", () => ({
 
 import { LiveLayoutPanel } from "./live-layout-panel";
 import { toast } from "sonner";
-import type { DocumentPdfLayout } from "@/lib/types";
+import type { DocumentPdfLayout, PdfPreset } from "@/lib/types";
 
 // A complete effective layout, as the server resolves and passes in.
 const EFFECTIVE_LAYOUT: DocumentPdfLayout = {
@@ -58,6 +58,33 @@ const TOGGLES: { key: keyof DocumentPdfLayout; name: RegExp }[] = [
   { key: "show_code_column", name: /show code column/i },
   { key: "show_item_notes", name: /show item notes/i },
 ];
+
+// A saved org preset (#486). A preset carries the eight shared toggles + the
+// title, but no `show_document_title` — deliberately the opposite of the
+// EFFECTIVE_LAYOUT toggles so a test can tell "the preset's choices were copied"
+// apart from "the document's own look was kept".
+function makePreset(over: Partial<PdfPreset> = {}): PdfPreset {
+  return {
+    id: "preset-1",
+    organization_id: "org-1",
+    name: "Branded",
+    document_type: "estimate",
+    document_title: "Quote",
+    show_markup: false,
+    show_discount: false,
+    show_tax: false,
+    show_opening_statement: false,
+    show_closing_statement: false,
+    show_category_subtotals: true,
+    show_code_column: false,
+    show_item_notes: false,
+    is_default: false,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -437,5 +464,206 @@ describe("LiveLayoutPanel", () => {
       "Estimate",
     );
     expect(toast.error).toHaveBeenCalled();
+  });
+
+  // ── #486: presets — apply as a starting point + Save as preset ─────────────
+
+  it("lists the organization's saved presets as one-click starting points", () => {
+    renderPanel({
+      presets: [
+        makePreset({ id: "p1", name: "Clean" }),
+        makePreset({ id: "p2", name: "Detailed" }),
+      ],
+    });
+
+    expect(screen.getByRole("button", { name: /clean/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /detailed/i })).toBeDefined();
+  });
+
+  it("applying a preset copies its choices onto the document layout and autosaves the full snapshot", async () => {
+    const preset = makePreset({ id: "p1", name: "Branded" });
+    // The document currently HIDES its title; the preset carries no
+    // show_document_title, so the applied snapshot must preserve that `false`.
+    renderPanel({
+      layout: { ...EFFECTIVE_LAYOUT, show_document_title: false },
+      presets: [preset],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /branded/i }));
+    expect(fetchMock).not.toHaveBeenCalled(); // debounced, like every other save
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // Exactly one PATCH carrying the COMPLETE layout copied from the preset —
+    // not a partial overlay and not a reference. show_document_title rides along
+    // from the document's current look.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/estimates/est-1/layout");
+    expect((init as RequestInit).method).toBe("PATCH");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      document_title: preset.document_title,
+      show_document_title: false, // preserved from the document, not the preset
+      show_markup: preset.show_markup,
+      show_discount: preset.show_discount,
+      show_tax: preset.show_tax,
+      show_opening_statement: preset.show_opening_statement,
+      show_closing_statement: preset.show_closing_statement,
+      show_category_subtotals: preset.show_category_subtotals,
+      show_code_column: preset.show_code_column,
+      show_item_notes: preset.show_item_notes,
+    });
+    // ADR 0012: the document gets a SNAPSHOT, never a binding link — no preset
+    // identity is persisted, so later edits to the preset can't reach back.
+    expect(body).not.toHaveProperty("id");
+    expect(body).not.toHaveProperty("preset_id");
+  });
+
+  it("reflects the applied preset's toggles in the panel immediately (optimistic)", async () => {
+    // markup is ON in the effective layout; the preset turns it OFF. Applying the
+    // preset must flip the visible switch right away, before any save resolves.
+    renderPanel({
+      layout: { ...EFFECTIVE_LAYOUT, show_markup: true },
+      presets: [makePreset({ id: "p1", name: "Branded", show_markup: false })],
+    });
+
+    expect(
+      screen
+        .getByRole("switch", { name: /show markup row in totals/i })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+
+    fireEvent.click(screen.getByRole("button", { name: /branded/i }));
+
+    expect(
+      screen
+        .getByRole("switch", { name: /show markup row in totals/i })
+        .getAttribute("aria-checked"),
+    ).toBe("false");
+
+    // Drain the scheduled debounced save so it doesn't flush after teardown.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+  });
+
+  it("does not apply a preset on a read-only document (button disabled, no save)", async () => {
+    renderPanel({
+      locked: true,
+      presets: [makePreset({ id: "p1", name: "Branded" })],
+    });
+
+    const btn = screen.getByRole("button", { name: /branded/i }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    fireEvent.click(btn);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Save as preset POSTs the current layout as a new reusable preset (manage permission)", async () => {
+    renderPanel({
+      canManagePresets: true,
+      layout: {
+        ...EFFECTIVE_LAYOUT,
+        document_title: "Final Proposal",
+        show_markup: false,
+        show_category_subtotals: true,
+      },
+    });
+
+    // Open the inline form, name the preset, and submit.
+    fireEvent.click(screen.getByRole("button", { name: /save as preset/i }));
+    fireEvent.change(screen.getByRole("textbox", { name: /preset name/i }), {
+      target: { value: "My House Style" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    });
+
+    // One POST to the existing presets endpoint, carrying the current layout's
+    // eight shared toggles + title. It is an explicit action — NOT debounced.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("/api/pdf-presets");
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      name: "My House Style",
+      document_type: "estimate",
+      document_title: "Final Proposal",
+      show_markup: false,
+      show_discount: EFFECTIVE_LAYOUT.show_discount,
+      show_tax: EFFECTIVE_LAYOUT.show_tax,
+      show_opening_statement: EFFECTIVE_LAYOUT.show_opening_statement,
+      show_closing_statement: EFFECTIVE_LAYOUT.show_closing_statement,
+      show_category_subtotals: true,
+      show_code_column: EFFECTIVE_LAYOUT.show_code_column,
+      show_item_notes: EFFECTIVE_LAYOUT.show_item_notes,
+      is_default: false,
+    });
+    // show_document_title is a document-only field — a preset has no such column,
+    // so it must NOT be sent.
+    expect(body).not.toHaveProperty("show_document_title");
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it("hides Save as preset from a user without manage_pdf_presets (edit-only)", () => {
+    // An edit-only user can still flip toggles and apply presets, but cannot turn
+    // the look into a reusable preset — the control is absent, not merely disabled.
+    renderPanel({ canEdit: true, canManagePresets: false });
+
+    expect(screen.queryByRole("button", { name: /save as preset/i })).toBeNull();
+    // The toggles remain interactive — edit rights are unaffected.
+    expect(
+      (screen.getByRole("switch", { name: /show markup row in totals/i }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it("shows Save as preset to a user who holds manage_pdf_presets", () => {
+    renderPanel({ canManagePresets: true });
+    expect(screen.getByRole("button", { name: /save as preset/i })).toBeDefined();
+  });
+
+  it("works on the Invoice View — applies presets to the invoice route and saves with document_type invoice (AC5)", async () => {
+    // The same shared component serves both views (#485). On an invoice it must
+    // apply presets via the invoice layout route and save presets typed invoice.
+    renderPanel({
+      documentType: "invoice",
+      documentId: "inv-1",
+      previewSrc: "/api/invoices/inv-1/preview",
+      previewTitle: "Invoice INV-1",
+      canManagePresets: true,
+      presets: [makePreset({ id: "ip1", name: "Invoice Clean", document_type: "invoice" })],
+    });
+
+    // Apply → PATCH the INVOICE layout route, not the estimate one.
+    fireEvent.click(screen.getByRole("button", { name: /invoice clean/i }));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/invoices/inv-1/layout");
+
+    // Save as preset → POST carrying document_type: "invoice".
+    fireEvent.click(screen.getByRole("button", { name: /save as preset/i }));
+    fireEvent.change(screen.getByRole("textbox", { name: /preset name/i }), {
+      target: { value: "Invoice Style" },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [url2, init2] = fetchMock.mock.calls[1];
+    expect(url2).toBe("/api/pdf-presets");
+    const body2 = JSON.parse((init2 as RequestInit).body as string);
+    expect(body2.document_type).toBe("invoice");
   });
 });

--- a/src/components/documents/live-layout-panel.tsx
+++ b/src/components/documents/live-layout-panel.tsx
@@ -6,7 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { PdfPreviewFrame } from "@/components/documents/pdf-preview-frame";
 import { toast } from "sonner";
-import type { DocumentPdfLayout, DocumentType } from "@/lib/types";
+import { presetToLayout } from "@/lib/pdf-layout";
+import type { DocumentPdfLayout, DocumentType, PdfPreset } from "@/lib/types";
 
 const SAVE_DELAY_MS = 600;
 
@@ -49,6 +50,17 @@ interface LiveLayoutPanelProps {
   canEdit: boolean;
   /** The document is frozen (a converted estimate, or a paid/voided invoice) — read-only. */
   locked: boolean;
+  /**
+   * The Organization's saved presets for this document type (server-prefetched).
+   * Each is a one-click starting point: applying one COPIES its choices onto the
+   * document's own layout (ADR 0012 snapshot, never a binding link). #486.
+   */
+  presets?: PdfPreset[];
+  /**
+   * Caller holds `manage_pdf_presets` — gates the "Save as preset" action. An
+   * edit-only user can change the look (and apply presets) but cannot save one.
+   */
+  canManagePresets?: boolean;
 }
 
 // The live PDF layout panel, shared by the Estimate View (#483/#484) and the
@@ -62,12 +74,17 @@ export function LiveLayoutPanel({
   layout: initialLayout,
   canEdit,
   locked,
+  presets = [],
+  canManagePresets = false,
 }: LiveLayoutPanelProps) {
   // A frozen document, or a caller without the edit grant, sees the look but
   // cannot change it (ADR 0012 reuses the edit-document boundary + freeze).
   const readOnly = !canEdit || locked;
   const [layout, setLayout] = useState<DocumentPdfLayout>(initialLayout);
   const [version, setVersion] = useState(0);
+  // "Save as preset" inline form: closed until the user opts in, then a name box.
+  const [naming, setNaming] = useState(false);
+  const [presetName, setPresetName] = useState("");
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   // The edit currently waiting on the debounce timer — flushed on teardown so a
   // fast navigate-away inside the window doesn't silently drop it.
@@ -168,6 +185,50 @@ export function LiveLayoutPanel({
     save(next);
   };
 
+  // Apply a preset as a starting point (#486): COPY its choices onto the
+  // document's own layout (ADR 0012 snapshot — no binding link, so later edits
+  // to the preset never reach this document) and persist the whole snapshot
+  // through the identical debounced save. `show_document_title` is preserved from
+  // the current look (the preset has no such field).
+  const applyPreset = (preset: PdfPreset) => {
+    if (readOnly) return;
+    const next = presetToLayout(preset, layout.show_document_title);
+    setLayout(next); // optimistic
+    save(next);
+  };
+
+  // Save the document's current look as a new reusable org preset (#486), via the
+  // existing POST /api/pdf-presets (gated `manage_pdf_presets` server-side too).
+  // `show_document_title` is a document-only field with no preset column, so it is
+  // dropped; the eight shared toggles + the title become the preset. This is an
+  // explicit action, not debounced.
+  const saveAsPreset = async () => {
+    const name = presetName.trim();
+    if (!name) return;
+    const { show_document_title: _omit, ...sharedFields } = layout;
+    void _omit;
+    const res = await fetch("/api/pdf-presets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        document_type: documentType,
+        ...sharedFields, // document_title + the eight shared toggles
+        is_default: false,
+      }),
+    });
+    if (res.ok) {
+      toast.success("Preset saved");
+      setNaming(false);
+      setPresetName("");
+    } else {
+      const { error } = await res
+        .json()
+        .catch(() => ({ error: undefined as string | undefined }));
+      toast.error(error ?? "Couldn't save preset");
+    }
+  };
+
   // version 0 is the untouched server-rendered preview; later versions append a
   // cache-busting param so the preview frame (also keyed on src) re-fetches live.
   const src = version === 0 ? previewSrc : `${previewSrc}?v=${version}`;
@@ -176,6 +237,26 @@ export function LiveLayoutPanel({
     <div className="space-y-4">
       <div className="rounded-lg border border-border bg-card px-5 py-4">
         <h2 className="text-sm font-medium text-foreground mb-3">Document layout</h2>
+        {presets.length > 0 && (
+          <div className="mb-4 border-b border-border pb-3">
+            <p className="text-sm font-medium text-foreground mb-2">
+              Start from a preset
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {presets.map((p) => (
+                <button
+                  key={p.id}
+                  type="button"
+                  disabled={readOnly}
+                  onClick={() => applyPreset(p)}
+                  className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {p.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
         <div className="space-y-3">
           <div>
             <Label htmlFor="document_title">Document title</Label>
@@ -206,6 +287,51 @@ export function LiveLayoutPanel({
             </div>
           ))}
         </div>
+
+        {/* "Save as preset" — turn the current look into a reusable org preset.
+            Gated behind manage_pdf_presets: an edit-only user can change the look
+            (and apply presets) but never sees this control (#486). */}
+        {canManagePresets && (
+          <div className="mt-4 border-t border-border pt-3">
+            {naming ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  aria-label="Preset name"
+                  placeholder="Preset name"
+                  value={presetName}
+                  maxLength={200}
+                  onChange={(e) => setPresetName(e.target.value)}
+                />
+                <button
+                  type="button"
+                  onClick={saveAsPreset}
+                  disabled={!presetName.trim()}
+                  className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+                >
+                  Create
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setNaming(false);
+                    setPresetName("");
+                  }}
+                  className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setNaming(true)}
+                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium text-foreground shadow-sm hover:bg-muted transition-colors"
+              >
+                Save as preset
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <PdfPreviewFrame key={src} src={src} title={previewTitle} />
     </div>

--- a/src/components/invoices/invoice-read-only-client.tsx
+++ b/src/components/invoices/invoice-read-only-client.tsx
@@ -10,7 +10,7 @@ import { SendButton } from "@/components/send-modal/button";
 import { TrashedBanner } from "@/components/trash/trashed-banner";
 import { LiveLayoutPanel } from "@/components/documents/live-layout-panel";
 import { getStatusBadgeClasses, formatStatusLabel } from "@/lib/estimate-status";
-import type { DocumentPdfLayout, InvoiceWithContents } from "@/lib/types";
+import type { DocumentPdfLayout, InvoiceWithContents, PdfPreset } from "@/lib/types";
 
 export interface InvoiceReadOnlyClientProps {
   invoice: InvoiceWithContents & {
@@ -33,6 +33,10 @@ export interface InvoiceReadOnlyClientProps {
   canEdit: boolean;
   /** The invoice is frozen (paid or voided) or trashed — the panel is read-only. */
   locked: boolean;
+  /** The Organization's saved invoice presets — the panel's one-click starting points (#486). */
+  presets?: PdfPreset[];
+  /** Caller holds manage_pdf_presets — gates the panel's "Save as preset" action (#486). */
+  canManagePresets?: boolean;
 }
 
 export default function InvoiceReadOnlyClient({
@@ -43,6 +47,8 @@ export default function InvoiceReadOnlyClient({
   layout,
   canEdit,
   locked,
+  presets = [],
+  canManagePresets = false,
 }: InvoiceReadOnlyClientProps) {
   const [paymentRequestOpen, setPaymentRequestOpen] = useState(false);
   const [recordPaymentOpen, setRecordPaymentOpen] = useState(false);
@@ -122,6 +128,8 @@ export default function InvoiceReadOnlyClient({
           layout={layout}
           canEdit={canEdit}
           locked={locked}
+          presets={presets}
+          canManagePresets={canManagePresets}
         />
       </div>
 

--- a/src/lib/pdf-layout.test.ts
+++ b/src/lib/pdf-layout.test.ts
@@ -3,6 +3,7 @@ import {
   isLayoutLocked,
   resolveEffectiveLayout,
   parseLayoutPayload,
+  presetToLayout,
   LAYOUT_FIELD_DEFAULTS,
   DOCUMENT_TITLE_MAX_LENGTH,
 } from "./pdf-layout";
@@ -137,6 +138,47 @@ describe("resolveEffectiveLayout — precedence (#482)", () => {
     // The missing field falls through to the preset (false), not "off" and not
     // the field default (true) — proving per-field, not all-or-nothing, merge.
     expect(resolved.show_tax).toBe(false);
+  });
+});
+
+// #486 — applying a saved preset COPIES its choices onto the document's own
+// layout (ADR 0012 snapshot, never a binding link). A preset carries the eight
+// shared toggles + the title, but has no `show_document_title` column — that one
+// document-level field is preserved from the document's current look rather than
+// reset, so applying a preset never silently flips the title on or off.
+describe("presetToLayout — snapshot a preset's choices onto a document layout (#486)", () => {
+  it("copies the preset's eight toggles + title and preserves the current show_document_title", () => {
+    const preset = customPreset(); // every toggle the opposite of the field defaults
+    // The document currently hides its title; the preset has no opinion on that
+    // field, so applying it must leave show_document_title alone.
+    expect(presetToLayout(preset, false)).toEqual({
+      document_title: preset.document_title,
+      show_document_title: false, // preserved from the document, not the preset
+      show_markup: preset.show_markup,
+      show_discount: preset.show_discount,
+      show_tax: preset.show_tax,
+      show_opening_statement: preset.show_opening_statement,
+      show_closing_statement: preset.show_closing_statement,
+      show_category_subtotals: preset.show_category_subtotals,
+      show_code_column: preset.show_code_column,
+      show_item_notes: preset.show_item_notes,
+    });
+  });
+
+  it("falls back to the field default for show_document_title when no current value is given", () => {
+    expect(presetToLayout(customPreset()).show_document_title).toBe(
+      LAYOUT_FIELD_DEFAULTS.show_document_title,
+    );
+  });
+
+  it("returns exactly the canonical layout shape — no preset-only keys leak through", () => {
+    const result = presetToLayout(customPreset(), true);
+    expect(Object.keys(result).sort()).toEqual(
+      Object.keys(LAYOUT_FIELD_DEFAULTS).sort(),
+    );
+    for (const leaked of ["id", "organization_id", "is_default", "name", "document_type"]) {
+      expect(result).not.toHaveProperty(leaked);
+    }
   });
 });
 

--- a/src/lib/pdf-layout.ts
+++ b/src/lib/pdf-layout.ts
@@ -85,6 +85,31 @@ export function resolveEffectiveLayout(
   };
 }
 
+// Snapshot a saved preset's choices onto a document's own layout (#486). Per
+// ADR 0012 applying a preset is a *copy*, never a binding link — the document
+// gets its own complete layout, so later edits to the preset never reach back
+// into it. The preset carries the eight shared toggles + the title but has no
+// `show_document_title` column, so that one document-level field is preserved
+// from the document's current look (default: the field default) rather than
+// silently reset. Pure.
+export function presetToLayout(
+  preset: PdfPreset,
+  currentShowDocumentTitle: boolean = LAYOUT_FIELD_DEFAULTS.show_document_title,
+): DocumentPdfLayout {
+  return {
+    document_title: preset.document_title,
+    show_document_title: currentShowDocumentTitle,
+    show_markup: preset.show_markup,
+    show_discount: preset.show_discount,
+    show_tax: preset.show_tax,
+    show_opening_statement: preset.show_opening_statement,
+    show_closing_statement: preset.show_closing_statement,
+    show_category_subtotals: preset.show_category_subtotals,
+    show_code_column: preset.show_code_column,
+    show_item_notes: preset.show_item_notes,
+  };
+}
+
 // Validate an untrusted PATCH body into a `DocumentPdfLayout`. Accepts only a
 // well-formed layout — exactly the nine boolean toggles plus a string
 // `document_title` — and returns it normalized (extra keys stripped) so only the


### PR DESCRIPTION
Closes #486.

## What

Adds preset support to the shared `LiveLayoutPanel` (Estimate + Invoice Views):

- **Apply a preset as a starting point** — the picker lists the org's saved presets for the document type. Applying one **copies** its choices onto the document's layout (a per-document snapshot per **ADR 0012** — never a binding link, so later preset edits never reach the document) and reuses the existing debounced PATCH autosave pipeline.
- **Save as preset** — turns the document's current layout into a new reusable preset via the existing `POST /api/pdf-presets`, gated behind `manage_pdf_presets`. Edit-only users can change the look but cannot save a preset (control hidden in the UI + server returns 403).

## How

- `presetToLayout(preset, currentShowDocumentTitle)` pure helper in `src/lib/pdf-layout.ts` copies the preset's 8 toggles + `document_title` and preserves the document's own `show_document_title` (presets have no such column).
- Presets are **server-prefetched as props** (`listPresets`) — no mount-time fetch, so the existing panel tests that count fetch calls stay valid. `canManagePresets` is derived from `requirePagePermission`. The invoice path threads both through `InvoiceReadOnlyClient`.
- Save-as-preset POSTs the current layout (dropping `show_document_title`) with `is_default: false`.

## Acceptance criteria

| AC | Status |
|----|--------|
| AC1 — picker lists org presets for the doc type | ✅ |
| AC2 — apply copies choices; later preset edits don't change the doc (snapshot) | ✅ |
| AC3 — Save-as-preset creates a reusable preset | ✅ |
| AC4 — gated behind manage_pdf_presets (hidden + server 403) | ✅ |
| AC5 — both Estimate and Invoice Views | ✅ |

## Tests

`+549 / -12` across 8 files. **72/72** pass across the 4 affected test files; ESLint clean; `tsc` errors unchanged from baseline (0 in touched files).

- `pdf-layout.test.ts` — `presetToLayout` shape / `show_document_title` precedence
- `live-layout-panel.test.tsx` — apply copies full snapshot via PATCH, Save-as-preset POSTs current layout, both views, read-only blocks apply, permission gating
- `pdf-presets/route.test.ts` — POST `manage_pdf_presets` gate (401 / 403 edit-only / 201 grant-holder / 201 admin)

## Review

A multi-lens adversarial review (each finding independently verified) found **no AC, correctness, security, or ADR-0012 break**. Residual notes, all low/nit and non-blocking, deferred by decision: no in-flight guard on the Create button (fast double-click could create a duplicate preset — recoverable/deletable), and a raw server error string surfaced when saving with an empty document title (correct rejection, developer-y copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
