### PR TITLE
feat(photo-viewer): navigation across the Job's photos + delete-advances + undo (#515)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -113,6 +113,10 @@ export default function JobDetail({ jobId }: { jobId: string }) {
   const [loading, setLoading] = useState(true);
   const [photoUploadOpen, setPhotoUploadOpen] = useState(false);
   const [selectedPhoto, setSelectedPhoto] = useState<Photo | null>(null);
+  // The grid's full loaded list, captured when a Photo is opened, so the viewer
+  // (and the Annotator it hands off to) navigates continuously across every
+  // Photo the grid shows — not just the newest screenful in `photos` (#515).
+  const [viewerPhotos, setViewerPhotos] = useState<Photo[]>([]);
   const [annotatorOpen, setAnnotatorOpen] = useState(false);
   const [annotatorPhoto, setAnnotatorPhoto] = useState<Photo | null>(null);
   const [editJobOpen, setEditJobOpen] = useState(false);
@@ -1052,7 +1056,10 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           onPhotosAdded={fetchData}
           onPhotoUpdated={fetchData}
           onCoverPhotoChanged={fetchData}
-          onSelectPhoto={(photo) => setSelectedPhoto(photo)}
+          onSelectPhoto={(photo, orderedPhotos) => {
+            setViewerPhotos(orderedPhotos);
+            setSelectedPhoto(photo);
+          }}
         />
       )}
 
@@ -1074,8 +1081,8 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         onOpenChange={(open) => {
           if (!open) setSelectedPhoto(null);
         }}
-        photos={photos}
-        initialPhotoIndex={photos.findIndex((p) => p.id === selectedPhoto?.id)}
+        photos={viewerPhotos}
+        initialPhotoIndex={viewerPhotos.findIndex((p) => p.id === selectedPhoto?.id)}
         allTags={tags}
         supabaseUrl={supabaseUrl}
         coverPhotoId={job?.cover_photo_id ?? null}
@@ -1097,8 +1104,8 @@ export default function JobDetail({ jobId }: { jobId: string }) {
             setAnnotatorPhoto(null);
           }
         }}
-        photos={photos}
-        initialPhotoIndex={photos.findIndex((p) => p.id === annotatorPhoto?.id)}
+        photos={viewerPhotos}
+        initialPhotoIndex={viewerPhotos.findIndex((p) => p.id === annotatorPhoto?.id)}
         onSaved={fetchData}
       />
     </div>

--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -20,7 +20,9 @@ interface JobPhotosTabProps {
   onPhotosAdded: () => void;
   onPhotoUpdated: () => void;
   onCoverPhotoChanged: () => void;
-  onSelectPhoto: (photo: Photo) => void;
+  // Hands up the clicked Photo plus the grid's full loaded list, so the viewer
+  // can navigate continuously across every Photo the grid shows (#515).
+  onSelectPhoto: (photo: Photo, orderedPhotos: Photo[]) => void;
 }
 
 const PAGE_SIZE = 50;
@@ -616,7 +618,7 @@ export default function JobPhotosTab({
                           if (e.shiftKey || selectedIds.size > 0) {
                             toggleSelect(photo.id, e.shiftKey);
                           } else {
-                            onSelectPhoto(photo);
+                            onSelectPhoto(photo, photos);
                           }
                         }}
                         onContextMenu={(e) => {

--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -89,7 +89,11 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
   getActiveOrganizationId: vi.fn(async () => "org-1"),
 }));
 
-vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+// `toast` is both callable (the Undo toast: toast(msg, { action })) and a
+// namespace of variants (toast.success / .error).
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
+}));
 
 import { toast } from "sonner";
 import PhotoViewer from "./photo-viewer";
@@ -322,23 +326,6 @@ describe("PhotoViewer — toolbar actions", () => {
     expect(h.del).not.toHaveBeenCalledWith("photos", "id", expect.anything());
   });
 
-  it("Confirming Delete hard-deletes the Photo and closes the viewer", async () => {
-    const { photo, onUpdated, onOpenChange } = renderViewer();
-    await act(async () => {});
-
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
-    });
-    await act(async () => {
-      fireEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
-    });
-
-    expect(h.remove).toHaveBeenCalledWith("photos", [photo.storage_path]);
-    expect(h.del).toHaveBeenCalledWith("photos", "id", photo.id);
-    expect(onUpdated).toHaveBeenCalled();
-    expect(onOpenChange).toHaveBeenCalledWith(false);
-  });
-
   it("Edit hands off to the Annotator with the photo and its display URL", async () => {
     const { photo, onAnnotate } = renderViewer();
     await act(async () => {});
@@ -351,6 +338,122 @@ describe("PhotoViewer — toolbar actions", () => {
       photo,
       photoUrl(photo, SUPABASE_URL, "full"),
     );
+  });
+});
+
+describe("PhotoViewer — delete (deferred advance + Undo)", () => {
+  const UNDO_WINDOW_MS = 5000;
+
+  // Three Photos so "advance to the next" is observable.
+  const a = makePhoto({ id: "a", storage_path: "job-1/a.jpg", created_at: "2026-05-03T10:00:00Z" });
+  const b = makePhoto({ id: "b", storage_path: "job-1/b.jpg", created_at: "2026-05-02T10:00:00Z" });
+  const c = makePhoto({ id: "c", storage_path: "job-1/c.jpg", created_at: "2026-05-01T10:00:00Z" });
+  const trio = [a, b, c];
+
+  const src = () => (screen.getByRole("img") as HTMLImageElement).getAttribute("src");
+
+  async function confirmDelete() {
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+    });
+  }
+
+  // Pull the Undo handler out of the last toast(message, { action }) call.
+  function lastUndo(): () => void {
+    const call = (toast as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1);
+    const opts = call?.[1] as { action?: { label: string; onClick: () => void } };
+    return opts!.action!.onClick;
+  }
+
+  it("advances to the next Photo and shows an Undo toast, deferring the delete", async () => {
+    const { onOpenChange } = renderViewer({ photos: trio, initialPhotoIndex: 0 });
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(a, SUPABASE_URL, "full"));
+
+    await confirmDelete();
+
+    // Advanced to the next Photo, viewer stays open.
+    expect(src()).toBe(photoUrl(b, SUPABASE_URL, "full"));
+    expect(onOpenChange).not.toHaveBeenCalled();
+    // An Undo toast was shown…
+    expect(toast).toHaveBeenCalledWith(
+      expect.stringMatching(/deleted/i),
+      expect.objectContaining({
+        action: expect.objectContaining({ label: expect.stringMatching(/undo/i) }),
+      }),
+    );
+    // …and the hard delete has NOT fired yet (it waits out the window).
+    expect(h.del).not.toHaveBeenCalledWith("photos", "id", "a");
+    expect(h.remove).not.toHaveBeenCalled();
+  });
+
+  it("closes the viewer when the last remaining Photo is deleted", async () => {
+    const { onOpenChange } = renderViewer({ photos: [a], initialPhotoIndex: 0 });
+    await act(async () => {});
+
+    await confirmDelete();
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toast).toHaveBeenCalledWith(
+      expect.stringMatching(/deleted/i),
+      expect.objectContaining({
+        action: expect.objectContaining({ label: expect.stringMatching(/undo/i) }),
+      }),
+    );
+  });
+
+  it("commits the hard delete once the Undo window elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      const { onUpdated } = renderViewer({ photos: trio, initialPhotoIndex: 0 });
+      await act(async () => {});
+      await confirmDelete();
+
+      // Nothing committed mid-window.
+      expect(h.remove).not.toHaveBeenCalled();
+
+      await act(async () => {
+        vi.advanceTimersByTime(UNDO_WINDOW_MS);
+      });
+      await act(async () => {}); // flush the commit's awaited writes
+
+      expect(h.remove).toHaveBeenCalledWith("photos", [a.storage_path]);
+      expect(h.del).toHaveBeenCalledWith("photos", "id", "a");
+      expect(onUpdated).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("Undo cancels the commit and restores the Photo", async () => {
+    vi.useFakeTimers();
+    try {
+      renderViewer({ photos: trio, initialPhotoIndex: 0 });
+      await act(async () => {});
+      await confirmDelete();
+      expect(src()).toBe(photoUrl(b, SUPABASE_URL, "full"));
+
+      // Undo within the window.
+      await act(async () => {
+        lastUndo()();
+      });
+
+      // The deleted Photo is back…
+      expect(src()).toBe(photoUrl(a, SUPABASE_URL, "full"));
+
+      // …and the window elapsing never deletes it.
+      await act(async () => {
+        vi.advanceTimersByTime(UNDO_WINDOW_MS);
+      });
+      await act(async () => {});
+      expect(h.remove).not.toHaveBeenCalled();
+      expect(h.del).not.toHaveBeenCalledWith("photos", "id", "a");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 
@@ -489,6 +592,117 @@ describe("PhotoViewer — Cover indicator", () => {
     await act(async () => {});
 
     expect(screen.queryByTitle(/current cover/i)).toBeNull();
+  });
+});
+
+describe("PhotoViewer — navigation across the Job's Photos", () => {
+  // Two days, deliberately out of order on input — the viewer orders them
+  // newest-first and walks one continuous run across the grid's date divider.
+  const newest = makePhoto({
+    id: "p-new",
+    storage_path: "job-1/new.jpg",
+    created_at: "2026-05-03T10:00:00Z",
+  });
+  const middle = makePhoto({
+    id: "p-mid",
+    storage_path: "job-1/mid.jpg",
+    created_at: "2026-05-02T10:00:00Z",
+  });
+  const oldest = makePhoto({
+    id: "p-old",
+    storage_path: "job-1/old.jpg",
+    created_at: "2026-05-01T10:00:00Z",
+  });
+  const shuffled = [middle, oldest, newest];
+
+  const src = () => (screen.getByRole("img") as HTMLImageElement).getAttribute("src");
+
+  it("Next advances to the next (older) Photo, continuous across dates", async () => {
+    // Open on the newest; one Next crosses the May 3 → May 2 divider.
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(newest) });
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(newest, SUPABASE_URL, "full"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    });
+    expect(src()).toBe(photoUrl(middle, SUPABASE_URL, "full"));
+  });
+
+  it("ArrowRight / ArrowLeft move between Photos", async () => {
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(newest) });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+    });
+    expect(src()).toBe(photoUrl(middle, SUPABASE_URL, "full"));
+
+    await act(async () => {
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+    });
+    expect(src()).toBe(photoUrl(newest, SUPABASE_URL, "full"));
+  });
+
+  it("swiping left shows the next Photo, swiping right the previous", async () => {
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(newest) });
+    await act(async () => {});
+    const surface = screen.getByRole("img").parentElement as HTMLElement;
+
+    // Finger travels right → left: advance to the next (older) Photo.
+    await act(async () => {
+      fireEvent.touchStart(surface, { touches: [{ clientX: 240 }] });
+      fireEvent.touchEnd(surface, { changedTouches: [{ clientX: 80 }] });
+    });
+    expect(src()).toBe(photoUrl(middle, SUPABASE_URL, "full"));
+
+    // Finger travels left → right: back to the previous (newer) Photo.
+    await act(async () => {
+      fireEvent.touchStart(surface, { touches: [{ clientX: 80 }] });
+      fireEvent.touchEnd(surface, { changedTouches: [{ clientX: 240 }] });
+    });
+    expect(src()).toBe(photoUrl(newest, SUPABASE_URL, "full"));
+  });
+
+  it("ignores a tap that does not pass the swipe threshold", async () => {
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(newest) });
+    await act(async () => {});
+    const surface = screen.getByRole("img").parentElement as HTMLElement;
+
+    await act(async () => {
+      fireEvent.touchStart(surface, { touches: [{ clientX: 200 }] });
+      fireEvent.touchEnd(surface, { changedTouches: [{ clientX: 188 }] });
+    });
+    expect(src()).toBe(photoUrl(newest, SUPABASE_URL, "full"));
+  });
+
+  it("Prev returns to the newer Photo", async () => {
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(middle) });
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(middle, SUPABASE_URL, "full"));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+    });
+    expect(src()).toBe(photoUrl(newest, SUPABASE_URL, "full"));
+  });
+
+  it("hides Prev on the newest Photo and Next on the oldest (clamped)", async () => {
+    // On the newest: no Prev, but Next is available.
+    const { unmount } = renderViewer({
+      photos: shuffled,
+      initialPhotoIndex: shuffled.indexOf(newest),
+    });
+    await act(async () => {});
+    expect(screen.queryByRole("button", { name: /previous/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /next/i })).toBeTruthy();
+    unmount();
+
+    // On the oldest: no Next, but Prev is available.
+    renderViewer({ photos: shuffled, initialPhotoIndex: shuffled.indexOf(oldest) });
+    await act(async () => {});
+    expect(screen.queryByRole("button", { name: /next/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /previous/i })).toBeTruthy();
   });
 });
 

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { createClient } from "@/lib/supabase";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Photo, PhotoTag } from "@/lib/types";
 import { photoUrl } from "@/lib/jobs/photo-url";
+import {
+  orderPhotosForViewer,
+  nextPhotoIndex,
+  prevPhotoIndex,
+  hasNext,
+  hasPrev,
+  indexAfterDelete,
+} from "@/lib/jobs/photo-viewer-navigation";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import {
@@ -19,9 +27,15 @@ import {
   X,
   MoreHorizontal,
   Star,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
+
+// How long the deleted Photo lingers — hidden but recoverable — before the
+// permanent hard delete commits (#515). Matches the Undo toast's lifetime.
+const UNDO_WINDOW_MS = 5000;
 
 export default function PhotoViewer({
   open,
@@ -44,8 +58,75 @@ export default function PhotoViewer({
   onUpdated: () => void;
   onAnnotate: (photo: Photo, url: string) => void;
 }) {
-  const currentPhoto = photos[initialPhotoIndex];
+  // Navigation runs over the Job's Photos newest-first and continuous across
+  // the grid's date dividers (#515) — the dividers are display context, not
+  // navigation stops. `removedIds` hides a Photo the instant its delete is
+  // confirmed while the real delete waits out the Undo window, so the viewer
+  // advances immediately and Undo can bring it straight back.
+  const ordered = useMemo(() => orderPhotosForViewer(photos), [photos]);
+  const [removedIds, setRemovedIds] = useState<Set<string>>(new Set());
+  const visiblePhotos = useMemo(
+    () => ordered.filter((p) => !removedIds.has(p.id)),
+    [ordered, removedIds],
+  );
+
+  const initialId = photos[initialPhotoIndex]?.id ?? null;
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // Seed the position when the viewer opens on a Photo. Keyed on the opened
+  // Photo (not the `photos` array) so a background refetch doesn't yank the
+  // user back to where they started.
+  useEffect(() => {
+    if (!open) return;
+    setRemovedIds(new Set());
+    const idx = ordered.findIndex((p) => p.id === initialId);
+    setCurrentIndex(idx >= 0 ? idx : 0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialId]);
+
+  const safeIndex = Math.min(currentIndex, visiblePhotos.length - 1);
+  const currentPhoto = visiblePhotos[safeIndex];
   const isCover = !!currentPhoto && currentPhoto.id === coverPhotoId;
+
+  const goNext = () =>
+    setCurrentIndex(nextPhotoIndex(safeIndex, visiblePhotos.length));
+  const goPrev = () => setCurrentIndex(prevPhotoIndex(safeIndex));
+
+  // Deletes still inside their Undo window, keyed by Photo id. Each holds the
+  // pending commit timer and the Photo, so a commit (on window-elapse) or an
+  // undo (clear timer) can run without re-deriving it from the list.
+  const pendingDeletes = useRef<
+    Map<string, { timer: ReturnType<typeof setTimeout>; photo: Photo }>
+  >(new Map());
+
+  // On unmount, commit any deletes still in their Undo window so a confirmed
+  // delete isn't silently lost when the user leaves the Job.
+  useEffect(() => {
+    const pending = pendingDeletes.current;
+    return () => {
+      pending.forEach(({ timer, photo }) => {
+        clearTimeout(timer);
+        const supabase = createClient();
+        void supabase.storage.from("photos").remove([photo.storage_path]);
+        void supabase.from("photos").delete().eq("id", photo.id);
+      });
+      pending.clear();
+    };
+  }, []);
+
+  // Touch swipe: a horizontal drag past the threshold steps between Photos —
+  // left for the next (older), right for the previous (newer).
+  const SWIPE_THRESHOLD = 50;
+  const touchStartX = useRef<number | null>(null);
+  const onTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0]?.clientX ?? null;
+  };
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return;
+    const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartX.current;
+    touchStartX.current = null;
+    if (dx <= -SWIPE_THRESHOLD) goNext();
+    else if (dx >= SWIPE_THRESHOLD) goPrev();
+  };
 
   const [caption, setCaption] = useState("");
   const [beforeAfterRole, setBeforeAfterRole] = useState<
@@ -55,7 +136,6 @@ export default function PhotoViewer({
   const [saving, setSaving] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-  const [deleting, setDeleting] = useState(false);
   const [restoring, setRestoring] = useState(false);
   const [hasOriginalBackup, setHasOriginalBackup] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
@@ -166,6 +246,22 @@ export default function PhotoViewer({
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [open, onOpenChange]);
 
+  // Arrow keys move between Photos, mirroring the on-screen arrows. Kept apart
+  // from the Escape handler so its deps track the current position; the step
+  // logic is inlined so the listener never closes over a stale index.
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "ArrowRight") {
+        setCurrentIndex(nextPhotoIndex(safeIndex, visiblePhotos.length));
+      } else if (e.key === "ArrowLeft") {
+        setCurrentIndex(prevPhotoIndex(safeIndex));
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, safeIndex, visiblePhotos.length]);
+
   function toggleTag(tagId: string) {
     setAssignedTagIds((prev) =>
       prev.includes(tagId) ? prev.filter((t) => t !== tagId) : [...prev, tagId],
@@ -264,29 +360,66 @@ export default function PhotoViewer({
     onUpdated();
   }
 
-  // Permanent hard delete: remove the storage object and the photos row (which
-  // cascades tag assignments + annotations), then close the viewer (1A — no
-  // advance-to-next, no recycle bin). Gated behind the confirm step.
-  async function handleDelete() {
-    if (!currentPhoto) return;
-    setDeleting(true);
-    const supabase = createClient();
-
-    await supabase.storage.from("photos").remove([currentPhoto.storage_path]);
-
-    const { error } = await supabase
-      .from("photos")
-      .delete()
-      .eq("id", currentPhoto.id);
-
-    if (error) {
-      toast.error("Failed to delete photo.");
-    } else {
-      toast.success("Photo deleted.");
-      onOpenChange(false);
+  // Delete is deferred behind an Undo window (#515). Confirming hides the Photo
+  // and advances to the next (or closes on the last) immediately, then shows an
+  // Undo toast; the permanent hard delete — storage object + photos row, which
+  // cascades tag assignments + annotations — commits only once the window
+  // elapses. Because there is no recycle bin, deferral is what makes the delete
+  // recoverable: Undo cancels the pending commit before it ever runs.
+  function commitDelete(photo: Photo) {
+    pendingDeletes.current.delete(photo.id);
+    void (async () => {
+      const supabase = createClient();
+      await supabase.storage.from("photos").remove([photo.storage_path]);
+      const { error } = await supabase
+        .from("photos")
+        .delete()
+        .eq("id", photo.id);
+      if (error) {
+        // The delete didn't take — surface the Photo again.
+        toast.error("Failed to delete photo.");
+        setRemovedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(photo.id);
+          return next;
+        });
+        return;
+      }
       onUpdated();
+    })();
+  }
+
+  function undoDelete(photo: Photo) {
+    const pending = pendingDeletes.current.get(photo.id);
+    if (pending) {
+      clearTimeout(pending.timer);
+      pendingDeletes.current.delete(photo.id);
     }
-    setDeleting(false);
+    setRemovedIds((prev) => {
+      const next = new Set(prev);
+      next.delete(photo.id);
+      return next;
+    });
+  }
+
+  function handleConfirmDelete() {
+    if (!currentPhoto) return;
+    const photo = currentPhoto;
+    const outcome = indexAfterDelete(safeIndex, visiblePhotos.length);
+
+    setConfirmDelete(false);
+    setMoreOpen(false);
+    setRemovedIds((prev) => new Set(prev).add(photo.id));
+    if (outcome.close) onOpenChange(false);
+    else setCurrentIndex(outcome.index);
+
+    const timer = setTimeout(() => commitDelete(photo), UNDO_WINDOW_MS);
+    pendingDeletes.current.set(photo.id, { timer, photo });
+
+    toast("Photo deleted", {
+      action: { label: "Undo", onClick: () => undoDelete(photo) },
+      duration: UNDO_WINDOW_MS,
+    });
   }
 
   if (!open || !currentPhoto) return null;
@@ -298,12 +431,47 @@ export default function PhotoViewer({
   return (
     <div className="fixed inset-0 z-[90] flex bg-black">
       {/* Photo, centered + letterboxed on black, with the action toolbar over it */}
-      <div className="flex-1 relative flex items-center justify-center overflow-hidden">
+      <div
+        className="flex-1 relative flex items-center justify-center overflow-hidden"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
         <img
           src={displayUrl}
           alt={currentPhoto.caption || "Photo"}
           className="max-w-full max-h-full object-contain"
         />
+
+        {/* Prev / next — newest-first, continuous across the grid's date
+            dividers, clamped at the ends (#515). */}
+        {hasPrev(safeIndex) && (
+          <button
+            type="button"
+            aria-label="Previous photo"
+            title="Previous photo"
+            onClick={goPrev}
+            className={cn(
+              toolbarBtn,
+              "absolute left-3 top-1/2 -translate-y-1/2 hover:bg-black/70",
+            )}
+          >
+            <ChevronLeft size={22} />
+          </button>
+        )}
+        {hasNext(safeIndex, visiblePhotos.length) && (
+          <button
+            type="button"
+            aria-label="Next photo"
+            title="Next photo"
+            onClick={goNext}
+            className={cn(
+              toolbarBtn,
+              "absolute right-3 top-1/2 -translate-y-1/2 hover:bg-black/70",
+            )}
+          >
+            <ChevronRight size={22} />
+          </button>
+        )}
 
         {/* Close back to the Job */}
         <button
@@ -408,11 +576,9 @@ export default function PhotoViewer({
           <div className="absolute top-14 right-3 bg-white rounded-lg shadow-lg p-3 flex items-center gap-2">
             <button
               type="button"
-              onClick={handleDelete}
-              disabled={deleting}
-              className="text-sm text-white bg-[#C41E2A] hover:bg-[#A3171F] px-3 py-1 rounded-lg transition-colors flex items-center gap-1 disabled:opacity-50"
+              onClick={handleConfirmDelete}
+              className="text-sm text-white bg-[#C41E2A] hover:bg-[#A3171F] px-3 py-1 rounded-lg transition-colors flex items-center gap-1"
             >
-              {deleting && <Loader2 size={12} className="animate-spin" />}
               Confirm Delete
             </button>
             <button

--- a/src/lib/jobs/photo-viewer-navigation.test.ts
+++ b/src/lib/jobs/photo-viewer-navigation.test.ts
@@ -1,0 +1,129 @@
+// Issue #515 — the pure navigation model behind the full-screen Photo viewer.
+// Ordering / next / prev / delete-advances / close-on-last, verified without
+// rendering. The viewer's UI (arrows, swipe, keys, the deferred-delete + undo
+// toast) is driven through these functions and covered in the component test.
+
+import { describe, it, expect } from "vitest";
+import type { Photo } from "@/lib/types";
+import {
+  orderPhotosForViewer,
+  nextPhotoIndex,
+  prevPhotoIndex,
+  hasNext,
+  hasPrev,
+  indexAfterDelete,
+} from "./photo-viewer-navigation";
+
+// A Photo with only the fields the navigation model reads (created_at + id).
+function photo(id: string, createdAt: string): Photo {
+  return {
+    id,
+    organization_id: "org-1",
+    job_id: "job-1",
+    storage_path: `job-1/${id}.jpg`,
+    annotated_path: null,
+    caption: null,
+    taken_at: null,
+    taken_by: "Eric",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: createdAt,
+    uploaded_from: "web",
+    client_capture_id: null,
+  };
+}
+
+describe("orderPhotosForViewer — newest-first, continuous across date dividers", () => {
+  it("returns one descending sequence regardless of input order, spanning days", () => {
+    // Two days, shuffled on input. The grid draws a divider between the days,
+    // but navigation is one continuous newest-first run — the divider is not a
+    // navigation stop.
+    const may3 = photo("may3", "2026-05-03T09:00:00Z");
+    const may1 = photo("may1", "2026-05-01T15:00:00Z");
+    const may2 = photo("may2", "2026-05-02T12:00:00Z");
+
+    const ordered = orderPhotosForViewer([may1, may3, may2]);
+
+    expect(ordered.map((p) => p.id)).toEqual(["may3", "may2", "may1"]);
+  });
+
+  it("keeps incoming order among Photos that share a timestamp (stable)", () => {
+    const ts = "2026-05-02T12:00:00Z";
+    const a = photo("a", ts);
+    const b = photo("b", ts);
+    const c = photo("c", ts);
+
+    const ordered = orderPhotosForViewer([a, b, c]);
+
+    expect(ordered.map((p) => p.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+// index 0 is the newest Photo; higher indices are older. "Next" walks toward
+// older Photos, "prev" toward newer — matching the on-screen right/left arrows.
+describe("nextPhotoIndex / prevPhotoIndex — clamped at the ends", () => {
+  it("next advances toward older Photos", () => {
+    expect(nextPhotoIndex(0, 4)).toBe(1);
+    expect(nextPhotoIndex(2, 4)).toBe(3);
+  });
+
+  it("next clamps at the oldest Photo (no wrap)", () => {
+    expect(nextPhotoIndex(3, 4)).toBe(3);
+  });
+
+  it("prev moves toward newer Photos", () => {
+    expect(prevPhotoIndex(3)).toBe(2);
+    expect(prevPhotoIndex(1)).toBe(0);
+  });
+
+  it("prev clamps at the newest Photo (no wrap)", () => {
+    expect(prevPhotoIndex(0)).toBe(0);
+  });
+});
+
+// The arrows hide at the ends — there is nowhere further to go.
+describe("hasNext / hasPrev — end boundaries", () => {
+  it("has a next while older Photos remain, none at the oldest", () => {
+    expect(hasNext(0, 3)).toBe(true);
+    expect(hasNext(1, 3)).toBe(true);
+    expect(hasNext(2, 3)).toBe(false);
+  });
+
+  it("has a prev once past the newest, none at the newest", () => {
+    expect(hasPrev(0)).toBe(false);
+    expect(hasPrev(1)).toBe(true);
+  });
+
+  it("offers neither when there is a single Photo", () => {
+    expect(hasNext(0, 1)).toBe(false);
+    expect(hasPrev(0)).toBe(false);
+  });
+});
+
+// Deleting a Photo advances to the next one; only removing the last Photo
+// closes the viewer. `count` is the size before removal.
+describe("indexAfterDelete — advance to next, close on last", () => {
+  it("advances to the next (older) Photo when deleting from the middle", () => {
+    // 4 Photos, viewing index 1. After deleting, the Photo that was at index 2
+    // slides into index 1 — staying at index 1 shows the next one.
+    expect(indexAfterDelete(1, 4)).toEqual({ close: false, index: 1 });
+  });
+
+  it("advances to the next Photo when deleting the newest", () => {
+    expect(indexAfterDelete(0, 3)).toEqual({ close: false, index: 0 });
+  });
+
+  it("clamps back to the new last Photo when deleting the oldest", () => {
+    // Viewing the oldest (index 3 of 4). Nothing older follows, so the viewer
+    // falls back to the previous Photo, now the last at index 2.
+    expect(indexAfterDelete(3, 4)).toEqual({ close: false, index: 2 });
+  });
+
+  it("closes the viewer when the last remaining Photo is deleted", () => {
+    expect(indexAfterDelete(0, 1)).toEqual({ close: true, index: 0 });
+  });
+});

--- a/src/lib/jobs/photo-viewer-navigation.ts
+++ b/src/lib/jobs/photo-viewer-navigation.ts
@@ -1,0 +1,71 @@
+// The pure navigation model behind the full-screen Photo viewer (#515).
+//
+// The viewer lets the user move through the Job's Photos — prev/next arrows,
+// swipe, and arrow keys — and deleting one advances to the next. All of that
+// ordering and index math lives here, free of React and the DOM, so it can be
+// verified without rendering. The viewer component is the thin shell that wires
+// these decisions to buttons, key handlers, touch events, and the toast.
+
+import type { Photo } from "@/lib/types";
+
+/**
+ * Order a Job's Photos for the viewer: newest-first and **continuous**.
+ *
+ * The grid groups Photos under date dividers, but those dividers are display
+ * context, not navigation stops — the viewer walks one flat newest-first run
+ * straight across them. Ordering here (rather than trusting the caller) keeps
+ * the viewer independent of however its Photos arrived. The sort is stable, so
+ * Photos sharing a timestamp keep their incoming order.
+ */
+export function orderPhotosForViewer(photos: Photo[]): Photo[] {
+  return [...photos].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+}
+
+// In the ordered list, index 0 is the newest Photo and higher indices are
+// older. "Next" walks toward older Photos (the on-screen right arrow), "prev"
+// toward newer (the left arrow). Both clamp at the ends — there is no wrap.
+
+/** The index after stepping toward older Photos, clamped at the last one. */
+export function nextPhotoIndex(index: number, count: number): number {
+  return Math.min(index + 1, count - 1);
+}
+
+/** The index after stepping toward newer Photos, clamped at the first one. */
+export function prevPhotoIndex(index: number): number {
+  return Math.max(index - 1, 0);
+}
+
+/** Whether an older Photo exists to step to (drives the next arrow). */
+export function hasNext(index: number, count: number): boolean {
+  return index < count - 1;
+}
+
+/** Whether a newer Photo exists to step to (drives the prev arrow). */
+export function hasPrev(index: number): boolean {
+  return index > 0;
+}
+
+/** What the viewer should do after the Photo at `index` is deleted. */
+export interface DeleteOutcome {
+  /** True only when the last remaining Photo was removed — close the viewer. */
+  close: boolean;
+  /** The index to show next when not closing. */
+  index: number;
+}
+
+/**
+ * Decide where the viewer lands after deleting the Photo at `index`.
+ *
+ * `count` is the number of Photos before removal. Deleting advances to the
+ * next (older) Photo, which — because the rest shift up — means staying at the
+ * same index. Deleting the oldest Photo clamps back to the new last one, and
+ * deleting the only Photo closes the viewer.
+ */
+export function indexAfterDelete(index: number, count: number): DeleteOutcome {
+  const remaining = count - 1;
+  if (remaining <= 0) return { close: true, index: 0 };
+  return { close: false, index: Math.min(index, remaining - 1) };
+}


### PR DESCRIPTION
Closes #515. Builds on #513 (full-screen viewer) and #514 (More menu).

## What this adds
- **Navigation** between a Job's Photos via on-screen **prev/next arrows**, **touch swipe**, and **arrow keys** — newest-first and **continuous across the grid's date dividers** (dividers are display context, not navigation stops). Arrows clamp at the ends (no wrap).
- **Delete-advances + Undo**: confirming a delete hides the Photo and advances to the next one, closing the viewer **only when the last Photo is removed**. An **Undo toast** appears; the permanent hard-delete (storage object + `photos` row) commits only after the ~5s window, and **Undo cancels** it. Photos have no soft-delete column, so deferral is what makes the hard delete recoverable.
- The viewer (and the Annotator it hands off to) now navigates the **grid's full loaded list** — previously it only saw the newest-12 screenful `job-detail` held.

## Pure module
The ordering / next / prev / delete-advances / close-on-last logic lives in a pure, React-free module — `src/lib/jobs/photo-viewer-navigation.ts` — covered by **13 unit tests** (verified without rendering), following the `photo-load-priority.ts` convention.

## Tests
- **Unit** (`photo-viewer-navigation.test.ts`): ordering (newest-first, continuous, stable on ties), clamped next/prev, end boundaries, and `indexAfterDelete` (advance / clamp-at-oldest / close-on-last).
- **Component** (`photo-viewer.test.tsx`): arrow/key/swipe navigation, end-clamped arrow visibility, and the deferred delete — confirm required, advances to next + Undo toast shown, close-on-last, commit-after-window, and Undo-cancels-and-restores.
- 44 tests green (13 unit + 31 component); `tsc --noEmit` clean; no new lint errors on the changed files.

## Notes / out of scope
- The viewer navigates a **snapshot** of the grid list captured when a Photo is opened (it doesn't grow as you infinite-scroll inside the viewer).
- The grid not auto-refreshing after a viewer delete is **pre-existing** (the `onUpdated` wiring is unchanged from #513) and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)