### PR TITLE
feat(phone): inbound voice routing + Settings inbound-rule editor (#312)

### DIFF
--- a/src/app/api/phone/conversations/[id]/calls/route.test.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.test.ts
@@ -1,0 +1,102 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312).
+//
+// GET /api/phone/conversations/[id]/calls — return the voice calls in the
+// conversation, sorted by `started_at` ascending. The Phone-tab thread
+// fetches this alongside /messages and interleaves the two (mergeThreadItems).
+// RLS enforces the ADR 0003 matrix; the route is a thin pass-through —
+// additive, leaving the messages route untouched.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/phone/conversations/[id]/calls", () => {
+  it("returns 401 unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when caller lacks view_phone", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "u-1" },
+        tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+      }) as never,
+    );
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns the conversation's calls for an authorized caller", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      {
+        id: "call-1",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "in",
+        from_e164: "+15551234567",
+        to_e164: "+15125550000",
+        status: "completed",
+        duration_seconds: 42,
+        job_tag: null,
+        started_at: "2026-05-27T10:00:00Z",
+        ended_at: "2026-05-27T10:00:42Z",
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([
+      expect.objectContaining({
+        id: "call-1",
+        direction: "in",
+        status: "completed",
+        duration_seconds: 42,
+      }),
+    ]);
+  });
+});

--- a/src/app/api/phone/conversations/[id]/calls/route.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — thread call history.
+//
+// Returns every voice call in the named conversation, sorted by
+// `started_at` ascending (chronological). The Phone-tab thread fetches this
+// alongside /messages and interleaves the two via mergeThreadItems, so a
+// call and a text to the same outside number render inline.
+//
+// Additive: a separate endpoint from /messages so the slice-4 thread route
+// is untouched. RLS (migration-312) enforces the ADR 0003 matrix; the route
+// is a thin pass-through — a caller who cannot see a row simply doesn't get
+// it back.
+
+const FIELDS =
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at";
+
+export const GET = withRequestContext(
+  { permission: "view_phone" },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+    const { data, error } = await ctx.supabase
+      .from("phone_calls")
+      .select(FIELDS)
+      .eq("conversation_id", id)
+      .order("started_at", { ascending: true });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data ?? []);
+  },
+);

--- a/src/app/api/phone/numbers/[id]/route.test.ts
+++ b/src/app/api/phone/numbers/[id]/route.test.ts
@@ -1,0 +1,291 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — configure a Shared number's
+// inbound rule.
+//
+// PATCH /api/phone/numbers/[id]
+// The Settings → Phone editor saves a Shared number's answer rule here.
+// Admin-only (canManage, ADR 0003). The body's `inbound_rule` is run
+// through the parseInboundRule trust boundary before it touches the jsonb
+// column, so only the four routable shapes are ever persisted.
+//
+// Inbound rules are a Shared-number concept (ADR 0005/0006) — Personal
+// numbers always go to voicemail and never reach decideShared, so
+// PATCHing one is a 409.
+//
+// The test runs the REAL withRequestContext (mocking only the Supabase
+// client factories + active-org), so the wrapper's auth/permission gate is
+// exercised end-to-end. The Service client is a local recorder so the
+// persisted patch can be asserted.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+type Row = Record<string, unknown>;
+
+// A Service-client recorder: the shared fakeServiceClient passes `update`
+// through and returns the unchanged seeded row, so it can't prove what was
+// written. This records the patch + filters and returns the merged row.
+function makeServiceClient(seed: Record<string, Row[]>) {
+  const tables: Record<string, Row[]> = { phone_numbers: [], ...seed };
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = tables[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingUpdate: Row | null = null;
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.single = async () => {
+      if (pendingUpdate) {
+        updates.push({
+          table,
+          patch: pendingUpdate,
+          filters: { ...ctx.filters },
+        });
+        return { data: { ...(rows[0] ?? {}), ...pendingUpdate }, error: null };
+      }
+      return {
+        data: rows[0] ?? null,
+        error: rows[0] ? null : { message: "no rows" },
+      };
+    };
+    return b;
+  }
+
+  return { client: { from: builder }, tables, updates };
+}
+
+const idParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const adminTables = memberTables({ userId: "admin-1", role: "admin", grants: [] });
+
+const SHARED_ROW = {
+  id: "pn-1",
+  organization_id: "org-1",
+  kind: "shared" as const,
+  user_id: null,
+  inbound_rule: null,
+};
+
+function patchReq(body: unknown): Request {
+  return new Request("http://test/api/phone/numbers/pn-1", {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("PATCH /api/phone/numbers/[id] — saves a Shared number's rule (tracer)", () => {
+  it("admin saves a ring-all rule: validated, persisted to inbound_rule, returns the row", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "ring-all", users: ["u1", "u2"] } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_numbers");
+    expect(upd).toBeDefined();
+    expect(upd!.filters).toMatchObject({ id: "pn-1" });
+    expect(upd!.patch.inbound_rule).toEqual({
+      kind: "ring-all",
+      users: ["u1", "u2"],
+    });
+
+    const json = await res.json();
+    expect(json.inbound_rule).toEqual({ kind: "ring-all", users: ["u1", "u2"] });
+  });
+
+  it("persists a round-robin rule's sequence verbatim", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({
+        inbound_rule: { kind: "round-robin", sequence: ["u3", "u1"] },
+      }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_numbers");
+    expect(upd!.patch.inbound_rule).toEqual({
+      kind: "round-robin",
+      sequence: ["u3", "u1"],
+    });
+  });
+
+  it("persists a voicemail rule (admin can switch a number back to voicemail)", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({
+      phone_numbers: [
+        { ...SHARED_ROW, inbound_rule: { kind: "ring-all", users: ["u1"] } },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "voicemail" } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_numbers");
+    expect(upd!.patch.inbound_rule).toEqual({ kind: "voicemail" });
+  });
+});
+
+describe("PATCH /api/phone/numbers/[id] — auth + permission gate", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "voicemail" } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(401);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("returns 403 when the caller is not an admin", async () => {
+    authed({
+      user: { id: "crew-1" },
+      tables: memberTables({
+        userId: "crew-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "voicemail" } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe("PATCH /api/phone/numbers/[id] — not found / cross-org", () => {
+  it("returns 404 when the number does not exist", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client } = makeServiceClient({ phone_numbers: [] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "voicemail" } }),
+      idParams("missing"),
+    );
+
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 when the number belongs to another organization", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({
+      phone_numbers: [{ ...SHARED_ROW, organization_id: "org-other" }],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "voicemail" } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(updates).toHaveLength(0);
+  });
+});
+
+describe("PATCH /api/phone/numbers/[id] — Shared-only + body validation", () => {
+  it("returns 409 when the number is Personal (inbound rule not configurable)", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({
+      phone_numbers: [
+        { ...SHARED_ROW, kind: "personal", user_id: "owner-1" },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "ring-all", users: ["u1"] } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(409);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("returns 400 when inbound_rule is a malformed shape", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(
+      patchReq({ inbound_rule: { kind: "page-everyone" } }),
+      idParams("pn-1"),
+    );
+
+    expect(res.status).toBe(400);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("returns 400 when inbound_rule is missing from the body", async () => {
+    authed({ user: { id: "admin-1" }, tables: adminTables });
+    const { client, updates } = makeServiceClient({ phone_numbers: [SHARED_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await PATCH(patchReq({}), idParams("pn-1"));
+
+    expect(res.status).toBe(400);
+    expect(updates).toHaveLength(0);
+  });
+});

--- a/src/app/api/phone/numbers/[id]/route.ts
+++ b/src/app/api/phone/numbers/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { canManage } from "@/lib/phone/phone-event-access";
+import { parseInboundRule } from "@/lib/phone/parse-inbound-rule";
+
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — configure a Shared number's
+// inbound rule.
+//
+// PATCH /api/phone/numbers/[id]
+// The Settings → Phone editor saves a Shared number's answer rule here.
+//
+// Flow (mirrors the release route's gate order):
+//   1. Look up the row via the Service client (RLS bypassed — the admin
+//      gate is enforced below, not by RLS).
+//   2. Missing / cross-org → 404 (privacy-preserving; same convention as
+//      the release route and the email-access routes).
+//   3. canManage → 403 (Shared is admin-only, ADR 0003).
+//   4. Personal numbers always go to voicemail and never reach
+//      decideShared (ADR 0005/0006), so a rule cannot be configured on
+//      one → 409. This is checked AFTER canManage so a non-admin never
+//      learns the number's kind.
+//   5. Validate the body's `inbound_rule` through the parseInboundRule
+//      trust boundary → 400 on a malformed shape; only the four routable
+//      shapes ever touch the jsonb column.
+//   6. Persist and return the updated row.
+
+const PHONE_NUMBER_FIELDS =
+  "id, organization_id, twilio_sid, e164, label, kind, user_id, inbound_rule, voicemail_greeting_url, monthly_cost_cents, is_active, released_at, created_at, updated_at";
+
+interface PhoneNumberRow {
+  id: string;
+  organization_id: string;
+  kind: "shared" | "personal";
+  user_id: string | null;
+}
+
+export const PATCH = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    const { data: row } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .select("id, organization_id, kind, user_id")
+      .eq("id", id)
+      .maybeSingle<PhoneNumberRow>();
+
+    // Cross-org callers cannot prove the row exists → 404, the same
+    // privacy-preserving response as a genuinely missing row.
+    if (!row || row.organization_id !== ctx.orgId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const allowed = canManage(
+      {
+        userId: ctx.userId,
+        organizationId: ctx.orgId ?? "",
+        role: ctx.role,
+      },
+      {
+        kind: row.kind,
+        organizationId: row.organization_id,
+        userId: row.user_id,
+      },
+    );
+    if (!allowed) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    // Inbound rules are Shared-only. A Personal number's inbound rule is
+    // implicitly "voicemail" and is not editable.
+    if (row.kind !== "shared") {
+      return NextResponse.json(
+        { error: "Inbound rules are only configurable on Shared numbers" },
+        { status: 409 },
+      );
+    }
+
+    const body = (await request.json().catch(() => null)) as
+      | { inbound_rule?: unknown }
+      | null;
+
+    const parsed = parseInboundRule(body?.inbound_rule);
+    if (!parsed.ok) {
+      return NextResponse.json({ error: parsed.error }, { status: 400 });
+    }
+
+    const { data, error } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .update({
+        inbound_rule: parsed.rule,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .select(PHONE_NUMBER_FIELDS)
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data);
+  },
+);

--- a/src/app/api/phone/webhook/voice-inbound/route.test.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.test.ts
@@ -1,0 +1,326 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — inbound VOICE webhook.
+//
+// Twilio calls this URL when a customer dials one of our numbers. The route
+// is a thin shell:
+//   1. Validate X-Twilio-Signature → 403 on invalid.
+//   2. Parse the form-encoded payload (From, To, CallSid, CallStatus).
+//   3. Look up the phone_numbers row by `To` (the org + kind + inbound_rule).
+//      Unknown number → empty <Response/> (Twilio hangs up).
+//   4. Thread + smart-attach via the shared `routeInbound` (Body="" — a
+//      call has no body; the tag decision is body-independent).
+//   5. Dial plan:
+//        - Personal number → always voicemail (ADR 0005 / issue #312:
+//          "voicemail is their inbound rule always").
+//        - Shared number → decideShared(inbound_rule, members, cursor).
+//          Members are the org roster with a cell on file; round-robin
+//          persists its advanced cursor to phone_number_round_robin.
+//   6. buildVoiceTwiml(decision, { callerId: <our number> }).
+//   7. Write a ringing phone_calls row via ingestInboundCall.
+//   8. Return 200 with the TwiML.
+//
+// The Twilio SDK boundary (validateTwilioSignature) and Supabase are mocked;
+// the REAL buildVoiceTwiml + decideShared + routeInbound + ingestInboundCall
+// run, so the TwiML and persistence are asserted end-to-end.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/phone/twilio-client")>();
+  return {
+    ...actual,
+    validateTwilioSignature: (...args: unknown[]) =>
+      validateSignatureMock(...args),
+  };
+});
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+type Row = Record<string, unknown>;
+
+interface BuilderTables {
+  phone_numbers: Row[];
+  contacts: Row[];
+  jobs: Row[];
+  user_organizations: Row[];
+  phone_number_round_robin: Row[];
+  phone_conversations: Row[];
+  phone_calls: Row[];
+}
+
+function makeServiceClient(tables: BuilderTables) {
+  const inserts: { table: string; row: Row }[] = [];
+  const upserts: { table: string; row: Row; onConflict: string | undefined }[] =
+    [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = (tables as unknown as Record<string, Row[]>)[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.order = () => b;
+    b.limit = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.in = (col: string, vals: unknown[]) => {
+      rows = rows.filter((r) => vals.includes(r[col]));
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opts?: { onConflict?: string }) => {
+      pendingInsert = row;
+      upserts.push({ table, row, onConflict: opts?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.single = async () => {
+      if (pendingInsert) {
+        const row = {
+          id: `new-${inserts.length + upserts.length}`,
+          ...pendingInsert,
+        };
+        (tables as unknown as Record<string, Row[]>)[table].push(row);
+        return { data: row, error: null };
+      }
+      return {
+        data: rows[0] ?? null,
+        error: rows[0] ? null : { message: "no rows" },
+      };
+    };
+    b.then = (resolve: (v: unknown) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  return { client: { from: builder }, inserts, upserts, updates };
+}
+
+function voiceForm(opts: {
+  From?: string;
+  To?: string;
+  CallSid?: string;
+  CallStatus?: string;
+}): Request {
+  const params = new URLSearchParams();
+  params.set("From", opts.From ?? "+15551234567");
+  params.set("To", opts.To ?? "+15125550000");
+  params.set("CallSid", opts.CallSid ?? "CA-test");
+  params.set("CallStatus", opts.CallStatus ?? "ringing");
+  return new Request("http://test/api/phone/webhook/voice-inbound", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid",
+    },
+    body: params.toString(),
+  });
+}
+
+// A Shared number whose inbound_rule rings two manually-selected members.
+function ringAllTables(): BuilderTables {
+  return {
+    phone_numbers: [
+      {
+        id: "pn-1",
+        organization_id: "org-1",
+        e164: "+15125550000",
+        kind: "shared",
+        user_id: null,
+        released_at: null,
+        inbound_rule: { kind: "ring-all", users: ["u1", "u2"] },
+      },
+    ],
+    contacts: [],
+    jobs: [],
+    user_organizations: [
+      { user_id: "u1", organization_id: "org-1", user_profiles: { phone: "+15125550011" } },
+      { user_id: "u2", organization_id: "org-1", user_profiles: { phone: "+15125550022" } },
+      { user_id: "u3", organization_id: "org-1", user_profiles: { phone: null } },
+    ],
+    phone_number_round_robin: [],
+    phone_conversations: [],
+    phone_calls: [],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+describe("POST /api/phone/webhook/voice-inbound — ring-all (tracer)", () => {
+  it("dials every selected member's cell and writes a ringing phone_calls row", async () => {
+    const { client, inserts } = makeServiceClient(ringAllTables());
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({ From: "+15551234567", To: "+15125550000" }));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/xml/);
+    const xml = await res.text();
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Number>+15125550011</Number>");
+    expect(xml).toContain("<Number>+15125550022</Number>");
+    // The caller ID presented on the outbound legs is our Nookleus number.
+    expect(xml).toContain('callerId="+15125550000"');
+
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert).toBeDefined();
+    expect(callInsert!.row).toMatchObject({
+      organization_id: "org-1",
+      direction: "in",
+      from_e164: "+15551234567",
+      to_e164: "+15125550000",
+      twilio_call_sid: "CA-test",
+      status: "ringing",
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — signature", () => {
+  it("returns 403 when the X-Twilio-Signature is missing or invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client } = makeServiceClient(ringAllTables());
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — round-robin", () => {
+  it("dials the cursor member and persists the advanced cursor", async () => {
+    const tables = ringAllTables();
+    tables.phone_numbers[0].inbound_rule = {
+      kind: "round-robin",
+      sequence: ["u1", "u2", "u3"],
+    };
+    tables.user_organizations = [
+      { user_id: "u1", organization_id: "org-1", user_profiles: { phone: "+15125550011" } },
+      { user_id: "u2", organization_id: "org-1", user_profiles: { phone: "+15125550022" } },
+      { user_id: "u3", organization_id: "org-1", user_profiles: { phone: "+15125550033" } },
+    ];
+    // A cursor already at 1 → this call rings the second member (u2).
+    tables.phone_number_round_robin = [
+      { phone_number_id: "pn-1", organization_id: "org-1", rotation_cursor: 1 },
+    ];
+    const { client, upserts } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(xml).toContain("<Number>+15125550022</Number>");
+    expect(xml).not.toContain("+15125550011");
+    expect(xml).not.toContain("+15125550033");
+    // The advanced cursor (2) is persisted for the next call.
+    const rr = upserts.find((u) => u.table === "phone_number_round_robin");
+    expect(rr).toBeDefined();
+    expect(rr!.onConflict).toBe("phone_number_id");
+    expect(rr!.row).toMatchObject({
+      phone_number_id: "pn-1",
+      organization_id: "org-1",
+      rotation_cursor: 2,
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — forward", () => {
+  it("dials only the configured forward target's cell", async () => {
+    const tables = ringAllTables();
+    tables.phone_numbers[0].inbound_rule = {
+      kind: "forward",
+      forwardUserId: "u2",
+    };
+    const { client } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Number>+15125550022</Number>");
+    expect(xml).not.toContain("+15125550011");
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — voicemail / unconfigured", () => {
+  it("routes a Shared number with NO rule (null) to voicemail and still records the call", async () => {
+    const tables = ringAllTables();
+    tables.phone_numbers[0].inbound_rule = null;
+    const { client, inserts } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain("<Record");
+    expect(xml).not.toContain("<Dial");
+    // The inbound attempt is still persisted.
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeDefined();
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — Personal number", () => {
+  it("always routes a Personal number to voicemail, ignoring any inbound_rule", async () => {
+    const tables = ringAllTables();
+    // A Personal number carrying a ring-all rule that WOULD dial if honored.
+    tables.phone_numbers[0].kind = "personal";
+    tables.phone_numbers[0].user_id = "owner-1";
+    tables.phone_numbers[0].inbound_rule = { kind: "ring-all", users: ["u1", "u2"] };
+    const { client, inserts } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(xml).toContain("<Record");
+    expect(xml).not.toContain("<Dial");
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeDefined();
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — unknown number", () => {
+  it("hangs up (empty <Response/>) and writes no call row when To matches no org number", async () => {
+    const tables = ringAllTables();
+    const { client, inserts } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({ To: "+19998887777" }));
+    const xml = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(xml).toContain("<Response");
+    expect(xml).not.toContain("<Dial");
+    expect(xml).not.toContain("<Record");
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+});

--- a/src/app/api/phone/webhook/voice-inbound/route.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.ts
@@ -1,0 +1,214 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import {
+  validateTwilioSignature,
+  buildVoiceTwiml,
+} from "@/lib/phone/twilio-client";
+import { normalizePhoneToE164 } from "@/lib/phone";
+import {
+  routeInbound,
+  type ContactForRoute,
+  type PhoneNumberForRoute,
+} from "@/lib/phone/route-inbound";
+import type { ActiveJob } from "@/lib/phone/smart-attach";
+import {
+  decideShared,
+  type InboundRule,
+  type RoutableMember,
+  type DecideSharedResult,
+} from "@/lib/phone/route-shared-call";
+import { ingestInboundCall } from "@/lib/phone/ingest-inbound-call";
+
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — Inbound voice webhook.
+//
+// Twilio calls this URL when a customer dials one of our numbers. Like the
+// inbound-SMS webhook it is unauthenticated and gated solely by the
+// X-Twilio-Signature HMAC. All DB work uses the Service client — the
+// webhook has no auth user, so RLS would refuse every read otherwise.
+//
+// Flow:
+//   1. Validate the signature. 403 on invalid.
+//   2. Look up the phone_numbers row by `To` to discover the org, the
+//      number kind, and (for Shared) the inbound_rule. Unknown / released
+//      number → empty <Response/> (Twilio hangs up).
+//   3. Smart-attach + thread via the shared `routeInbound` (Body="" — a
+//      voice call has no body and the tag decision is body-independent).
+//   4. Decide the dial plan:
+//        - Personal → always voicemail (ADR 0005: voicemail is a Personal
+//          number's inbound rule always; the configurable rule is Shared-only).
+//        - Shared → decideShared(inbound_rule, members, round-robin cursor).
+//          `members` is the org roster with a cell on file (user_profiles.phone
+//          normalized to E.164). Round-robin persists its advanced cursor to
+//          phone_number_round_robin so the rotation survives restarts.
+//   5. buildVoiceTwiml(decision, { callerId: <our number> }).
+//   6. ingestInboundCall writes a ringing phone_calls row threaded on the
+//      same conversation as the slice-4 messages.
+//   7. 200 with the TwiML.
+
+const ACTIVE_STATUSES = ["new", "in_progress", "pending_invoice"] as const;
+
+// Empty TwiML — Twilio executes it as "hang up". Used for a call to a
+// number that is not (or no longer) ours.
+const HANGUP_TWIML = '<?xml version="1.0" encoding="UTF-8"?><Response/>';
+
+// The phone_numbers slice the voice route needs: the routing fields plus
+// the Shared-only inbound_rule jsonb.
+interface PhoneNumberForVoiceRoute extends PhoneNumberForRoute {
+  inbound_rule: InboundRule | null;
+}
+
+// A user_organizations row with the embedded profile cell. Supabase returns
+// the to-one embed as an object (older shapes returned a single-element
+// array); we normalize both.
+interface MemberRow {
+  user_id: string;
+  user_profiles: { phone: string | null } | { phone: string | null }[] | null;
+}
+
+function twimlResponse(xml: string, status = 200): Response {
+  return new Response(xml, {
+    status,
+    headers: { "content-type": "text/xml; charset=utf-8" },
+  });
+}
+
+function profilePhone(row: MemberRow): string | null {
+  const p = Array.isArray(row.user_profiles)
+    ? row.user_profiles[0]
+    : row.user_profiles;
+  return p?.phone ?? null;
+}
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const fromE164 = normalizePhoneToE164(params.From ?? "");
+  const toE164 = normalizePhoneToE164(params.To ?? "");
+  if (!fromE164 || !toE164) {
+    return twimlResponse(HANGUP_TWIML);
+  }
+
+  const supabase = createServiceClient();
+
+  // 1. Resolve the number (org + kind + inbound_rule) from the To address.
+  const { data: numberRow } = await supabase
+    .from("phone_numbers")
+    .select("id, organization_id, e164, kind, user_id, released_at, inbound_rule")
+    .eq("e164", toE164)
+    .maybeSingle<PhoneNumberForVoiceRoute>();
+
+  if (!numberRow || numberRow.released_at) {
+    return twimlResponse(HANGUP_TWIML);
+  }
+
+  // 2. Load the org's jobs + contacts so routeInbound can smart-attach and
+  //    thread. Mirrors the inbound-SMS webhook.
+  const { data: jobRows } = await supabase
+    .from("jobs")
+    .select("id, contact_id, status, job_number")
+    .eq("organization_id", numberRow.organization_id);
+  const jobsList = (jobRows ?? []) as Array<{
+    id: string;
+    contact_id: string;
+    status: string;
+    job_number: string;
+  }>;
+
+  const contactIds = Array.from(new Set(jobsList.map((j) => j.contact_id)));
+  let contacts: ContactForRoute[] = [];
+  if (contactIds.length > 0) {
+    const { data: contactRows } = await supabase
+      .from("contacts")
+      .select("id, phone")
+      .in("id", contactIds);
+    contacts = (contactRows ?? []) as ContactForRoute[];
+  }
+
+  const activeJobsByContact: Record<string, ActiveJob[]> = {};
+  for (const j of jobsList) {
+    if (!ACTIVE_STATUSES.includes(j.status as (typeof ACTIVE_STATUSES)[number])) {
+      continue;
+    }
+    (activeJobsByContact[j.contact_id] ??= []).push({
+      id: j.id,
+      label: j.job_number,
+    });
+  }
+
+  const decision = routeInbound({
+    payload: { From: fromE164, To: toE164, Body: "" },
+    orgNumbers: [numberRow],
+    contacts,
+    activeJobsByContact,
+  });
+  if (!decision) return twimlResponse(HANGUP_TWIML);
+
+  // 3. Decide the dial plan.
+  let result: DecideSharedResult;
+  if (numberRow.kind === "personal") {
+    // A Personal number's inbound rule is always voicemail (ADR 0005).
+    result = { kind: "voicemail" };
+  } else {
+    const config = (numberRow.inbound_rule ?? null) as InboundRule | null;
+
+    const { data: memberRows } = await supabase
+      .from("user_organizations")
+      .select("user_id, user_profiles:user_id(phone)")
+      .eq("organization_id", numberRow.organization_id);
+    const members: RoutableMember[] = ((memberRows ?? []) as MemberRow[]).map(
+      (r) => {
+        const raw = profilePhone(r);
+        return {
+          userId: r.user_id,
+          cellE164: raw ? normalizePhoneToE164(raw) : null,
+        };
+      },
+    );
+
+    const { data: rrRow } = await supabase
+      .from("phone_number_round_robin")
+      .select("rotation_cursor")
+      .eq("phone_number_id", numberRow.id)
+      .maybeSingle<{ rotation_cursor: number }>();
+    const cursor = rrRow?.rotation_cursor ?? 0;
+
+    result = decideShared({ config, members, roundRobinCursor: cursor });
+
+    // Persist the advanced rotation cursor so the next call picks the next
+    // member. Monotonic — decideShared mods by the reachable count.
+    if (result.kind === "round-robin") {
+      await supabase.from("phone_number_round_robin").upsert(
+        {
+          phone_number_id: numberRow.id,
+          organization_id: numberRow.organization_id,
+          rotation_cursor: result.nextCursor,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: "phone_number_id" },
+      );
+    }
+  }
+
+  const twiml = buildVoiceTwiml(result, { callerId: toE164 });
+
+  // 4. Persist the ringing call row, threaded on the conversation.
+  await ingestInboundCall({
+    supabase,
+    decision,
+    toE164,
+    twilioCallSid: params.CallSid ?? null,
+    status: "ringing",
+  });
+
+  return twimlResponse(twiml);
+}

--- a/src/app/api/phone/webhook/voice-status/route.test.ts
+++ b/src/app/api/phone/webhook/voice-status/route.test.ts
@@ -1,0 +1,207 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — inbound VOICE status callback.
+//
+// Twilio POSTs here for every voice call we route, on each CallStatus
+// transition. The callback carries:
+//   CallSid      — matches the `twilio_call_sid` we stored on phone_calls
+//   CallStatus   — 'queued' | 'ringing' | 'in-progress' | 'completed' |
+//                  'busy' | 'no-answer' | 'failed' | 'canceled'
+//   CallDuration — seconds (present once the call has ended)
+//
+// The route looks the row up by CallSid and advances `status` (mapping
+// Twilio's hyphenated vocabulary — 'in-progress', 'no-answer' — to our
+// underscore CHECK vocabulary). On a terminal status it also writes
+// `duration_seconds` (from CallDuration) and `ended_at`.
+//
+// Unauthenticated; gated solely by X-Twilio-Signature. Service-client
+// UPDATE — no auth user, so RLS would otherwise refuse.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  validateTwilioSignature: (...args: unknown[]) => validateSignatureMock(...args),
+}));
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+type Row = Record<string, unknown>;
+
+function makeServiceClient(seed: Record<string, Row[]>) {
+  const tables: Record<string, Row[]> = { phone_calls: [], ...seed };
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = tables[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingUpdate: Row | null = null;
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.then = (resolve: (v: { data: Row[]; error: null }) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: [], error: null });
+      }
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  return { client: { from: builder }, tables, updates };
+}
+
+function callbackForm(opts: {
+  CallSid?: string;
+  CallStatus?: string;
+  CallDuration?: string;
+}): Request {
+  const params = new URLSearchParams();
+  params.set("CallSid", opts.CallSid ?? "CA-1");
+  if (opts.CallStatus !== undefined) params.set("CallStatus", opts.CallStatus);
+  if (opts.CallDuration !== undefined)
+    params.set("CallDuration", opts.CallDuration);
+  return new Request("http://test/api/phone/webhook/voice-status", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid",
+    },
+    body: params.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+describe("POST /api/phone/webhook/voice-status — terminal completed (tracer)", () => {
+  it("updates status, duration_seconds, and ended_at by twilio_call_sid", async () => {
+    const { client, updates } = makeServiceClient({
+      phone_calls: [{ id: "call-1", twilio_call_sid: "CA-1", status: "ringing" }],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      callbackForm({ CallSid: "CA-1", CallStatus: "completed", CallDuration: "42" }),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_calls");
+    expect(upd).toBeDefined();
+    expect(upd!.filters).toMatchObject({ twilio_call_sid: "CA-1" });
+    expect(upd!.patch).toMatchObject({ status: "completed", duration_seconds: 42 });
+    expect(upd!.patch.ended_at).toBeTruthy();
+  });
+});
+
+describe("POST /api/phone/webhook/voice-status — signature + guards", () => {
+  it("returns 403 when the Twilio signature is invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(callbackForm({ CallStatus: "completed" }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when CallSid is missing", async () => {
+    const { client } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+    const req = new Request("http://test/api/phone/webhook/voice-status", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        "x-twilio-signature": "valid",
+      },
+      body: "CallStatus=completed",
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 200 (silent drop) when CallSid matches no row", async () => {
+    const { client, updates } = makeServiceClient({ phone_calls: [] });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(callbackForm({ CallSid: "CA-unknown", CallStatus: "completed" }));
+
+    // The UPDATE still runs (matching zero rows); 200 so Twilio stops retrying.
+    expect(res.status).toBe(200);
+    expect(updates).toHaveLength(1);
+  });
+});
+
+describe("POST /api/phone/webhook/voice-status — Twilio status vocabulary mapping", () => {
+  it("maps hyphenated 'in-progress' to 'in_progress' without stamping ended_at (non-terminal)", async () => {
+    const { client, updates } = makeServiceClient({
+      phone_calls: [{ id: "call-1", twilio_call_sid: "CA-1", status: "ringing" }],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(callbackForm({ CallSid: "CA-1", CallStatus: "in-progress" }));
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_calls");
+    expect(upd!.patch).toMatchObject({ status: "in_progress" });
+    // Mid-call: no duration, no ended_at yet.
+    expect(upd!.patch.ended_at).toBeUndefined();
+    expect(upd!.patch.duration_seconds).toBeUndefined();
+  });
+
+  it("maps 'no-answer' to 'no_answer' and stamps ended_at (terminal)", async () => {
+    const { client, updates } = makeServiceClient({
+      phone_calls: [{ id: "call-1", twilio_call_sid: "CA-1", status: "ringing" }],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(callbackForm({ CallSid: "CA-1", CallStatus: "no-answer" }));
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_calls");
+    expect(upd!.patch).toMatchObject({ status: "no_answer" });
+    expect(upd!.patch.ended_at).toBeTruthy();
+  });
+
+  it("accepts every Twilio voice CallStatus without throwing", async () => {
+    const statuses = [
+      "queued",
+      "ringing",
+      "in-progress",
+      "completed",
+      "busy",
+      "no-answer",
+      "failed",
+      "canceled",
+    ];
+    for (const status of statuses) {
+      const { client, updates } = makeServiceClient({
+        phone_calls: [{ id: "call", twilio_call_sid: "CA-1", status: "ringing" }],
+      });
+      createServiceClientMock.mockReturnValue(client);
+
+      const res = await POST(callbackForm({ CallSid: "CA-1", CallStatus: status }));
+
+      expect(res.status).toBe(200);
+      // The persisted status never contains a hyphen (our CHECK vocabulary).
+      expect(String(updates[0]?.patch.status)).not.toContain("-");
+    }
+  });
+});

--- a/src/app/api/phone/webhook/voice-status/route.ts
+++ b/src/app/api/phone/webhook/voice-status/route.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { validateTwilioSignature } from "@/lib/phone/twilio-client";
+
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — inbound voice status callback.
+//
+// Twilio POSTs here on every CallStatus transition for a call we routed
+// (the inbound-voice webhook sets this URL as the call's statusCallback).
+// The callback carries CallSid, CallStatus, and — once the call ends —
+// CallDuration. We advance the matching phone_calls row by CallSid.
+//
+// Twilio's voice CallStatus vocabulary uses hyphens ('in-progress',
+// 'no-answer'); our status CHECK uses underscores ('in_progress',
+// 'no_answer'). A `-` → `_` replace maps the whole vocabulary; the
+// hyphen-free values ('completed', 'busy', 'failed', 'canceled', 'queued',
+// 'ringing') pass through unchanged.
+//
+// Unauthenticated; gated solely by X-Twilio-Signature. Service-client
+// UPDATE under the hood — no auth user is present.
+
+// The call has ended on these statuses — stamp ended_at.
+const TERMINAL_STATUSES = new Set([
+  "completed",
+  "busy",
+  "failed",
+  "no_answer",
+  "canceled",
+]);
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const sid = params.CallSid;
+  if (!sid) {
+    return new Response("CallSid required", { status: 400 });
+  }
+
+  const status = params.CallStatus
+    ? params.CallStatus.replace(/-/g, "_")
+    : null;
+
+  const patch: Record<string, unknown> = { status };
+
+  // CallDuration is present once the call has ended.
+  const durationRaw = params.CallDuration;
+  if (durationRaw !== undefined && durationRaw !== "") {
+    const seconds = Number.parseInt(durationRaw, 10);
+    if (Number.isFinite(seconds)) {
+      patch.duration_seconds = seconds;
+    }
+  }
+
+  if (status && TERMINAL_STATUSES.has(status)) {
+    patch.ended_at = new Date().toISOString();
+  }
+
+  const supabase = createServiceClient();
+  await supabase.from("phone_calls").update(patch).eq("twilio_call_sid", sid);
+
+  return new Response("", { status: 200 });
+}

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -1068,3 +1068,241 @@ describe("PhonePageClient — thread media render (#310)", () => {
     await waitFor(() => expect(link.href).toContain("estimate.pdf"));
   });
 });
+
+// ---------------------------------------------------------------------------
+// Slice 8 (#312) — voice calls in the thread.
+//
+// A call threads on the same conversation as the texts. The thread fetches
+// /calls alongside /messages and interleaves them chronologically
+// (mergeThreadItems). A call row shows a direction icon, the status, the
+// duration when known, and the time. Clicking it opens the slice-11
+// placeholder (call detail/recording lands later).
+// ---------------------------------------------------------------------------
+
+describe("PhonePageClient — call events (#312)", () => {
+  function setupThread(opts: {
+    messages?: Array<Record<string, unknown>>;
+    calls?: Array<Record<string, unknown>>;
+  }) {
+    mockFetch.mockImplementation(async (input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      if (path === "/api/phone/conversations/conv-1/messages") {
+        return { ok: true, status: 200, json: async () => opts.messages ?? [] };
+      }
+      if (path === "/api/phone/conversations/conv-1/calls") {
+        return { ok: true, status: 200, json: async () => opts.calls ?? [] };
+      }
+      throw new Error(`unmocked fetch: ${path}`);
+    });
+  }
+
+  it("interleaves a voice call into the thread chronologically with messages", async () => {
+    setupThread({
+      messages: [
+        {
+          id: "m-1",
+          conversation_id: "conv-1",
+          direction: "out",
+          body: "Hi back",
+          sent_at: "2026-05-27T10:05:00Z",
+          job_tag: null,
+        },
+      ],
+      calls: [
+        {
+          id: "call-1",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "completed",
+          duration_seconds: 42,
+          started_at: "2026-05-27T10:00:00Z",
+          ended_at: "2026-05-27T10:00:42Z",
+        },
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    const callRow = await screen.findByText(/incoming call/i);
+    const message = screen.getByText("Hi back");
+    // The call started at 10:00, the text at 10:05 — the call row renders
+    // before the message bubble in the DOM.
+    expect(
+      callRow.compareDocumentPosition(message) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("shows a call's status, with its duration only when the call has one", async () => {
+    setupThread({
+      messages: [],
+      calls: [
+        {
+          id: "call-done",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "completed",
+          duration_seconds: 125,
+          started_at: "2026-05-27T10:00:00Z",
+          ended_at: "2026-05-27T10:02:05Z",
+        },
+        {
+          id: "call-ringing",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "ringing",
+          duration_seconds: null,
+          started_at: "2026-05-27T10:05:00Z",
+          ended_at: null,
+        },
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    // Both calls carry a human-readable status…
+    expect(await screen.findByText("Completed")).toBeDefined();
+    expect(screen.getByText("Ringing")).toBeDefined();
+    // …but only the completed call shows a duration (mm:ss); the ringing
+    // call has none yet, so exactly one duration timecode is present.
+    const durations = screen.getAllByText(/^\d+:\d{2}$/);
+    expect(durations).toHaveLength(1);
+    expect(durations[0].textContent).toBe("2:05");
+  });
+
+  it("uses a distinct direction icon for incoming vs outgoing calls", async () => {
+    setupThread({
+      messages: [],
+      calls: [
+        {
+          id: "c-in",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "completed",
+          duration_seconds: 10,
+          started_at: "2026-05-27T10:00:00Z",
+          ended_at: "2026-05-27T10:00:10Z",
+        },
+        {
+          id: "c-out",
+          conversation_id: "conv-1",
+          direction: "out",
+          status: "completed",
+          duration_seconds: 20,
+          started_at: "2026-05-27T10:05:00Z",
+          ended_at: "2026-05-27T10:05:20Z",
+        },
+      ],
+    });
+
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByText(/incoming call/i);
+
+    // An inbound call gets an incoming-call glyph; an outbound call an
+    // outgoing-call glyph — the icon reinforces the textual direction.
+    expect(container.querySelector(".lucide-phone-incoming")).not.toBeNull();
+    expect(container.querySelector(".lucide-phone-outgoing")).not.toBeNull();
+  });
+
+  it("shows the call's start time", async () => {
+    const startedAt = "2026-05-27T18:30:00Z";
+    setupThread({
+      messages: [],
+      calls: [
+        {
+          id: "c-time",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "completed",
+          duration_seconds: 7,
+          started_at: startedAt,
+          ended_at: "2026-05-27T18:30:07Z",
+        },
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    await screen.findByText(/incoming call/i);
+
+    // The start time renders as a local clock time. Compute the expected
+    // string the same way so the assertion is timezone-agnostic, and
+    // normalize whitespace (Intl can emit a narrow no-break space).
+    const expected = new Date(startedAt).toLocaleTimeString([], {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+    const norm = (s: string) => s.replace(/\s+/g, " ").trim();
+    expect(
+      screen.getByText((content) => norm(content) === norm(expected)),
+    ).toBeDefined();
+  });
+
+  it("opens a slice-11 recording placeholder when a call row is clicked", async () => {
+    setupThread({
+      messages: [],
+      calls: [
+        {
+          id: "c-click",
+          conversation_id: "conv-1",
+          direction: "in",
+          status: "completed",
+          duration_seconds: 30,
+          started_at: "2026-05-27T10:00:00Z",
+          ended_at: "2026-05-27T10:00:30Z",
+        },
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+    const callRow = await screen.findByText(/incoming call/i);
+
+    // Nothing about slice 11 until the row is clicked…
+    expect(screen.queryByText(/slice 11/i)).toBeNull();
+    // …recording playback ships in slice 11, so for now the click reveals
+    // a placeholder pointing there (AC: "Click on a row opens a future
+    // placeholder").
+    fireEvent.click(callRow);
+    expect(await screen.findByText(/slice 11/i)).toBeDefined();
+  });
+});

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -2,7 +2,16 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Phone as PhoneIcon, Plus, UserPlus, Send, Paperclip, X } from "lucide-react";
+import {
+  Phone as PhoneIcon,
+  PhoneIncoming,
+  PhoneOutgoing,
+  Plus,
+  UserPlus,
+  Send,
+  Paperclip,
+  X,
+} from "lucide-react";
 import { createClient } from "@/lib/supabase";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
 import { usePhoneSync } from "@/lib/phone/use-phone-sync";
@@ -13,6 +22,7 @@ import {
   PhoneAttachmentLightbox,
   type PhoneAttachmentRef,
 } from "@/components/phone/message-attachment";
+import { mergeThreadItems } from "@/lib/phone/merge-thread-items";
 
 // PRD #304 — Nookleus Phone. Slice 4 (#308) — two-pane Phone-tab UI.
 //
@@ -49,6 +59,20 @@ interface PhoneMessage {
   sent_at: string;
   job_tag: string | null;
   media_urls?: PhoneAttachmentRef[];
+}
+
+// Slice 8 (#312) — a voice call in the thread. Threads on the same
+// conversation as the messages; `started_at` is its timeline anchor.
+// `status`/`duration_seconds` are null until the status-callback webhook
+// advances the row (a 'ringing' insert has neither yet).
+interface PhoneCall {
+  id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  status: string | null;
+  duration_seconds: number | null;
+  started_at: string;
+  ended_at: string | null;
 }
 
 // Slice 6 (#310) — a staged attachment in the compose strip. Either the
@@ -97,6 +121,7 @@ export function PhonePageClient({
   );
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [messages, setMessages] = useState<PhoneMessage[]>([]);
+  const [calls, setCalls] = useState<PhoneCall[]>([]);
   const [loadingThread, setLoadingThread] = useState(false);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
@@ -110,6 +135,10 @@ export function PhonePageClient({
   // Slice 6 (#310) — lightbox state: the storage_path of the image
   // currently being shown full-size, or null.
   const [lightboxPath, setLightboxPath] = useState<string | null>(null);
+  // Slice 8 (#312) — the call whose detail placeholder is open, or null.
+  // Recording playback ships in slice 11; until then a click on a call row
+  // opens this placeholder.
+  const [callDetail, setCallDetail] = useState<PhoneCall | null>(null);
   // #309 outbound surfaces are gated on the A2P 10DLC feature flag.
   // Computed once at mount — the flag flips by env-var redeploy, not at
   // runtime, so we never need to re-evaluate. The read path (thread,
@@ -141,14 +170,35 @@ export function PhonePageClient({
     }
   }, []);
 
+  // Slice 8 (#312) — calls thread alongside the messages; fetched in
+  // parallel and interleaved chronologically (mergeThreadItems). A failed
+  // calls fetch degrades gracefully — the text thread still renders.
+  const loadCalls = useCallback(async (convId: string) => {
+    try {
+      const res = await fetch(`/api/phone/conversations/${convId}/calls`);
+      if (!res.ok) return;
+      const data = (await res.json()) as PhoneCall[];
+      setCalls(data);
+    } catch {
+      // Network/parse error — leave calls empty; messages are unaffected.
+    }
+  }, []);
+
   useEffect(() => {
     if (!selectedId) return;
     setDraft("");
     setSendError(null);
     setAttachments([]);
     setAttachError(null);
+    setCalls([]);
     void loadMessages(selectedId);
-  }, [selectedId, loadMessages]);
+    void loadCalls(selectedId);
+  }, [selectedId, loadMessages, loadCalls]);
+
+  const threadItems = useMemo(
+    () => mergeThreadItems(messages, calls),
+    [messages, calls],
+  );
 
   // Slice 6 (#310) — pre-upload one picked/dropped file. Returns the
   // staged ID so the caller can correlate the in-flight slot.
@@ -579,6 +629,33 @@ export function PhonePageClient({
         />
       ) : null}
 
+      {/* Slice 8 (#312) — call-detail placeholder. Recording playback
+          lands in slice 11 (#11); until then a tapped call row shows this. */}
+      {callDetail ? (
+        <div
+          role="dialog"
+          aria-label="Call details"
+          onClick={() => setCallDetail(null)}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            className="max-w-sm rounded-lg bg-background p-6 text-center shadow-lg"
+          >
+            <p className="text-sm text-muted-foreground">
+              Recording playback will land in slice 11.
+            </p>
+            <button
+              type="button"
+              onClick={() => setCallDetail(null)}
+              className="mt-4 rounded-md bg-[var(--brand-primary)] px-4 py-2 text-sm font-medium text-white"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {/* Right pane — selected thread */}
       <section className="flex-1 flex flex-col">
         {selected ? (
@@ -601,14 +678,24 @@ export function PhonePageClient({
               {loadingThread ? (
                 <p className="text-sm text-muted-foreground">Loading…</p>
               ) : null}
-              {messages.map((m) => {
+              {threadItems.map((item) => {
+                if (item.kind === "call") {
+                  return (
+                    <CallRow
+                      key={`call-${item.call.id}`}
+                      call={item.call}
+                      onOpen={() => setCallDetail(item.call)}
+                    />
+                  );
+                }
+                const m = item.message;
                 const showChips =
                   m.direction === "in" &&
                   m.job_tag === null &&
                   selected.active_jobs.length >= 2;
                 const retagOpen = retagMenuFor === m.id;
                 return (
-                  <div key={m.id} className="flex flex-col gap-1">
+                  <div key={`msg-${m.id}`} className="flex flex-col gap-1">
                     {showChips ? (
                       <div className="flex flex-wrap gap-2 text-xs">
                         <span className="text-muted-foreground self-center">
@@ -844,6 +931,50 @@ export function PhonePageClient({
           </div>
         )}
       </section>
+    </div>
+  );
+}
+
+// Slice 8 (#312) — render a Twilio status code as human-readable text.
+// "no_answer" → "No answer", "in_progress" → "In progress", etc.
+function formatCallStatus(status: string): string {
+  const words = status.replace(/_/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+// Slice 8 (#312) — seconds → mm:ss (e.g. 125 → "2:05").
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+// Slice 8 (#312) — a voice call rendered inline in the thread, centered
+// like a system row (distinct from the left/right message bubbles).
+function CallRow({ call, onOpen }: { call: PhoneCall; onOpen: () => void }) {
+  const incoming = call.direction === "in";
+  const label = incoming ? "Incoming call" : "Outgoing call";
+  const DirectionIcon = incoming ? PhoneIncoming : PhoneOutgoing;
+  return (
+    <div className="flex justify-center">
+      <button
+        type="button"
+        onClick={onOpen}
+        className="inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground hover:bg-muted/70"
+      >
+        <DirectionIcon size={12} aria-hidden="true" />
+        <span>{label}</span>
+        {call.status && <span>{formatCallStatus(call.status)}</span>}
+        {call.duration_seconds !== null && (
+          <span>{formatDuration(call.duration_seconds)}</span>
+        )}
+        <span>
+          {new Date(call.started_at).toLocaleTimeString([], {
+            hour: "numeric",
+            minute: "2-digit",
+          })}
+        </span>
+      </button>
     </div>
   );
 }

--- a/src/app/settings/phone/phone-numbers-tab.test.tsx
+++ b/src/app/settings/phone/phone-numbers-tab.test.tsx
@@ -72,11 +72,20 @@ type Available = {
   region: string | null;
 };
 
+type Member = {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  role: string;
+};
+
 function stubFetch(opts: {
   rows?: PhoneNumberRow[];
   available?: Available[];
+  members?: Member[];
   postResult?: PhoneNumberRow;
   releaseResult?: PhoneNumberRow;
+  patchResult?: PhoneNumberRow;
 }) {
   const json = (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), {
@@ -84,6 +93,9 @@ function stubFetch(opts: {
       headers: { "Content-Type": "application/json" },
     });
   const spy = vi.fn(async (url: string, init?: RequestInit) => {
+    if (url.startsWith("/api/settings/users")) {
+      return json(opts.members ?? []);
+    }
     if (url.startsWith("/api/phone/numbers/available")) {
       return json(opts.available ?? []);
     }
@@ -93,6 +105,9 @@ function stubFetch(opts: {
     if (url.startsWith("/api/phone/numbers")) {
       if (init?.method === "POST") {
         return json(opts.postResult ?? row({ id: "row-new" }), 201);
+      }
+      if (init?.method === "PATCH") {
+        return json(opts.patchResult ?? row(), 200);
       }
       return json(opts.rows ?? []);
     }
@@ -144,13 +159,59 @@ describe("PhoneNumbersTab — list rendering", () => {
     expect(screen.getByText("Shared")).toBeDefined();
   });
 
-  it("shows the inbound-rule placeholder copy for Shared rows (slice 8 lands the configurator)", async () => {
+  it("summarizes an unconfigured Shared number as Voicemail (decideShared's null default)", async () => {
     asAdmin();
-    stubFetch({ rows: [row()] });
+    stubFetch({ rows: [row({ inbound_rule: null })] });
 
     render(<PhoneNumbersTab />);
 
-    expect(await screen.findByText(/ring-all default/i)).toBeDefined();
+    await screen.findByText("Marketing");
+    // An unconfigured Shared number has inbound_rule = null. decideShared
+    // falls through to voicemail for a null config, so the cell must say
+    // Voicemail — not the old (untruthful) "ring-all default" placeholder.
+    expect(screen.getByText(/^voicemail$/i)).toBeDefined();
+  });
+
+  it("summarizes a ring-all rule with the member count", async () => {
+    asAdmin();
+    stubFetch({
+      rows: [
+        row({ inbound_rule: { kind: "ring-all", users: ["u1", "u2"] } }),
+      ],
+    });
+
+    render(<PhoneNumbersTab />);
+
+    await screen.findByText("Marketing");
+    expect(screen.getByText(/ring all \(2\)/i)).toBeDefined();
+  });
+
+  it("summarizes a round-robin rule with the sequence length", async () => {
+    asAdmin();
+    stubFetch({
+      rows: [
+        row({
+          inbound_rule: { kind: "round-robin", sequence: ["u1", "u2", "u3"] },
+        }),
+      ],
+    });
+
+    render(<PhoneNumbersTab />);
+
+    await screen.findByText("Marketing");
+    expect(screen.getByText(/round robin \(3\)/i)).toBeDefined();
+  });
+
+  it("summarizes a forward rule as Forward", async () => {
+    asAdmin();
+    stubFetch({
+      rows: [row({ inbound_rule: { kind: "forward", forwardUserId: "u2" } })],
+    });
+
+    render(<PhoneNumbersTab />);
+
+    await screen.findByText("Marketing");
+    expect(screen.getByText(/^forward$/i)).toBeDefined();
   });
 
   it("shows the empty-state when no rows exist", async () => {
@@ -252,6 +313,214 @@ describe("PhoneNumbersTab — Add Shared Number flow", () => {
       expect(postCall).toBeDefined();
       const body = JSON.parse(String((postCall![1] as RequestInit).body));
       expect(body).toEqual({ phoneNumber: "+15125551234", label: "New" });
+    });
+  });
+});
+
+describe("PhoneNumbersTab — inbound-rule editor", () => {
+  it("admin clicks Configure on a Shared row and the editor opens with the four answer rules", async () => {
+    asAdmin();
+    stubFetch({ rows: [row({ id: "pn-1" })], members: [] });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+
+    // The kind picker offers the four routable rules (ADR 0006).
+    expect(await screen.findByLabelText(/ring all/i)).toBeDefined();
+    expect(screen.getByLabelText(/round robin/i)).toBeDefined();
+    expect(screen.getByLabelText(/forward/i)).toBeDefined();
+    expect(screen.getByLabelText(/^voicemail$/i)).toBeDefined();
+  });
+
+  it("hides the Configure button from a non-admin (Shared is admin-only, ADR 0003)", async () => {
+    asNonAdmin();
+    stubFetch({ rows: [row({ id: "pn-1" })], members: [] });
+
+    render(<PhoneNumbersTab />);
+
+    await screen.findByText("Marketing");
+    expect(
+      screen.queryByRole("button", { name: /configure/i }),
+    ).toBeNull();
+  });
+
+  it("lists members with a cell as selectable, omitting those without one", async () => {
+    asAdmin();
+    stubFetch({
+      rows: [row({ id: "pn-1", inbound_rule: { kind: "ring-all", users: [] } })],
+      members: [
+        { id: "u1", full_name: "Has Cell", phone: "+15125550001", role: "admin" },
+        { id: "u2", full_name: "No Cell", phone: null, role: "crew_lead" },
+      ],
+    });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+
+    // A member with a cell on file is offered; one without is not —
+    // decideShared drops cell-less members, so they could never be part of a
+    // routable rule.
+    expect(await screen.findByText("Has Cell")).toBeDefined();
+    expect(screen.queryByText("No Cell")).toBeNull();
+  });
+
+  it("admin checks members and saves a ring-all rule via PATCH", async () => {
+    asAdmin();
+    const fetchSpy = stubFetch({
+      rows: [row({ id: "pn-1", inbound_rule: { kind: "ring-all", users: [] } })],
+      members: [
+        { id: "u1", full_name: "Has Cell", phone: "+15125550001", role: "admin" },
+      ],
+      patchResult: row({
+        id: "pn-1",
+        inbound_rule: { kind: "ring-all", users: ["u1"] },
+      }),
+    });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+    fireEvent.click(await screen.findByLabelText(/has cell/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchSpy.mock.calls.find(
+        (c) =>
+          String(c[0]) === "/api/phone/numbers/pn-1" &&
+          (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String((patchCall![1] as RequestInit).body));
+      expect(body).toEqual({
+        inbound_rule: { kind: "ring-all", users: ["u1"] },
+      });
+    });
+  });
+
+  it("admin switches a number to voicemail and saves via PATCH", async () => {
+    asAdmin();
+    const fetchSpy = stubFetch({
+      rows: [
+        row({ id: "pn-1", inbound_rule: { kind: "ring-all", users: ["u1"] } }),
+      ],
+      members: [
+        { id: "u1", full_name: "Has Cell", phone: "+15125550001", role: "admin" },
+      ],
+      patchResult: row({ id: "pn-1", inbound_rule: { kind: "voicemail" } }),
+    });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+    fireEvent.click(await screen.findByLabelText(/^voicemail$/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchSpy.mock.calls.find(
+        (c) =>
+          String(c[0]) === "/api/phone/numbers/pn-1" &&
+          (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String((patchCall![1] as RequestInit).body));
+      expect(body).toEqual({ inbound_rule: { kind: "voicemail" } });
+    });
+  });
+
+  it("admin picks one member to forward to (single-select) and saves via PATCH", async () => {
+    asAdmin();
+    const fetchSpy = stubFetch({
+      rows: [row({ id: "pn-1", inbound_rule: { kind: "voicemail" } })],
+      members: [
+        {
+          id: "u1",
+          full_name: "First Cell",
+          phone: "+15125550001",
+          role: "admin",
+        },
+        {
+          id: "u2",
+          full_name: "Second Cell",
+          phone: "+15125550002",
+          role: "crew_lead",
+        },
+      ],
+      patchResult: row({
+        id: "pn-1",
+        inbound_rule: { kind: "forward", forwardUserId: "u2" },
+      }),
+    });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+    fireEvent.click(await screen.findByLabelText(/forward/i));
+    // Forward is single-select: picking First then Second forwards to Second
+    // only — the second pick replaces the first.
+    fireEvent.click(await screen.findByLabelText(/^first cell$/i));
+    fireEvent.click(await screen.findByLabelText(/^second cell$/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchSpy.mock.calls.find(
+        (c) =>
+          String(c[0]) === "/api/phone/numbers/pn-1" &&
+          (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String((patchCall![1] as RequestInit).body));
+      expect(body).toEqual({
+        inbound_rule: { kind: "forward", forwardUserId: "u2" },
+      });
+    });
+  });
+
+  it("admin orders members and saves a round-robin rule (sequence keeps click order)", async () => {
+    asAdmin();
+    const fetchSpy = stubFetch({
+      rows: [row({ id: "pn-1", inbound_rule: { kind: "voicemail" } })],
+      members: [
+        {
+          id: "u1",
+          full_name: "First Cell",
+          phone: "+15125550001",
+          role: "admin",
+        },
+        {
+          id: "u2",
+          full_name: "Second Cell",
+          phone: "+15125550002",
+          role: "crew_lead",
+        },
+      ],
+      patchResult: row({
+        id: "pn-1",
+        inbound_rule: { kind: "round-robin", sequence: ["u2", "u1"] },
+      }),
+    });
+
+    render(<PhoneNumbersTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /configure/i }));
+    fireEvent.click(await screen.findByLabelText(/round robin/i));
+    // The sequence follows click order: Second, then First.
+    fireEvent.click(await screen.findByLabelText(/^second cell$/i));
+    fireEvent.click(await screen.findByLabelText(/^first cell$/i));
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const patchCall = fetchSpy.mock.calls.find(
+        (c) =>
+          String(c[0]) === "/api/phone/numbers/pn-1" &&
+          (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse(String((patchCall![1] as RequestInit).body));
+      expect(body).toEqual({
+        inbound_rule: { kind: "round-robin", sequence: ["u2", "u1"] },
+      });
     });
   });
 });

--- a/src/app/settings/phone/phone-numbers-tab.tsx
+++ b/src/app/settings/phone/phone-numbers-tab.tsx
@@ -39,9 +39,95 @@ interface AvailableLocalNumber {
   region: string | null;
 }
 
+// An org member as returned by GET /api/settings/users. `phone` is the cell
+// on file (E.164) or null — the inbound router (decideShared) drops anyone
+// without a cell, so only members with one are selectable in the editor.
+interface OrgMember {
+  id: string;
+  full_name: string;
+  phone: string | null;
+  role: string;
+}
+
+type InboundKind = "ring-all" | "round-robin" | "forward" | "voicemail";
+
+// The four routable shapes decideShared understands (ADR 0006). The editor
+// builds one of these and PATCHes it; parseInboundRule re-validates server-side.
+type InboundRule =
+  | { kind: "ring-all"; users: string[] }
+  | { kind: "round-robin"; sequence: string[] }
+  | { kind: "forward"; forwardUserId: string }
+  | { kind: "voicemail" };
+
+const INBOUND_KIND_OPTIONS: { kind: InboundKind; label: string; help: string }[] =
+  [
+    {
+      kind: "ring-all",
+      label: "Ring all",
+      help: "Ring every selected member's cell at once; first to answer wins.",
+    },
+    {
+      kind: "round-robin",
+      label: "Round robin",
+      help: "Ring one selected member per call, rotating through the list.",
+    },
+    {
+      kind: "forward",
+      label: "Forward",
+      help: "Always forward to one member's cell.",
+    },
+    {
+      kind: "voicemail",
+      label: "Voicemail",
+      help: "Send every caller straight to voicemail.",
+    },
+  ];
+
+// Map a persisted inbound_rule back to the editor's kind so opening the
+// editor pre-selects the number's current rule. A null/unknown rule opens
+// on voicemail (decideShared's null fallthrough).
+function ruleToKind(rule: unknown): InboundKind {
+  if (rule && typeof rule === "object" && "kind" in rule) {
+    const k = (rule as { kind: string }).kind;
+    if (
+      k === "ring-all" ||
+      k === "round-robin" ||
+      k === "forward" ||
+      k === "voicemail"
+    ) {
+      return k;
+    }
+  }
+  return "voicemail";
+}
+
 function formatCents(cents: number | null): string {
   if (cents === null) return "—";
   return `$${(cents / 100).toFixed(2)}`;
+}
+
+// A one-line, human summary of a Shared number's inbound_rule for the table
+// cell. Mirrors decideShared: a null (unconfigured) rule falls through to
+// voicemail, so it summarizes as "Voicemail" — never the old "ring-all
+// default" copy, which was untruthful.
+function summarizeInboundRule(rule: unknown): string {
+  if (rule && typeof rule === "object" && "kind" in rule) {
+    const r = rule as {
+      kind: string;
+      users?: unknown[];
+      sequence?: unknown[];
+    };
+    if (r.kind === "ring-all" && Array.isArray(r.users)) {
+      return `Ring all (${r.users.length})`;
+    }
+    if (r.kind === "round-robin" && Array.isArray(r.sequence)) {
+      return `Round robin (${r.sequence.length})`;
+    }
+    if (r.kind === "forward") {
+      return "Forward";
+    }
+  }
+  return "Voicemail";
 }
 
 export function PhoneNumbersTab() {
@@ -67,6 +153,16 @@ export function PhoneNumbersTab() {
   const [releasing, setReleasing] = useState<PhoneNumberRow | null>(null);
   const [releaseInFlight, setReleaseInFlight] = useState(false);
 
+  // Inbound-rule editor state — the Shared row the admin clicked Configure on.
+  const [editing, setEditing] = useState<PhoneNumberRow | null>(null);
+  const [editKind, setEditKind] = useState<InboundKind>("voicemail");
+  // Selected member ids: the ring-all users / round-robin sequence (in click
+  // order) and, for forward, the single chosen id at index 0.
+  const [editUsers, setEditUsers] = useState<string[]>([]);
+  const [members, setMembers] = useState<OrgMember[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const [saveInFlight, setSaveInFlight] = useState(false);
+
   const load = useCallback(async () => {
     setLoading(true);
     try {
@@ -87,6 +183,89 @@ export function PhoneNumbersTab() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // Open the inbound-rule editor for a Shared row: pre-select the number's
+  // current rule and lazy-load the org roster (only admins reach this, and
+  // they have access_settings). Members without a cell are filtered at
+  // render — the router would drop them anyway.
+  async function openEditor(r: PhoneNumberRow) {
+    const rule = r.inbound_rule as
+      | { kind?: string; users?: string[]; sequence?: string[]; forwardUserId?: string }
+      | null;
+    setEditKind(ruleToKind(r.inbound_rule));
+    if (rule?.kind === "ring-all" && Array.isArray(rule.users)) {
+      setEditUsers(rule.users);
+    } else if (rule?.kind === "round-robin" && Array.isArray(rule.sequence)) {
+      setEditUsers(rule.sequence);
+    } else if (rule?.kind === "forward" && typeof rule.forwardUserId === "string") {
+      setEditUsers([rule.forwardUserId]);
+    } else {
+      setEditUsers([]);
+    }
+    setEditing(r);
+
+    setMembersLoading(true);
+    try {
+      const res = await fetch("/api/settings/users");
+      if (res.ok) {
+        setMembers((await res.json()) as OrgMember[]);
+      }
+    } finally {
+      setMembersLoading(false);
+    }
+  }
+
+  // Toggle a member in/out of the selected set, preserving click order (the
+  // round-robin sequence and ring-all set both read off editUsers).
+  function toggleUser(id: string) {
+    setEditUsers((prev) =>
+      prev.includes(id) ? prev.filter((u) => u !== id) : [...prev, id],
+    );
+  }
+
+  // Only members with a cell on file are routable — decideShared drops the
+  // rest, so they are never offered.
+  const selectableMembers = members.filter((m) => m.phone !== null);
+
+  // Build the routable rule from the editor's current selection. Returns null
+  // for a kind the editor cannot yet express, so Save is a no-op rather than
+  // PATCHing a half-formed rule.
+  function buildRule(): InboundRule | null {
+    switch (editKind) {
+      case "ring-all":
+        return { kind: "ring-all", users: editUsers };
+      case "round-robin":
+        return { kind: "round-robin", sequence: editUsers };
+      case "forward":
+        return editUsers[0]
+          ? { kind: "forward", forwardUserId: editUsers[0] }
+          : null;
+      case "voicemail":
+        return { kind: "voicemail" };
+      default:
+        return null;
+    }
+  }
+
+  async function handleSaveRule() {
+    if (!editing) return;
+    const rule = buildRule();
+    if (!rule) return;
+    setSaveInFlight(true);
+    try {
+      const res = await fetch(`/api/phone/numbers/${editing.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ inbound_rule: rule }),
+      });
+      if (res.ok) {
+        setEditing(null);
+        await load();
+      }
+    } finally {
+      setSaveInFlight(false);
+    }
+  }
 
   const liveRows = useMemo(
     () => rows.filter((r) => r.released_at === null),
@@ -232,7 +411,22 @@ export function PhoneNumbersTab() {
                     {r.kind === "shared" ? "—" : r.user_id ?? "—"}
                   </td>
                   <td className="px-3 py-2 text-muted-foreground text-xs">
-                    ring-all default — configurable in slice 8
+                    <div className="flex items-center gap-2">
+                      <span>
+                        {summarizeInboundRule(
+                          r.kind === "shared" ? r.inbound_rule : null,
+                        )}
+                      </span>
+                      {isAdmin && r.kind === "shared" && (
+                        <button
+                          type="button"
+                          onClick={() => void openEditor(r)}
+                          className="text-[var(--brand-primary)] font-medium hover:underline"
+                        >
+                          Configure
+                        </button>
+                      )}
+                    </div>
                   </td>
                   <td className="px-3 py-2 text-foreground">
                     {formatCents(r.monthly_cost_cents)}
@@ -383,6 +577,105 @@ export function PhoneNumbersTab() {
                 className="rounded-md bg-destructive text-destructive-foreground px-3 py-1.5 text-sm font-medium disabled:opacity-50"
               >
                 {releaseInFlight ? "Releasing…" : "Confirm"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Inbound-rule editor — pick an answer rule + (for ring/forward) the
+          members to dial. Saves to PATCH /api/phone/numbers/[id]. */}
+      {editing && (
+        <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-card rounded-xl border border-border w-full max-w-md p-5 space-y-4">
+            <h3 className="text-lg font-semibold text-foreground">
+              Inbound rule — {formatPhoneNumber(editing.e164)}
+            </h3>
+
+            <fieldset className="space-y-2">
+              <legend className="text-sm font-medium text-foreground">
+                When a call comes in
+              </legend>
+              {INBOUND_KIND_OPTIONS.map((opt) => (
+                <label
+                  key={opt.kind}
+                  className="flex items-start gap-2 text-sm cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    name="inbound-kind"
+                    value={opt.kind}
+                    aria-label={opt.label}
+                    checked={editKind === opt.kind}
+                    onChange={() => setEditKind(opt.kind)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <span className="font-medium text-foreground">
+                      {opt.label}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {opt.help}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </fieldset>
+
+            {editKind !== "voicemail" && (
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">Members</p>
+                {membersLoading ? (
+                  <p className="text-xs text-muted-foreground">Loading…</p>
+                ) : selectableMembers.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    No members with a cell on file.
+                  </p>
+                ) : (
+                  selectableMembers.map((m) => {
+                    // Forward goes to exactly one member (single-select radio);
+                    // ring-all / round-robin select a set (checkboxes).
+                    const single = editKind === "forward";
+                    return (
+                      <label
+                        key={m.id}
+                        className="flex items-center gap-2 text-sm cursor-pointer"
+                      >
+                        <input
+                          type={single ? "radio" : "checkbox"}
+                          name={single ? "forward-member" : undefined}
+                          checked={
+                            single
+                              ? editUsers[0] === m.id
+                              : editUsers.includes(m.id)
+                          }
+                          onChange={() =>
+                            single ? setEditUsers([m.id]) : toggleUser(m.id)
+                          }
+                        />
+                        <span className="text-foreground">{m.full_name}</span>
+                      </label>
+                    );
+                  })
+                )}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => setEditing(null)}
+                className="rounded-md px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleSaveRule()}
+                disabled={saveInFlight}
+                className="rounded-md bg-[var(--brand-primary)] px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50"
+              >
+                {saveInFlight ? "Saving…" : "Save"}
               </button>
             </div>
           </div>

--- a/src/lib/phone/ingest-inbound-call.test.ts
+++ b/src/lib/phone/ingest-inbound-call.test.ts
@@ -1,0 +1,192 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — ingestInboundCall helper.
+//
+// The conversation-threading + call-row persistence the inbound VOICE
+// webhook performs. It mirrors `ingestInbound` (the SMS helper): a voice
+// call threads on the SAME phone_conversations row as the slice-4 messages
+// (natural key: phone_number_id + outside_e164), so a call and a text to
+// the same outside number interleave in one Phone-tab thread.
+//
+// Responsibilities:
+//   1. Upsert the Conversation by (phone_number_id, outside_e164) — sets
+//      last_event_at so the thread sorts to the top.
+//   2. Insert a phone_calls row (direction='in', status='ringing' at
+//      dial-start) carrying the smart-attach job_tag when the decision is
+//      'auto'. The status-callback webhook later advances status +
+//      duration_seconds + ended_at.
+//
+// Unlike ingestInbound, a call does NOT bump unread_count: a 'ringing'
+// insert happens before we know whether the call was answered, so counting
+// every inbound call as unread would inflate the badge for answered calls.
+// The missed-call surfacing is a thread-render concern, not a counter.
+//
+// These tests use the same lightweight Supabase-builder fake as the
+// inbound-webhook + ingestInbound tests — verifying observable database
+// effects, not wiring.
+
+import { describe, it, expect } from "vitest";
+import { ingestInboundCall } from "./ingest-inbound-call";
+import type { RouteInboundDecision } from "./route-inbound";
+
+type Row = Record<string, unknown>;
+
+interface BuilderTables {
+  phone_conversations: Row[];
+  phone_calls: Row[];
+}
+
+function makeServiceClient(tables: BuilderTables) {
+  const inserts: { table: string; row: Row }[] = [];
+  const upserts: { table: string; row: Row; onConflict: string | undefined }[] = [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = (tables as unknown as Record<string, Row[]>)[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.order = () => b;
+    b.limit = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opts?: { onConflict?: string }) => {
+      pendingInsert = row;
+      upserts.push({ table, row, onConflict: opts?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.single = async () => {
+      if (pendingInsert) {
+        const row = { id: `new-${inserts.length + upserts.length}`, ...pendingInsert };
+        (tables as unknown as Record<string, Row[]>)[table].push(row);
+        return { data: row, error: null };
+      }
+      return { data: rows[0] ?? null, error: rows[0] ? null : { message: "no rows" } };
+    };
+    b.then = (resolve: (v: unknown) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  return {
+    client: { from: builder } as unknown as Parameters<typeof ingestInboundCall>[0]["supabase"],
+    inserts,
+    upserts,
+    updates,
+  };
+}
+
+const BASE_DECISION: RouteInboundDecision = {
+  organizationId: "org-1",
+  phoneNumberId: "pn-1",
+  phoneNumberKind: "shared",
+  phoneNumberOwnerId: null,
+  outsideE164: "+15551234567",
+  conversationKey: { phoneNumberId: "pn-1", outsideE164: "+15551234567" },
+  contactId: null,
+  smartAttach: { kind: "untagged" },
+};
+
+describe("ingestInboundCall — call-row persistence", () => {
+  it("upserts the conversation then inserts a ringing inbound phone_calls row", async () => {
+    const { client, upserts, inserts } = makeServiceClient({
+      phone_conversations: [],
+      phone_calls: [],
+    });
+
+    await ingestInboundCall({
+      supabase: client,
+      decision: BASE_DECISION,
+      toE164: "+15125550000",
+      twilioCallSid: "CA-abc",
+      status: "ringing",
+    });
+
+    // Threaded on the same natural key as the SMS path.
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toMatchObject({
+      table: "phone_conversations",
+      onConflict: "phone_number_id,outside_e164",
+      row: {
+        organization_id: "org-1",
+        phone_number_id: "pn-1",
+        outside_e164: "+15551234567",
+        contact_id: null,
+      },
+    });
+    // The call row.
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert).toBeDefined();
+    expect(callInsert!.row).toMatchObject({
+      organization_id: "org-1",
+      direction: "in",
+      from_e164: "+15551234567",
+      to_e164: "+15125550000",
+      twilio_call_sid: "CA-abc",
+      status: "ringing",
+      initiated_by_user_id: null,
+    });
+  });
+
+  it("carries the smart-attach job_tag when the decision is 'auto'", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_conversations: [],
+      phone_calls: [],
+    });
+
+    await ingestInboundCall({
+      supabase: client,
+      decision: {
+        ...BASE_DECISION,
+        contactId: "c-1",
+        smartAttach: { kind: "auto", jobId: "job-1" },
+      },
+      toE164: "+15125550000",
+      twilioCallSid: "CA-auto",
+      status: "ringing",
+    });
+
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert!.row).toMatchObject({
+      job_tag: "job-1",
+      tagged_by_user_id: null, // auto-tagged, not a human action
+    });
+  });
+
+  it("leaves job_tag null when the decision is untagged", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_conversations: [],
+      phone_calls: [],
+    });
+
+    await ingestInboundCall({
+      supabase: client,
+      decision: BASE_DECISION, // smartAttach: { kind: "untagged" }
+      toE164: "+15125550000",
+      twilioCallSid: "CA-untagged",
+      status: "ringing",
+    });
+
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert!.row.job_tag).toBeNull();
+  });
+});

--- a/src/lib/phone/ingest-inbound-call.ts
+++ b/src/lib/phone/ingest-inbound-call.ts
@@ -1,0 +1,77 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — ingestInboundCall helper.
+//
+// The conversation-threading + call-row persistence the inbound VOICE
+// webhook performs, mirroring `ingestInbound` (the SMS helper). A voice
+// call threads on the SAME phone_conversations row as the slice-4 messages
+// (natural key: phone_number_id + outside_e164), so a call and a text to
+// the same outside number interleave in one Phone-tab thread.
+//
+//   1. Upsert the Conversation by (phone_number_id, outside_e164) — sets
+//      last_event_at so the thread sorts to the top.
+//   2. Insert a phone_calls row (direction='in', status='ringing' at
+//      dial-start) carrying the smart-attach job_tag when the decision is
+//      'auto'. The status-callback webhook later advances status +
+//      duration_seconds + ended_at.
+//
+// Unlike ingestInbound, a call does NOT bump unread_count — a 'ringing'
+// insert happens before we know whether the call was answered.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { RouteInboundDecision } from "./route-inbound";
+
+export interface IngestInboundCallInput {
+  // The Service client (the webhook has no auth user, so RLS would refuse).
+  supabase: SupabaseClient;
+  decision: RouteInboundDecision;
+  // The org's `phone_numbers.e164` the customer dialed — stored as the
+  // call row's to_e164.
+  toE164: string;
+  // Twilio's CallSid; the status-callback webhook keys on this to advance
+  // the row's status as the call progresses.
+  twilioCallSid: string | null;
+  // The status to write at dial-start — 'ringing'.
+  status: string;
+}
+
+export async function ingestInboundCall(
+  input: IngestInboundCallInput,
+): Promise<void> {
+  const { supabase, decision, toE164, twilioCallSid, status } = input;
+
+  const now = new Date().toISOString();
+
+  // 1. Upsert the Conversation (same natural key as the SMS path).
+  const { data: conv } = await supabase
+    .from("phone_conversations")
+    .upsert(
+      {
+        organization_id: decision.organizationId,
+        phone_number_id: decision.phoneNumberId,
+        outside_e164: decision.outsideE164,
+        contact_id: decision.contactId,
+        last_event_at: now,
+      },
+      { onConflict: "phone_number_id,outside_e164" },
+    )
+    .select("id")
+    .single<{ id: string }>();
+  if (!conv) return;
+
+  // 2. Insert the inbound call row.
+  const jobTag =
+    decision.smartAttach.kind === "auto" ? decision.smartAttach.jobId : null;
+  await supabase.from("phone_calls").insert({
+    organization_id: decision.organizationId,
+    conversation_id: conv.id,
+    direction: "in",
+    from_e164: decision.outsideE164,
+    to_e164: toE164,
+    twilio_call_sid: twilioCallSid,
+    status,
+    duration_seconds: null,
+    job_tag: jobTag,
+    tagged_by_user_id: null,
+    initiated_by_user_id: null,
+    started_at: now,
+  });
+}

--- a/src/lib/phone/merge-thread-items.test.ts
+++ b/src/lib/phone/merge-thread-items.test.ts
@@ -1,0 +1,45 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — thread interleave.
+//
+// `mergeThreadItems` merges a conversation's text messages and voice calls
+// into one chronologically-ordered list of tagged items, so the Phone-tab
+// thread can render a call and a text to the same outside number inline
+// (ADR: a call threads on the same phone_conversations row as messages).
+//
+// Messages carry `sent_at`; calls carry `started_at`. The helper is pure
+// (no I/O) and generic over the row shapes — it only reads the timestamp.
+
+import { describe, it, expect } from "vitest";
+import { mergeThreadItems } from "./merge-thread-items";
+
+describe("mergeThreadItems", () => {
+  it("interleaves a message and an earlier call in chronological order", () => {
+    const items = mergeThreadItems(
+      [{ id: "m1", sent_at: "2026-05-27T10:05:00Z" }],
+      [{ id: "c1", started_at: "2026-05-27T10:00:00Z" }],
+    );
+
+    // The call started first, so it sorts ahead of the later message.
+    expect(items.map((i) => i.kind)).toEqual(["call", "message"]);
+  });
+
+  it("fully interleaves multiple messages and calls ascending by time, breaking ties message-first", () => {
+    const items = mergeThreadItems(
+      [
+        { id: "m-early", sent_at: "2026-05-27T09:00:00Z" },
+        { id: "m-tie", sent_at: "2026-05-27T10:00:00Z" },
+        { id: "m-late", sent_at: "2026-05-27T12:00:00Z" },
+      ],
+      [
+        { id: "c-tie", started_at: "2026-05-27T10:00:00Z" },
+        { id: "c-latest", started_at: "2026-05-27T13:00:00Z" },
+      ],
+    );
+
+    const ids = items.map((i) =>
+      i.kind === "message" ? i.message.id : i.call.id,
+    );
+    // Ascending by timestamp; the equal-timestamp pair is deterministic
+    // (message before call) so React keys/render order never flicker.
+    expect(ids).toEqual(["m-early", "m-tie", "c-tie", "m-late", "c-latest"]);
+  });
+});

--- a/src/lib/phone/merge-thread-items.ts
+++ b/src/lib/phone/merge-thread-items.ts
@@ -1,0 +1,45 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — thread interleave.
+//
+// Merge a conversation's text messages and voice calls into one
+// chronologically-ordered list of tagged items. A call threads on the same
+// phone_conversations row as the messages (natural key: phone_number_id +
+// outside_e164), so the Phone-tab thread shows calls and texts to the same
+// outside number inline.
+//
+// Pure (no I/O) and generic: messages need only a `sent_at`, calls only a
+// `started_at` — the caller's richer row shapes flow through untouched.
+
+export interface ThreadMessageLike {
+  sent_at: string;
+}
+
+export interface ThreadCallLike {
+  started_at: string;
+}
+
+export type ThreadItem<M extends ThreadMessageLike, C extends ThreadCallLike> =
+  | { kind: "message"; at: number; message: M }
+  | { kind: "call"; at: number; call: C };
+
+export function mergeThreadItems<
+  M extends ThreadMessageLike,
+  C extends ThreadCallLike,
+>(messages: M[], calls: C[]): Array<ThreadItem<M, C>> {
+  const items: Array<ThreadItem<M, C>> = [
+    ...messages.map(
+      (message): ThreadItem<M, C> => ({
+        kind: "message",
+        at: new Date(message.sent_at).getTime(),
+        message,
+      }),
+    ),
+    ...calls.map(
+      (call): ThreadItem<M, C> => ({
+        kind: "call",
+        at: new Date(call.started_at).getTime(),
+        call,
+      }),
+    ),
+  ];
+  return items.sort((a, b) => a.at - b.at);
+}

--- a/src/lib/phone/parse-inbound-rule.test.ts
+++ b/src/lib/phone/parse-inbound-rule.test.ts
@@ -1,0 +1,110 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — inbound-rule validation.
+//
+// `parseInboundRule` is the trust boundary between the Settings → Phone
+// editor's PATCH body (untrusted JSON) and the `phone_numbers.inbound_rule`
+// jsonb column. It accepts only the four well-formed shapes the router
+// understands (ring-all / round-robin / forward / voicemail) and rejects
+// everything else with a human-readable error. Pure: no I/O.
+//
+// The shapes mirror the `InboundRule` discriminated union the router
+// (decideShared) consumes, so a saved rule is always routable.
+
+import { describe, it, expect } from "vitest";
+import { parseInboundRule } from "./parse-inbound-rule";
+
+describe("parseInboundRule — ring-all", () => {
+  it("accepts a ring-all rule with a users array", () => {
+    const result = parseInboundRule({ kind: "ring-all", users: ["u1", "u2"] });
+    expect(result).toEqual({
+      ok: true,
+      rule: { kind: "ring-all", users: ["u1", "u2"] },
+    });
+  });
+});
+
+describe("parseInboundRule — round-robin", () => {
+  it("accepts a round-robin rule with a sequence array", () => {
+    const result = parseInboundRule({
+      kind: "round-robin",
+      sequence: ["u1", "u2", "u3"],
+    });
+    expect(result).toEqual({
+      ok: true,
+      rule: { kind: "round-robin", sequence: ["u1", "u2", "u3"] },
+    });
+  });
+});
+
+describe("parseInboundRule — forward", () => {
+  it("accepts a forward rule with a forwardUserId string", () => {
+    const result = parseInboundRule({ kind: "forward", forwardUserId: "u2" });
+    expect(result).toEqual({
+      ok: true,
+      rule: { kind: "forward", forwardUserId: "u2" },
+    });
+  });
+});
+
+describe("parseInboundRule — voicemail", () => {
+  it("accepts a bare voicemail rule (no extra fields required)", () => {
+    const result = parseInboundRule({ kind: "voicemail" });
+    expect(result).toEqual({
+      ok: true,
+      rule: { kind: "voicemail" },
+    });
+  });
+});
+
+describe("parseInboundRule — rejects malformed input", () => {
+  it("rejects a non-object (null)", () => {
+    expect(parseInboundRule(null)).toMatchObject({ ok: false });
+  });
+
+  it("rejects a non-object (string)", () => {
+    expect(parseInboundRule("ring-all")).toMatchObject({ ok: false });
+  });
+
+  it("rejects an unknown kind", () => {
+    const result = parseInboundRule({ kind: "page-everyone" });
+    expect(result).toMatchObject({ ok: false });
+    if (!result.ok) expect(result.error).toContain("page-everyone");
+  });
+
+  it("rejects ring-all when users is not a string array", () => {
+    expect(parseInboundRule({ kind: "ring-all", users: "u1" })).toMatchObject({
+      ok: false,
+    });
+    expect(parseInboundRule({ kind: "ring-all" })).toMatchObject({ ok: false });
+    expect(
+      parseInboundRule({ kind: "ring-all", users: [1, 2] }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("rejects round-robin when sequence is not a string array", () => {
+    expect(
+      parseInboundRule({ kind: "round-robin", sequence: "u1" }),
+    ).toMatchObject({ ok: false });
+    expect(parseInboundRule({ kind: "round-robin" })).toMatchObject({
+      ok: false,
+    });
+  });
+
+  it("rejects forward when forwardUserId is missing or not a string", () => {
+    expect(parseInboundRule({ kind: "forward" })).toMatchObject({ ok: false });
+    expect(
+      parseInboundRule({ kind: "forward", forwardUserId: 42 }),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("does not let extra fields leak into the parsed rule", () => {
+    const result = parseInboundRule({
+      kind: "ring-all",
+      users: ["u1"],
+      malicious: "DROP TABLE",
+    });
+    expect(result).toEqual({
+      ok: true,
+      rule: { kind: "ring-all", users: ["u1"] },
+    });
+  });
+});

--- a/src/lib/phone/parse-inbound-rule.ts
+++ b/src/lib/phone/parse-inbound-rule.ts
@@ -1,0 +1,50 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312) — inbound-rule validation.
+//
+// The trust boundary between the Settings → Phone editor's PATCH body
+// (untrusted JSON) and the `phone_numbers.inbound_rule` jsonb column.
+// Accepts only the four shapes `decideShared` understands and rejects
+// everything else with a human-readable error. Pure: no I/O.
+
+import type { InboundRule } from "./route-shared-call";
+
+export type ParseInboundRuleResult =
+  | { ok: true; rule: InboundRule }
+  | { ok: false; error: string };
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+export function parseInboundRule(raw: unknown): ParseInboundRuleResult {
+  if (typeof raw !== "object" || raw === null) {
+    return { ok: false, error: "inbound_rule must be an object" };
+  }
+  const obj = raw as Record<string, unknown>;
+
+  if (obj.kind === "ring-all") {
+    if (!isStringArray(obj.users)) {
+      return { ok: false, error: "ring-all requires a users string array" };
+    }
+    return { ok: true, rule: { kind: "ring-all", users: obj.users } };
+  }
+
+  if (obj.kind === "round-robin") {
+    if (!isStringArray(obj.sequence)) {
+      return { ok: false, error: "round-robin requires a sequence string array" };
+    }
+    return { ok: true, rule: { kind: "round-robin", sequence: obj.sequence } };
+  }
+
+  if (obj.kind === "forward") {
+    if (typeof obj.forwardUserId !== "string") {
+      return { ok: false, error: "forward requires a forwardUserId string" };
+    }
+    return { ok: true, rule: { kind: "forward", forwardUserId: obj.forwardUserId } };
+  }
+
+  if (obj.kind === "voicemail") {
+    return { ok: true, rule: { kind: "voicemail" } };
+  }
+
+  return { ok: false, error: `unknown inbound_rule kind "${String(obj.kind)}"` };
+}

--- a/src/lib/phone/route-shared-call.test.ts
+++ b/src/lib/phone/route-shared-call.test.ts
@@ -1,0 +1,171 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312).
+//
+// Tests for the inbound Shared-number routing decision (ADR 0006 §
+// "Programmable Voice with TwiML for inbound routing — ring-all /
+// round-robin / forward / voicemail per-number"). Pure: no I/O.
+//
+// The rule lives on `phone_numbers.inbound_rule` (jsonb, Shared-only).
+// Per the slice-8 design decision (issue #312, Q2): ring-all and
+// round-robin dial *only the members an admin manually selected* into the
+// rule — there is no role-derived roster. `decideShared` resolves those
+// selected user ids against the org roster (`members`), keeps only the
+// ones with a cell on file, and collapses "nobody reachable" to
+// voicemail. The round-robin cursor is monotonic: it comes in, the next
+// value goes out, and the caller persists it per-number so the rotation
+// survives restarts.
+
+import { describe, it, expect } from "vitest";
+import { decideShared } from "./route-shared-call";
+
+describe("decideShared — ring-all", () => {
+  it("rings every manually-selected member that has a cell on file", () => {
+    const result = decideShared({
+      config: { kind: "ring-all", users: ["u1", "u2"] },
+      members: [
+        { userId: "u1", cellE164: "+15125550001" },
+        { userId: "u2", cellE164: "+15125550002" },
+        { userId: "u3", cellE164: "+15125550003" }, // not selected
+      ],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({
+      kind: "ring-all",
+      cells: ["+15125550001", "+15125550002"],
+    });
+  });
+
+  it("falls back to voicemail when no selected member has a cell on file", () => {
+    const result = decideShared({
+      config: { kind: "ring-all", users: ["u1", "u2"] },
+      members: [
+        { userId: "u1", cellE164: null },
+        { userId: "u2", cellE164: null },
+      ],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "voicemail" });
+  });
+});
+
+describe("decideShared — round-robin", () => {
+  const roster = [
+    { userId: "u1", cellE164: "+15125550001" },
+    { userId: "u2", cellE164: "+15125550002" },
+    { userId: "u3", cellE164: "+15125550003" },
+  ];
+
+  it("dials the member at the current cursor and advances the cursor", () => {
+    const result = decideShared({
+      config: { kind: "round-robin", sequence: ["u1", "u2", "u3"] },
+      members: roster,
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({
+      kind: "round-robin",
+      cell: "+15125550001",
+      nextCursor: 1,
+    });
+  });
+
+  it("wraps to the start of the sequence as the cursor grows past its length", () => {
+    const result = decideShared({
+      config: { kind: "round-robin", sequence: ["u1", "u2", "u3"] },
+      members: roster,
+      roundRobinCursor: 3, // one full lap completed → back to the first member
+    });
+    expect(result).toEqual({
+      kind: "round-robin",
+      cell: "+15125550001",
+      nextCursor: 4,
+    });
+  });
+
+  it("skips sequence members without a cell, keeping the rest in order", () => {
+    const result = decideShared({
+      config: { kind: "round-robin", sequence: ["u1", "u2", "u3"] },
+      members: [
+        { userId: "u1", cellE164: "+15125550001" },
+        { userId: "u2", cellE164: null }, // no cell → skipped
+        { userId: "u3", cellE164: "+15125550003" },
+      ],
+      roundRobinCursor: 1, // second reachable member
+    });
+    expect(result).toEqual({
+      kind: "round-robin",
+      cell: "+15125550003",
+      nextCursor: 2,
+    });
+  });
+
+  it("falls back to voicemail when no member in the sequence has a cell", () => {
+    const result = decideShared({
+      config: { kind: "round-robin", sequence: ["u1", "u2"] },
+      members: [
+        { userId: "u1", cellE164: null },
+        { userId: "u2", cellE164: null },
+      ],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "voicemail" });
+  });
+});
+
+describe("decideShared — single-forward", () => {
+  it("forwards to the configured user's cell", () => {
+    const result = decideShared({
+      config: { kind: "forward", forwardUserId: "u2" },
+      members: [
+        { userId: "u1", cellE164: "+15125550001" },
+        { userId: "u2", cellE164: "+15125550002" },
+      ],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "forward", cell: "+15125550002" });
+  });
+
+  it("falls back to voicemail when the forward target has no cell on file", () => {
+    const result = decideShared({
+      config: { kind: "forward", forwardUserId: "u2" },
+      members: [{ userId: "u2", cellE164: null }],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "voicemail" });
+  });
+});
+
+describe("decideShared — voicemail and unconfigured numbers", () => {
+  it("routes to voicemail when the rule is explicitly voicemail", () => {
+    const result = decideShared({
+      config: { kind: "voicemail" },
+      members: [{ userId: "u1", cellE164: "+15125550001" }],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "voicemail" });
+  });
+
+  // Slice 3 inserts inbound_rule = NULL. With Q2 ("only manually-selected
+  // members"), an unconfigured Shared number has nobody selected, so it
+  // routes to voicemail until an admin configures it in Settings → Phone.
+  it("routes to voicemail when the number has no rule configured (NULL)", () => {
+    const result = decideShared({
+      config: null,
+      members: [{ userId: "u1", cellE164: "+15125550001" }],
+      roundRobinCursor: 0,
+    });
+    expect(result).toEqual({ kind: "voicemail" });
+  });
+});
+
+describe("decideShared — currentHour is a Layer-2 placeholder", () => {
+  it("ignores currentHour (business-hours routing is a future slice)", () => {
+    const base = {
+      config: { kind: "ring-all" as const, users: ["u1"] },
+      members: [{ userId: "u1", cellE164: "+15125550001" }],
+      roundRobinCursor: 0,
+    };
+    const atNoon = decideShared({ ...base, currentHour: 12 });
+    const atMidnight = decideShared({ ...base, currentHour: 0 });
+    expect(atNoon).toEqual(atMidnight);
+    expect(atNoon).toEqual({ kind: "ring-all", cells: ["+15125550001"] });
+  });
+});

--- a/src/lib/phone/route-shared-call.ts
+++ b/src/lib/phone/route-shared-call.ts
@@ -1,0 +1,85 @@
+// PRD #304 — Nookleus Phone. Slice 8 (#312). Inbound Shared-number
+// routing decision. Pure: no I/O.
+//
+// ADR 0006 gives Shared numbers four inbound answer rules — ring-all /
+// round-robin / forward / voicemail — configured per-number on
+// `phone_numbers.inbound_rule` (jsonb, Shared-only; Personal numbers
+// always go to voicemail and never reach here). The inbound voice
+// webhook hands this function the number's rule, the org roster, and the
+// number's persisted round-robin cursor; this returns the dial decision
+// the webhook turns into TwiML.
+//
+// Slice-8 design decision (issue #312, Q2): ring-all and round-robin dial
+// *only the members an admin manually selected* into the rule — there is
+// no role-derived roster. The selected user ids are resolved against the
+// roster, members without a cell on file are skipped, and "nobody
+// reachable" collapses to voicemail (a customer never hears dead air).
+
+export type InboundRule =
+  | { kind: "ring-all"; users: string[] }
+  | { kind: "round-robin"; sequence: string[] }
+  | { kind: "forward"; forwardUserId: string }
+  | { kind: "voicemail" };
+
+export interface RoutableMember {
+  userId: string;
+  /** The member's cell on file (E.164), or null when none is set. */
+  cellE164: string | null;
+}
+
+export interface DecideSharedInput {
+  /** The Shared number's inbound_rule. NULL = unconfigured (slice 3 inserts NULL). */
+  config: InboundRule | null;
+  /** Org roster, used to resolve selected user ids to reachable cells. */
+  members: RoutableMember[];
+  /** Persisted rotation cursor for this number; monotonic, 0 if never rung. */
+  roundRobinCursor: number;
+  /** Layer-2 placeholder for business-hours routing; unused today. */
+  currentHour?: number;
+}
+
+export type DecideSharedResult =
+  | { kind: "ring-all"; cells: string[] }
+  | { kind: "round-robin"; cell: string; nextCursor: number }
+  | { kind: "forward"; cell: string }
+  | { kind: "voicemail" };
+
+const VOICEMAIL: DecideSharedResult = { kind: "voicemail" };
+
+/** Resolve selected user ids to their cells, in selection order, dropping
+ *  anyone without a cell on file. */
+function resolveCells(
+  userIds: string[],
+  members: RoutableMember[],
+): string[] {
+  const byId = new Map(members.map((m) => [m.userId, m.cellE164]));
+  return userIds
+    .map((id) => byId.get(id) ?? null)
+    .filter((cell): cell is string => cell !== null);
+}
+
+export function decideShared(input: DecideSharedInput): DecideSharedResult {
+  const { config } = input;
+
+  if (config?.kind === "ring-all") {
+    const cells = resolveCells(config.users, input.members);
+    return cells.length > 0 ? { kind: "ring-all", cells } : VOICEMAIL;
+  }
+
+  if (config?.kind === "round-robin") {
+    const cells = resolveCells(config.sequence, input.members);
+    if (cells.length === 0) return VOICEMAIL;
+    return {
+      kind: "round-robin",
+      cell: cells[input.roundRobinCursor % cells.length],
+      nextCursor: input.roundRobinCursor + 1,
+    };
+  }
+
+  if (config?.kind === "forward") {
+    const [cell] = resolveCells([config.forwardUserId], input.members);
+    return cell ? { kind: "forward", cell } : VOICEMAIL;
+  }
+
+  return VOICEMAIL;
+}

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  buildVoiceTwiml,
   createTwilioClient,
   listAvailableLocalNumbers,
   provisionNumber,
@@ -372,5 +373,60 @@ describe("createTwilioClient — Phone demo mode guard (#368)", () => {
     vi.stubEnv("NODE_ENV", "development");
 
     expect(() => createTwilioClient()).toThrow(/TWILIO_ACCOUNT_SID|TWILIO_AUTH_TOKEN/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 8 (#312) — buildVoiceTwiml. Turns a decideShared() decision into the
+// TwiML Twilio executes for an inbound voice call. Pure (uses the Twilio
+// SDK's twiml.VoiceResponse builder for correct XML escaping; no network).
+// twilio-client is the only file allowed to import twilio, so the builder
+// lives here alongside the other Twilio-boundary helpers.
+// ---------------------------------------------------------------------------
+describe("buildVoiceTwiml — ring-all", () => {
+  it("dials every cell as a <Number> child of one <Dial> (parallel ring)", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "ring-all", cells: ["+15125550001", "+15125550002"] },
+      { callerId: "+15125550000" },
+    );
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Number>+15125550001</Number>");
+    expect(xml).toContain("<Number>+15125550002</Number>");
+  });
+});
+
+describe("buildVoiceTwiml — forward", () => {
+  it("dials the single forward-target cell", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "forward", cell: "+15125550009" },
+      { callerId: "+15125550000" },
+    );
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Number>+15125550009</Number>");
+  });
+});
+
+describe("buildVoiceTwiml — round-robin", () => {
+  it("dials the single member the cursor selected (nextCursor is the caller's concern)", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "round-robin", cell: "+15125550007", nextCursor: 3 },
+      { callerId: "+15125550000" },
+    );
+    expect(xml).toContain("<Dial");
+    expect(xml).toContain("<Number>+15125550007</Number>");
+    // The cursor is rotation bookkeeping persisted by the webhook — it must
+    // never leak into the TwiML Twilio executes.
+    expect(xml).not.toContain("nextCursor");
+    expect(xml).not.toContain("3");
+  });
+});
+
+describe("buildVoiceTwiml — voicemail", () => {
+  it("speaks a default greeting then records the caller", () => {
+    const xml = buildVoiceTwiml({ kind: "voicemail" });
+    expect(xml).toContain("<Say");
+    expect(xml).toContain("<Record");
+    // No dial leg — the call goes straight to the recorder.
+    expect(xml).not.toContain("<Dial");
   });
 });

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -18,6 +18,7 @@
 
 import twilio, { validateRequest } from "twilio";
 import { createFakeTwilioClient } from "./fake-twilio-client";
+import type { DecideSharedResult } from "./route-shared-call";
 
 // A narrowed slice of an item returned by `availablePhoneNumbers.list` —
 // the four fields the UI's "pick a number" step actually shows. Twilio
@@ -254,4 +255,56 @@ export function validateTwilioSignature(
     throw new Error("twilio-client: TWILIO_AUTH_TOKEN must be set");
   }
   return validateRequest(authToken, twilioSignatureHeader, url, params);
+}
+
+// ---------------------------------------------------------------------------
+// Slice 8 (#312) — inbound voice TwiML. `buildVoiceTwiml` turns a
+// `decideShared()` decision (the pure routing module's output) into the XML
+// Twilio executes when an inbound call hits a Shared number. twilio-client is
+// the only file allowed to import twilio, so the TwiML builder lives here —
+// using the SDK's `twiml.VoiceResponse` for correct XML escaping rather than
+// hand-concatenating strings.
+// ---------------------------------------------------------------------------
+export interface VoiceTwimlOptions {
+  // The Nookleus number to present as the caller ID on the outbound legs, so
+  // the team member's phone shows the business number (not the outside
+  // caller) and a call-back rings the Nookleus number.
+  callerId?: string;
+}
+
+// Spoken when an inbound call falls through to voicemail and no custom
+// greeting is configured for the number.
+const DEFAULT_VOICEMAIL_GREETING =
+  "You've reached us. Please leave a message after the tone and we'll get back to you.";
+
+/**
+ * Build the inbound-call TwiML for a `decideShared` decision. Each decision
+ * kind maps to a Twilio verb:
+ *   - ring-all     → one <Dial> with every reachable cell as a <Number>
+ *                     child (Twilio rings them in parallel; first to answer
+ *                     wins).
+ *   - forward      → one <Dial> to the single forward-target cell.
+ *   - round-robin  → one <Dial> to the single cell the cursor selected. The
+ *                     returned nextCursor is the webhook's to persist; it is
+ *                     never reflected in the TwiML.
+ *   - voicemail    → a spoken greeting then a <Record> of the caller.
+ */
+export function buildVoiceTwiml(
+  decision: DecideSharedResult,
+  opts: VoiceTwimlOptions = {},
+): string {
+  const vr = new twilio.twiml.VoiceResponse();
+  if (decision.kind === "ring-all") {
+    const dial = vr.dial({ callerId: opts.callerId });
+    for (const cell of decision.cells) {
+      dial.number(cell);
+    }
+  } else if (decision.kind === "forward" || decision.kind === "round-robin") {
+    const dial = vr.dial({ callerId: opts.callerId });
+    dial.number(decision.cell);
+  } else {
+    vr.say(DEFAULT_VOICEMAIL_GREETING);
+    vr.record({});
+  }
+  return vr.toString();
 }

--- a/supabase/migration-312-phone-calls.sql
+++ b/supabase/migration-312-phone-calls.sql
@@ -1,0 +1,203 @@
+-- issue #312 (PRD #304, ADR 0005 + ADR 0006) — phone_calls +
+-- phone_number_round_robin.
+--
+-- Purpose:   The call-event table for Nookleus Phone. One row per inbound
+--            (this slice) or outbound (slice 10+) voice call, threaded on
+--            the SAME phone_conversations row as the slice-4 messages so a
+--            call and a text to the same outside number interleave in one
+--            Phone-tab thread. The inbound voice webhook writes a row with
+--            status='ringing' at dial-start; the Twilio status-callback
+--            webhook updates status + duration_seconds + ended_at as the
+--            call progresses.
+--
+--            phone_number_round_robin holds the per-Shared-number rotation
+--            cursor for the round-robin inbound rule (ADR 0006). It is its
+--            own table — not a column on phone_numbers — so that the
+--            high-churn "advance on every inbound call" write never
+--            rewrites the low-churn phone_numbers settings row (issue #312,
+--            Q1). The issue sketched a `phone_number_state` table; named
+--            phone_number_round_robin here because the rotation cursor is
+--            the only state it carries today.
+--
+-- Shape:     phone_calls is PRD #304 § Schema verbatim. No updated_at /
+--            update trigger — like phone_messages, a call row's lifecycle
+--            is status transitions written by the status-callback webhook,
+--            not a generic updated_at. initiated_by_user_id is NULL for
+--            inbound (no Nookleus user starts the call); it is set for
+--            outbound in a later slice. The status CHECK enforces the
+--            Twilio call-status vocabulary; NULL passes the CHECK (a row
+--            may exist momentarily before its first status is known,
+--            mirroring phone_messages' lenient nullable status).
+--
+-- RLS:       phone_calls SELECT is a structural copy of
+--            phone_messages_select (migration-308) — the SAME ADR 0005
+--            matrix: Shared (tagged or not) is team-visible, Personal is
+--            owner-visible, Job-tagged on any number is visible to whoever
+--            can see the Job. The matrix lives in
+--            `phone-event-access.canRead` for Service-client paths and in
+--            these policies for User-client paths; the smoke test pins them
+--            in sync. NOTE: like phone_messages, the policy does NOT check
+--            view_phone — the feature gate is applied at the route via
+--            withRequestContext; RLS encodes only the Shared/Personal/Job
+--            matrix. The "Crew Member without view_phone sees no call rows"
+--            acceptance criterion is a route + RTL concern, not an RLS one.
+--
+--            phone_number_round_robin is internal routing state, written
+--            only by the inbound webhook on the Service client (which
+--            bypasses RLS). RLS is ENABLED with no authenticated policy so
+--            the table is locked to the Service role — no user-facing read
+--            path exists in this slice.
+--
+-- Indexes:   idx_phone_calls_conversation_started_at — renders the thread
+--            chronologically (mirrors idx_phone_messages_conversation_sent_at).
+--            idx_phone_calls_org_job_started_at — feeds the Job-page Calls
+--            section (mirrors idx_phone_messages_org_job_sent_at).
+--            idx_phone_calls_twilio_call_sid — the status-callback webhook
+--            looks a row up by Twilio CallSid to apply status updates;
+--            partial on non-null sid.
+--
+-- Depends on: schema.sql (organizations, jobs, contacts), migration-307
+--            (phone_numbers), migration-308 (phone_conversations), and
+--            `nookleus.active_organization_id()` / `nookleus.is_member_of()`.
+--
+-- Smoke test: supabase/migration-312-smoke-test.sql exercises every cell of
+--            the ADR 0005 matrix on phone_calls, mirroring
+--            migration-308-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. phone_calls. One row per voice call, threaded on phone_conversations.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_calls (
+  id                  uuid primary key default gen_random_uuid(),
+  organization_id     uuid not null references public.organizations(id) on delete cascade,
+  conversation_id     uuid not null references public.phone_conversations(id) on delete cascade,
+  direction           text not null check (direction in ('in', 'out')),
+  from_e164           text not null,
+  to_e164             text not null,
+  -- Twilio's CallSid. The status-callback webhook keys on this to update
+  -- status/duration/ended_at as the call progresses.
+  twilio_call_sid     text,
+  -- Twilio call-status vocabulary. NULL passes the CHECK (a row may exist
+  -- before its first status is known); the webhook writes 'ringing' at
+  -- dial-start and the status-callback advances it from there.
+  status              text check (status in (
+                        'queued', 'ringing', 'in_progress', 'completed',
+                        'busy', 'no_answer', 'failed', 'canceled')),
+  -- Filled from Twilio's CallDuration on the terminal status callback.
+  duration_seconds    integer,
+  -- The Job tag from smart-attach (NULL when untagged). Mirrors
+  -- phone_messages.job_tag; slice-9 tag chips fill/change it, slice-13
+  -- Personal-number access depends on whether it is non-null.
+  job_tag             uuid references public.jobs(id) on delete set null,
+  -- Null when auto-tagged; set when a user tagged via the chips UI.
+  tagged_by_user_id   uuid references auth.users(id) on delete set null,
+  -- NULL for inbound (no Nookleus user starts the call). Set to the
+  -- placing user for outbound in a later slice.
+  initiated_by_user_id uuid references auth.users(id) on delete set null,
+  started_at          timestamptz not null default now(),
+  ended_at            timestamptz,
+  created_at          timestamptz not null default now()
+);
+
+create index if not exists idx_phone_calls_conversation_started_at
+  on public.phone_calls (conversation_id, started_at);
+
+create index if not exists idx_phone_calls_org_job_started_at
+  on public.phone_calls (organization_id, job_tag, started_at)
+  where job_tag is not null;
+
+create index if not exists idx_phone_calls_twilio_call_sid
+  on public.phone_calls (twilio_call_sid)
+  where twilio_call_sid is not null;
+
+-- ---------------------------------------------------------------------------
+-- 2. phone_number_round_robin. Per-Shared-number rotation cursor for the
+--    round-robin inbound rule. Its own table so advancing the cursor on
+--    every inbound call never rewrites the phone_numbers settings row
+--    (issue #312, Q1). rotation_cursor is monotonic — the webhook reads it
+--    (default 0 when no row), passes it to decideShared, and writes back
+--    the returned nextCursor. decideShared mods by the reachable-member
+--    count, so the stored value can grow without bound safely.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_number_round_robin (
+  phone_number_id     uuid primary key references public.phone_numbers(id) on delete cascade,
+  organization_id     uuid not null references public.organizations(id) on delete cascade,
+  rotation_cursor     integer not null default 0,
+  updated_at          timestamptz not null default now()
+);
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS.
+-- ---------------------------------------------------------------------------
+alter table public.phone_calls              enable row level security;
+alter table public.phone_number_round_robin enable row level security;
+
+drop policy if exists phone_calls_select on public.phone_calls;
+create policy phone_calls_select on public.phone_calls
+  for select to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1
+        from public.phone_numbers pn
+        join public.phone_conversations pc on pc.phone_number_id = pn.id
+       where pc.id = phone_calls.conversation_id
+         and pn.organization_id = phone_calls.organization_id
+         and (
+           -- Shared number: team-visible regardless of job_tag.
+           pn.user_id is null
+           -- Personal number, owner: visible regardless of job_tag.
+           or pn.user_id = auth.uid()
+           -- Job-tagged, caller can see the Job. Mirrors phone_messages:
+           -- slice-4's job-access policy is "every member of the active
+           -- org sees every Job"; when a per-user Job ACL lands, replace
+           -- this clause with the corresponding access query.
+           or (
+             phone_calls.job_tag is not null
+             and exists (
+               select 1
+                 from public.jobs j
+                where j.id = phone_calls.job_tag
+                  and j.organization_id = phone_calls.organization_id
+             )
+           )
+         )
+    )
+  );
+
+drop policy if exists phone_calls_insert on public.phone_calls;
+create policy phone_calls_insert on public.phone_calls
+  for insert to authenticated
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  );
+
+drop policy if exists phone_calls_update on public.phone_calls;
+create policy phone_calls_update on public.phone_calls
+  for update to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and nookleus.is_member_of(organization_id)
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+  );
+
+-- phone_number_round_robin: no authenticated policy. RLS is enabled so the
+-- table is locked to the Service role (the inbound webhook). There is no
+-- user-facing read or write path for the rotation cursor in this slice.
+
+-- ROLLBACK ---
+-- drop policy if exists phone_calls_update on public.phone_calls;
+-- drop policy if exists phone_calls_insert on public.phone_calls;
+-- drop policy if exists phone_calls_select on public.phone_calls;
+-- alter table public.phone_number_round_robin disable row level security;
+-- alter table public.phone_calls disable row level security;
+-- drop index if exists public.idx_phone_calls_twilio_call_sid;
+-- drop index if exists public.idx_phone_calls_org_job_started_at;
+-- drop index if exists public.idx_phone_calls_conversation_started_at;
+-- drop table if exists public.phone_number_round_robin;
+-- drop table if exists public.phone_calls;

--- a/supabase/migration-312-smoke-test.sql
+++ b/supabase/migration-312-smoke-test.sql
@@ -1,0 +1,235 @@
+-- issue #312 (PRD #304, ADR 0005 + ADR 0006) — phone_calls access-matrix
+-- smoke test.
+--
+-- Purpose:   Verify that the migration-312 phone_calls RLS policy encodes
+--            every cell of the ADR 0005 read-path matrix at the database,
+--            in the SAME shape migration-308-smoke-test.sql pins for
+--            phone_messages. The phone-event-access TypeScript module has
+--            the same matrix in code; the two are kept in sync by these
+--            cases mirroring src/lib/phone/phone-event-access.test.ts.
+--
+--            Matrix exercised (phone_calls SELECT):
+--              - Shared untagged          → every same-org member sees
+--              - Shared Job-tagged        → every same-org member sees
+--              - Personal untagged, owner → owner sees
+--              - Personal untagged, other → hidden
+--              - Personal Job-tagged, any → sees (Job-visible team)
+--              - Cross-org caller         → never sees
+--
+-- Shape:     One transaction, rolled back at the end. Service-role seeds
+--            two orgs, four users, two phone_numbers (Shared + Personal),
+--            two conversations, one Job, four phone_calls covering the
+--            matrix. Each assertion block sets the JWT claims, switches to
+--            `authenticated`, runs a SELECT, and asserts the row-count.
+--
+-- Run:       Via Supabase MCP `execute_sql` against the target project.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed. Service-role bypass for orgs / users / memberships.
+--      Org 1: smoke-312-org-1
+--        User A — admin
+--        User B — crew_lead (non-owner of any Personal number)
+--        User C — crew_lead (owner of the Personal number)
+--      Org 2: smoke-312-org-2
+--        User D — admin
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('31200000-0000-0000-0000-000000000001', 'smoke-312-org-1', 'smoke-312-org-1'),
+  ('31200000-0000-0000-0000-000000000002', 'smoke-312-org-2', 'smoke-312-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('31200000-0000-0000-0000-000000000010', 'smoke-312-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31200000-0000-0000-0000-000000000011', 'smoke-312-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31200000-0000-0000-0000-000000000012', 'smoke-312-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31200000-0000-0000-0000-000000000013', 'smoke-312-d@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('31200000-0000-0000-0000-000000000010', '31200000-0000-0000-0000-000000000001', 'admin'),
+  ('31200000-0000-0000-0000-000000000011', '31200000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31200000-0000-0000-0000-000000000012', '31200000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31200000-0000-0000-0000-000000000013', '31200000-0000-0000-0000-000000000002', 'admin');
+
+-- Two phone numbers in org-1: one Shared, one Personal owned by User C.
+insert into public.phone_numbers
+  (id, organization_id, twilio_sid, e164, kind, user_id)
+values
+  ('31200000-0000-0000-0000-0000000000a1', '31200000-0000-0000-0000-000000000001',
+   'PN-smoke312-shared', '+15125550000', 'shared', null),
+  ('31200000-0000-0000-0000-0000000000a2', '31200000-0000-0000-0000-000000000001',
+   'PN-smoke312-personal', '+15125550001', 'personal',
+   '31200000-0000-0000-0000-000000000012');
+
+-- Two conversations — one on each number.
+insert into public.phone_conversations
+  (id, organization_id, phone_number_id, outside_e164)
+values
+  ('31200000-0000-0000-0000-0000000000b1', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000a1', '+15551110001'),
+  ('31200000-0000-0000-0000-0000000000b2', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000a2', '+15551110002');
+
+-- One Job in org-1 for the Job-tagged cases. Contact is a placeholder.
+insert into public.contacts (id, full_name)
+values ('31200000-0000-0000-0000-0000000000c1', 'smoke-312-contact');
+
+insert into public.jobs
+  (id, organization_id, contact_id, damage_type, property_address)
+values
+  ('31200000-0000-0000-0000-0000000000d1', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000c1', 'water', '1 smoke st');
+
+-- Four calls cover the matrix. twilio_call_sid carries the label so the
+-- assertions can string_agg the visible set (mirrors phone_messages.body).
+--   call1: Shared, untagged
+--   call2: Shared, tagged (job d1)
+--   call3: Personal (owner C), untagged
+--   call4: Personal (owner C), tagged (job d1)
+insert into public.phone_calls
+  (id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, job_tag)
+values
+  ('31200000-0000-0000-0000-0000000000f1', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000b1', 'in', '+15551110001', '+15125550000', 'shared-untagged', 'completed', null),
+  ('31200000-0000-0000-0000-0000000000f2', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000b1', 'in', '+15551110001', '+15125550000', 'shared-tagged', 'completed',
+   '31200000-0000-0000-0000-0000000000d1'),
+  ('31200000-0000-0000-0000-0000000000f3', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000b2', 'in', '+15551110002', '+15125550001', 'personal-untagged', 'completed', null),
+  ('31200000-0000-0000-0000-0000000000f4', '31200000-0000-0000-0000-000000000001',
+   '31200000-0000-0000-0000-0000000000b2', 'in', '+15551110002', '+15125550001', 'personal-tagged', 'completed',
+   '31200000-0000-0000-0000-0000000000d1');
+
+-- ---------------------------------------------------------------------------
+-- 1. User A (admin, org-1) — sees Shared-untagged, Shared-tagged,
+--    Personal-tagged (Job-visible), but NOT Personal-untagged (admin
+--    cannot read untagged Personal content per ADR 0005).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31200000-0000-0000-0000-000000000010","active_organization_id":"31200000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(twilio_call_sid, ',' order by twilio_call_sid)
+    into v_count, v_ids
+    from public.phone_calls;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-312 smoke (case 1: admin): expected 3 visible calls, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-312 smoke (case 1: admin): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-312 smoke (case 1: admin) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. User B (crew_lead, org-1, NOT owner of any Personal number) — sees
+--    Shared-untagged, Shared-tagged, Personal-tagged, NOT Personal-untagged.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31200000-0000-0000-0000-000000000011","active_organization_id":"31200000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(twilio_call_sid, ',' order by twilio_call_sid)
+    into v_count, v_ids
+    from public.phone_calls;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-312 smoke (case 2: crew_lead non-owner): expected 3 visible calls, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-312 smoke (case 2: crew_lead non-owner): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-312 smoke (case 2: crew_lead non-owner) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. User C (crew_lead, org-1, OWNER of Personal +15125550001) — sees all 4.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31200000-0000-0000-0000-000000000012","active_organization_id":"31200000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_calls;
+
+  reset role;
+
+  if v_count <> 4 then
+    raise exception 'migration-312 smoke (case 3: Personal owner): expected 4 visible calls, got %', v_count;
+  end if;
+  raise notice 'migration-312 smoke (case 3: Personal owner) — sees all 4 of own + Shared rows';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. User D (admin, org-2) — cross-org. Should see 0 calls.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31200000-0000-0000-0000-000000000013","active_organization_id":"31200000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_calls;
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-312 smoke (case 4: cross-org admin): expected 0 visible calls, got %', v_count;
+  end if;
+  raise notice 'migration-312 smoke (case 4: cross-org admin) — sees nothing';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. phone_number_round_robin is locked to the Service role (RLS enabled,
+--    no authenticated policy). An authenticated caller — even an org admin
+--    — sees zero rows. Seed one cursor row under service-role bypass, then
+--    assert User A reads none.
+-- ---------------------------------------------------------------------------
+insert into public.phone_number_round_robin (phone_number_id, organization_id, rotation_cursor)
+values ('31200000-0000-0000-0000-0000000000a1', '31200000-0000-0000-0000-000000000001', 2);
+
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31200000-0000-0000-0000-000000000010","active_organization_id":"31200000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_number_round_robin;
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-312 smoke (case 5: round-robin lock): expected 0 rows visible to authenticated, got %', v_count;
+  end if;
+  raise notice 'migration-312 smoke (case 5: round-robin lock) — internal cursor table is Service-role only';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 6. Done.
+-- ---------------------------------------------------------------------------
+rollback;


### PR DESCRIPTION
Closes #312. Phone slice 8 (PRD #304) — inbound voice routing + Settings inbound-rule editor, built with strict TDD.

## What this delivers
A customer dials a Shared number; Nookleus routes per an admin-configured per-number rule (ring-all / round-robin / single-forward / voicemail). The call lands in the Phone-tab thread as an event interleaved chronologically with the slice-4 messages, threaded on the same conversation.

## Schema & RLS
- **`migration-312-phone-calls.sql`** — `phone_calls` (one row per voice call, threaded on `phone_conversations`; 3 indexes for thread render, Job-page filter, and CallSid lookup) + `phone_number_round_robin` (per-number rotation cursor in its **own** table so the high-churn advance never rewrites the low-churn `phone_numbers` settings row). RLS on `phone_calls` mirrors `phone_messages` (ADR 0005 matrix); the cursor table is locked to the Service role. Full rollback block included.
- **`migration-312-smoke-test.sql`** — pins every cell of the ADR 0005 read matrix for `phone_calls`, mirroring the `phone_messages` smoke test (admin, crew-lead non-owner, Personal owner, cross-org, + round-robin lock).

## Routing
- **`route-shared-call`** — pure `decideShared(...)` → `ring-all | round-robin | forward | voicemail`; resolves selected users to reachable cells, dropping members with no cell (nobody reachable → voicemail). `currentHour` reserved for the Layer-2 business-hours follow-up.
- **`twilio-client.buildVoiceTwiml`** — decision → TwiML via the SDK (parallel `<Dial>` for ring-all, single `<Dial>` for forward/round-robin, `<Say>`+`<Record>` for voicemail). twilio-client remains the only file importing `twilio`.
- **voice-inbound webhook** — validate signature → `decideShared` → emit TwiML, writing a `phone_calls` row `status='ringing'` at dial-start.
- **voice-status webhook** — advances `status` + `duration_seconds` + `ended_at` on the Twilio status callback.
- **`ingest-inbound-call`** — upserts the conversation by `(phone_number_id, outside_e164)` and inserts the call row with the smart-attach Job tag.

## Surfaces
- **Phone-tab thread** renders call events (direction icon, status, duration-when-known, time); a click opens the slice-11 recording placeholder. `GET /api/phone/conversations/[id]/calls` is additive and `view_phone`-gated; `mergeThreadItems` interleaves calls + messages chronologically.
- **Settings → Phone** per-Shared-number inbound-rule editor (admin-only per ADR 0003): kind radios + member pickers, `PATCH /api/phone/numbers/[id]` with `parse-inbound-rule` validation. Only members with a cell on file are selectable (mirrors `decideShared`).
- Crew Members without `view_phone` never receive call rows (route 403 + RLS).

## Verification
- Phone test surface: **415 passing / 40 files**.
- Full repo suite: 2287 passing; the 4 failures are the pre-existing `estimate-drag-end` localStorage baseline (0 new). `tsc` at the known 13 `tests/integration/*.pg.test.ts` errors (0 new). eslint clean on changed files.

## Deploy note
The migration has **not** yet been applied to prod (`rzzprgidqbnqcdupmpfe`). It + the smoke test will run on explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
