### PR TITLE
feat(photo-viewer): zoom — pinch / scroll / pan / double-tap (#516)

### DIFF
--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -706,6 +706,275 @@ describe("PhotoViewer — navigation across the Job's Photos", () => {
   });
 });
 
+describe("PhotoViewer — zoom", () => {
+  // jsdom gives every element a 0×0 rect; the zoom math needs a real viewport.
+  // Stub a 1000×800 surface (origin 0,0) so focal points equal clientX/clientY,
+  // and size the Photo 4000×3000 so fit spans the full width (fitW = 1000).
+  let rectSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    rectSpy = vi.spyOn(Element.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 1000,
+      height: 800,
+      left: 0,
+      top: 0,
+      right: 1000,
+      bottom: 800,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  });
+  afterEach(() => rectSpy.mockRestore());
+
+  const zoomPhoto = (overrides: Partial<Photo> = {}) =>
+    makePhoto({ width: 4000, height: 3000, ...overrides });
+
+  const img = () => screen.getByRole("img") as HTMLImageElement;
+  // The applied magnification, parsed out of the CSS transform on the image.
+  const scaleOf = (el: HTMLElement) => {
+    const m = /scale\(([\d.]+)\)/.exec(el.style.transform);
+    return m ? parseFloat(m[1]) : 1;
+  };
+  // The horizontal pan offset, parsed out of the CSS transform's translate().
+  const offsetXOf = (el: HTMLElement) => {
+    const m = /translate\((-?[\d.]+)px/.exec(el.style.transform);
+    return m ? parseFloat(m[1]) : 0;
+  };
+  const src = () => img().getAttribute("src");
+  const zoomIn = async () =>
+    act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    });
+
+  it("magnifies the Photo when the ＋ (zoom in) button is pressed", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+    expect(scaleOf(img())).toBe(1);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    });
+
+    expect(scaleOf(img())).toBeGreaterThan(1);
+  });
+
+  it("− (zoom out) is disabled at fit and brings a zoomed Photo back", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    const zoomOut = () => screen.getByRole("button", { name: /zoom out/i }) as HTMLButtonElement;
+    expect(zoomOut().disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    });
+    expect(zoomOut().disabled).toBe(false);
+    const zoomedIn = scaleOf(img());
+
+    await act(async () => {
+      fireEvent.click(zoomOut());
+    });
+    expect(scaleOf(img())).toBeLessThan(zoomedIn);
+  });
+
+  it("scroll-wheel up magnifies the Photo", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    await act(async () => {
+      // Negative deltaY = scroll up = zoom in, about the cursor.
+      fireEvent.wheel(img(), { deltaY: -200, clientX: 500, clientY: 400 });
+    });
+
+    expect(scaleOf(img())).toBeGreaterThan(1);
+  });
+
+  it("double-click snaps to zoomed, and again back to fit", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.doubleClick(img(), { clientX: 500, clientY: 400 });
+    });
+    expect(scaleOf(img())).toBe(2);
+
+    await act(async () => {
+      fireEvent.doubleClick(img(), { clientX: 500, clientY: 400 });
+    });
+    expect(scaleOf(img())).toBe(1);
+  });
+
+  it("resets to fit when paging to another Photo", async () => {
+    const a = zoomPhoto({ id: "a", storage_path: "job-1/a.jpg", created_at: "2026-05-02T10:00:00Z" });
+    const b = zoomPhoto({ id: "b", storage_path: "job-1/b.jpg", created_at: "2026-05-01T10:00:00Z" });
+    renderViewer({ photos: [a, b], initialPhotoIndex: 0 });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    });
+    expect(scaleOf(img())).toBeGreaterThan(1);
+
+    // Page to the next Photo — it should open at fit, not inherit the zoom.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    });
+    expect(scaleOf(img())).toBe(1);
+  });
+
+  it("drags to pan once zoomed, clamped within the image", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+    await zoomIn();
+    expect(offsetXOf(img())).toBe(0);
+
+    // Drag left by 100px → the image shifts left (negative offset).
+    await act(async () => {
+      fireEvent.mouseDown(img(), { clientX: 500, clientY: 400 });
+      fireEvent.mouseMove(img(), { clientX: 400, clientY: 400 });
+      fireEvent.mouseUp(img(), { clientX: 400, clientY: 400 });
+    });
+
+    expect(offsetXOf(img())).toBeLessThan(0);
+  });
+
+  it("does not pan at fit (a stray drag leaves the image centred)", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.mouseDown(img(), { clientX: 500, clientY: 400 });
+      fireEvent.mouseMove(img(), { clientX: 300, clientY: 400 });
+      fireEvent.mouseUp(img(), { clientX: 300, clientY: 400 });
+    });
+
+    expect(offsetXOf(img())).toBe(0);
+  });
+
+  it("suppresses swipe navigation while zoomed (the drag pans instead)", async () => {
+    const a = zoomPhoto({ id: "a", storage_path: "job-1/a.jpg", created_at: "2026-05-02T10:00:00Z" });
+    const b = zoomPhoto({ id: "b", storage_path: "job-1/b.jpg", created_at: "2026-05-01T10:00:00Z" });
+    renderViewer({ photos: [a, b], initialPhotoIndex: 0 });
+    await act(async () => {});
+    await zoomIn();
+    const before = src();
+
+    // A leftward one-finger swipe that would normally advance a Photo.
+    await act(async () => {
+      fireEvent.touchStart(img(), { touches: [{ clientX: 240, clientY: 400 }] });
+      fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 80, clientY: 400 }] });
+    });
+
+    // Still on the same Photo — paging was suppressed.
+    expect(src()).toBe(before);
+  });
+
+  it("pinching two fingers apart magnifies the Photo", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    await act(async () => {
+      // Two fingers 40px apart, then spread to 200px apart (5×), centred.
+      fireEvent.touchStart(img(), {
+        touches: [
+          { clientX: 480, clientY: 400 },
+          { clientX: 520, clientY: 400 },
+        ],
+      });
+      fireEvent.touchMove(img(), {
+        touches: [
+          { clientX: 400, clientY: 400 },
+          { clientX: 600, clientY: 400 },
+        ],
+      });
+      fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 400, clientY: 400 }] });
+    });
+
+    expect(scaleOf(img())).toBeGreaterThan(1);
+  });
+
+  it("double-tap (touch) snaps to zoomed", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+
+    const tap = () =>
+      act(async () => {
+        fireEvent.touchStart(img(), { touches: [{ clientX: 500, clientY: 400 }] });
+        fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 500, clientY: 400 }] });
+      });
+
+    await tap();
+    await tap();
+
+    expect(scaleOf(img())).toBe(2);
+  });
+
+  it("one-finger drag pans once zoomed (touch)", async () => {
+    renderViewer({ photos: [zoomPhoto()] });
+    await act(async () => {});
+    await zoomIn();
+
+    await act(async () => {
+      fireEvent.touchStart(img(), { touches: [{ clientX: 500, clientY: 400 }] });
+      fireEvent.touchMove(img(), { touches: [{ clientX: 400, clientY: 400 }] });
+      fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 400, clientY: 400 }] });
+    });
+
+    expect(offsetXOf(img())).toBeLessThan(0);
+  });
+
+  it("ignores a pinch on a video (Zoom doesn't apply)", async () => {
+    renderViewer({ photos: [zoomPhoto({ media_type: "video" })] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.touchStart(img(), {
+        touches: [
+          { clientX: 480, clientY: 400 },
+          { clientX: 520, clientY: 400 },
+        ],
+      });
+      fireEvent.touchMove(img(), {
+        touches: [
+          { clientX: 400, clientY: 400 },
+          { clientX: 600, clientY: 400 },
+        ],
+      });
+      fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 400, clientY: 400 }] });
+    });
+
+    expect(scaleOf(img())).toBe(1);
+  });
+});
+
+describe("PhotoViewer — media capabilities (video hides Zoom & Draw)", () => {
+  const video = () =>
+    makePhoto({ media_type: "video", storage_path: "job-1/clip.mp4" });
+
+  it("hides the Zoom controls for a video", async () => {
+    renderViewer({ photos: [video()] });
+    await act(async () => {});
+
+    expect(screen.queryByRole("button", { name: /zoom in/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /zoom out/i })).toBeNull();
+  });
+
+  it("hides the Edit (Draw) action for a video", async () => {
+    renderViewer({ photos: [video()] });
+    await act(async () => {});
+
+    expect(screen.queryByRole("button", { name: /^edit$/i })).toBeNull();
+  });
+
+  it("still offers Zoom and Edit for a still photo", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    expect(screen.queryByRole("button", { name: /zoom in/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^edit$/i })).toBeTruthy();
+  });
+});
+
 describe("PhotoViewer — guard", () => {
   it("renders nothing when closed", () => {
     const { container } = renderViewer({ open: false });

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -13,6 +13,18 @@ import {
   hasPrev,
   indexAfterDelete,
 } from "@/lib/jobs/photo-viewer-navigation";
+import { mediaCapabilities } from "@/lib/jobs/photo-media-capabilities";
+import {
+  FIT,
+  ZOOM_STEP,
+  zoomBy,
+  zoomAbout,
+  doubleTap,
+  pan,
+  type Transform,
+  type ViewportContext,
+  type Focal,
+} from "@/lib/jobs/photo-zoom-transform";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import {
@@ -29,6 +41,8 @@ import {
   Star,
   ChevronLeft,
   ChevronRight,
+  ZoomIn,
+  ZoomOut,
 } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -113,17 +127,197 @@ export default function PhotoViewer({
     };
   }, []);
 
-  // Touch swipe: a horizontal drag past the threshold steps between Photos —
-  // left for the next (older), right for the previous (newer).
-  const SWIPE_THRESHOLD = 50;
-  const touchStartX = useRef<number | null>(null);
+  // Zoom/pan state, applied on top of the image's object-contain fit. All the
+  // math lives in the pure zoom-transform module; this is just the live state
+  // plus the DOM measurements the gestures need. Each Photo opens at fit.
+  const [transform, setTransform] = useState<Transform>(FIT);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const imgRef = useRef<HTMLImageElement>(null);
+  const isZoomed = transform.scale > 1;
+
+  // The transform reasons in pixels: the surface's measured size is the
+  // viewport, and the Photo's stored dimensions (falling back to the decoded
+  // image) are the source size. Null until something is measurable, so handlers
+  // no-op rather than divide by zero.
+  function viewportCtx(): ViewportContext | null {
+    const el = surfaceRef.current;
+    if (!el || !currentPhoto) return null;
+    const rect = el.getBoundingClientRect();
+    const imageW = currentPhoto.width ?? imgRef.current?.naturalWidth ?? rect.width;
+    const imageH = currentPhoto.height ?? imgRef.current?.naturalHeight ?? rect.height;
+    if (!rect.width || !rect.height || !imageW || !imageH) return null;
+    return { imageW, imageH, viewportW: rect.width, viewportH: rect.height };
+  }
+
+  // A client coordinate expressed relative to the surface (the focal point a
+  // gesture zooms about).
+  function focalFrom(clientX: number, clientY: number): Focal {
+    const rect = surfaceRef.current?.getBoundingClientRect();
+    return { x: clientX - (rect?.left ?? 0), y: clientY - (rect?.top ?? 0) };
+  }
+
+  const viewportCentre = (ctx: ViewportContext): Focal => ({
+    x: ctx.viewportW / 2,
+    y: ctx.viewportH / 2,
+  });
+
+  // ＋ / − buttons zoom a fixed step about the centre of the image.
+  function zoomStep(direction: 1 | -1) {
+    const ctx = viewportCtx();
+    if (!ctx) return;
+    const factor = direction > 0 ? ZOOM_STEP : 1 / ZOOM_STEP;
+    setTransform((t) => zoomBy(t, factor, viewportCentre(ctx), ctx));
+  }
+
+  // Scroll-wheel / trackpad zoom about the cursor. The delta maps to a smooth
+  // multiplicative factor so a trackpad's fine deltas and a mouse wheel's coarse
+  // notches both feel even. preventDefault is best-effort (React's wheel
+  // listener is passive) — enough to stop the page jumping under the viewer.
+  function onWheel(e: React.WheelEvent) {
+    if (!caps.canZoom) return;
+    const ctx = viewportCtx();
+    if (!ctx) return;
+    e.preventDefault();
+    const factor = Math.exp(-e.deltaY * 0.0015);
+    const focal = focalFrom(e.clientX, e.clientY);
+    setTransform((t) => zoomBy(t, factor, focal, ctx));
+  }
+
+  // Double-click / double-tap snaps between fit and zoomed about the point.
+  function onDoubleClick(e: React.MouseEvent) {
+    if (!caps.canZoom) return;
+    const ctx = viewportCtx();
+    if (!ctx) return;
+    const focal = focalFrom(e.clientX, e.clientY);
+    setTransform((t) => doubleTap(t, focal, ctx));
+  }
+
+  // Mouse drag-to-pan (desktop). Only active while zoomed; each move pans by
+  // the delta since the last point and the pure module clamps it to the edges.
+  const dragOrigin = useRef<{ x: number; y: number } | null>(null);
+  function onMouseDown(e: React.MouseEvent) {
+    if (!isZoomed) return;
+    dragOrigin.current = { x: e.clientX, y: e.clientY };
+  }
+  function onMouseMove(e: React.MouseEvent) {
+    const origin = dragOrigin.current;
+    if (!origin) return;
+    const ctx = viewportCtx();
+    if (!ctx) return;
+    const dx = e.clientX - origin.x;
+    const dy = e.clientY - origin.y;
+    dragOrigin.current = { x: e.clientX, y: e.clientY };
+    setTransform((t) => pan(t, dx, dy, ctx));
+  }
+  function endDrag() {
+    dragOrigin.current = null;
+  }
+
+  // Touch gestures share the surface and are dispatched by finger count and
+  // zoom state: two fingers pinch-zoom; one finger pans when zoomed or swipes
+  // between Photos at fit; a quick double-tap toggles zoom. The pure module does
+  // every transform; these refs only hold the in-flight gesture's start state.
+  const SWIPE_THRESHOLD = 50; // px a one-finger swipe must travel to page
+  const TAP_MOVE = 10; // px under which a touch counts as a tap, not a drag
+  const DOUBLE_TAP_MS = 300; // window for a second tap to count as a double-tap
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const pinchStart = useRef<{ dist: number; transform: Transform } | null>(null);
+  const touchPanLast = useRef<{ x: number; y: number } | null>(null);
+  const lastTap = useRef<{ time: number; x: number; y: number } | null>(null);
+
+  const touchDistance = (t: React.TouchList) =>
+    Math.hypot(
+      (t[0]?.clientX ?? 0) - (t[1]?.clientX ?? 0),
+      (t[0]?.clientY ?? 0) - (t[1]?.clientY ?? 0),
+    );
+  const touchMidpoint = (t: React.TouchList): Focal =>
+    focalFrom(
+      ((t[0]?.clientX ?? 0) + (t[1]?.clientX ?? 0)) / 2,
+      ((t[0]?.clientY ?? 0) + (t[1]?.clientY ?? 0)) / 2,
+    );
+
   const onTouchStart = (e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0]?.clientX ?? null;
+    if (e.touches.length >= 2) {
+      // Two fingers only ever mean pinch-zoom; ignore them where Zoom doesn't
+      // apply (video) so the transform stays at fit.
+      if (caps.canZoom) {
+        pinchStart.current = { dist: touchDistance(e.touches), transform };
+      }
+      touchStart.current = null;
+      touchPanLast.current = null;
+      return;
+    }
+    const t0 = e.touches[0];
+    const x = t0?.clientX ?? 0;
+    const y = t0?.clientY ?? 0;
+    touchStart.current = { x, y };
+    touchPanLast.current = isZoomed ? { x, y } : null;
   };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    if (pinchStart.current && e.touches.length >= 2) {
+      const ctx = viewportCtx();
+      if (!ctx) return;
+      const start = pinchStart.current;
+      const factor = touchDistance(e.touches) / start.dist;
+      const focal = touchMidpoint(e.touches);
+      setTransform(() =>
+        zoomAbout(start.transform, start.transform.scale * factor, focal, ctx),
+      );
+      return;
+    }
+    const last = touchPanLast.current;
+    if (last && e.touches.length === 1) {
+      const ctx = viewportCtx();
+      if (!ctx) return;
+      const t0 = e.touches[0];
+      const x = t0?.clientX ?? 0;
+      const y = t0?.clientY ?? 0;
+      const dx = x - last.x;
+      const dy = y - last.y;
+      touchPanLast.current = { x, y };
+      setTransform((t) => pan(t, dx, dy, ctx));
+    }
+  };
+
   const onTouchEnd = (e: React.TouchEvent) => {
-    if (touchStartX.current === null) return;
-    const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartX.current;
-    touchStartX.current = null;
+    const pinched = pinchStart.current !== null;
+    const panned = touchPanLast.current !== null;
+    const start = touchStart.current;
+    pinchStart.current = null;
+    touchPanLast.current = null;
+    touchStart.current = null;
+    if (pinched) return;
+
+    const end = e.changedTouches[0];
+    const ex = end?.clientX ?? 0;
+    const ey = end?.clientY ?? 0;
+    const dx = start ? ex - start.x : 0;
+    const moved = start ? Math.hypot(ex - start.x, ey - start.y) : 0;
+
+    // A near-stationary touch is a tap — a second one inside the window snaps
+    // zoom about the point (the touch equivalent of a double-click).
+    if (moved < TAP_MOVE) {
+      const now = Date.now();
+      const prev = lastTap.current;
+      if (
+        prev &&
+        now - prev.time < DOUBLE_TAP_MS &&
+        Math.hypot(ex - prev.x, ey - prev.y) < TAP_MOVE
+      ) {
+        lastTap.current = null;
+        const ctx = viewportCtx();
+        if (caps.canZoom && ctx) {
+          setTransform((t) => doubleTap(t, focalFrom(ex, ey), ctx));
+        }
+      } else {
+        lastTap.current = { time: now, x: ex, y: ey };
+      }
+      return;
+    }
+
+    // A drag: it already panned if zoomed; at fit it pages between Photos.
+    if (panned || isZoomed) return;
     if (dx <= -SWIPE_THRESHOLD) goNext();
     else if (dx >= SWIPE_THRESHOLD) goPrev();
   };
@@ -167,11 +361,13 @@ export default function PhotoViewer({
   }
 
   // Seed the editable fields from the opened Photo (re-seed if it changes).
+  // Each Photo opens at fit — a leftover zoom must not carry into the next one.
   useEffect(() => {
     if (currentPhoto) {
       setCaption(currentPhoto.caption || "");
       setBeforeAfterRole(currentPhoto.before_after_role);
       setConfirmDelete(false);
+      setTransform(FIT);
       fetchTags(currentPhoto.id);
       checkOriginalBackup(currentPhoto);
     }
@@ -424,6 +620,10 @@ export default function PhotoViewer({
 
   if (!open || !currentPhoto) return null;
 
+  // Zoom and Draw act on a still image; a video has neither (PRD #511). The
+  // pure rule decides, so the viewer hides those controls for video in one place.
+  const caps = mediaCapabilities(currentPhoto);
+
   const displayUrl = photoUrl(currentPhoto, supabaseUrl, "full");
   const toolbarBtn =
     "inline-flex items-center justify-center w-9 h-9 rounded-full bg-black/50 text-white transition-colors";
@@ -432,15 +632,56 @@ export default function PhotoViewer({
     <div className="fixed inset-0 z-[90] flex bg-black">
       {/* Photo, centered + letterboxed on black, with the action toolbar over it */}
       <div
+        ref={surfaceRef}
         className="flex-1 relative flex items-center justify-center overflow-hidden"
         onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
         onTouchEnd={onTouchEnd}
+        onWheel={onWheel}
+        onDoubleClick={onDoubleClick}
+        onMouseDown={onMouseDown}
+        onMouseMove={onMouseMove}
+        onMouseUp={endDrag}
+        onMouseLeave={endDrag}
+        style={{ cursor: isZoomed ? "grab" : undefined }}
       >
         <img
+          ref={imgRef}
           src={displayUrl}
           alt={currentPhoto.caption || "Photo"}
           className="max-w-full max-h-full object-contain"
+          style={{
+            transform: `translate(${transform.offsetX}px, ${transform.offsetY}px) scale(${transform.scale})`,
+            transformOrigin: "center center",
+          }}
+          draggable={false}
         />
+
+        {/* Zoom controls (desktop) — scroll-wheel and double-click also zoom;
+            hidden for media that can't zoom (video). */}
+        {caps.canZoom && (
+          <div className="absolute bottom-3 left-3 flex flex-col gap-2">
+            <button
+              type="button"
+              aria-label="Zoom in"
+              title="Zoom in"
+              onClick={() => zoomStep(1)}
+              className={cn(toolbarBtn, "hover:bg-black/70")}
+            >
+              <ZoomIn size={18} />
+            </button>
+            <button
+              type="button"
+              aria-label="Zoom out"
+              title="Zoom out"
+              onClick={() => zoomStep(-1)}
+              disabled={!isZoomed}
+              className={cn(toolbarBtn, "hover:bg-black/70 disabled:opacity-40")}
+            >
+              <ZoomOut size={18} />
+            </button>
+          </div>
+        )}
 
         {/* Prev / next — newest-first, continuous across the grid's date
             dividers, clamped at the ends (#515). */}
@@ -498,17 +739,21 @@ export default function PhotoViewer({
 
         {/* Toolbar over the photo */}
         <div className="absolute top-3 right-3 flex items-center gap-2">
-          <button
-            type="button"
-            aria-label="Edit"
-            title="Edit"
-            onClick={() =>
-              onAnnotate(currentPhoto, photoUrl(currentPhoto, supabaseUrl, "full"))
-            }
-            className={cn(toolbarBtn, "hover:bg-black/70")}
-          >
-            <Pencil size={18} />
-          </button>
+          {/* Edit hands off to the Annotator (drawing) — hidden for media that
+              can't be drawn on (video). */}
+          {caps.canDraw && (
+            <button
+              type="button"
+              aria-label="Edit"
+              title="Edit"
+              onClick={() =>
+                onAnnotate(currentPhoto, photoUrl(currentPhoto, supabaseUrl, "full"))
+              }
+              className={cn(toolbarBtn, "hover:bg-black/70")}
+            >
+              <Pencil size={18} />
+            </button>
+          )}
           <button
             type="button"
             aria-label="Download"

--- a/src/lib/jobs/photo-media-capabilities.test.ts
+++ b/src/lib/jobs/photo-media-capabilities.test.ts
@@ -1,0 +1,53 @@
+// Issue #516 — the pure rule for which viewer capabilities apply to a Photo.
+// Zoom and Draw operate on a still raster image; a video has neither (it plays
+// instead). Derived from `photos.media_type`, free of React/DOM so the
+// photo-vs-video decision is verified in one place. The viewer reads these
+// flags to hide the Zoom controls and the Edit (Draw) handoff where they don't
+// apply (PRD #511, user story 33).
+
+import { describe, it, expect } from "vitest";
+import type { Photo } from "@/lib/types";
+import { mediaCapabilities } from "./photo-media-capabilities";
+
+// A Photo with only the field the capabilities rule reads (media_type).
+function photo(mediaType: Photo["media_type"]): Photo {
+  return {
+    id: "p1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    storage_path: "job-1/p1.jpg",
+    annotated_path: null,
+    caption: null,
+    taken_at: null,
+    taken_by: "Eric",
+    media_type: mediaType,
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-01T00:00:00Z",
+    uploaded_from: "web",
+    client_capture_id: null,
+  };
+}
+
+describe("mediaCapabilities — a still Photo supports Zoom and Draw", () => {
+  it("reports canZoom and canDraw for a photo", () => {
+    const caps = mediaCapabilities(photo("photo"));
+
+    expect(caps.canZoom).toBe(true);
+    expect(caps.canDraw).toBe(true);
+    expect(caps.isVideo).toBe(false);
+  });
+});
+
+describe("mediaCapabilities — a video plays, so Zoom and Draw don't apply", () => {
+  it("hides canZoom and canDraw for a video", () => {
+    const caps = mediaCapabilities(photo("video"));
+
+    expect(caps.canZoom).toBe(false);
+    expect(caps.canDraw).toBe(false);
+    expect(caps.isVideo).toBe(true);
+  });
+});

--- a/src/lib/jobs/photo-media-capabilities.ts
+++ b/src/lib/jobs/photo-media-capabilities.ts
@@ -1,0 +1,24 @@
+// Issue #516 — the pure rule for which viewer capabilities apply to a Photo.
+//
+// Zoom and Draw act on a still raster image: zoom magnifies it, Draw hands off
+// to the Annotator to paint on it. A video has neither — it plays inline with a
+// scrub bar instead — so the viewer hides those controls for video (PRD #511,
+// user story 33). The decision is `photos.media_type` and nothing more, kept
+// here free of React/DOM so the photo-vs-video rule lives in one tested place.
+
+import type { Photo } from "@/lib/types";
+
+export interface MediaCapabilities {
+  /** Pinch / scroll / pan / double-tap magnification applies. */
+  canZoom: boolean;
+  /** The Edit handoff to the Annotator (drawing) applies. */
+  canDraw: boolean;
+  /** This Photo is a video (plays inline) rather than a still image. */
+  isVideo: boolean;
+}
+
+/** Which viewer capabilities apply to `photo`, off its `media_type`. */
+export function mediaCapabilities(photo: Pick<Photo, "media_type">): MediaCapabilities {
+  const isVideo = photo.media_type === "video";
+  return { canZoom: !isVideo, canDraw: !isVideo, isVideo };
+}

--- a/src/lib/jobs/photo-zoom-transform.test.ts
+++ b/src/lib/jobs/photo-zoom-transform.test.ts
@@ -1,0 +1,200 @@
+// Issue #516 — the pure zoom/pan math behind the full-screen Photo viewer.
+//
+// The viewer lets the user magnify a Photo (pinch / scroll / ＋－), pan around
+// when zoomed, and double-tap to snap between fit and zoomed. All of that
+// transform math — scale clamping, panning kept within the image edges,
+// zoom-about-a-point, and the double-tap toggle — lives here, free of React,
+// the DOM, and canvas, so it can be verified without rendering. The component
+// is the thin shell that wires pointer/touch/wheel events to these functions
+// and writes the result out as a CSS transform.
+
+import { describe, it, expect } from "vitest";
+import {
+  FIT,
+  MIN_SCALE,
+  MAX_SCALE,
+  clampScale,
+  panBounds,
+  clampOffset,
+  pan,
+  zoomAbout,
+  doubleTap,
+  zoomBy,
+  DOUBLE_TAP_SCALE,
+  ZOOM_STEP,
+  type ViewportContext,
+} from "./photo-zoom-transform";
+
+// Viewport centre of the 1000×800 fixture — what the ＋/－ buttons zoom about.
+const centre = { x: 500, y: 400 };
+
+// On-screen position (relative to viewport centre, one axis) of the image
+// content coordinate `u`, under offset/scale. Zoom-about-a-point means: the `u`
+// that sat under the focal point before the zoom sits under it after, too.
+const screenOf = (u: number, offset: number, scale: number) => offset + scale * u;
+
+// A landscape viewport with a landscape image that fits wider than tall.
+const ctx: ViewportContext = {
+  imageW: 4000,
+  imageH: 3000,
+  viewportW: 1000,
+  viewportH: 800,
+};
+
+describe("clampScale — never below fit, never past the max", () => {
+  it("leaves a scale within range untouched", () => {
+    expect(clampScale(2)).toBe(2);
+    expect(clampScale(4.5)).toBe(4.5);
+  });
+
+  it("clamps below fit up to MIN_SCALE (you can't pinch out smaller than fit)", () => {
+    expect(clampScale(0.5)).toBe(MIN_SCALE);
+    expect(MIN_SCALE).toBe(1);
+  });
+
+  it("clamps past the ceiling down to MAX_SCALE", () => {
+    expect(clampScale(99)).toBe(MAX_SCALE);
+    expect(MAX_SCALE).toBe(8);
+  });
+
+  it("FIT is the centered, unzoomed baseline", () => {
+    expect(FIT).toEqual({ scale: 1, offsetX: 0, offsetY: 0 });
+  });
+});
+
+// At fit, fitW = 1000 (= viewportW, spans full width) and fitH = 750 (< 800,
+// letterboxed). So the image fills the width but is shorter than the viewport.
+describe("panBounds — how far the centre may travel before an edge gaps", () => {
+  it("allows no panning at fit (the image is centred, nothing overflows)", () => {
+    expect(panBounds(1, ctx)).toEqual({ maxOffsetX: 0, maxOffsetY: 0 });
+  });
+
+  it("allows panning by half the overflow once zoomed past fit", () => {
+    // scale 2: displayed 2000×1500 over a 1000×800 viewport.
+    // overflow 1000×700 → half is 500×350.
+    expect(panBounds(2, ctx)).toEqual({ maxOffsetX: 500, maxOffsetY: 350 });
+  });
+
+  it("keeps a dimension centred while it still fits, even as the other pans", () => {
+    // scale 1.05: width 1050 overflows by 50 (→ 25), height 787.5 still under
+    // 800 → that axis stays pinned at 0.
+    expect(panBounds(1.05, ctx)).toEqual({ maxOffsetX: 25, maxOffsetY: 0 });
+  });
+});
+
+describe("pan — drag the image, but never past its edges", () => {
+  it("does nothing at fit: the image is pinned to centre", () => {
+    expect(pan(FIT, 120, -90, ctx)).toEqual(FIT);
+  });
+
+  it("moves freely while the drag stays within bounds", () => {
+    // scale 2 → bounds 500×350; this drag lands well inside them.
+    const t = { scale: 2, offsetX: 0, offsetY: 0 };
+    expect(pan(t, -200, -100, ctx)).toEqual({
+      scale: 2,
+      offsetX: -200,
+      offsetY: -100,
+    });
+  });
+
+  it("clamps a drag that would pull an edge into view", () => {
+    const t = { scale: 2, offsetX: 0, offsetY: 0 };
+    // Overshoot both axes; clamps to ±(500, 350).
+    expect(pan(t, -9999, 9999, ctx)).toEqual({
+      scale: 2,
+      offsetX: -500,
+      offsetY: 350,
+    });
+  });
+
+  it("clampOffset pulls an out-of-bounds transform back to its edge", () => {
+    expect(clampOffset({ scale: 2, offsetX: 800, offsetY: -800 }, ctx)).toEqual({
+      scale: 2,
+      offsetX: 500,
+      offsetY: -350,
+    });
+  });
+});
+
+// Viewport centre is (500, 400) for the 1000×800 fixture.
+describe("zoomAbout — magnify around a point, keeping it fixed", () => {
+  it("zooming about the centre keeps the image centred", () => {
+    expect(zoomAbout(FIT, 2, { x: 500, y: 400 }, ctx)).toEqual({
+      scale: 2,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it("zooming about an off-centre point shifts so that point stays put", () => {
+    // Focal 200px right of centre. Result derived: offsetX = (1−r)·fx = −200.
+    const result = zoomAbout(FIT, 2, { x: 700, y: 400 }, ctx);
+    expect(result).toEqual({ scale: 2, offsetX: -200, offsetY: 0 });
+
+    // The content under the focal before the zoom is still under it after.
+    const fx = 700 - 500;
+    const uUnderFocal = (fx - FIT.offsetX) / FIT.scale;
+    expect(screenOf(uUnderFocal, result.offsetX, result.scale)).toBeCloseTo(fx);
+  });
+
+  it("clamps the scale to the ceiling and stays put about the centre", () => {
+    expect(zoomAbout(FIT, 99, { x: 500, y: 400 }, ctx)).toEqual({
+      scale: 8,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it("clamps the resulting offset so a corner zoom can't gap an edge", () => {
+    // Zoom about the bottom-right corner: the raw shift (−500, −400) exceeds
+    // the y-bound (±350), so it clamps there.
+    expect(zoomAbout(FIT, 2, { x: 1000, y: 800 }, ctx)).toEqual({
+      scale: 2,
+      offsetX: -500,
+      offsetY: -350,
+    });
+  });
+});
+
+describe("doubleTap — snap between fit and zoomed", () => {
+  it("jumps from fit to the double-tap scale about the tapped point", () => {
+    expect(DOUBLE_TAP_SCALE).toBe(2);
+    // Same effect as zooming to 2× about that off-centre point.
+    expect(doubleTap(FIT, { x: 700, y: 400 }, ctx)).toEqual({
+      scale: 2,
+      offsetX: -200,
+      offsetY: 0,
+    });
+  });
+
+  it("snaps any zoomed state back to fit, ignoring the tap point", () => {
+    const zoomed = { scale: 4, offsetX: 300, offsetY: -120 };
+    expect(doubleTap(zoomed, { x: 50, y: 750 }, ctx)).toEqual(FIT);
+  });
+});
+
+describe("zoomBy — a relative factor (wheel / pinch / ＋－)", () => {
+  it("multiplies the current scale about the focal point", () => {
+    expect(zoomBy({ scale: 2, offsetX: 0, offsetY: 0 }, 1.5, centre, ctx)).toEqual({
+      scale: 3,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it("clamps at the ceiling instead of overshooting", () => {
+    expect(zoomBy({ scale: 6, offsetX: 0, offsetY: 0 }, 4, centre, ctx)).toEqual({
+      scale: 8,
+      offsetX: 0,
+      offsetY: 0,
+    });
+  });
+
+  it("a ＋ step then a − step returns to the starting scale", () => {
+    expect(ZOOM_STEP).toBeGreaterThan(1);
+    const inOnce = zoomBy(FIT, ZOOM_STEP, centre, ctx);
+    expect(inOnce.scale).toBeGreaterThan(1);
+    const backOut = zoomBy(inOnce, 1 / ZOOM_STEP, centre, ctx);
+    expect(backOut.scale).toBeCloseTo(1);
+  });
+});

--- a/src/lib/jobs/photo-zoom-transform.ts
+++ b/src/lib/jobs/photo-zoom-transform.ts
@@ -1,0 +1,194 @@
+// Issue #516 — the pure zoom/pan math behind the full-screen Photo viewer.
+//
+// The viewer shows a Photo `object-contain` (centered, letterboxed on black).
+// This module layers a magnification on top of that fit baseline and answers
+// every gesture — pinch, scroll, ＋－, drag-pan, double-tap — as a clamped
+// {@link Transform}. It never touches the DOM or canvas: the component reads
+// pointer/touch/wheel events, calls in here, and writes the result out as a CSS
+// `translate(...) scale(...)`. Keeping the math here means the tricky parts —
+// edge-clamped panning and zoom-about-a-point — are verified without rendering.
+
+/** The fixed pixel sizes the transform math reasons about. */
+export interface ViewportContext {
+  /** Natural pixel size of the source image. */
+  imageW: number;
+  imageH: number;
+  /** Pixel size of the surface the image is shown on. */
+  viewportW: number;
+  viewportH: number;
+}
+
+/**
+ * A zoom/pan state, applied on top of the `object-contain` fit.
+ *
+ * `scale` is relative to fit: `1` is the letterboxed baseline and the math
+ * never goes below it. `offsetX/offsetY` translate the image **centre** away
+ * from the viewport centre, in viewport pixels; at fit the image is centred so
+ * both are `0`. This maps straight to CSS `translate(offsetX, offsetY)
+ * scale(scale)` with a centred transform-origin.
+ */
+export interface Transform {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+}
+
+/** Fit can't be zoomed out past; this is the floor for {@link clampScale}. */
+export const MIN_SCALE = 1;
+/** The magnification ceiling — deep enough to inspect a detail (#516). */
+export const MAX_SCALE = 8;
+/** Where a double-tap / double-click jumps to from fit. */
+export const DOUBLE_TAP_SCALE = 2;
+/** The factor one press of the ＋ (or − as its reciprocal) button applies. */
+export const ZOOM_STEP = 1.5;
+
+/** The centred, unzoomed baseline: the Photo at `object-contain` fit. */
+export const FIT: Transform = { scale: MIN_SCALE, offsetX: 0, offsetY: 0 };
+
+/** Clamp a desired scale into the allowed `[MIN_SCALE, MAX_SCALE]` range. */
+export function clampScale(scale: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale));
+}
+
+/**
+ * The `object-contain` fit factor: image pixels → on-screen pixels at fit.
+ *
+ * The image is shrunk until it fits inside the viewport, so the limiting
+ * dimension is whichever axis is relatively larger. Multiplying the image size
+ * by this gives the letterboxed display size at `scale === 1`.
+ */
+function fitScale(ctx: ViewportContext): number {
+  return Math.min(ctx.viewportW / ctx.imageW, ctx.viewportH / ctx.imageH);
+}
+
+/** Per-axis cap on how far the image centre may shift away from centre. */
+export interface PanBounds {
+  maxOffsetX: number;
+  maxOffsetY: number;
+}
+
+/**
+ * How far the image centre may travel, per axis, before a black gap would open
+ * at an edge.
+ *
+ * The displayed image is `imageSize × fitScale × scale`. Whatever it overflows
+ * the viewport by can be split evenly to either side, so the centre may move by
+ * half the overflow. An axis that still fits within the viewport (overflow ≤ 0)
+ * stays pinned at the centre.
+ */
+export function panBounds(scale: number, ctx: ViewportContext): PanBounds {
+  const fit = fitScale(ctx);
+  const dispW = ctx.imageW * fit * scale;
+  const dispH = ctx.imageH * fit * scale;
+  return {
+    maxOffsetX: Math.max(0, (dispW - ctx.viewportW) / 2),
+    maxOffsetY: Math.max(0, (dispH - ctx.viewportH) / 2),
+  };
+}
+
+const clamp = (v: number, limit: number): number => {
+  const c = Math.min(limit, Math.max(-limit, v));
+  // Normalise -0 → 0 so offsets stay canonical (and never leak `-0px` into a
+  // style string or surprise an equality check).
+  return c === 0 ? 0 : c;
+};
+
+/**
+ * Pull a transform's offsets back inside the pan bounds for its scale.
+ *
+ * Used both directly (after a drag) and as the final step of every zoom, so a
+ * gesture can never leave the image showing a gap. A dimension whose bound is
+ * `0` (still letterboxed) collapses to centred.
+ */
+export function clampOffset(t: Transform, ctx: ViewportContext): Transform {
+  const { maxOffsetX, maxOffsetY } = panBounds(t.scale, ctx);
+  return {
+    scale: t.scale,
+    offsetX: clamp(t.offsetX, maxOffsetX),
+    offsetY: clamp(t.offsetY, maxOffsetY),
+  };
+}
+
+/** Drag the image by `(dx, dy)` viewport pixels, clamped to its edges. */
+export function pan(
+  t: Transform,
+  dx: number,
+  dy: number,
+  ctx: ViewportContext,
+): Transform {
+  return clampOffset(
+    { scale: t.scale, offsetX: t.offsetX + dx, offsetY: t.offsetY + dy },
+    ctx,
+  );
+}
+
+/** A point on the viewport surface, in viewport pixels from its top-left. */
+export interface Focal {
+  x: number;
+  y: number;
+}
+
+/**
+ * Zoom to `targetScale` about a focal point, keeping the image content under
+ * that point fixed on screen.
+ *
+ * This is the heart of pinch / scroll / double-tap: whatever pixel sits under
+ * your fingers (or cursor) should stay under them as the image grows. Working
+ * in viewport coordinates measured from the centre, the on-screen position of a
+ * content point is `offset + scale · u`, so holding the focal point fixed gives
+ * `offset' = (1 − r)·focal + r·offset`, where `r = scale'/scale`. The scale is
+ * clamped first and the offset clamped after, so a zoom can neither exceed the
+ * limits nor pan past an edge.
+ */
+export function zoomAbout(
+  t: Transform,
+  targetScale: number,
+  focal: Focal,
+  ctx: ViewportContext,
+): Transform {
+  const scale = clampScale(targetScale);
+  const r = scale / t.scale;
+  const fx = focal.x - ctx.viewportW / 2;
+  const fy = focal.y - ctx.viewportH / 2;
+  return clampOffset(
+    {
+      scale,
+      offsetX: (1 - r) * fx + r * t.offsetX,
+      offsetY: (1 - r) * fy + r * t.offsetY,
+    },
+    ctx,
+  );
+}
+
+/**
+ * Toggle between fit and zoomed on a double-tap / double-click.
+ *
+ * From fit it jumps to {@link DOUBLE_TAP_SCALE} about the tapped point (so the
+ * detail you tapped lands in view); from any zoomed state it snaps straight
+ * back to centred fit, regardless of where the tap landed.
+ */
+export function doubleTap(
+  t: Transform,
+  focal: Focal,
+  ctx: ViewportContext,
+): Transform {
+  if (t.scale > MIN_SCALE) return FIT;
+  return zoomAbout(t, DOUBLE_TAP_SCALE, focal, ctx);
+}
+
+/**
+ * Zoom by a relative `factor` about a focal point.
+ *
+ * The natural verb for the continuous gestures: a scroll wheel turns its delta
+ * into a factor just above/below 1, a pinch into the ratio of finger distances,
+ * and the ＋/－ buttons into {@link ZOOM_STEP} (or its reciprocal). Multiplying
+ * keeps each step proportional, so zooming feels even across the range.
+ */
+export function zoomBy(
+  t: Transform,
+  factor: number,
+  focal: Focal,
+  ctx: ViewportContext,
+): Transform {
+  return zoomAbout(t, t.scale * factor, focal, ctx);
+}


### PR DESCRIPTION
## Photo viewer 4: zoom

Closes #516 (slice of PRD #511; ADR 0014). Lets the user magnify a Photo in the full-screen viewer: **pinch** on touch, **scroll-wheel / ＋－** on desktop, **drag to pan** when zoomed, and **double-tap / double-click** to snap between fit and zoomed.

### Approach — two pure modules + thin wiring (built with `/tdd`)

- **`src/lib/jobs/photo-zoom-transform.ts`** — the gesture math, DOM-free. `scale = 1` is the `object-contain` fit baseline; offsets are the image-center displacement in viewport px (maps straight to a CSS `translate(…) scale(…)`). Covers: `clampScale` (`[1, 8]`), `panBounds`/`clampOffset`/`pan` (edge-clamped; a non-overflowing axis stays centered), `zoomAbout` (the content under the focal point stays fixed: `offset' = (1−r)·focal + r·offset`), `doubleTap` (fit↔2×), and `zoomBy` (the factor wheel/pinch/＋－ apply).
- **`src/lib/jobs/photo-media-capabilities.ts`** — `mediaCapabilities(photo) → { canZoom, canDraw, isVideo }` off `photos.media_type`, so "Zoom + Draw don't apply to video" is one tested rule.
- **`photo-viewer.tsx`** — wires pointer/touch/wheel events to those functions, applies the transform as a CSS transform, resets to fit on paging, suppresses swipe-nav while zoomed, and hides the Zoom controls + Edit (Draw) handoff where capabilities say so.

### Acceptance criteria

- [x] Pinch (touch) and scroll / ＋－ (desktop) zoom the Photo
- [x] Dragging pans when zoomed; panning cannot go past the image edges
- [x] Double-tap / double-click snaps between fit and zoomed
- [x] Pure zoom-transform module encodes the math, unit-tested (clamp, pan-bounds, double-tap, zoom-about-point)
- [x] Pure media-capabilities module reports canZoom / canDraw, unit-tested
- [x] Zoom is hidden where it doesn't apply (video shows no ＋－, no Edit, ignores pinch/wheel/double-click)
- [x] No new test failures beyond the known-red baseline

### Verification

- **81 passed** across zoom-transform (20), media-capabilities (2), photo-viewer component (46, +14 new), and the adjacent navigation suite (13)
- `tsc --noEmit`: **0 errors** project-wide
- `eslint --quiet` on the source files: **0 errors** (the 2 remaining warnings — the `<img>` element and the `[currentPhoto?.id]` effect — pre-date this change on `main`)

### Notes

- `media-capabilities` exposes `isVideo` alongside `canZoom`/`canDraw` (the underlying truth both derive from). The PRD's eventual `src` field is for the later video-playback slice and isn't needed here.
- Wheel `preventDefault` is best-effort (React's wheel listener is passive) — fine while the viewer is a fixed full-screen overlay; can harden with a native non-passive listener later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)