### PR TITLE
feat(phone): Job-page Messages (N) section + Text button (#311)

### DIFF
--- a/src/app/api/phone/messages/route.test.ts
+++ b/src/app/api/phone/messages/route.test.ts
@@ -52,7 +52,7 @@ vi.mock("@/lib/phone/attachments-storage", () => ({
   signedUrlForPhoneAttachment: (...args: unknown[]) => signedUrlMock(...args),
 }));
 
-import { POST } from "./route";
+import { POST, GET } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
@@ -161,6 +161,35 @@ function sendReq(body: Record<string, unknown>) {
   return new Request("http://test/api/phone/messages", {
     method: "POST",
     body: JSON.stringify(body),
+  });
+}
+
+// GET reads through the User client (RLS pass-through), so its tests seed
+// `phone_messages` straight onto the authenticated fake client rather than
+// the Service client.
+function authedWith(
+  userId: string,
+  role: "admin" | "crew_lead" | "crew_member",
+  extraTables: Record<string, Row[]> = {},
+) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: userId },
+      tables: {
+        ...memberTables({
+          userId,
+          role,
+          grants: role === "crew_member" ? [] : ["view_phone"],
+        }),
+        ...extraTables,
+      },
+    }) as never,
+  );
+}
+
+function getReq(query: string) {
+  return new Request(`http://test/api/phone/messages${query}`, {
+    method: "GET",
   });
 }
 
@@ -644,5 +673,113 @@ describe("POST /api/phone/messages — MMS attachments", () => {
     expect(signedUrlMock).not.toHaveBeenCalled();
     expect(sendSmsMock).not.toHaveBeenCalled();
     expect(inserts.find((i) => i.table === "phone_messages")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Job-page Text — outbound auto-tag persistence (slice 7 / #311)
+//
+// The Job-page Text button posts sourceContext { kind: 'job', jobId }. The
+// route hands that to decideJobTag, which auto-tags the send to that Job —
+// no chip prompt, regardless of the contact's Active-job count. The pure
+// decision is unit-tested in smart-attach.test.ts; here we pin where it
+// actually lands: the inserted phone_messages row carries job_tag, and the
+// 201 echoes smartAttach. This is the persistence headline AC6 rests on.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/messages — Job-page auto-tag (#311)", () => {
+  it("persists job_tag from a { kind:'job', jobId } source and echoes smartAttach:auto", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "On our way",
+        sourceContext: { kind: "job", jobId: "job-1" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    // The route echoes the decision so the client can confirm the tag.
+    expect(body.smartAttach).toEqual({ kind: "auto", jobId: "job-1" });
+    // And it persists onto the row — the Job's Messages (N) section reads
+    // by job_tag, so an unpersisted tag would silently drop the message.
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row.job_tag).toBe("job-1");
+  });
+
+  it("leaves job_tag null for a phone-tab send with no Active jobs (no source-driven tag)", async () => {
+    // Pins that the Job auto-tag is source-driven, not a blanket default:
+    // a phone-tab send with no contact match falls through to untagged.
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "no job here",
+        sourceContext: "phone-tab",
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.smartAttach).toEqual({ kind: "untagged" });
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row.job_tag).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. GET — Job-page Messages read (slice 7 / #311)
+//
+// The Job-page Messages (N) section reads every text/MMS tagged to a Job
+// through GET /api/phone/messages?jobId=. Like the conversation-thread
+// read route it is a thin RLS pass-through over the User client — a caller
+// who cannot see a row simply does not get it back. The section itself is
+// hidden from anyone without view_phone, and so is this endpoint.
+// ---------------------------------------------------------------------------
+
+describe("GET /api/phone/messages?jobId= — Job-page Messages read", () => {
+  it("returns only the messages tagged to the requested job", async () => {
+    authedWith("user-1", "crew_lead", {
+      phone_messages: [
+        { id: "a", job_tag: "job-1", body: "one", sent_at: "2026-06-01T10:00:00Z" },
+        { id: "b", job_tag: "job-1", body: "two", sent_at: "2026-06-01T11:00:00Z" },
+        { id: "c", job_tag: "job-2", body: "other", sent_at: "2026-06-01T12:00:00Z" },
+      ],
+    });
+
+    const res = await GET(getReq("?jobId=job-1"), noParams);
+
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as Array<{ id: string }>;
+    expect(rows.map((r) => r.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("returns 400 when jobId is missing", async () => {
+    authedWith("user-1", "crew_lead", { phone_messages: [] });
+
+    const res = await GET(getReq(""), noParams);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 when the caller lacks view_phone (crew_member)", async () => {
+    authedWith("user-cm", "crew_member", { phone_messages: [] });
+
+    const res = await GET(getReq("?jobId=job-1"), noParams);
+
+    expect(res.status).toBe(403);
   });
 });

--- a/src/app/api/phone/messages/route.ts
+++ b/src/app/api/phone/messages/route.ts
@@ -101,6 +101,34 @@ function parseSourceContext(input: unknown): SmartAttachSource {
   return { kind: "phone-tab" };
 }
 
+// Slice 7 (#311) — the Job-page Messages (N) section reads every text/MMS
+// tagged to a Job here. A thin RLS pass-through over the User client,
+// mirroring the conversation-thread read route: RLS (migration-308)
+// enforces the ADR 0005 access matrix, so a caller who cannot see a row
+// simply does not get it back. The section is hidden from anyone without
+// view_phone, and so is this endpoint.
+const JOB_MESSAGE_FIELDS =
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, body, media_urls, twilio_sid, status, job_tag, tagged_by_user_id, sent_by_user_id, sent_at, created_at";
+
+export const GET = withRequestContext(
+  { permission: "view_phone" },
+  async (request, ctx) => {
+    const jobId = new URL(request.url).searchParams.get("jobId");
+    if (!jobId) {
+      return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+    }
+    const { data, error } = await ctx.supabase
+      .from("phone_messages")
+      .select(JOB_MESSAGE_FIELDS)
+      .eq("job_tag", jobId)
+      .order("sent_at", { ascending: true });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  },
+);
+
 export const POST = withRequestContext(
   { permission: "view_phone", serviceClient: true },
   async (request, ctx) => {

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -7,10 +7,12 @@ import { createClient } from "@/lib/supabase";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import { usePhoneSync } from "@/lib/phone/use-phone-sync";
 import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
+import { validateMmsAttachment } from "@/lib/phone/mms-attachments";
 import {
-  validateMmsAttachment,
-  isMmsImageMediaType,
-} from "@/lib/phone/mms-attachments";
+  MessageAttachment,
+  PhoneAttachmentLightbox,
+  type PhoneAttachmentRef,
+} from "@/components/phone/message-attachment";
 
 // PRD #304 — Nookleus Phone. Slice 4 (#308) — two-pane Phone-tab UI.
 //
@@ -37,12 +39,6 @@ export interface PhoneConversationItem {
   last_event_at: string;
   unread_count: number;
   active_jobs: Array<{ id: string; label: string }>;
-}
-
-interface PhoneAttachmentRef {
-  storage_path: string;
-  media_type: string;
-  filename?: string;
 }
 
 interface PhoneMessage {
@@ -848,112 +844,6 @@ export function PhonePageClient({
           </div>
         )}
       </section>
-    </div>
-  );
-}
-
-// Slice 6 (#310) — render one stored attachment in a message bubble.
-// Images load via the signed-URL endpoint and click open the lightbox;
-// non-image media is a labelled download link (also via the signed URL).
-function MessageAttachment({
-  attachment,
-  onOpenLightbox,
-}: {
-  attachment: PhoneAttachmentRef;
-  onOpenLightbox: (path: string) => void;
-}) {
-  const [url, setUrl] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const res = await fetch(
-        `/api/phone/attachments?path=${encodeURIComponent(attachment.storage_path)}`,
-      );
-      if (!res.ok) return;
-      const body = (await res.json()) as { url: string };
-      if (!cancelled) setUrl(body.url);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [attachment.storage_path]);
-
-  if (isMmsImageMediaType(attachment.media_type)) {
-    return (
-      <button
-        type="button"
-        aria-label={`Open attachment ${attachment.filename ?? ""}`.trim()}
-        onClick={() => onOpenLightbox(attachment.storage_path)}
-        className="block overflow-hidden rounded border border-border bg-background"
-      >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={url ?? ""}
-          alt={`attachment ${attachment.filename ?? ""}`.trim()}
-          className="block h-32 w-32 object-cover"
-        />
-      </button>
-    );
-  }
-  const label = attachment.filename ?? "Download attachment";
-  return (
-    <a
-      href={url ?? "#"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground hover:underline"
-    >
-      {label}
-    </a>
-  );
-}
-
-// Slice 6 (#310) — full-size image overlay. Click outside or press Escape
-// to dismiss. Loads via the same signed-URL endpoint so a fresh URL is
-// minted; the TTL is short, but the URL is fetched at open time.
-function PhoneAttachmentLightbox({
-  path,
-  onClose,
-}: {
-  path: string;
-  onClose: () => void;
-}) {
-  const [url, setUrl] = useState<string | null>(null);
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      const res = await fetch(
-        `/api/phone/attachments?path=${encodeURIComponent(path)}`,
-      );
-      if (!res.ok) return;
-      const body = (await res.json()) as { url: string };
-      if (!cancelled) setUrl(body.url);
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [path]);
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [onClose]);
-  return (
-    <div
-      role="dialog"
-      aria-label="Attachment preview"
-      onClick={onClose}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
-    >
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src={url ?? ""}
-        alt="attachment full size"
-        className="max-h-[90vh] max-w-[90vw] rounded shadow-lg"
-        onClick={(e) => e.stopPropagation()}
-      />
     </div>
   );
 }

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -31,6 +31,8 @@ import PhotoAnnotator from "@/components/photo-annotator";
 import ComposeEmailModal from "@/components/compose-email";
 import { JobEmailRow } from "@/components/email/job-email-row";
 import { buildQuotedReply } from "@/components/email/build-quoted-reply";
+import { JobMessagesSection } from "@/components/job-detail/job-messages-section";
+import { buildJobTextContacts } from "@/components/job-detail/job-text-contacts";
 import JarvisJobPanel from "@/components/jarvis/JarvisJobPanel";
 import JobFiles from "@/components/job-files";
 import ContractsSection from "@/components/contracts/contracts-section";
@@ -1007,6 +1009,15 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           </div>
         )}
       </div>
+
+      {/* Messages (texts/MMS) — mirrors Emails. Hidden from users without
+          view_phone; renders every text tagged to this Job across all
+          numbers (Shared + Personal). PRD #304, slice 7 (#311). */}
+      <JobMessagesSection
+        jobId={jobId}
+        organizationId={job.organization_id}
+        contacts={buildJobTextContacts(job)}
+      />
 
       {/* Custom Fields */}
       {customFields.length > 0 && (

--- a/src/components/job-detail/job-messages-section.test.tsx
+++ b/src/components/job-detail/job-messages-section.test.tsx
@@ -1,0 +1,359 @@
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Messages (N) section.
+//
+// RTL integration tests for the Messages section that mirrors the Emails
+// section on every Job page. AC bullets pinned here:
+//   - "Job page renders Messages (N) for view_phone users"
+//   - "Section hidden for users without view_phone"
+//   - "(N) = count of phone_messages whose job_tag = current job"
+//   - "messages render per Phone-tab thread treatment"
+//   - "Text button opens compose with one of the Job's Contacts pre-filled"
+//   - "an untagged Phone-tab message re-tagged to a Job immediately surfaces"
+//
+// The section is a client component; we mock useAuth (the view_phone gate)
+// and fetch (the GET /api/phone/messages?jobId= read).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const auth = vi.hoisted(() => ({
+  value: {
+    loading: false,
+    hasPermission: (_k: string) => false as boolean,
+  },
+}));
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => auth.value,
+}));
+
+// Capture the realtime subscription the section wires up so a test can fire
+// INSERT/UPDATE events at it. The section feeds usePhoneSync a browser
+// Supabase client; we stub createClient so the client component can mount
+// under jsdom without a real connection.
+const sync = vi.hoisted(() => ({
+  input: null as {
+    organizationId: string | null;
+    onNewMessage?: (row: unknown) => void;
+    onMessageUpdate?: (row: unknown) => void;
+  } | null,
+}));
+vi.mock("@/lib/phone/use-phone-sync", () => ({
+  usePhoneSync: (input: unknown) => {
+    sync.input = input as typeof sync.input;
+  },
+}));
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({}) as never,
+}));
+
+import { JobMessagesSection } from "./job-messages-section";
+
+type MessageRow = {
+  id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  body: string | null;
+  media_urls: unknown[];
+  sent_at: string;
+  job_tag: string | null;
+};
+
+function msg(overrides: Partial<MessageRow> = {}): MessageRow {
+  return {
+    id: "m1",
+    direction: "in",
+    from_e164: "+15125550001",
+    to_e164: "+15125559999",
+    body: "Roof is leaking",
+    media_urls: [],
+    sent_at: "2026-06-01T10:00:00Z",
+    job_tag: "job-1",
+    ...overrides,
+  };
+}
+
+function asViewPhone() {
+  auth.value = {
+    loading: false,
+    hasPermission: (k: string) => k === "view_phone",
+  };
+}
+function asNoPhone() {
+  auth.value = { loading: false, hasPermission: () => false };
+}
+
+function stubMessages(rows: MessageRow[]) {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+const contacts = [{ id: "c1", name: "Homer Owner", phone: "+15125550001" }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sync.input = null;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("JobMessagesSection — render", () => {
+  it("renders Messages (N) with the job's message bodies for a view_phone user", async () => {
+    asViewPhone();
+    stubMessages([
+      msg({ id: "m1", direction: "in", body: "Roof is leaking" }),
+      msg({ id: "m2", direction: "out", body: "On our way" }),
+    ]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    expect(await screen.findByText("Messages (2)")).toBeDefined();
+    expect(screen.getByText("Roof is leaking")).toBeDefined();
+    expect(screen.getByText("On our way")).toBeDefined();
+  });
+
+  it("renders nothing — and does not even fetch — for a user without view_phone", () => {
+    asNoPhone();
+    const spy = stubMessages([msg()]);
+
+    const { container } = render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    expect(container.querySelector("h3")).toBeNull();
+    expect(screen.queryByText(/Messages \(/)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+    // …and it withholds the realtime subscription end-to-end: the section
+    // feeds usePhoneSync organizationId:null when the user lacks view_phone,
+    // so the hook (proven by its own null-org test) opens no channel. Pins
+    // against a regression where someone passes organizationId unconditionally.
+    expect(sync.input?.organizationId).toBeNull();
+  });
+
+  it("shows Messages (0) and an empty-state when the job has no messages", async () => {
+    asViewPhone();
+    stubMessages([]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    expect(await screen.findByText("Messages (0)")).toBeDefined();
+    expect(screen.getByText(/no (text )?messages/i)).toBeDefined();
+  });
+});
+
+describe("JobMessagesSection — counterparty labels", () => {
+  it("labels each message with the matching contact name, or a formatted number when unknown", async () => {
+    asViewPhone();
+    stubMessages([
+      // inbound from a known contact → his name
+      msg({
+        id: "m1",
+        direction: "in",
+        from_e164: "+15125550001",
+        to_e164: "+15125559999",
+        body: "hi",
+      }),
+      // inbound from an unknown number → the formatted number
+      msg({
+        id: "m2",
+        direction: "in",
+        from_e164: "+15125557777",
+        to_e164: "+15125559999",
+        body: "yo",
+      }),
+    ]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={[{ id: "c1", name: "Homer Owner", phone: "+15125550001" }]}
+      />,
+    );
+
+    expect(await screen.findByText("Homer Owner")).toBeDefined();
+    expect(screen.getByText("(512) 555-7777")).toBeDefined();
+  });
+});
+
+describe("JobMessagesSection — Text button", () => {
+  it("opens compose with the primary contact pre-filled when outbound SMS is enabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "true");
+    asViewPhone();
+    stubMessages([]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    fireEvent.click(screen.getByRole("button", { name: /^text$/i }));
+
+    expect(
+      screen.getByRole("dialog", { name: /text a contact/i }),
+    ).toBeDefined();
+    expect(screen.getByText("Homer Owner")).toBeDefined();
+  });
+
+  it("hides the Text button when outbound SMS is disabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "");
+    asViewPhone();
+    stubMessages([]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    expect(screen.queryByRole("button", { name: /^text$/i })).toBeNull();
+  });
+});
+
+describe("JobMessagesSection — send integration", () => {
+  it("Text → compose → send lands the message in the section, with no chip prompt", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "true");
+    asViewPhone();
+
+    // The section's GET returns [] first, then the new outbound message
+    // after the post-send refetch. The compose POST returns 201.
+    let getCount = 0;
+    const spy = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/phone/messages") && method === "POST") {
+        return new Response(
+          JSON.stringify({ id: "sent-1", status: "queued" }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      getCount += 1;
+      const rows =
+        getCount === 1
+          ? []
+          : [
+              msg({
+                id: "m-new",
+                direction: "out",
+                from_e164: "+15125559999",
+                to_e164: "+15125550001",
+                body: "On our way",
+              }),
+            ];
+      return new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    fireEvent.click(screen.getByRole("button", { name: /^text$/i }));
+    fireEvent.change(screen.getByLabelText(/message/i), {
+      target: { value: "On our way" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send text/i }));
+
+    // The outbound POST carried the Job smart-attach source — no chip prompt.
+    await waitFor(() => {
+      const post = spy.mock.calls.find(
+        (c) => (c[1] as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeDefined();
+      expect(
+        JSON.parse(String((post![1] as RequestInit).body)).sourceContext,
+      ).toEqual({ kind: "job", jobId: "job-1" });
+    });
+
+    // After the post-send refetch the message surfaces in the section.
+    expect(await screen.findByText("On our way")).toBeDefined();
+    expect(screen.getByText("Messages (1)")).toBeDefined();
+    expect(screen.queryByText(/tag to/i)).toBeNull();
+  });
+});
+
+describe("JobMessagesSection — realtime re-tag", () => {
+  it("subscribes for the org and surfaces a message re-tagged to this job on an UPDATE event", async () => {
+    asViewPhone();
+
+    // First GET: nothing tagged yet. After the re-tag UPDATE fires, the
+    // refetch returns the freshly job-tagged message.
+    let getCount = 0;
+    const spy = vi.fn(async () => {
+      getCount += 1;
+      const rows =
+        getCount === 1
+          ? []
+          : [
+              msg({
+                id: "m-retag",
+                direction: "in",
+                body: "now tagged",
+                job_tag: "job-1",
+              }),
+            ];
+      return new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    // The section wired a realtime subscription scoped to the active org.
+    expect(sync.input?.organizationId).toBe("org-1");
+
+    // A teammate re-tags an untagged Phone-tab message to this Job → the
+    // UPDATE arrives over realtime and the section refetches.
+    sync.input!.onMessageUpdate!({ id: "m-retag", job_tag: "job-1" });
+
+    expect(await screen.findByText("now tagged")).toBeDefined();
+    expect(screen.getByText("Messages (1)")).toBeDefined();
+  });
+});

--- a/src/components/job-detail/job-messages-section.tsx
+++ b/src/components/job-detail/job-messages-section.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { MessageSquare, Send } from "lucide-react";
+import { useAuth } from "@/lib/auth-context";
+import { createClient } from "@/lib/supabase";
+import { findContactByPhone, formatPhoneNumber } from "@/lib/phone";
+import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
+import { usePhoneSync } from "@/lib/phone/use-phone-sync";
+import { JobMessageRow } from "@/components/phone/job-message-row";
+import { ComposeTextModal } from "@/components/phone/compose-text-modal";
+import type { PhoneAttachmentRef } from "@/components/phone/message-attachment";
+
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Messages (N) section.
+//
+// Mirrors the Emails (N) section on every Job page. Renders every text/MMS
+// tagged to this Job — across all numbers (Shared and Personal) and all
+// teammates who corresponded about it. The list is read through
+// GET /api/phone/messages?jobId= (RLS enforces per-message visibility);
+// the whole section is hidden from anyone without `view_phone`.
+
+export interface JobMessageContact {
+  id: string;
+  name: string;
+  phone: string | null;
+}
+
+export interface JobMessage {
+  id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  body: string | null;
+  media_urls: PhoneAttachmentRef[];
+  sent_at: string;
+  job_tag: string | null;
+}
+
+export function JobMessagesSection({
+  jobId,
+  organizationId,
+  contacts,
+}: {
+  jobId: string;
+  organizationId: string | null;
+  contacts: JobMessageContact[];
+}) {
+  const { hasPermission, loading } = useAuth();
+  const canView = !loading && hasPermission("view_phone");
+  const [messages, setMessages] = useState<JobMessage[]>([]);
+  const [composeOpen, setComposeOpen] = useState(false);
+
+  // Only contacts with a phone number can be texted; the Text button is
+  // hidden when there's no one to text or while outbound SMS is gated
+  // (#305 A2P 10DLC).
+  const textableContacts = contacts.filter((c) => c.phone);
+  const canText = isPhoneOutboundEnabled() && textableContacts.length > 0;
+
+  const fetchMessages = useCallback(async () => {
+    const res = await fetch(
+      `/api/phone/messages?jobId=${encodeURIComponent(jobId)}`,
+    );
+    if (!res.ok) return;
+    const data = (await res.json()) as JobMessage[];
+    setMessages(Array.isArray(data) ? data : []);
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!canView) return;
+    void fetchMessages();
+  }, [canView, fetchMessages]);
+
+  // Realtime: re-pull this Job's tagged messages whenever a phone_message in
+  // the org is inserted (a new Job-tagged text arrives) or updated (an
+  // existing message is re-tagged to a Job). The refetch re-applies the
+  // job_tag filter server-side, so the org-wide subscription stays a coarse
+  // "something changed → reload" signal — the simplest correct thing, like
+  // the Phone tab (slice 4). Non-view_phone users hold no subscription.
+  const supabase = useMemo(() => createClient(), []);
+  usePhoneSync({
+    supabase,
+    organizationId: canView ? organizationId : null,
+    onNewMessage: () => void fetchMessages(),
+    onMessageUpdate: () => void fetchMessages(),
+  });
+
+  if (!canView) return null;
+
+  return (
+    <div className="bg-card rounded-xl border border-border p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-semibold text-foreground">
+          <MessageSquare size={16} className="inline mr-2 -mt-0.5" />
+          Messages ({messages.length})
+        </h3>
+        {canText && (
+          <button
+            onClick={() => setComposeOpen(true)}
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-colors gap-1.5"
+          >
+            <Send size={14} />
+            Text
+          </button>
+        )}
+      </div>
+      <ComposeTextModal
+        open={composeOpen}
+        onClose={() => setComposeOpen(false)}
+        jobId={jobId}
+        contacts={textableContacts}
+        onSent={fetchMessages}
+      />
+      {messages.length > 0 && (
+        <div className="space-y-2">
+          {messages.map((m) => {
+            const number = m.direction === "in" ? m.from_e164 : m.to_e164;
+            const contact = findContactByPhone(contacts, number);
+            return (
+              <JobMessageRow
+                key={m.id}
+                message={{
+                  id: m.id,
+                  direction: m.direction,
+                  from_e164: m.from_e164,
+                  to_e164: m.to_e164,
+                  body: m.body,
+                  media_urls: m.media_urls ?? [],
+                  sent_at: m.sent_at,
+                  counterpartyLabel: contact
+                    ? contact.name
+                    : formatPhoneNumber(number),
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+      {messages.length === 0 && (
+        <div className="text-center py-6">
+          <MessageSquare
+            size={32}
+            className="mx-auto text-muted-foreground/40 mb-2"
+          />
+          <p className="text-sm text-muted-foreground/60">
+            No text messages linked to this job yet.
+          </p>
+          <p className="text-xs text-muted-foreground/40 mt-1">
+            Text a contact using the button above.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/job-detail/job-text-contacts.test.ts
+++ b/src/components/job-detail/job-text-contacts.test.ts
@@ -1,0 +1,64 @@
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Messages section.
+//
+// `buildJobTextContacts` maps a Job to the contact list the Messages
+// section's Text button offers. Confirmed design (issue #311): the
+// homeowner is the default (first), followed by the Job's adjusters with
+// the PRIMARY adjuster ahead of the rest. Insurance and HOA contacts are
+// intentionally excluded — you don't text the carrier or the HOA from a
+// Job. The section itself filters this list down to those with a phone.
+
+import { describe, it, expect } from "vitest";
+import type { Job, Contact } from "@/lib/types";
+import { buildJobTextContacts } from "./job-text-contacts";
+
+// Minimal Contact — the builder only reads id/full_name/phone.
+function contact(over: Partial<Contact>): Contact {
+  return {
+    id: "c",
+    full_name: "x",
+    phone: null,
+    ...over,
+  } as Contact;
+}
+
+describe("buildJobTextContacts", () => {
+  it("lists the homeowner first, then adjusters with the primary ahead of the rest", () => {
+    const job = {
+      contact: contact({ id: "home", full_name: "Homer Owner", phone: "+15125550001" }),
+      job_adjusters: [
+        // Deliberately out of order: a non-primary listed before the primary.
+        { id: "ja2", is_primary: false, adjuster: contact({ id: "adj2", full_name: "Sec Ondary", phone: "+15125550003" }) },
+        { id: "ja1", is_primary: true, adjuster: contact({ id: "adj1", full_name: "Pri Mary", phone: "+15125550002" }) },
+      ],
+    } as unknown as Job;
+
+    const result = buildJobTextContacts(job);
+
+    expect(result.map((c) => c.id)).toEqual(["home", "adj1", "adj2"]);
+    expect(result[0]).toEqual({ id: "home", name: "Homer Owner", phone: "+15125550001" });
+    expect(result[1]).toEqual({ id: "adj1", name: "Pri Mary", phone: "+15125550002" });
+  });
+
+  it("skips adjuster rows with no joined contact and passes a null phone through", () => {
+    const job = {
+      contact: contact({ id: "home", full_name: "Homer Owner", phone: null }),
+      job_adjusters: [
+        { id: "ja1", is_primary: true, adjuster: contact({ id: "adj1", full_name: "Pri Mary", phone: null }) },
+        // A join that didn't resolve (RLS-hidden or deleted contact) — skip it.
+        { id: "ja-orphan", is_primary: false, adjuster: undefined },
+      ],
+    } as unknown as Job;
+
+    const result = buildJobTextContacts(job);
+
+    expect(result.map((c) => c.id)).toEqual(["home", "adj1"]);
+    // A phone-less contact is still listed (the section filters textables);
+    // its null phone is preserved verbatim.
+    expect(result[0].phone).toBeNull();
+    expect(result[1].phone).toBeNull();
+  });
+
+  it("returns an empty list for a job with neither a contact nor adjusters", () => {
+    expect(buildJobTextContacts({} as Job)).toEqual([]);
+  });
+});

--- a/src/components/job-detail/job-text-contacts.ts
+++ b/src/components/job-detail/job-text-contacts.ts
@@ -1,0 +1,42 @@
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Messages section.
+//
+// Map a Job to the contacts its Text button offers: the homeowner first
+// (the default recipient), then the Job's adjusters with the primary ahead
+// of the rest. Insurance and HOA contacts are intentionally excluded. The
+// Messages section filters the result down to those with a phone number.
+
+import type { Job } from "@/lib/types";
+import type { JobMessageContact } from "./job-messages-section";
+
+export function buildJobTextContacts(
+  job: Pick<Job, "contact" | "job_adjusters">,
+): JobMessageContact[] {
+  const contacts: JobMessageContact[] = [];
+
+  if (job.contact) {
+    contacts.push({
+      id: job.contact.id,
+      name: job.contact.full_name,
+      phone: job.contact.phone,
+    });
+  }
+
+  // Stable sort floats the primary adjuster to the front while preserving
+  // the existing order among the rest (Array.prototype.sort is stable).
+  const adjusters = [...(job.job_adjusters ?? [])].sort(
+    (a, b) => Number(b.is_primary) - Number(a.is_primary),
+  );
+  for (const ja of adjusters) {
+    // The contacts join can be absent (RLS-hidden or a deleted contact) —
+    // skip those rather than surfacing a nameless recipient.
+    const adjuster = ja.adjuster;
+    if (!adjuster) continue;
+    contacts.push({
+      id: adjuster.id,
+      name: adjuster.full_name,
+      phone: adjuster.phone,
+    });
+  }
+
+  return contacts;
+}

--- a/src/components/phone/compose-text-modal.test.tsx
+++ b/src/components/phone/compose-text-modal.test.tsx
@@ -1,0 +1,140 @@
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Text compose.
+//
+// The Job-page Text button opens this modal with one of the Job's Contacts
+// pre-filled. Sending posts to /api/phone/messages with
+// sourceContext: { kind: 'job', jobId } so smart-attach auto-tags the
+// outbound to this Job — there is NO tagging-chip prompt in this path
+// (the tag is definite). AC bullets pinned here:
+//   - "Text button opens compose with one of the Job's Contacts pre-filled"
+//   - "outbound text auto-tagged (job_tag set, no chip prompt)"
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ComposeTextModal } from "./compose-text-modal";
+
+const homeowner = { id: "c1", name: "Homer Owner", phone: "+15125550001" };
+const adjuster = { id: "c2", name: "Adjuster Joe", phone: "+15125550002" };
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function stubSendOk() {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ id: "sent-1", status: "queued" }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+describe("ComposeTextModal — recipient pre-fill", () => {
+  it("opens with the first (primary) contact pre-filled as the recipient", () => {
+    render(
+      <ComposeTextModal
+        open
+        onClose={() => {}}
+        jobId="job-1"
+        contacts={[homeowner]}
+      />,
+    );
+    expect(screen.getByText("Homer Owner")).toBeDefined();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ComposeTextModal
+        open={false}
+        onClose={() => {}}
+        jobId="job-1"
+        contacts={[homeowner]}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("ComposeTextModal — multiple contacts", () => {
+  it("shows a recipient dropdown listing every contact, defaulting to the first", () => {
+    render(
+      <ComposeTextModal
+        open
+        onClose={() => {}}
+        jobId="job-1"
+        contacts={[homeowner, adjuster]}
+      />,
+    );
+    const select = screen.getByLabelText(/recipient/i) as HTMLSelectElement;
+    expect(select.value).toBe("c1");
+    expect(screen.getByRole("option", { name: "Homer Owner" })).toBeDefined();
+    expect(screen.getByRole("option", { name: "Adjuster Joe" })).toBeDefined();
+  });
+});
+
+describe("ComposeTextModal — no tagging prompt", () => {
+  it("never renders the smart-attach tagging chips (the Job tag is definite here)", () => {
+    render(
+      <ComposeTextModal
+        open
+        onClose={() => {}}
+        jobId="job-1"
+        contacts={[homeowner, adjuster]}
+      />,
+    );
+    expect(screen.queryByText(/tag to/i)).toBeNull();
+    expect(screen.queryByText(/re-tag/i)).toBeNull();
+  });
+});
+
+describe("ComposeTextModal — send", () => {
+  it("posts to /api/phone/messages with the recipient and sourceContext {kind:'job',jobId}, then fires onSent + onClose", async () => {
+    const spy = stubSendOk();
+    const onSent = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <ComposeTextModal
+        open
+        onClose={onClose}
+        jobId="job-1"
+        contacts={[homeowner]}
+        onSent={onSent}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/message/i), {
+      target: { value: "On our way" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const [url, init] = spy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("/api/phone/messages");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      outsideE164: "+15125550001",
+      body: "On our way",
+      sourceContext: { kind: "job", jobId: "job-1" },
+    });
+
+    await waitFor(() => expect(onSent).toHaveBeenCalled());
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not send an empty message", () => {
+    const spy = stubSendOk();
+    render(
+      <ComposeTextModal
+        open
+        onClose={() => {}}
+        jobId="job-1"
+        contacts={[homeowner]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /send/i }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/phone/compose-text-modal.tsx
+++ b/src/components/phone/compose-text-modal.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { useState } from "react";
+import { Send, X } from "lucide-react";
+
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Text compose.
+//
+// Opened by the Job-page Text button with one of the Job's Contacts
+// pre-filled. Sending posts to /api/phone/messages with
+// sourceContext: { kind: 'job', jobId }, so smart-attach auto-tags the
+// outbound to this Job. There is deliberately NO tagging-chip prompt here
+// — on the Job page the tag is definite.
+
+export interface ComposeContact {
+  id: string;
+  name: string;
+  phone: string | null;
+}
+
+export function ComposeTextModal({
+  open,
+  onClose,
+  jobId,
+  contacts,
+  onSent,
+}: {
+  open: boolean;
+  onClose: () => void;
+  jobId: string;
+  contacts: ComposeContact[];
+  onSent?: () => void;
+}) {
+  const [selectedId, setSelectedId] = useState(contacts[0]?.id ?? "");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const selected = contacts.find((c) => c.id === selectedId) ?? contacts[0];
+
+  async function handleSend() {
+    if (sending || body.trim().length === 0 || !selected?.phone) return;
+    setSending(true);
+    setError(null);
+    const res = await fetch("/api/phone/messages", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        outsideE164: selected.phone,
+        body,
+        // Smart-attach Job branch — the outbound is auto-tagged to this
+        // Job, no chip prompt. See decideJobTag().
+        sourceContext: { kind: "job", jobId },
+      }),
+    });
+    setSending(false);
+    if (!res.ok) {
+      setError("Could not send the text. Please try again.");
+      return;
+    }
+    setBody("");
+    onSent?.();
+    onClose();
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Text a contact"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-foreground">Text</h3>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          To
+        </label>
+        {contacts.length > 1 ? (
+          <select
+            aria-label="Recipient"
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="mb-3 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+          >
+            {contacts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <div className="mb-3 text-sm text-foreground">{selected?.name}</div>
+        )}
+
+        <textarea
+          aria-label="Message"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          rows={4}
+          placeholder="Type a message…"
+          className="mb-3 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+        />
+
+        {error ? (
+          <p className="mb-3 text-xs text-destructive">{error}</p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={sending || body.trim().length === 0}
+            className="inline-flex items-center justify-center gap-1.5 rounded-md bg-[image:var(--gradient-primary)] px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:brightness-110 disabled:opacity-50"
+          >
+            <Send size={14} />
+            Send Text
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/phone/job-message-row.test.tsx
+++ b/src/components/phone/job-message-row.test.tsx
@@ -1,0 +1,117 @@
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page message row.
+//
+// One text/MMS in the Job-page Messages section. Keeps the Phone-tab
+// bubble treatment (inbound left/muted, outbound right/brand) and adds a
+// per-message context header (counterparty + timestamp) — the Job section
+// shows messages across many conversations, so each needs to say who it
+// was with and when.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { JobMessageRow } from "./job-message-row";
+import type { PhoneAttachmentRef } from "./message-attachment";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+type Row = {
+  id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  body: string | null;
+  media_urls: PhoneAttachmentRef[];
+  sent_at: string;
+  counterpartyLabel: string;
+};
+
+function row(overrides: Partial<Row> = {}): Row {
+  return {
+    id: "m1",
+    direction: "in",
+    from_e164: "+15125550001",
+    to_e164: "+15125559999",
+    body: "Roof leaking",
+    media_urls: [],
+    sent_at: "2026-06-01T10:00:00Z",
+    counterpartyLabel: "Homer Owner",
+    ...overrides,
+  };
+}
+
+describe("JobMessageRow — bubble treatment", () => {
+  it("renders an inbound message left-aligned in the muted bubble", () => {
+    render(
+      <JobMessageRow message={row({ direction: "in", body: "Roof leaking" })} />,
+    );
+    const bubble = screen.getByText("Roof leaking");
+    expect(bubble.className).toContain("bg-muted");
+    expect(bubble.parentElement!.className).toMatch(/items-start|self-start/);
+  });
+
+  it("renders an outbound message right-aligned in the brand bubble", () => {
+    render(
+      <JobMessageRow message={row({ direction: "out", body: "On our way" })} />,
+    );
+    const bubble = screen.getByText("On our way");
+    expect(bubble.className).toContain("bg-[var(--brand-primary)]");
+    expect(bubble.className).toContain("text-white");
+    expect(bubble.parentElement!.className).toMatch(/items-end|self-end/);
+  });
+});
+
+describe("JobMessageRow — context header", () => {
+  it("shows the counterparty label and a formatted timestamp", () => {
+    render(
+      <JobMessageRow
+        message={row({
+          counterpartyLabel: "Homer Owner",
+          sent_at: "2026-06-01T15:30:00Z",
+        })}
+      />,
+    );
+    expect(screen.getByText("Homer Owner")).toBeDefined();
+    // Clock time in `h:mm a` form — assert the shape, not the exact value
+    // (jsdom's timezone is environment-dependent).
+    expect(screen.getByText(/\d{1,2}:\d{2}\s*(AM|PM)/i)).toBeDefined();
+  });
+});
+
+describe("JobMessageRow — MMS attachments", () => {
+  it("renders an image attachment as a thumbnail button and a non-image as a download link", async () => {
+    const spy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ url: "https://signed.example/x" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <JobMessageRow
+        message={row({
+          body: "see photos",
+          media_urls: [
+            {
+              storage_path: "org/img.jpg",
+              media_type: "image/jpeg",
+              filename: "img.jpg",
+            },
+            {
+              storage_path: "org/doc.pdf",
+              media_type: "application/pdf",
+              filename: "doc.pdf",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /open attachment img\.jpg/i }),
+    ).toBeDefined();
+    expect(screen.getByRole("link", { name: /doc\.pdf/i })).toBeDefined();
+  });
+});

--- a/src/components/phone/job-message-row.tsx
+++ b/src/components/phone/job-message-row.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useState } from "react";
+import { format } from "date-fns";
+import {
+  MessageAttachment,
+  PhoneAttachmentLightbox,
+  type PhoneAttachmentRef,
+} from "./message-attachment";
+
+// PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page message row.
+//
+// One text/MMS in the Job-page Messages section. Reuses the Phone-tab
+// bubble treatment (inbound left/muted, outbound right/brand) and the
+// shared MessageAttachment so a message reads the same wherever it
+// appears, and adds a per-message context header (who it was with + when)
+// because the Job section spans many conversations and numbers.
+
+export interface JobMessageRowData {
+  id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  body: string | null;
+  media_urls: PhoneAttachmentRef[];
+  sent_at: string;
+  counterpartyLabel: string;
+}
+
+export function JobMessageRow({ message }: { message: JobMessageRowData }) {
+  const isIn = message.direction === "in";
+  const [lightboxPath, setLightboxPath] = useState<string | null>(null);
+  const attachments = message.media_urls ?? [];
+  return (
+    <div className={`flex flex-col gap-1 ${isIn ? "items-start" : "items-end"}`}>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <span className="font-medium text-foreground/70">
+          {message.counterpartyLabel}
+        </span>
+        <span>{format(new Date(message.sent_at), "MMM d, h:mm a")}</span>
+      </div>
+      <div
+        className={`max-w-[70%] rounded-lg px-3 py-2 text-sm ${
+          isIn ? "bg-muted" : "bg-[var(--brand-primary)] text-white"
+        }`}
+      >
+        {message.body}
+        {attachments.length > 0 ? (
+          <ul className="mt-2 flex flex-wrap gap-2">
+            {attachments.map((mu, idx) => (
+              <li key={`${message.id}-att-${idx}`}>
+                <MessageAttachment
+                  attachment={mu}
+                  onOpenLightbox={(p) => setLightboxPath(p)}
+                />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+      {lightboxPath ? (
+        <PhoneAttachmentLightbox
+          path={lightboxPath}
+          onClose={() => setLightboxPath(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/phone/message-attachment.tsx
+++ b/src/components/phone/message-attachment.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { isMmsImageMediaType } from "@/lib/phone/mms-attachments";
+
+// PRD #304 — Nookleus Phone. Slice 6 (#310) / slice 7 (#311).
+//
+// Shared message-attachment rendering, used by both the Phone-tab thread
+// and the Job-page Messages section so an MMS reads identically wherever
+// it appears. Images load via the signed-URL endpoint and click open the
+// lightbox; non-image media is a labelled download link (also via the
+// signed URL).
+
+export interface PhoneAttachmentRef {
+  storage_path: string;
+  media_type: string;
+  filename?: string;
+}
+
+export function MessageAttachment({
+  attachment,
+  onOpenLightbox,
+}: {
+  attachment: PhoneAttachmentRef;
+  onOpenLightbox: (path: string) => void;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/attachments?path=${encodeURIComponent(attachment.storage_path)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.storage_path]);
+
+  if (isMmsImageMediaType(attachment.media_type)) {
+    return (
+      <button
+        type="button"
+        aria-label={`Open attachment ${attachment.filename ?? ""}`.trim()}
+        onClick={() => onOpenLightbox(attachment.storage_path)}
+        className="block overflow-hidden rounded border border-border bg-background"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={url ?? ""}
+          alt={`attachment ${attachment.filename ?? ""}`.trim()}
+          className="block h-32 w-32 object-cover"
+        />
+      </button>
+    );
+  }
+  const label = attachment.filename ?? "Download attachment";
+  return (
+    <a
+      href={url ?? "#"}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 rounded border border-border bg-background px-2 py-1 text-xs text-foreground hover:underline"
+    >
+      {label}
+    </a>
+  );
+}
+
+export function PhoneAttachmentLightbox({
+  path,
+  onClose,
+}: {
+  path: string;
+  onClose: () => void;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/attachments?path=${encodeURIComponent(path)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [path]);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [onClose]);
+  return (
+    <div
+      role="dialog"
+      aria-label="Attachment preview"
+      onClick={onClose}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+    >
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url ?? ""}
+        alt="attachment full size"
+        className="max-h-[90vh] max-w-[90vw] rounded shadow-lg"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}

--- a/src/lib/phone/smart-attach.test.ts
+++ b/src/lib/phone/smart-attach.test.ts
@@ -133,3 +133,52 @@ describe("decideJobTag — inbound branches (PRD #304, slice 4)", () => {
     });
   });
 });
+
+describe("decideJobTag — outbound branches (PRD #304, Job-page Text #311)", () => {
+  // The Job-page Text button (#311) sends sourceContext { kind: 'job', jobId }.
+  // This is the decision AC6 rests on: a Job-page send is auto-tagged to that
+  // Job — no chip prompt — so the message lands in that Job's Messages section.
+  it("outbound from a Job page: auto-tags to that Job regardless of the contact's Active-job count", () => {
+    // Definite tag — auto even when the contact has multiple Active jobs that
+    // would otherwise prompt. The Job page IS the disambiguation.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "job", jobId: "job-9" },
+        contactId: CONTACT_ID,
+        activeJobs: [
+          job("job-1", "WTR-2026-0001"),
+          job("job-2", "FYR-2026-0005"),
+        ],
+      }),
+    ).toEqual({ kind: "auto", jobId: "job-9" });
+  });
+
+  it("outbound from a Job page auto-tags from the source even with no contact and no Active jobs", () => {
+    // The route's Job-source path skips the contact/Active-jobs lookup
+    // entirely; the jobId comes straight from the source context.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "job", jobId: "job-9" },
+        contactId: null,
+        activeJobs: [],
+      }),
+    ).toEqual({ kind: "auto", jobId: "job-9" });
+  });
+
+  it("outbound from the Phone tab does NOT auto-tag from the source (only a Job-page source carries a jobId)", () => {
+    // Pins that the kind:'job' short-circuit is the ONLY source-driven
+    // auto-tag: a phone-tab send falls through to the contact rules, so with
+    // no Active jobs it stays untagged. A one-char change to the source check
+    // (matching 'phone-tab') would wrongly auto-tag here.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "phone-tab" },
+        contactId: CONTACT_ID,
+        activeJobs: [],
+      }),
+    ).toEqual({ kind: "untagged" });
+  });
+});

--- a/src/lib/phone/use-phone-sync.test.ts
+++ b/src/lib/phone/use-phone-sync.test.ts
@@ -160,3 +160,86 @@ describe("usePhoneSync", () => {
     expect(supabase.channel).not.toHaveBeenCalled();
   });
 });
+
+// Slice 7 (#311) — re-tag support. A message tagged to a Job after the fact
+// (an untagged Phone-tab message UPDATEd with a job_tag) must surface in the
+// Job's Messages section in realtime. That's an UPDATE, not an INSERT, so the
+// hook grows an optional `onMessageUpdate` callback that registers a *second*
+// subscription. The Phone-tab caller passes none, so its behavior is
+// unchanged (no UPDATE subscription at all).
+describe("usePhoneSync — onMessageUpdate (re-tag)", () => {
+  it("registers a second UPDATE subscription and fires onMessageUpdate with the updated row", () => {
+    const supabase = fakeSupabase();
+    const onMessageUpdate = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+        onMessageUpdate,
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    // INSERT stays the first .on() (existing callers read calls[0]); UPDATE
+    // is the second.
+    expect(ch.on.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ event: "INSERT" }),
+    );
+    expect(ch.on).toHaveBeenCalledWith(
+      "postgres_changes",
+      expect.objectContaining({
+        event: "UPDATE",
+        schema: "public",
+        table: "phone_messages",
+        filter: "organization_id=eq.org-1",
+      }),
+      expect.any(Function),
+    );
+
+    const updateHandler = ch.on.mock.calls[1][2] as (payload: {
+      new: Record<string, unknown>;
+    }) => void;
+    act(() => {
+      updateHandler({
+        new: {
+          id: "m-9",
+          organization_id: "org-1",
+          conversation_id: "conv-1",
+          direction: "in",
+          body: "now tagged",
+          job_tag: "job-1",
+        },
+      });
+    });
+
+    expect(onMessageUpdate).toHaveBeenCalledWith({
+      id: "m-9",
+      organization_id: "org-1",
+      conversation_id: "conv-1",
+      direction: "in",
+      body: "now tagged",
+      job_tag: "job-1",
+    });
+  });
+
+  it("registers no UPDATE subscription when onMessageUpdate is omitted", () => {
+    const supabase = fakeSupabase();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    // INSERT only — exactly one .on() call, and it's not an UPDATE.
+    expect(ch.on).toHaveBeenCalledTimes(1);
+    expect(ch.on.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ event: "INSERT" }),
+    );
+  });
+});

--- a/src/lib/phone/use-phone-sync.ts
+++ b/src/lib/phone/use-phone-sync.ts
@@ -34,22 +34,35 @@ export interface UsePhoneSyncInput {
   // the hook holds no subscription in that state.
   organizationId: string | null;
   onNewMessage: (row: PhoneMessageRow) => void;
+  // Slice 7 (#311) — optional. When provided, the hook also subscribes to
+  // `phone_messages` UPDATEs so a message re-tagged to a Job after the fact
+  // (job_tag changed) can resurface in realtime. Omitted by the Phone-tab
+  // caller, which only cares about new arrivals — so no UPDATE subscription
+  // is registered there and its behavior is unchanged.
+  onMessageUpdate?: (row: PhoneMessageRow) => void;
 }
 
 export function usePhoneSync(input: UsePhoneSyncInput): void {
   const onNewMessageRef = useRef(input.onNewMessage);
+  const onMessageUpdateRef = useRef(input.onMessageUpdate);
   // useLayoutEffect (or useEffect — either works since the effect runs
   // before the next event-loop tick that fires the subscription handler)
   // keeps the ref read-only during render, satisfying react-hooks/refs.
   useLayoutEffect(() => {
     onNewMessageRef.current = input.onNewMessage;
-  }, [input.onNewMessage]);
+    onMessageUpdateRef.current = input.onMessageUpdate;
+  }, [input.onNewMessage, input.onMessageUpdate]);
 
   const { supabase, organizationId } = input;
+  // Whether to register the UPDATE subscription is decided once per
+  // (org) effect run; toggling the callback's presence is rare and a
+  // remount-worthy change, so it gates the effect rather than living
+  // behind the ref.
+  const wantsUpdates = input.onMessageUpdate != null;
 
   useEffect(() => {
     if (!organizationId) return;
-    const channel = supabase
+    let channel = supabase
       .channel(`phone-messages-${organizationId}`)
       .on(
         "postgres_changes",
@@ -62,11 +75,27 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
         (payload: { new: PhoneMessageRow }) => {
           onNewMessageRef.current(payload.new);
         },
-      )
-      .subscribe();
+      );
+
+    if (wantsUpdates) {
+      channel = channel.on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "phone_messages",
+          filter: `organization_id=eq.${organizationId}`,
+        },
+        (payload: { new: PhoneMessageRow }) => {
+          onMessageUpdateRef.current?.(payload.new);
+        },
+      );
+    }
+
+    const subscribed = channel.subscribe();
 
     return () => {
-      channel.unsubscribe();
+      subscribed.unsubscribe();
     };
-  }, [supabase, organizationId]);
+  }, [supabase, organizationId, wantsUpdates]);
 }

--- a/supabase/migration-311-smoke-test.sql
+++ b/supabase/migration-311-smoke-test.sql
@@ -1,0 +1,210 @@
+-- issue #311 (PRD #304, ADR 0005) — Job-page Messages (N) section RLS smoke.
+--
+-- Purpose:   Slice 7 adds NO schema or RLS migration — the Job Messages
+--            section reads through GET /api/phone/messages?jobId=, which
+--            runs `select … from phone_messages where job_tag = :jobId`
+--            on the User client (RLS). This smoke pins that the EXISTING
+--            migration-308 phone_messages_select policy makes that exact
+--            query return the right rows for the slice-7 acceptance case:
+--
+--              "a Job-tagged message on a Personal number appears for any
+--               teammate who can see the Job"
+--
+--            migration-308-smoke covers the full ADR-0005 matrix cell-by
+--            -cell; this script is narrower and query-shaped: it filters by
+--            job_tag exactly as the route does and asserts the section sees
+--            every Job-tagged message ACROSS numbers (Shared + Personal),
+--            for a NON-owner teammate — the scenario the section depends on
+--            but cannot itself prove (the section's own tests mock the
+--            route; only the database enforces cross-number visibility).
+--
+--            NOTE: view_phone is a route-wrapper gate (withRequestContext),
+--            not an RLS predicate — so it is intentionally NOT modelled
+--            here. This script verifies only the row-level visibility the
+--            route's user-client SELECT is subject to.
+--
+-- Shape:     One transaction, rolled back at the end. Service-role seeds
+--            one org (+ a cross-org), three users, a Shared and a Personal
+--            number, a conversation on each, two Jobs, and four messages.
+--            Each assertion sets JWT claims, switches to `authenticated`,
+--            runs the route's job_tag-filtered SELECT, and asserts.
+--
+-- Run:       Read-only — via Supabase MCP `execute_sql` against any project
+--            that has the phone schema. BEGIN/ROLLBACK, no migration, no
+--            committed writes.
+--
+-- Status (2026-06-07): NOT YET RUNNABLE against prod (rzzprgidqbnqcdupmpfe).
+--            The phone core schema is staged but undeployed there — only
+--            migration-306 (view_phone) and migration-309 (phone_opt_outs)
+--            are applied; migration-307 (phone_numbers) and migration-308
+--            (phone_conversations/phone_messages, + the RLS this exercises)
+--            are not. Run this once 307+308 land on the target project. The
+--            RLS contract itself is already proven by migration-308-smoke
+--            -test.sql case 2 (a crew_lead non-owner sees a Personal-number
+--            Job-tagged message, not an untagged one) — slice 7 adds NO new
+--            policy, so this script only re-pins it through the section's
+--            exact job_tag-filtered query shape.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed.
+--      Org 1: smoke-311-org-1
+--        User A — admin, OWNER of the Personal number
+--        User B — crew_lead, NON-owner teammate (the "can see the Job" case)
+--      Org 2: smoke-311-org-2
+--        User D — admin (cross-org)
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('a9000000-0000-0000-0000-000000000001', 'smoke-311-org-1', 'smoke-311-org-1'),
+  ('a9000000-0000-0000-0000-000000000002', 'smoke-311-org-2', 'smoke-311-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('a9000000-0000-0000-0000-000000000010', 'smoke-311-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('a9000000-0000-0000-0000-000000000011', 'smoke-311-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('a9000000-0000-0000-0000-000000000013', 'smoke-311-d@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('a9000000-0000-0000-0000-000000000010', 'a9000000-0000-0000-0000-000000000001', 'admin'),
+  ('a9000000-0000-0000-0000-000000000011', 'a9000000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('a9000000-0000-0000-0000-000000000013', 'a9000000-0000-0000-0000-000000000002', 'admin');
+
+-- A Shared number and a Personal number owned by User A.
+insert into public.phone_numbers
+  (id, organization_id, twilio_sid, e164, kind, user_id)
+values
+  ('a9000000-0000-0000-0000-0000000000a1', 'a9000000-0000-0000-0000-000000000001',
+   'PN-smoke311-shared', '+15125550100', 'shared', null),
+  ('a9000000-0000-0000-0000-0000000000a2', 'a9000000-0000-0000-0000-000000000001',
+   'PN-smoke311-personal', '+15125550101', 'personal',
+   'a9000000-0000-0000-0000-000000000010');
+
+-- One conversation on each number.
+insert into public.phone_conversations
+  (id, organization_id, phone_number_id, outside_e164)
+values
+  ('a9000000-0000-0000-0000-0000000000b1', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000a1', '+15551110101'),
+  ('a9000000-0000-0000-0000-0000000000b2', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000a2', '+15551110102');
+
+-- Two Jobs: d1 is "this job" (the section's jobId); d2 is a decoy.
+insert into public.contacts (id, full_name)
+values ('a9000000-0000-0000-0000-0000000000c1', 'smoke-311-contact');
+
+insert into public.jobs
+  (id, organization_id, contact_id, damage_type, property_address)
+values
+  ('a9000000-0000-0000-0000-0000000000d1', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000c1', 'water', '1 smoke st'),
+  ('a9000000-0000-0000-0000-0000000000d2', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000c1', 'water', '2 smoke st');
+
+-- Four messages:
+--   m1: Shared,   tagged d1  → in the section
+--   m2: Personal, tagged d1  → in the section (the headline case: Personal,
+--                              owned by A, must surface for non-owner B)
+--   m3: Personal, untagged   → NOT in the section (no job_tag) and owner-only
+--   m4: Shared,   tagged d2  → NOT in the section (different Job)
+insert into public.phone_messages
+  (id, organization_id, conversation_id, direction, from_e164, to_e164, body, job_tag)
+values
+  ('a9000000-0000-0000-0000-0000000000e1', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'shared-job1',
+   'a9000000-0000-0000-0000-0000000000d1'),
+  ('a9000000-0000-0000-0000-0000000000e2', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'personal-job1',
+   'a9000000-0000-0000-0000-0000000000d1'),
+  ('a9000000-0000-0000-0000-0000000000e3', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'personal-untagged', null),
+  ('a9000000-0000-0000-0000-0000000000e4', 'a9000000-0000-0000-0000-000000000001',
+   'a9000000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'shared-job2',
+   'a9000000-0000-0000-0000-0000000000d2');
+
+-- ---------------------------------------------------------------------------
+-- 1. The headline case. User B (crew_lead, NON-owner of the Personal
+--    number) runs the section's query — `where job_tag = d1` — and must see
+--    BOTH the Shared and the Personal Job-tagged messages, and ONLY those.
+--    The Personal message is owned by A; B sees it solely because it is
+--    tagged to a Job B can see.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_bodies text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a9000000-0000-0000-0000-000000000011","active_organization_id":"a9000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(body, ',' order by body)
+    into v_count, v_bodies
+    from public.phone_messages
+   where job_tag = 'a9000000-0000-0000-0000-0000000000d1';
+
+  reset role;
+
+  if v_count <> 2 then
+    raise exception 'migration-311 smoke (case 1: non-owner teammate): expected 2 Job-tagged messages, got % (%)', v_count, v_bodies;
+  end if;
+  if v_bodies <> 'personal-job1,shared-job1' then
+    raise exception 'migration-311 smoke (case 1: non-owner teammate): wrong rows — expected personal-job1,shared-job1 got %', v_bodies;
+  end if;
+  raise notice 'migration-311 smoke (case 1) — non-owner teammate sees the Job''s messages across Shared + Personal numbers';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Sanity: User A (owner of the Personal number) sees the same two
+--    Job-tagged messages via the section's query.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a9000000-0000-0000-0000-000000000010","active_organization_id":"a9000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count
+    from public.phone_messages
+   where job_tag = 'a9000000-0000-0000-0000-0000000000d1';
+
+  reset role;
+
+  if v_count <> 2 then
+    raise exception 'migration-311 smoke (case 2: Personal owner): expected 2 Job-tagged messages, got %', v_count;
+  end if;
+  raise notice 'migration-311 smoke (case 2) — Personal-number owner sees the same Job-tagged set';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Cross-org: User D (admin, org-2) runs the same query and sees nothing —
+--    org isolation holds even when filtering by another org's job_tag.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"a9000000-0000-0000-0000-000000000013","active_organization_id":"a9000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*) into v_count
+    from public.phone_messages
+   where job_tag = 'a9000000-0000-0000-0000-0000000000d1';
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-311 smoke (case 3: cross-org): expected 0 Job-tagged messages, got %', v_count;
+  end if;
+  raise notice 'migration-311 smoke (case 3) — cross-org caller sees none of the Job''s messages';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Done — nothing committed.
+-- ---------------------------------------------------------------------------
+rollback;


### PR DESCRIPTION
PRD #304 slice 7 (closes #311).

## What this adds
- **Messages (N) section** on every Job page, mirroring **Emails (N)** — renders every text/MMS tagged to the Job across all numbers (Shared + Personal) and teammates, read via `GET /api/phone/messages?jobId=` (RLS enforces per-message visibility per **ADR 0005**).
- **Job-page Text button** — opens compose with a Job Contact pre-filled (homeowner default, adjusters primary-first) and auto-tags the outbound via `sourceContext {kind:'job',jobId}`. No tagging-chip prompt — the Job *is* the disambiguation.
- **Realtime** — section + (N) badge update live via an extended `use-phone-sync` (INSERT + a new UPDATE subscription so re-tags surface immediately).
- **Gating** — the whole section and the GET endpoint require `view_phone`; non-`view_phone` users get no section, no fetch, and no realtime subscription.
- **Dedup** — extracts the shared `MessageAttachment` / `PhoneAttachmentLightbox` / `PhoneAttachmentRef` out of `phone-page-client` into `components/phone/message-attachment.tsx` (byte-identical; no behavior change).

## Tests & quality
- **59 slice tests** (RTL section/compose/row + route + pure `decideJobTag`). Each headline behavior (job_tag persistence, outbound auto-tag decision, subscription-withheld) was **mutation-verified** to confirm the test catches the regression.
- `tsc` and `eslint` at the repo baseline (remaining tsc errors are the known `tests/integration/*.pg.test.ts` env baseline only).
- Built TDD red-green-refactor, vertical slices.

## Follow-up (not in this PR)
`supabase/migration-311-smoke-test.sql` is a read-only RLS smoke that becomes runnable once **migrations 307 + 308** deploy to prod — a separate deploy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)