### PR TITLE
feat(photo-viewer): ⋯ More menu + Set as cover (#514)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -1078,6 +1078,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         initialPhotoIndex={photos.findIndex((p) => p.id === selectedPhoto?.id)}
         allTags={tags}
         supabaseUrl={supabaseUrl}
+        coverPhotoId={job?.cover_photo_id ?? null}
         // Refetch only — the viewer stays open after a Save (the side panel is
         // always visible). Delete/Restore close themselves via onOpenChange.
         onUpdated={fetchData}

--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -91,6 +91,7 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
+import { toast } from "sonner";
 import PhotoViewer from "./photo-viewer";
 
 function makePhoto(overrides: Partial<Photo> = {}): Photo {
@@ -142,6 +143,7 @@ function renderViewer(
       initialPhotoIndex={0}
       allTags={[]}
       supabaseUrl={SUPABASE_URL}
+      coverPhotoId={null}
       onUpdated={onUpdated}
       onAnnotate={onAnnotate}
       {...props}
@@ -411,6 +413,82 @@ describe("PhotoViewer — close", () => {
     });
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("PhotoViewer — Set as cover (⋯ More)", () => {
+  it("Set as cover writes the Job's cover_photo_id to the current Photo", async () => {
+    const { photo } = renderViewer();
+    await act(async () => {});
+
+    // Open the ⋯ More menu, then choose Set as cover (the existing direct
+    // write the grid's star uses: jobs.cover_photo_id = this photo).
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /set as cover/i }));
+    });
+
+    expect(h.update).toHaveBeenCalledWith(
+      "jobs",
+      expect.objectContaining({ cover_photo_id: photo.id }),
+    );
+    expect(h.updateEq).toHaveBeenCalledWith("jobs", "id", photo.job_id);
+  });
+
+  it("refetches (onUpdated) so the grid reflects the new cover, and toasts success", async () => {
+    const { onUpdated } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /set as cover/i }));
+    });
+
+    expect(onUpdated).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(
+      expect.stringMatching(/cover/i),
+    );
+  });
+
+  it("reflects cover state: the menu entry is a disabled 'Cover photo', not an action", async () => {
+    const photo = makePhoto();
+    renderViewer({ photos: [photo], coverPhotoId: photo.id });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+
+    // It no longer offers to set the cover — it states the current one.
+    expect(
+      screen.queryByRole("button", { name: /set as cover/i }),
+    ).toBeNull();
+    const entry = screen.getByRole("button", {
+      name: /cover photo/i,
+    }) as HTMLButtonElement;
+    expect(entry.disabled).toBe(true);
+  });
+});
+
+describe("PhotoViewer — Cover indicator", () => {
+  it("shows a Cover badge when the current Photo is the Job's cover", async () => {
+    const photo = makePhoto();
+    renderViewer({ photos: [photo], coverPhotoId: photo.id });
+    await act(async () => {});
+
+    expect(screen.getByTitle(/current cover/i)).toBeTruthy();
+  });
+
+  it("hides the Cover badge when the current Photo is not the cover", async () => {
+    const photo = makePhoto();
+    renderViewer({ photos: [photo], coverPhotoId: "a-different-photo" });
+    await act(async () => {});
+
+    expect(screen.queryByTitle(/current cover/i)).toBeNull();
   });
 });
 

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -17,6 +17,8 @@ import {
   Pencil,
   RotateCcw,
   X,
+  MoreHorizontal,
+  Star,
 } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -28,6 +30,7 @@ export default function PhotoViewer({
   initialPhotoIndex,
   allTags,
   supabaseUrl,
+  coverPhotoId,
   onUpdated,
   onAnnotate,
 }: {
@@ -37,10 +40,12 @@ export default function PhotoViewer({
   initialPhotoIndex: number;
   allTags: PhotoTag[];
   supabaseUrl: string;
+  coverPhotoId: string | null;
   onUpdated: () => void;
   onAnnotate: (photo: Photo, url: string) => void;
 }) {
   const currentPhoto = photos[initialPhotoIndex];
+  const isCover = !!currentPhoto && currentPhoto.id === coverPhotoId;
 
   const [caption, setCaption] = useState("");
   const [beforeAfterRole, setBeforeAfterRole] = useState<
@@ -53,6 +58,8 @@ export default function PhotoViewer({
   const [deleting, setDeleting] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [hasOriginalBackup, setHasOriginalBackup] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const [settingCover, setSettingCover] = useState(false);
 
   async function fetchTags(photoId: string) {
     const supabase = createClient();
@@ -236,6 +243,27 @@ export default function PhotoViewer({
     setDownloading(false);
   }
 
+  // Promote the current Photo to the Job's cover. Uses the existing direct
+  // write the grid's star uses (jobs.cover_photo_id), keyed off this Photo's
+  // job_id so the viewer stays self-contained.
+  async function handleSetCover() {
+    if (!currentPhoto) return;
+    setSettingCover(true);
+    const supabase = createClient();
+    const { error } = await supabase
+      .from("jobs")
+      .update({ cover_photo_id: currentPhoto.id })
+      .eq("id", currentPhoto.job_id);
+    setSettingCover(false);
+    setMoreOpen(false);
+    if (error) {
+      toast.error("Failed to set cover photo.");
+      return;
+    }
+    toast.success("Cover photo updated.");
+    onUpdated();
+  }
+
   // Permanent hard delete: remove the storage object and the photos row (which
   // cascades tag assignments + annotations), then close the viewer (1A — no
   // advance-to-next, no recycle bin). Gated behind the confirm step.
@@ -288,6 +316,18 @@ export default function PhotoViewer({
           <X size={18} />
         </button>
 
+        {/* Cover badge — mirrors the grid's gold "Cover" pill so the viewer
+            indicates when the current Photo is the Job's cover. */}
+        {isCover && (
+          <div
+            className="absolute top-3 left-14 flex items-center gap-1 h-9 px-2.5 rounded-full bg-[#F5A623] text-white text-xs font-semibold"
+            title="Current cover photo"
+          >
+            <Star size={13} fill="currentColor" />
+            Cover
+          </div>
+        )}
+
         {/* Toolbar over the photo */}
         <div className="absolute top-3 right-3 flex items-center gap-2">
           <button
@@ -319,12 +359,49 @@ export default function PhotoViewer({
             type="button"
             aria-label="Delete"
             title="Delete"
-            onClick={() => setConfirmDelete(true)}
+            onClick={() => {
+              setConfirmDelete(true);
+              setMoreOpen(false);
+            }}
             className={cn(toolbarBtn, "hover:bg-[#C41E2A]")}
           >
             <Trash2 size={18} />
           </button>
+          <button
+            type="button"
+            aria-label="More"
+            title="More"
+            onClick={() => {
+              setMoreOpen((o) => !o);
+              setConfirmDelete(false);
+            }}
+            className={cn(toolbarBtn, "hover:bg-black/70")}
+          >
+            <MoreHorizontal size={18} />
+          </button>
         </div>
+
+        {/* ⋯ More menu — scaffolding for the less-frequent actions. Set as
+            cover lives here; later slices add Share, Save to device, Duplicate. */}
+        {moreOpen && (
+          <div className="absolute top-14 right-3 bg-white rounded-lg shadow-lg p-1.5 min-w-[180px] flex flex-col">
+            <button
+              type="button"
+              onClick={handleSetCover}
+              disabled={settingCover || isCover}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-[#1A1A1A] hover:bg-gray-100 rounded-md transition-colors disabled:opacity-60 disabled:hover:bg-transparent"
+            >
+              {settingCover ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : isCover ? (
+                <Check size={14} className="text-[#085041]" />
+              ) : (
+                <Star size={14} />
+              )}
+              {isCover ? "Cover photo" : "Set as cover"}
+            </button>
+          </div>
+        )}
 
         {/* Delete confirmation */}
         {confirmDelete && (


### PR DESCRIPTION
Closes #514. Parent PRD #511; builds on the full-screen viewer from #513.

## What this adds

A **⋯ More** menu in the Photo viewer toolbar with **Set as cover**, plus a cover indicator. The menu is the scaffolding later net-new actions (Share, Save to device, Duplicate) hang off.

- **Set as cover** uses the *existing direct write* the grid's star uses — `jobs.update({ cover_photo_id }).eq("id", job_id)` — keyed off `currentPhoto.job_id`, then toasts and calls `onUpdated()` to refetch.
- **Cover indicator:** a gold "Cover" badge over the photo (parity with the grid's pill) and, in the menu, a disabled "✓ Cover photo" entry replacing the action.
- **Grid reflects it:** `onUpdated={fetchData}` refetches the job, updating both the viewer badge and the grid pill.
- `coverPhotoId` plumbed through `job-detail.tsx`.
- Hardening: the More menu and Delete-confirm popover are mutually exclusive (shared anchor).

## Acceptance criteria

- [x] Viewer toolbar has a ⋯ More menu (desktop + phone — single responsive layout)
- [x] Set as cover sets the Job's Cover photo to the current Photo
- [x] Viewer indicates when the current Photo is the cover
- [x] Setting a new cover is reflected on the Job's photo grid
- [x] No new test failures beyond the known-red baseline

## Verification

- Built with **TDD** — 5 RED→GREEN slices.
- Viewer suite **22/22 green** (17 baseline + 5 new).
- `tsc --noEmit` clean.
- Lint: **no new problems** — HEAD and working tree both report the same 3 pre-existing #513 issues in the viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)