### PR TITLE
feat(photo-viewer): video — inline playback (Draw + Zoom hidden) (#517)

### DIFF
--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -924,26 +924,32 @@ describe("PhotoViewer — zoom", () => {
   });
 
   it("ignores a pinch on a video (Zoom doesn't apply)", async () => {
-    renderViewer({ photos: [zoomPhoto({ media_type: "video" })] });
+    // A video plays inline via a <video>, not the zoomable <img>; the pinch
+    // gesture bubbles to the same surface but Zoom is disabled for video.
+    const { container } = renderViewer({
+      photos: [zoomPhoto({ media_type: "video" })],
+    });
     await act(async () => {});
+    const video = container.querySelector("video") as HTMLVideoElement;
 
     await act(async () => {
-      fireEvent.touchStart(img(), {
+      fireEvent.touchStart(video, {
         touches: [
           { clientX: 480, clientY: 400 },
           { clientX: 520, clientY: 400 },
         ],
       });
-      fireEvent.touchMove(img(), {
+      fireEvent.touchMove(video, {
         touches: [
           { clientX: 400, clientY: 400 },
           { clientX: 600, clientY: 400 },
         ],
       });
-      fireEvent.touchEnd(img(), { changedTouches: [{ clientX: 400, clientY: 400 }] });
+      fireEvent.touchEnd(video, { changedTouches: [{ clientX: 400, clientY: 400 }] });
     });
 
-    expect(scaleOf(img())).toBe(1);
+    // The video carries no zoom transform — the pinch was ignored.
+    expect(scaleOf(video)).toBe(1);
   });
 });
 
@@ -972,6 +978,63 @@ describe("PhotoViewer — media capabilities (video hides Zoom & Draw)", () => {
 
     expect(screen.queryByRole("button", { name: /zoom in/i })).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^edit$/i })).toBeTruthy();
+  });
+});
+
+describe("PhotoViewer — video playback", () => {
+  const video = (overrides: Partial<Photo> = {}) =>
+    makePhoto({ media_type: "video", storage_path: "job-1/clip.mp4", ...overrides });
+
+  it("plays a video inline with a scrub bar (a <video controls> at the source)", async () => {
+    const photo = video();
+    const { container } = renderViewer({ photos: [photo] });
+    await act(async () => {});
+
+    const el = container.querySelector("video") as HTMLVideoElement | null;
+    expect(el).toBeTruthy();
+    // Native controls give the inline scrub bar.
+    expect(el!.hasAttribute("controls")).toBe(true);
+    // Loads the resolved media source (ADR 0008 routing).
+    expect(el!.getAttribute("src")).toBe(photoUrl(photo, SUPABASE_URL, "full"));
+  });
+
+  it("renders the video element instead of a still <img>", async () => {
+    const { container } = renderViewer({ photos: [video()] });
+    await act(async () => {});
+
+    expect(container.querySelector("video")).toBeTruthy();
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+
+  it("prev/next page across a video — it isn't special-cased out of navigation", async () => {
+    const vid = video({ id: "vid", created_at: "2026-05-02T10:00:00Z" });
+    const still = makePhoto({
+      id: "still",
+      storage_path: "job-1/still.jpg",
+      created_at: "2026-05-01T10:00:00Z",
+    });
+    // Newest-first ordering opens on the video; Next pages to the older still.
+    const { container } = renderViewer({
+      photos: [vid, still],
+      initialPhotoIndex: 0,
+    });
+    await act(async () => {});
+    expect(container.querySelector("video")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    });
+    // Advanced to the still: the <img> shows, the <video> is gone.
+    expect(container.querySelector("video")).toBeNull();
+    expect(
+      (screen.getByRole("img") as HTMLImageElement).getAttribute("src"),
+    ).toBe(photoUrl(still, SUPABASE_URL, "full"));
+
+    // Prev returns to the video.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+    });
+    expect(container.querySelector("video")).toBeTruthy();
   });
 });
 

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -620,11 +620,13 @@ export default function PhotoViewer({
 
   if (!open || !currentPhoto) return null;
 
-  // Zoom and Draw act on a still image; a video has neither (PRD #511). The
-  // pure rule decides, so the viewer hides those controls for video in one place.
-  const caps = mediaCapabilities(currentPhoto);
+  // Zoom and Draw act on a still image; a video has neither — it plays inline
+  // with a scrub bar (PRD #511). The pure rule decides photo-vs-video and
+  // supplies the media source, so the viewer branches in one place.
+  // caps.source is the uniform media URL — the <img> src for a still, the
+  // <video> src for a clip.
+  const caps = mediaCapabilities(currentPhoto, supabaseUrl);
 
-  const displayUrl = photoUrl(currentPhoto, supabaseUrl, "full");
   const toolbarBtn =
     "inline-flex items-center justify-center w-9 h-9 rounded-full bg-black/50 text-white transition-colors";
 
@@ -645,17 +647,30 @@ export default function PhotoViewer({
         onMouseLeave={endDrag}
         style={{ cursor: isZoomed ? "grab" : undefined }}
       >
-        <img
-          ref={imgRef}
-          src={displayUrl}
-          alt={currentPhoto.caption || "Photo"}
-          className="max-w-full max-h-full object-contain"
-          style={{
-            transform: `translate(${transform.offsetX}px, ${transform.offsetY}px) scale(${transform.scale})`,
-            transformOrigin: "center center",
-          }}
-          draggable={false}
-        />
+        {caps.isVideo ? (
+          /* A video plays inline with the browser's native scrub bar (controls).
+             Zoom/Draw don't apply, so it carries no zoom transform; playsInline
+             keeps it in the viewer on iOS rather than hijacking to fullscreen. */
+          <video
+            src={caps.source}
+            controls
+            playsInline
+            aria-label={currentPhoto.caption || "Video"}
+            className="max-w-full max-h-full object-contain"
+          />
+        ) : (
+          <img
+            ref={imgRef}
+            src={caps.source}
+            alt={currentPhoto.caption || "Photo"}
+            className="max-w-full max-h-full object-contain"
+            style={{
+              transform: `translate(${transform.offsetX}px, ${transform.offsetY}px) scale(${transform.scale})`,
+              transformOrigin: "center center",
+            }}
+            draggable={false}
+          />
+        )}
 
         {/* Zoom controls (desktop) — scroll-wheel and double-click also zoom;
             hidden for media that can't zoom (video). */}

--- a/src/lib/jobs/photo-media-capabilities.test.ts
+++ b/src/lib/jobs/photo-media-capabilities.test.ts
@@ -8,14 +8,22 @@
 import { describe, it, expect } from "vitest";
 import type { Photo } from "@/lib/types";
 import { mediaCapabilities } from "./photo-media-capabilities";
+import { photoUrl } from "./photo-url";
 
-// A Photo with only the field the capabilities rule reads (media_type).
-function photo(mediaType: Photo["media_type"]): Photo {
+const SUPABASE_URL = "https://example.supabase.co";
+
+// A Photo with the fields the capabilities rule reads (media_type for the
+// photo-vs-video decision; storage_path/annotated_path so it can resolve the
+// media's source URL).
+function photo(
+  mediaType: Photo["media_type"],
+  storagePath = "job-1/p1.jpg",
+): Photo {
   return {
     id: "p1",
     organization_id: "org-1",
     job_id: "job-1",
-    storage_path: "job-1/p1.jpg",
+    storage_path: storagePath,
     annotated_path: null,
     caption: null,
     taken_at: null,
@@ -34,20 +42,33 @@ function photo(mediaType: Photo["media_type"]): Photo {
 
 describe("mediaCapabilities — a still Photo supports Zoom and Draw", () => {
   it("reports canZoom and canDraw for a photo", () => {
-    const caps = mediaCapabilities(photo("photo"));
+    const still = photo("photo");
+    const caps = mediaCapabilities(still, SUPABASE_URL);
 
     expect(caps.canZoom).toBe(true);
     expect(caps.canDraw).toBe(true);
     expect(caps.isVideo).toBe(false);
+    // Source is uniform: a still resolves the same full URL the <img> uses.
+    expect(caps.source).toBe(photoUrl(still, SUPABASE_URL, "full"));
   });
 });
 
 describe("mediaCapabilities — a video plays, so Zoom and Draw don't apply", () => {
   it("hides canZoom and canDraw for a video", () => {
-    const caps = mediaCapabilities(photo("video"));
+    const caps = mediaCapabilities(photo("video"), SUPABASE_URL);
 
     expect(caps.canZoom).toBe(false);
     expect(caps.canDraw).toBe(false);
     expect(caps.isVideo).toBe(true);
+  });
+});
+
+describe("mediaCapabilities — supplies the media's source URL", () => {
+  it("supplies a video's source so the viewer can play it inline", () => {
+    const clip = photo("video", "job-1/clip.mp4");
+    const caps = mediaCapabilities(clip, SUPABASE_URL);
+
+    // Routed through photoUrl — the single place Photo URLs are built (ADR 0008).
+    expect(caps.source).toBe(photoUrl(clip, SUPABASE_URL, "full"));
   });
 });

--- a/src/lib/jobs/photo-media-capabilities.ts
+++ b/src/lib/jobs/photo-media-capabilities.ts
@@ -1,12 +1,17 @@
-// Issue #516 — the pure rule for which viewer capabilities apply to a Photo.
+// Issue #516 / #517 — the pure rule for which viewer capabilities apply to a
+// Photo, plus the URL its media element loads.
 //
 // Zoom and Draw act on a still raster image: zoom magnifies it, Draw hands off
 // to the Annotator to paint on it. A video has neither — it plays inline with a
 // scrub bar instead — so the viewer hides those controls for video (PRD #511,
-// user story 33). The decision is `photos.media_type` and nothing more, kept
-// here free of React/DOM so the photo-vs-video rule lives in one tested place.
+// user story 33). The photo-vs-video decision is `photos.media_type` and
+// nothing more. The `source` is the URL the viewer loads — the <img> src for a
+// still, the <video> src for a clip — resolved through photoUrl so URL-building
+// stays in its one place (ADR 0008). Kept free of React/DOM so the rule lives
+// in one tested place.
 
 import type { Photo } from "@/lib/types";
+import { photoUrl, type PhotoUrlSource } from "./photo-url";
 
 export interface MediaCapabilities {
   /** Pinch / scroll / pan / double-tap magnification applies. */
@@ -15,10 +20,20 @@ export interface MediaCapabilities {
   canDraw: boolean;
   /** This Photo is a video (plays inline) rather than a still image. */
   isVideo: boolean;
+  /** The URL the media element loads: <img> src for a still, <video> src for a clip. */
+  source: string;
 }
 
-/** Which viewer capabilities apply to `photo`, off its `media_type`. */
-export function mediaCapabilities(photo: Pick<Photo, "media_type">): MediaCapabilities {
+/** Which viewer capabilities apply to `photo`, and the URL its media loads. */
+export function mediaCapabilities(
+  photo: Pick<Photo, "media_type"> & PhotoUrlSource,
+  supabaseUrl: string,
+): MediaCapabilities {
   const isVideo = photo.media_type === "video";
-  return { canZoom: !isVideo, canDraw: !isVideo, isVideo };
+  return {
+    canZoom: !isVideo,
+    canDraw: !isVideo,
+    isVideo,
+    source: photoUrl(photo, supabaseUrl, "full"),
+  };
 }


### PR DESCRIPTION
## What & why

Implements #517 (Photo viewer 7) — videos in the full-screen viewer.

A video Photo now **plays inline with a scrub bar** (`<video controls playsInline>`) instead of being forced through the still-image `<img>`. **Draw and Zoom stay hidden for video** (they don't apply to a clip). Tags, Before/After, Download, Delete and prev/next are media-agnostic, so they keep working for video.

The pure **media-capabilities** rule is extended to also supply the media `source` — the URL the element loads (the `<img>` src for a still, the `<video>` src for a clip) — resolved through `photoUrl` so URL-building stays in its one place (**ADR 0008**). The viewer branches the media element on `caps.isVideo` and uses `caps.source` uniformly (the old `displayUrl` alias is gone).

## Changes
- `src/lib/jobs/photo-media-capabilities.ts` — add `source` to `MediaCapabilities`; signature gains `supabaseUrl`. Still reports `isVideo` / `canZoom` / `canDraw`.
- `src/components/photo-viewer.tsx` — render `<video controls>` for video, `<img>` for stills; single uniform source.
- Tests — media-capabilities `source` units; viewer inline-`<video>` playback, `<img>` replacement, prev/next across a video; retargeted the existing *"ignores a pinch on a video"* test to the `<video>` element.

## Test plan / evidence
- `vitest run` on both changed files: **52 passed** (media-capabilities 3, photo-viewer 49).
- `tsc --noEmit`: **exit 0**.
- `eslint` on changed files: **0 errors** (2 pre-existing warnings: still-`<img>` LCP hint, unchanged seed-effect dep).
- Verified changed files in isolation, not the full suite, per the known worker-sharding flakiness.

## Scope note (please confirm)
The issue's action-parity criterion also lists **Share, Duplicate, Save to device**. Those actions **do not exist in the viewer yet** (the More-menu comment marks them as later slices) — nothing gates them on `media_type`, so video will inherit them when they land. I treated that bullet as forward-looking video parity, not in-scope build work for #517. If you'd rather split that into its own issue or keep #517 open until those exist, say the word.

Closes #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)