### PR TITLE
feat(phone): outbound bridge calling — Layer 1 (#314)

### DIFF
--- a/src/app/api/phone/calls/route.test.ts
+++ b/src/app/api/phone/calls/route.test.ts
@@ -1,0 +1,686 @@
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — outbound bridge call.
+//
+// Tests for the outbound bridge-call route. AC bullets covered:
+//   - "A Crew Lead clicks Call; Twilio rings THEIR OWN cell (from
+//      user_profiles.phone); on answer, bridges them to the customer with
+//      callerId = a Nookleus-owned number (never the crew lead's real cell)."
+//   - "phone_calls row with direction='out', initiated_by_user_id set, status
+//      tracking the Twilio state machine."
+//   - "Opt-out refused before any Twilio call."
+//   - "Refuse if the caller's profile has no cell."
+//   - "Refuse any `from` that is not an active Nookleus-owned org number."
+//   - "Job-page call auto-tags to that Job; Phone-tab / Contact-card calls
+//      untagged."
+//   - "Vitest route test: signature(view_phone gate), opt-out gate,
+//      profile-cell gate, owned-number gate, Twilio dispatch (mocked)."
+//
+// Route shape:
+//   POST /api/phone/calls
+//   body: {
+//     conversationId?: string,         // existing thread
+//     outsideE164?: string,            // first contact in a new thread
+//     sourceContext?: 'phone-tab' | 'contact' | 'contact-card'
+//                     | { kind: 'job', jobId }
+//   }
+//
+// view_phone gate; Twilio is mocked at the module boundary. The pure modules
+// (select-outbound-number, smart-attach) run for real. Unlike the SMS route
+// there is NO A2P feature-flag gate — voice has no 10DLC dependency, so the
+// route is live wherever view_phone is granted.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+const placeBridgeCallMock = vi.fn();
+const buildBridgeTwimlMock = vi.fn();
+const createTwilioClientMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  placeBridgeCall: (...args: unknown[]) => placeBridgeCallMock(...args),
+  buildBridgeTwiml: (...args: unknown[]) => buildBridgeTwimlMock(...args),
+  createTwilioClient: () => createTwilioClientMock(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+type Row = Record<string, unknown>;
+
+// A small Supabase service-client fake that records every insert / upsert /
+// update so tests can assert on them. Mirrors the fake in the SMS-send route
+// test; only the surface the route touches is implemented.
+function makeServiceClient(seed: Record<string, Row[]>) {
+  const tables: Record<string, Row[]> = {
+    phone_numbers: [],
+    phone_opt_outs: [],
+    phone_conversations: [],
+    phone_calls: [],
+    user_profiles: [],
+    jobs: [],
+    ...seed,
+  };
+  const inserts: { table: string; row: Row }[] = [];
+  const upserts: { table: string; row: Row; onConflict?: string }[] = [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    let rows = tables[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.order = () => b;
+    b.limit = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.in = (col: string, vals: unknown[]) => {
+      rows = rows.filter((r) => vals.includes(r[col] as unknown));
+      return b;
+    };
+    b.is = (col: string, val: unknown) => {
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opts?: { onConflict?: string }) => {
+      pendingInsert = row;
+      upserts.push({ table, row, onConflict: opts?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.single = async () => {
+      if (pendingInsert) {
+        const row: Row = {
+          id: `new-${inserts.length + upserts.length}`,
+          ...pendingInsert,
+        };
+        tables[table].push(row);
+        return { data: row, error: null };
+      }
+      return {
+        data: rows[0] ?? null,
+        error: rows[0] ? null : { message: "no rows" },
+      };
+    };
+    b.then = (resolve: (v: { data: Row[]; error: null }) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({
+          table,
+          patch: pendingUpdate,
+          filters: { ...ctx.filters },
+        });
+        return resolve({ data: [], error: null });
+      }
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  return { client: { from: builder }, tables, inserts, upserts, updates };
+}
+
+function authed(userId: string, role: "admin" | "crew_lead" | "crew_member") {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: userId },
+      tables: memberTables({
+        userId,
+        role,
+        grants: role === "crew_member" ? [] : ["view_phone"],
+      }),
+    }) as never,
+  );
+}
+
+function sendReq(body: Record<string, unknown>) {
+  return new Request("http://test/api/phone/calls", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+const noParams = { params: Promise.resolve({}) };
+
+const ORG = "org-1";
+const SHARED_NUM_ROW = {
+  id: "num-shared",
+  organization_id: ORG,
+  twilio_sid: "PNshared",
+  e164: "+15125550000",
+  kind: "shared",
+  user_id: null,
+  released_at: null,
+  is_active: true,
+  created_at: "2026-01-01T00:00:00Z",
+};
+const CREW_PROFILE = { id: "user-1", phone: "+15129990000" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue(ORG);
+  createTwilioClientMock.mockReturnValue({});
+  buildBridgeTwimlMock.mockReturnValue("<BRIDGE_TWIML>");
+  placeBridgeCallMock.mockResolvedValue({ sid: "CA-out", status: "queued" });
+  vi.stubEnv(
+    "PHONE_VOICE_STATUS_CALLBACK_URL",
+    "https://example.com/api/phone/webhook/voice-status",
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// 1. Tracer — the headline AC: ring the crew lead's cell, bridge to the
+//    customer with the Nookleus number, write the phone_calls row.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — bridge dispatch", () => {
+  it("rings the crew lead's own cell FROM the Nookleus number, bridges to the customer, and writes a direction:'out' phone_calls row", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+
+    // The bridge TwiML presents the Nookleus number to the customer — never
+    // the crew lead's real cell. This is the caller-ID-spoofing safety.
+    expect(buildBridgeTwimlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerE164: "+15551234567",
+        callerId: "+15125550000",
+      }),
+    );
+
+    // Twilio rings the crew lead's OWN cell, from the Nookleus number,
+    // executing the inline bridge twiml on answer.
+    expect(placeBridgeCallMock).toHaveBeenCalledTimes(1);
+    expect(placeBridgeCallMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        from: "+15125550000",
+        to: "+15129990000",
+        twiml: "<BRIDGE_TWIML>",
+        statusCallback: "https://example.com/api/phone/webhook/voice-status",
+      }),
+    );
+
+    // The phone_calls row records the LOGICAL call (Nookleus → customer); the
+    // crew lead's cell is a bridge detail and never appears on the row.
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert?.row).toMatchObject({
+      organization_id: ORG,
+      direction: "out",
+      from_e164: "+15125550000",
+      to_e164: "+15551234567",
+      twilio_call_sid: "CA-out",
+      status: "queued",
+      initiated_by_user_id: "user-1",
+    });
+
+    // The 201 echoes the SID + status so the client can render the in-flight row.
+    const body = await res.json();
+    expect(body).toMatchObject({
+      twilio_call_sid: "CA-out",
+      status: "queued",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Opt-out gate — refused BEFORE any Twilio call (TCPA).
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — opt-out gate", () => {
+  it("refuses with 403 and never calls Twilio when the customer has opted out", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_opt_outs: [
+        {
+          id: "opt-1",
+          organization_id: ORG,
+          outside_e164: "+15551234567",
+          re_opted_in_at: null,
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+
+  it("places the call when an earlier opt-out has been re-opted-in (re_opted_in_at set)", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_opt_outs: [
+        {
+          id: "opt-1",
+          organization_id: ORG,
+          outside_e164: "+15551234567",
+          re_opted_in_at: "2026-02-01T00:00:00Z",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(placeBridgeCallMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Profile-cell gate — refuse if the caller has no cell to ring.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — profile-cell gate", () => {
+  it("refuses with 422 and never calls Twilio when the caller's profile phone is null", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [{ id: "user-1", phone: null }],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+
+  it("refuses with 422 when the caller has no user_profiles row at all", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Owned-number gate — refuse any `from` that is not an active org number.
+//    The pure rule can only return a number the org owns; with none, 422.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — owned-number gate", () => {
+  it("refuses with 422 and never calls Twilio when the org owns no active number", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+
+  it("ignores a released number from another org and refuses 422 (cross-org / inactive cannot be selected)", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [
+        // Released → not selectable.
+        { ...SHARED_NUM_ROW, id: "num-released", released_at: "2026-01-02T00:00:00Z" },
+        // Other org → not selectable.
+        { ...SHARED_NUM_ROW, id: "num-other-org", organization_id: "org-2" },
+      ],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. view_phone gate (the wrapper) — a crew_member without the grant is 403.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — view_phone gate", () => {
+  it("returns 403 for a member without view_phone and never reaches Twilio", async () => {
+    authed("user-2", "crew_member"); // memberTables grants [] for crew_member
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(401);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Body validation.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — body validation", () => {
+  it("returns 400 when neither conversationId nor outsideE164 is given", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(sendReq({ sourceContext: "phone-tab" }), noParams);
+
+    expect(res.status).toBe(400);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when outsideE164 is not a valid phone number", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "not-a-phone", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(400);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. conversationId path — call into an existing thread.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — existing conversation", () => {
+  it("uses the conversation's outside_e164 and writes the row under that conversation", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_conversations: [
+        {
+          id: "conv-1",
+          organization_id: ORG,
+          phone_number_id: "num-shared",
+          outside_e164: "+15557654321",
+          contact_id: null,
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ conversationId: "conv-1", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(buildBridgeTwimlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ customerE164: "+15557654321" }),
+    );
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert?.row).toMatchObject({
+      conversation_id: "conv-1",
+      to_e164: "+15557654321",
+      direction: "out",
+    });
+  });
+
+  it("returns 404 for a conversation in another org (cross-org guard)", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_conversations: [
+        {
+          id: "conv-x",
+          organization_id: "org-2",
+          phone_number_id: "num-shared",
+          outside_e164: "+15557654321",
+          contact_id: null,
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ conversationId: "conv-x", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(404);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Smart-attach — Job-page Call auto-tags; ambiguous phone-tab stays
+//    untagged on the row (the chips are offered via the echoed smartAttach).
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — smart-attach", () => {
+  it("auto-tags a Job-page call to that Job (sourceContext { kind: 'job' })", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        sourceContext: { kind: "job", jobId: "job-77" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert?.row).toMatchObject({ job_tag: "job-77" });
+    const body = await res.json();
+    expect(body.smartAttach).toMatchObject({ kind: "auto", jobId: "job-77" });
+  });
+
+  it("auto-tags a Contact-card call when the contact has exactly one Active job", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_conversations: [
+        {
+          id: "conv-2",
+          organization_id: ORG,
+          phone_number_id: "num-shared",
+          outside_e164: "+15550001111",
+          contact_id: "contact-9",
+        },
+      ],
+      jobs: [
+        {
+          id: "job-5",
+          organization_id: ORG,
+          contact_id: "contact-9",
+          job_number: "JOB-005",
+          status: "in_progress",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ conversationId: "conv-2", sourceContext: "contact-card" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert?.row).toMatchObject({ job_tag: "job-5" });
+  });
+
+  it("leaves the row untagged and offers chips when the contact has 2+ Active jobs", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      phone_conversations: [
+        {
+          id: "conv-3",
+          organization_id: ORG,
+          phone_number_id: "num-shared",
+          outside_e164: "+15550002222",
+          contact_id: "contact-7",
+        },
+      ],
+      jobs: [
+        {
+          id: "job-a",
+          organization_id: ORG,
+          contact_id: "contact-7",
+          job_number: "JOB-00A",
+          status: "in_progress",
+        },
+        {
+          id: "job-b",
+          organization_id: ORG,
+          contact_id: "contact-7",
+          job_number: "JOB-00B",
+          status: "new",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ conversationId: "conv-3", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const callInsert = inserts.find((i) => i.table === "phone_calls");
+    expect(callInsert?.row).toMatchObject({ job_tag: null });
+    const body = await res.json();
+    expect(body.smartAttach.kind).toBe("prompt");
+    expect(body.smartAttach.candidates).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. Twilio failure — 502, and NO phone_calls row is written (we never claim
+//    a dispatch that didn't happen).
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — Twilio failure", () => {
+  it("returns 502 and writes no phone_calls row when placeBridgeCall throws", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+    placeBridgeCallMock.mockRejectedValueOnce(new Error("21215 unreachable"));
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(502);
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+});

--- a/src/app/api/phone/calls/route.ts
+++ b/src/app/api/phone/calls/route.ts
@@ -1,0 +1,341 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import {
+  buildBridgeTwiml,
+  createTwilioClient,
+  placeBridgeCall,
+} from "@/lib/phone/twilio-client";
+import { normalizePhoneToE164 } from "@/lib/phone";
+import {
+  selectOutboundNumber,
+  type SelectableNumber,
+} from "@/lib/phone/select-outbound-number";
+import {
+  decideJobTag,
+  type ActiveJob,
+  type SmartAttachSource,
+} from "@/lib/phone/smart-attach";
+
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — outbound bridge call.
+//
+// A Crew Lead clicks Call. Twilio rings THEIR OWN cell (the number on
+// `user_profiles.phone`); on answer Twilio executes the inline bridge TwiML
+// — `<Dial callerId="<Nookleus number>"><Number><customer></Number></Dial>`
+// — so the customer's phone shows the Nookleus number, never the crew
+// lead's real cell. The bridge is the caller-ID-spoofing safety: the cell
+// is a routing detail that never leaves this server and never lands on the
+// `phone_calls` row.
+//
+// Unlike the SMS route there is NO A2P 10DLC feature-flag gate — voice
+// carries no 10DLC dependency, so the route is live wherever view_phone is
+// granted. The gates, in order (cheapest refusal first, Twilio last):
+//   1. view_phone (the wrapper) — admins pass by role.
+//   2. Resolve the customer E.164 (existing conversation or first contact).
+//   3. Outbound-number rule — refuse if the org owns no active number to
+//      present as caller ID (owned-number safety; 422).
+//   4. Profile-cell gate — refuse if the caller has no cell to ring (422).
+//   5. TCPA opt-out — refuse before any Twilio call (403).
+//   6. Twilio dispatch BEFORE the DB write — we never want a phone_calls
+//      row claiming a dispatch that didn't happen (502 on Twilio error).
+//   7. Insert the phone_calls row (direction='out', initiated_by_user_id).
+//
+// The Twilio call lifecycle is tracked by the existing voice-status webhook
+// keyed on CallSid — generic over inbound/outbound, so the outbound row is
+// advanced through the state machine with no new webhook.
+
+interface Body {
+  conversationId?: unknown;
+  outsideE164?: unknown;
+  // Valid sources: 'phone-tab' / 'contact' / 'contact-card' (untagged) and
+  // `{ kind: 'job', jobId }` (Job-page Call, auto-tagged to that Job).
+  sourceContext?: unknown;
+}
+
+const E164_RE = /^\+[1-9]\d{6,14}$/;
+
+function parseSourceContext(input: unknown): SmartAttachSource {
+  if (typeof input === "string") {
+    if (input === "phone-tab") return { kind: "phone-tab" };
+    if (input === "contact" || input === "contact-card") {
+      return { kind: "contact-card" };
+    }
+    if (input === "inbound") return { kind: "inbound" };
+    return { kind: "phone-tab" };
+  }
+  if (input && typeof input === "object" && "kind" in input) {
+    const kind = (input as { kind?: unknown }).kind;
+    if (kind === "phone-tab" || kind === "contact-card" || kind === "inbound") {
+      return { kind };
+    }
+    if (kind === "contact") return { kind: "contact-card" };
+    if (kind === "job") {
+      const jobId = (input as { jobId?: unknown }).jobId;
+      if (typeof jobId === "string") {
+        return { kind: "job", jobId };
+      }
+    }
+  }
+  return { kind: "phone-tab" };
+}
+
+export const POST = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as Body | null;
+    if (!body) {
+      return NextResponse.json({ error: "body is required" }, { status: 400 });
+    }
+
+    const hasConv = typeof body.conversationId === "string";
+    const hasOutside = typeof body.outsideE164 === "string";
+    if (!hasConv && !hasOutside) {
+      return NextResponse.json(
+        { error: "conversationId or outsideE164 is required" },
+        { status: 400 },
+      );
+    }
+
+    // Resolve the customer E.164 — the far end of the bridge.
+    let outsideE164: string | null = null;
+    let existingConversationId: string | null = null;
+
+    if (hasConv) {
+      existingConversationId = body.conversationId as string;
+      const { data: conv } = await ctx.serviceClient!
+        .from("phone_conversations")
+        .select("id, organization_id, phone_number_id, outside_e164, contact_id")
+        .eq("id", existingConversationId)
+        .maybeSingle<{
+          id: string;
+          organization_id: string;
+          phone_number_id: string;
+          outside_e164: string;
+          contact_id: string | null;
+        }>();
+      if (!conv || conv.organization_id !== ctx.orgId) {
+        return NextResponse.json(
+          { error: "Conversation not found" },
+          { status: 404 },
+        );
+      }
+      outsideE164 = conv.outside_e164;
+    } else {
+      const raw = body.outsideE164 as string;
+      const normalized = normalizePhoneToE164(raw);
+      if (!normalized || !E164_RE.test(normalized)) {
+        return NextResponse.json(
+          { error: "outsideE164 is not a valid phone number" },
+          { status: 400 },
+        );
+      }
+      outsideE164 = normalized;
+    }
+
+    // Outbound-number selection — the caller ID the customer sees. Read every
+    // active number in the org and hand them all to the pure rule. The rule
+    // only ever returns a number the org actually owns and that is active and
+    // un-released, so this is the owned-number safety: a `from` that is not a
+    // live Nookleus org number can never be selected.
+    const { data: orgNumberRows } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .select(
+        "id, organization_id, twilio_sid, e164, kind, user_id, released_at, is_active, created_at",
+      )
+      .eq("organization_id", ctx.orgId);
+    const orgNumbers = (orgNumberRows ?? []) as Array<
+      SelectableNumber & { twilio_sid: string }
+    >;
+
+    const selected = selectOutboundNumber({
+      callerUserId: ctx.userId,
+      organizationId: ctx.orgId ?? "",
+      orgNumbers,
+    });
+    if (selected.kind === "none") {
+      return NextResponse.json(
+        {
+          error:
+            "No active phone number in this organization to call from. Provision one in Settings → Phone.",
+        },
+        { status: 422 },
+      );
+    }
+    const fromNumber = selected.number as SelectableNumber & {
+      twilio_sid: string;
+    };
+
+    // Profile-cell gate. The bridge rings the caller's own cell first; with
+    // no cell on file there is nothing to ring, so refuse before Twilio.
+    const { data: profile } = await ctx.serviceClient!
+      .from("user_profiles")
+      .select("phone")
+      .eq("id", ctx.userId)
+      .maybeSingle<{ phone: string | null }>();
+    const crewCell = profile?.phone ? normalizePhoneToE164(profile.phone) : null;
+    if (!crewCell || !E164_RE.test(crewCell)) {
+      return NextResponse.json(
+        {
+          error:
+            "Add a mobile number to your profile before placing a call — it is the phone we ring first.",
+        },
+        { status: 422 },
+      );
+    }
+
+    // Opt-out check. Org-scoped. The customer is opted out if any row exists
+    // with re_opted_in_at IS NULL. Refuse before Twilio is ever called.
+    const { data: optOuts } = await ctx.serviceClient!
+      .from("phone_opt_outs")
+      .select("id, re_opted_in_at")
+      .eq("organization_id", ctx.orgId)
+      .eq("outside_e164", outsideE164)
+      .is("re_opted_in_at", null);
+    if (optOuts && optOuts.length > 0) {
+      return NextResponse.json(
+        {
+          error:
+            "This number has opted out (TCPA). An admin can re-opt-in via Settings → Phone.",
+        },
+        { status: 403 },
+      );
+    }
+
+    // Resolve the conversation_id we'll write under — upsert by
+    // (phone_number_id, outside_e164), the natural key from migration-308.
+    let conversationId: string;
+    if (existingConversationId) {
+      conversationId = existingConversationId;
+    } else {
+      const now = new Date().toISOString();
+      const { data: convRow } = await ctx.serviceClient!
+        .from("phone_conversations")
+        .upsert(
+          {
+            organization_id: ctx.orgId,
+            phone_number_id: fromNumber.id,
+            outside_e164: outsideE164,
+            last_event_at: now,
+          },
+          { onConflict: "phone_number_id,outside_e164" },
+        )
+        .select("id")
+        .single<{ id: string }>();
+      if (!convRow) {
+        return NextResponse.json(
+          { error: "Failed to create conversation" },
+          { status: 500 },
+        );
+      }
+      conversationId = convRow.id;
+    }
+
+    // Smart-attach. A Job-page Call auto-tags to that Job; Phone-tab /
+    // Contact-card calls are untagged. The rule is given the conversation's
+    // contact + their Active jobs for the non-Job sources.
+    const source = parseSourceContext(body.sourceContext);
+    let activeJobs: ActiveJob[] = [];
+    let contactId: string | null = null;
+    if (source.kind === "phone-tab" || source.kind === "contact-card") {
+      const { data: convForTag } = await ctx.serviceClient!
+        .from("phone_conversations")
+        .select("contact_id")
+        .eq("id", conversationId)
+        .maybeSingle<{ contact_id: string | null }>();
+      contactId = convForTag?.contact_id ?? null;
+      if (contactId) {
+        const { data: jobRows } = await ctx.serviceClient!
+          .from("jobs")
+          .select("id, job_number, status")
+          .eq("organization_id", ctx.orgId)
+          .eq("contact_id", contactId);
+        const ACTIVE = new Set(["new", "in_progress", "pending_invoice"]);
+        activeJobs = (jobRows ?? [])
+          .filter((j: { status: string }) => ACTIVE.has(j.status))
+          .map((j: { id: string; job_number: string }) => ({
+            id: j.id,
+            label: j.job_number,
+          }));
+      }
+    }
+    const smartAttach = decideJobTag({
+      direction: "out",
+      sourceContext: source,
+      contactId,
+      activeJobs,
+    });
+    const jobTag = smartAttach.kind === "auto" ? smartAttach.jobId : null;
+
+    // Dispatch via Twilio. The inline bridge TwiML presents the Nookleus
+    // number to the customer; `placeBridgeCall` rings the crew lead's cell
+    // (`to`) FROM the Nookleus number (`from`) and runs the TwiML on answer.
+    const twiml = buildBridgeTwiml({
+      customerE164: outsideE164,
+      callerId: fromNumber.e164,
+    });
+    const statusCallback =
+      process.env.PHONE_VOICE_STATUS_CALLBACK_URL || undefined;
+    let dispatch: { sid: string; status: string };
+    try {
+      dispatch = await placeBridgeCall(createTwilioClient(), {
+        from: fromNumber.e164,
+        to: crewCell,
+        twiml,
+        ...(statusCallback ? { statusCallback } : {}),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Twilio error";
+      return NextResponse.json(
+        { error: `Twilio: ${message}` },
+        { status: 502 },
+      );
+    }
+
+    // Persist the call row. The crew lead's cell is a bridge detail and
+    // never appears here — the row records the LOGICAL call Nookleus →
+    // customer.
+    const now = new Date().toISOString();
+    const { data: callRow, error: callError } = await ctx.serviceClient!
+      .from("phone_calls")
+      .insert({
+        organization_id: ctx.orgId,
+        conversation_id: conversationId,
+        direction: "out",
+        from_e164: fromNumber.e164,
+        to_e164: outsideE164,
+        twilio_call_sid: dispatch.sid,
+        status: dispatch.status,
+        job_tag: jobTag,
+        tagged_by_user_id: null,
+        initiated_by_user_id: ctx.userId,
+        started_at: now,
+      })
+      .select("id")
+      .single<{ id: string }>();
+    if (callError || !callRow) {
+      return NextResponse.json(
+        {
+          error:
+            "Twilio placed the call but the local row could not be saved.",
+        },
+        { status: 500 },
+      );
+    }
+
+    // Bump last_event_at on the conversation.
+    await ctx.serviceClient!
+      .from("phone_conversations")
+      .update({ last_event_at: now })
+      .eq("id", conversationId);
+
+    return NextResponse.json(
+      {
+        id: callRow.id,
+        conversationId,
+        twilio_call_sid: dispatch.sid,
+        status: dispatch.status,
+        smartAttach,
+      },
+      { status: 201 },
+    );
+  },
+);

--- a/src/app/api/phone/webhook/voice-status/route.test.ts
+++ b/src/app/api/phone/webhook/voice-status/route.test.ts
@@ -149,6 +149,70 @@ describe("POST /api/phone/webhook/voice-status — signature + guards", () => {
   });
 });
 
+// Slice 10 (#314) — the OUTBOUND bridge call reuses this webhook unchanged.
+// The route keys updates on `twilio_call_sid` and never inspects direction,
+// so an outbound (direction:'out') row is advanced through the same state
+// machine. These tests document that reuse — no new webhook ships for #314.
+describe("POST /api/phone/webhook/voice-status — outbound bridge call (#314)", () => {
+  it("advances a direction:'out' row from ringing to in_progress to completed by CallSid", async () => {
+    // ringing → in_progress (non-terminal)
+    {
+      const { client, updates } = makeServiceClient({
+        phone_calls: [
+          {
+            id: "call-out",
+            twilio_call_sid: "CA-out",
+            direction: "out",
+            status: "ringing",
+          },
+        ],
+      });
+      createServiceClientMock.mockReturnValue(client);
+
+      const res = await POST(
+        callbackForm({ CallSid: "CA-out", CallStatus: "in-progress" }),
+      );
+
+      expect(res.status).toBe(200);
+      const upd = updates.find((u) => u.table === "phone_calls");
+      expect(upd!.filters).toMatchObject({ twilio_call_sid: "CA-out" });
+      expect(upd!.patch).toMatchObject({ status: "in_progress" });
+      expect(upd!.patch.ended_at).toBeUndefined();
+    }
+
+    // in_progress → completed (terminal — duration + ended_at)
+    {
+      const { client, updates } = makeServiceClient({
+        phone_calls: [
+          {
+            id: "call-out",
+            twilio_call_sid: "CA-out",
+            direction: "out",
+            status: "in_progress",
+          },
+        ],
+      });
+      createServiceClientMock.mockReturnValue(client);
+
+      const res = await POST(
+        callbackForm({
+          CallSid: "CA-out",
+          CallStatus: "completed",
+          CallDuration: "73",
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const upd = updates.find((u) => u.table === "phone_calls");
+      expect(upd!.patch).toMatchObject({
+        status: "completed",
+        duration_seconds: 73,
+      });
+      expect(upd!.patch.ended_at).toBeTruthy();
+    }
+  });
+});
+
 describe("POST /api/phone/webhook/voice-status — Twilio status vocabulary mapping", () => {
   it("maps hyphenated 'in-progress' to 'in_progress' without stamping ended_at (non-terminal)", async () => {
     const { client, updates } = makeServiceClient({

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -6,6 +6,7 @@ import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
 import { Contact } from "@/lib/types";
 import { formatPhoneNumber, normalizePhoneToE164, phoneMatchesQuery } from "@/lib/phone";
 import { ClickToText } from "@/components/phone/click-to-text";
+import { ClickToCall } from "@/components/phone/click-to-call";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -373,6 +374,13 @@ export default function ContactsPage() {
                           e164={normalizePhoneToE164(contact.phone) ?? contact.phone}
                           className="text-[11px] text-[var(--brand-primary)] hover:underline"
                           label="Text"
+                        />
+                        {/* Slice 10 (#314) — Contact-card click-to-call.
+                            Untagged (re-tag after the fact); no A2P gate. */}
+                        <ClickToCall
+                          e164={normalizePhoneToE164(contact.phone) ?? contact.phone}
+                          sourceContext={{ kind: "contact" }}
+                          className="inline-flex items-center gap-1 text-[11px] text-[var(--brand-primary)] hover:underline disabled:opacity-50"
                         />
                       </span>
                     )}

--- a/src/app/phone/page.test.tsx
+++ b/src/app/phone/page.test.tsx
@@ -26,11 +26,21 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 // keeps `createClient()` from reading process.env at module-eval time.
 vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
-    channel: () => ({
-      on: () => ({ subscribe: () => ({ unsubscribe: () => undefined }) }),
-      subscribe: () => ({ unsubscribe: () => undefined }),
-      unsubscribe: () => undefined,
-    }),
+    // The realtime hook chains `.on()` once per subscription (phone_messages
+    // INSERT, plus phone_calls INSERT/UPDATE since slice 10), so `.on()` must
+    // return the channel itself to stay chainable.
+    channel: () => {
+      const ch: {
+        on: () => typeof ch;
+        subscribe: () => { unsubscribe: () => void };
+        unsubscribe: () => void;
+      } = {
+        on: () => ch,
+        subscribe: () => ({ unsubscribe: () => undefined }),
+        unsubscribe: () => undefined,
+      };
+      return ch;
+    },
   }),
 }));
 

--- a/src/app/phone/phone-page-client.calls.test.tsx
+++ b/src/app/phone/phone-page-client.calls.test.tsx
@@ -1,0 +1,298 @@
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — outbound bridge calling.
+//
+// The headline RTL integration test: a Crew Lead clicks **Call** in the
+// Phone-tab thread; an in-flight call row appears immediately (queued);
+// then the (mocked) status-callback fires a phone_calls UPDATE over
+// realtime and the row advances to "Completed". This is the
+// "Call button → in-flight row in thread → status updates to completed on
+// hangup" acceptance criterion.
+//
+// Unlike the SMS compose box, the Call button has NO A2P 10DLC feature-flag
+// gate — voice carries no 10DLC dependency, so Call surfaces wherever the
+// Phone tab (view_phone) does, flag on or off.
+//
+// `usePhoneSync` is mocked so the test can drive the realtime callbacks
+// directly (the same capture-the-input pattern the Job-page section test
+// uses); fetch is stubbed at the global boundary.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+} from "@testing-library/react";
+import type { UsePhoneSyncInput } from "@/lib/phone/use-phone-sync";
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    channel: () => ({
+      on: () => ({ subscribe: () => ({ unsubscribe: () => undefined }) }),
+      subscribe: () => ({ unsubscribe: () => undefined }),
+      unsubscribe: () => undefined,
+    }),
+  }),
+}));
+
+const searchParamsMock = vi.fn<() => URLSearchParams>();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock(),
+}));
+
+// Capture the latest usePhoneSync input so the test can fire onCallUpdate /
+// onNewCall as if the status-callback webhook had advanced the row.
+const sync: { input?: UsePhoneSyncInput } = {};
+vi.mock("@/lib/phone/use-phone-sync", () => ({
+  usePhoneSync: (input: UsePhoneSyncInput) => {
+    sync.input = input;
+  },
+}));
+
+import { PhonePageClient } from "./phone-page-client";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sync.input = undefined;
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch as never;
+  searchParamsMock.mockReturnValue(new URLSearchParams());
+  vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "true");
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+function convo(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "conv-1",
+    organization_id: "org-1",
+    phone_number_id: "pn-1",
+    outside_e164: "+15551234567",
+    contact_id: "c-1" as string | null,
+    contact_name: "Alice" as string | null,
+    last_event_at: "2026-05-27T10:00:00Z",
+    unread_count: 0,
+    active_jobs: [] as Array<{ id: string; label: string }>,
+    ...overrides,
+  };
+}
+
+// GET messages/calls empty; POST /api/phone/calls returns a queued row.
+function callRoutes(
+  postResult: { ok: boolean; status: number; body: unknown },
+) {
+  mockFetch.mockImplementation(
+    async (input: RequestInfo, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      if (path === "/api/phone/conversations/conv-1/messages") {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      if (path === "/api/phone/conversations/conv-1/calls") {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      if (path === "/api/phone/calls" && init?.method === "POST") {
+        return {
+          ok: postResult.ok,
+          status: postResult.status,
+          json: async () => postResult.body,
+        };
+      }
+      throw new Error(`unmocked fetch: ${path} ${init?.method ?? "GET"}`);
+    },
+  );
+}
+
+async function openThread() {
+  render(
+    <PhonePageClient
+      organizationId="org-1"
+      initialConversations={[convo({ id: "conv-1" })]}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+  await screen.findByPlaceholderText(/text message/i);
+}
+
+describe("PhonePageClient — outbound call lifecycle (#314)", () => {
+  it("clicking Call posts to /api/phone/calls, shows an in-flight row, then advances to Completed on the status-callback UPDATE", async () => {
+    callRoutes({
+      ok: true,
+      status: 201,
+      body: {
+        id: "call-out",
+        conversationId: "conv-1",
+        twilio_call_sid: "CA-1",
+        status: "queued",
+        smartAttach: { kind: "untagged" },
+      },
+    });
+
+    await openThread();
+
+    // The Call button is in the thread header.
+    fireEvent.click(screen.getByRole("button", { name: /^call$/i }));
+
+    // It posts to the bridge-call route from the open thread (phone-tab).
+    await waitFor(() => {
+      const post = mockFetch.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/api/phone/calls") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeDefined();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect(body).toMatchObject({
+        conversationId: "conv-1",
+        sourceContext: { kind: "phone-tab" },
+      });
+    });
+
+    // The in-flight outbound call row appears immediately, queued.
+    await screen.findByText(/outgoing call/i);
+    expect(screen.getByText("Queued")).toBeDefined();
+
+    // The (mocked) status-callback webhook advances the phone_calls row;
+    // the realtime UPDATE flips the in-flight row to Completed with a
+    // duration. usePhoneSync is mocked, so fire its onCallUpdate directly.
+    expect(sync.input?.onCallUpdate).toBeTypeOf("function");
+    act(() => {
+      sync.input!.onCallUpdate!({
+        id: "call-out",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "out",
+        status: "completed",
+        duration_seconds: 30,
+        started_at: "2026-05-27T10:00:00Z",
+        ended_at: "2026-05-27T10:00:30Z",
+      });
+    });
+
+    await waitFor(() => expect(screen.getByText("Completed")).toBeDefined());
+    // Duration now renders (0:30) and the queued label is gone.
+    expect(screen.getByText("0:30")).toBeDefined();
+    expect(screen.queryByText("Queued")).toBeNull();
+  });
+
+  it("does not duplicate the in-flight row when the realtime INSERT echo arrives before the POST resolves", async () => {
+    // The mirror of onNewCall's own guard: there the optimistic insert beats
+    // the echo; here the echo beats the optimistic insert. onCall's append
+    // must dedupe on id, or the same call shows twice until a refetch.
+    let resolvePost: (() => void) | undefined;
+    const postPending = new Promise<void>((r) => {
+      resolvePost = r;
+    });
+    mockFetch.mockImplementation(
+      async (input: RequestInfo, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : (input as Request).url;
+        const path = url.replace(/^https?:\/\/[^/]+/, "");
+        if (path === "/api/phone/conversations/conv-1/messages") {
+          return { ok: true, status: 200, json: async () => [] };
+        }
+        if (path === "/api/phone/conversations/conv-1/calls") {
+          return { ok: true, status: 200, json: async () => [] };
+        }
+        if (path === "/api/phone/calls" && init?.method === "POST") {
+          await postPending;
+          return {
+            ok: true,
+            status: 201,
+            json: async () => ({
+              id: "call-out",
+              conversationId: "conv-1",
+              twilio_call_sid: "CA-1",
+              status: "queued",
+              smartAttach: { kind: "untagged" },
+            }),
+          };
+        }
+        throw new Error(`unmocked fetch: ${path} ${init?.method ?? "GET"}`);
+      },
+    );
+
+    await openThread();
+    fireEvent.click(screen.getByRole("button", { name: /^call$/i }));
+
+    // Realtime INSERT echo for our own outbound row lands while the POST is
+    // still in flight — it appends the row (its dedupe sees nothing yet).
+    expect(sync.input?.onNewCall).toBeTypeOf("function");
+    act(() => {
+      sync.input!.onNewCall!({
+        id: "call-out",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "out",
+        status: "queued",
+        duration_seconds: null,
+        started_at: "2026-05-27T10:00:00Z",
+        ended_at: null,
+      });
+    });
+    await screen.findByText(/outgoing call/i);
+
+    // Now the POST resolves; onCall's optimistic insert must see the echoed
+    // row and dedupe rather than appending a second copy.
+    await act(async () => {
+      resolvePost!();
+      await postPending;
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByText(/outgoing call/i)).toHaveLength(1),
+    );
+  });
+
+  it("surfaces the profile-cell error (422) and places no in-flight row when the caller has no cell", async () => {
+    callRoutes({
+      ok: false,
+      status: 422,
+      body: {
+        error:
+          "Add a mobile number to your profile before placing a call — it is the phone we ring first.",
+      },
+    });
+
+    await openThread();
+    fireEvent.click(screen.getByRole("button", { name: /^call$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/add a mobile number to your profile/i)).toBeDefined(),
+    );
+    // No call row was added.
+    expect(screen.queryByText(/outgoing call/i)).toBeNull();
+  });
+
+  it("shows the Call button even when outbound SMS is flag-gated off (voice has no A2P dependency)", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "");
+    mockFetch.mockImplementation(async (input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      if (path === "/api/phone/conversations/conv-1/messages") {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      if (path === "/api/phone/conversations/conv-1/calls") {
+        return { ok: true, status: 200, json: async () => [] };
+      }
+      throw new Error(`unmocked fetch: ${path}`);
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[convo({ id: "conv-1" })]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    // Compose box is hidden (SMS gated)…
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(/text message/i)).toBeNull(),
+    );
+    // …but the Call button is present.
+    expect(screen.getByRole("button", { name: /^call$/i })).toBeDefined();
+  });
+});

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -18,11 +18,21 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
-    channel: () => ({
-      on: () => ({ subscribe: () => ({ unsubscribe: () => undefined }) }),
-      subscribe: () => ({ unsubscribe: () => undefined }),
-      unsubscribe: () => undefined,
-    }),
+    // The realtime hook chains `.on()` once per subscription (phone_messages
+    // INSERT, plus phone_calls INSERT/UPDATE since slice 10), so `.on()` must
+    // return the channel itself to stay chainable.
+    channel: () => {
+      const ch: {
+        on: () => typeof ch;
+        subscribe: () => { unsubscribe: () => void };
+        unsubscribe: () => void;
+      } = {
+        on: () => ch,
+        subscribe: () => ({ unsubscribe: () => undefined }),
+        unsubscribe: () => undefined,
+      };
+      return ch;
+    },
   }),
 }));
 

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -126,6 +126,9 @@ export function PhonePageClient({
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
+  // Slice 10 (#314) — outbound bridge call in flight + its error, if any.
+  const [calling, setCalling] = useState(false);
+  const [callError, setCallError] = useState<string | null>(null);
   const [retagMenuFor, setRetagMenuFor] = useState<string | null>(null);
   // Slice 6 (#310) — staged MMS attachments + the file input ref the
   // paperclip button hands clicks to.
@@ -432,6 +435,73 @@ export function PhonePageClient({
     }
   }, [selected, draft, readyAttachments, anyUploading, attachments]);
 
+  // Slice 10 (#314) — place an outbound bridge call from the open thread.
+  // Twilio rings the Crew Lead's own cell (resolved server-side from their
+  // profile) and bridges to the customer with the Nookleus number as caller
+  // ID. The route returns the queued phone_calls row; we insert it
+  // optimistically as the in-flight indicator, and the status-callback
+  // webhook advances it live via the phone_calls realtime UPDATE below.
+  //
+  // No A2P 10DLC gate — voice has no 10DLC dependency, so Call is available
+  // wherever the Phone tab (view_phone) is, regardless of the SMS flag.
+  const onCall = useCallback(async () => {
+    if (!selected || calling) return;
+    setCalling(true);
+    setCallError(null);
+    try {
+      const res = await fetch("/api/phone/calls", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          conversationId: selected.id,
+          sourceContext: { kind: "phone-tab" },
+        }),
+      });
+      if (!res.ok) {
+        const errBody = (await res.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        setCallError(errBody.error ?? `Call failed (${res.status})`);
+        return;
+      }
+      const created = (await res.json()) as {
+        id: string;
+        conversationId: string;
+        twilio_call_sid: string;
+        status: string;
+      };
+      const now = new Date().toISOString();
+      // Dedupe: the realtime INSERT echo for this same row may have beaten
+      // this optimistic insert (the mirror of onNewCall's own guard). Append
+      // only if it isn't already present, or the call shows twice.
+      setCalls((prev) =>
+        prev.some((c) => c.id === created.id)
+          ? prev
+          : [
+              ...prev,
+              {
+                id: created.id,
+                conversation_id: selected.id,
+                direction: "out",
+                status: created.status,
+                duration_seconds: null,
+                started_at: now,
+                ended_at: null,
+              },
+            ],
+      );
+      setConversations((prev) =>
+        sortConversations(
+          prev.map((c) =>
+            c.id === selected.id ? { ...c, last_event_at: now } : c,
+          ),
+        ),
+      );
+    } finally {
+      setCalling(false);
+    }
+  }, [selected, calling]);
+
   // Realtime: when a new inbound lands, reload the affected thread and
   // bump the conversation in the list. Slice 4's update is intentionally
   // coarse — a full thread re-fetch on each incoming message — because
@@ -459,6 +529,45 @@ export function PhonePageClient({
         );
         return sortConversations(next);
       });
+    },
+    // Slice 10 (#314) — a call placed elsewhere (or an inbound ring) for the
+    // open thread arrives as an INSERT; add it if not already present
+    // (our own optimistic insert may have beaten the realtime echo).
+    onNewCall: (row) => {
+      if (selectedId !== row.conversation_id) return;
+      setCalls((prev) =>
+        prev.some((c) => c.id === row.id)
+          ? prev
+          : [
+              ...prev,
+              {
+                id: row.id,
+                conversation_id: row.conversation_id,
+                direction: row.direction,
+                status: row.status,
+                duration_seconds: row.duration_seconds,
+                started_at: row.started_at,
+                ended_at: row.ended_at,
+              },
+            ],
+      );
+    },
+    // Slice 10 (#314) — the status-callback webhook stamps status /
+    // duration / ended_at; patch the in-flight row in place so it advances
+    // queued → ringing → in_progress → completed without a refetch.
+    onCallUpdate: (row) => {
+      setCalls((prev) =>
+        prev.map((c) =>
+          c.id === row.id
+            ? {
+                ...c,
+                status: row.status,
+                duration_seconds: row.duration_seconds,
+                ended_at: row.ended_at,
+              }
+            : c,
+        ),
+      );
     },
   });
 
@@ -664,16 +773,36 @@ export function PhonePageClient({
               <div className="font-medium text-foreground">
                 {conversationLabel(selected)}
               </div>
-              {selected.contact_id === null ? (
+              <div className="flex items-center gap-4">
+                {/* Slice 10 (#314) — Call. No A2P 10DLC gate (voice has no
+                    10DLC dependency); shown wherever the Phone tab is. */}
                 <button
                   type="button"
-                  onClick={onSaveAsContact}
-                  className="inline-flex items-center gap-2 text-sm font-medium text-[var(--brand-primary)] hover:underline"
+                  onClick={() => void onCall()}
+                  disabled={calling}
+                  className="inline-flex items-center gap-2 text-sm font-medium text-[var(--brand-primary)] hover:underline disabled:opacity-50"
                 >
-                  <UserPlus size={16} /> Save as Contact
+                  <PhoneIcon size={16} /> Call
                 </button>
-              ) : null}
+                {selected.contact_id === null ? (
+                  <button
+                    type="button"
+                    onClick={onSaveAsContact}
+                    className="inline-flex items-center gap-2 text-sm font-medium text-[var(--brand-primary)] hover:underline"
+                  >
+                    <UserPlus size={16} /> Save as Contact
+                  </button>
+                ) : null}
+              </div>
             </header>
+            {callError ? (
+              <p
+                role="alert"
+                className="border-b border-border px-4 py-2 text-sm text-red-600 dark:text-red-400"
+              >
+                {callError}
+              </p>
+            ) : null}
             <div className="flex-1 overflow-y-auto p-4 space-y-3">
               {loadingThread ? (
                 <p className="text-sm text-muted-foreground">Loading…</p>

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -8,6 +8,7 @@ import { Job, JobAdjuster, Contact, JobActivity, Payment, Invoice, Photo, PhotoT
 import { pickPreloadUrls } from "@/lib/jobs/photo-preload";
 import { partitionPhotoReportsByTrash } from "@/lib/photo-report-trash";
 import { formatPhoneNumber, normalizePhoneToE164 } from "@/lib/phone";
+import { ClickToCall } from "@/components/phone/click-to-call";
 import { parseDateOnly } from "@/lib/date-field";
 import { OFFICIAL_INVOICE_STATUSES } from "@/lib/invoice-status";
 import FinancialsTab from "@/components/job-detail/financials-tab";
@@ -706,6 +707,16 @@ export default function JobDetail({ jobId }: { jobId: string }) {
                 <p className="text-xs text-muted-foreground">
                   {[formatPhoneNumber(job.contact.phone || ""), job.contact.email].filter(Boolean).join(" \u00b7 ")}
                 </p>
+                {/* Slice 10 (#314) \u2014 Homeowner-card click-to-call. */}
+                {job.contact.phone && (
+                  <div className="mt-1.5">
+                    <ClickToCall
+                      e164={normalizePhoneToE164(job.contact.phone) ?? job.contact.phone}
+                      sourceContext={{ kind: "contact" }}
+                      className="inline-flex items-center gap-1 text-[11px] text-[var(--brand-primary)] hover:underline disabled:opacity-50"
+                    />
+                  </div>
+                )}
               </div>
             )}
 
@@ -1273,6 +1284,16 @@ function AdjusterCard({
       </div>
       <p className="text-xs text-muted-foreground">{[adj.title, adj.company].filter(Boolean).join(" \u00b7 ")}</p>
       <p className="text-xs text-muted-foreground mt-0.5">{[formatPhoneNumber(adj.phone || ""), adj.email].filter(Boolean).join(" \u00b7 ")}</p>
+      {/* Slice 10 (#314) \u2014 Adjuster-card click-to-call. */}
+      {adj.phone && (
+        <div className="mt-1">
+          <ClickToCall
+            e164={normalizePhoneToE164(adj.phone) ?? adj.phone}
+            sourceContext={{ kind: "contact" }}
+            className="inline-flex items-center gap-1 text-xs text-[var(--brand-primary)] hover:underline disabled:opacity-50"
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/job-detail/job-messages-section.test.tsx
+++ b/src/components/job-detail/job-messages-section.test.tsx
@@ -13,7 +13,13 @@
 // and fetch (the GET /api/phone/messages?jobId= read).
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
 
 const auth = vi.hoisted(() => ({
   value: {
@@ -238,6 +244,78 @@ describe("JobMessagesSection — Text button", () => {
 
     await screen.findByText("Messages (0)");
     expect(screen.queryByRole("button", { name: /^text$/i })).toBeNull();
+  });
+});
+
+// Slice 10 (#314) — Job-page Call button. Sits alongside Text, but is NOT
+// gated on the A2P 10DLC flag (voice has no 10DLC dependency). Opening it
+// and placing the call POSTs to /api/phone/calls with the Job smart-attach
+// source so the call auto-tags to this Job.
+describe("JobMessagesSection — Call button (#314)", () => {
+  it("shows the Call button even when outbound SMS is flag-disabled", async () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "");
+    asViewPhone();
+    stubMessages([]);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    // Text is hidden (SMS gated), Call is present (voice ungated).
+    expect(screen.queryByRole("button", { name: /^text$/i })).toBeNull();
+    expect(screen.getByRole("button", { name: /^call$/i })).toBeDefined();
+  });
+
+  it("Call → place posts to /api/phone/calls with the Job smart-attach source", async () => {
+    asViewPhone();
+    const spy = vi.fn(async (url: string, init?: RequestInit) => {
+      const method = init?.method ?? "GET";
+      if (url.startsWith("/api/phone/calls") && method === "POST") {
+        return new Response(
+          JSON.stringify({ id: "call-1", twilio_call_sid: "CA-1", status: "queued" }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <JobMessagesSection
+        jobId="job-1"
+        organizationId="org-1"
+        contacts={contacts}
+      />,
+    );
+
+    await screen.findByText("Messages (0)");
+    fireEvent.click(screen.getByRole("button", { name: /^call$/i }));
+    // The Call dialog opens with the contact; place the call from within it
+    // (the header also has a Call button, so scope to the dialog).
+    const dialog = screen.getByRole("dialog", { name: /call a contact/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^call$/i }));
+
+    await waitFor(() => {
+      const post = spy.mock.calls.find(
+        ([u, init]) =>
+          String(u).startsWith("/api/phone/calls") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeDefined();
+      const body = JSON.parse(String((post![1] as RequestInit).body));
+      expect(body).toMatchObject({
+        outsideE164: "+15125550001",
+        sourceContext: { kind: "job", jobId: "job-1" },
+      });
+    });
   });
 });
 

--- a/src/components/job-detail/job-messages-section.tsx
+++ b/src/components/job-detail/job-messages-section.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { MessageSquare, Send } from "lucide-react";
+import { MessageSquare, Phone, Send } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 import { createClient } from "@/lib/supabase";
 import { findContactByPhone, formatPhoneNumber } from "@/lib/phone";
@@ -9,6 +9,7 @@ import { isPhoneOutboundEnabled } from "@/lib/phone/feature-flags";
 import { usePhoneSync } from "@/lib/phone/use-phone-sync";
 import { JobMessageRow } from "@/components/phone/job-message-row";
 import { ComposeTextModal } from "@/components/phone/compose-text-modal";
+import { ComposeCallModal } from "@/components/phone/compose-call-modal";
 import type { PhoneAttachmentRef } from "@/components/phone/message-attachment";
 
 // PRD #304 — Nookleus Phone. Slice 7 (#311) — Job-page Messages (N) section.
@@ -49,12 +50,19 @@ export function JobMessagesSection({
   const canView = !loading && hasPermission("view_phone");
   const [messages, setMessages] = useState<JobMessage[]>([]);
   const [composeOpen, setComposeOpen] = useState(false);
+  // Slice 10 (#314) — Job-page Call compose.
+  const [callOpen, setCallOpen] = useState(false);
 
   // Only contacts with a phone number can be texted; the Text button is
   // hidden when there's no one to text or while outbound SMS is gated
   // (#305 A2P 10DLC).
   const textableContacts = contacts.filter((c) => c.phone);
   const canText = isPhoneOutboundEnabled() && textableContacts.length > 0;
+  // Slice 10 (#314) — calling has the same callable-contact requirement but
+  // NO A2P 10DLC gate (voice carries no 10DLC dependency), so the Call
+  // button shows for any view_phone user with a callable contact.
+  const callableContacts = textableContacts;
+  const canCall = callableContacts.length > 0;
 
   const fetchMessages = useCallback(async () => {
     const res = await fetch(
@@ -93,15 +101,26 @@ export function JobMessagesSection({
           <MessageSquare size={16} className="inline mr-2 -mt-0.5" />
           Messages ({messages.length})
         </h3>
-        {canText && (
-          <button
-            onClick={() => setComposeOpen(true)}
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-colors gap-1.5"
-          >
-            <Send size={14} />
-            Text
-          </button>
-        )}
+        <div className="flex items-center gap-2">
+          {canCall && (
+            <button
+              onClick={() => setCallOpen(true)}
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 border border-border bg-background text-foreground shadow-sm hover:bg-accent transition-colors gap-1.5"
+            >
+              <Phone size={14} />
+              Call
+            </button>
+          )}
+          {canText && (
+            <button
+              onClick={() => setComposeOpen(true)}
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 transition-colors gap-1.5"
+            >
+              <Send size={14} />
+              Text
+            </button>
+          )}
+        </div>
       </div>
       <ComposeTextModal
         open={composeOpen}
@@ -109,6 +128,12 @@ export function JobMessagesSection({
         jobId={jobId}
         contacts={textableContacts}
         onSent={fetchMessages}
+      />
+      <ComposeCallModal
+        open={callOpen}
+        onClose={() => setCallOpen(false)}
+        jobId={jobId}
+        contacts={callableContacts}
       />
       {messages.length > 0 && (
         <div className="space-y-2">

--- a/src/components/phone/click-to-call.test.tsx
+++ b/src/components/phone/click-to-call.test.tsx
@@ -1,0 +1,112 @@
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — generic click-to-call.
+//
+// `ClickToCall` is the one-line affordance any surface that renders a phone
+// number wires up to place an outbound bridge call. Clicking it POSTs to
+// /api/phone/calls (which rings the Crew Lead's own cell and bridges to the
+// customer); a short status line tells the user their phone is about to
+// ring. Unlike `ClickToText`, it is NOT gated on the A2P 10DLC flag — voice
+// carries no 10DLC dependency.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ClickToCall } from "./click-to-call";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch as never;
+  vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "true");
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("ClickToCall", () => {
+  it("renders nothing when there is no phone number", () => {
+    const { container } = render(<ClickToCall e164={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("posts to /api/phone/calls with the number + sourceContext and shows a ringing hint", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        id: "call-1",
+        twilio_call_sid: "CA-1",
+        status: "queued",
+      }),
+    });
+
+    render(
+      <ClickToCall
+        e164="+15551234567"
+        sourceContext={{ kind: "job", jobId: "job-9" }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /call/i }));
+
+    await waitFor(() => {
+      const post = mockFetch.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/api/phone/calls") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      );
+      expect(post).toBeDefined();
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect(body).toMatchObject({
+        outsideE164: "+15551234567",
+        sourceContext: { kind: "job", jobId: "job-9" },
+      });
+    });
+
+    // A status line confirms the user's own phone is about to ring.
+    await screen.findByText(/ring/i);
+  });
+
+  it("defaults sourceContext to a contact-card call when none is given", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ id: "c", twilio_call_sid: "CA", status: "queued" }),
+    });
+
+    render(<ClickToCall e164="+15551234567" />);
+    fireEvent.click(screen.getByRole("button", { name: /call/i }));
+
+    await waitFor(() => {
+      const post = mockFetch.mock.calls.find(
+        ([u, init]) =>
+          String(u).endsWith("/api/phone/calls") &&
+          (init as RequestInit | undefined)?.method === "POST",
+      );
+      const body = JSON.parse((post![1] as RequestInit).body as string);
+      expect(body.sourceContext).toEqual({ kind: "contact" });
+    });
+  });
+
+  it("surfaces the server error when the profile-cell gate refuses the call", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      json: async () => ({
+        error:
+          "Add a mobile number to your profile before placing a call — it is the phone we ring first.",
+      }),
+    });
+
+    render(<ClickToCall e164="+15551234567" />);
+    fireEvent.click(screen.getByRole("button", { name: /call/i }));
+
+    await screen.findByText(/add a mobile number to your profile/i);
+  });
+
+  it("renders even when the A2P 10DLC SMS flag is off (voice has no 10DLC dependency)", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED", "");
+    render(<ClickToCall e164="+15551234567" />);
+    expect(screen.getByRole("button", { name: /call/i })).toBeDefined();
+  });
+});

--- a/src/components/phone/click-to-call.tsx
+++ b/src/components/phone/click-to-call.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { Phone } from "lucide-react";
+
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — generic click-to-call.
+//
+// The one-line affordance any surface that renders a phone number wires up
+// to place an outbound bridge call. Clicking POSTs to /api/phone/calls —
+// the route rings the Crew Lead's own cell (from their profile) and bridges
+// to the customer, presenting the Nookleus number as caller ID. Because the
+// call rings the *user's* phone (not the page), the only visible feedback
+// here is a short status line; the actual conversation happens on their cell.
+//
+// Unlike `ClickToText`, this is NOT gated on the A2P 10DLC flag: voice
+// carries no 10DLC dependency, so Call is live wherever `view_phone` is.
+//
+// `sourceContext` drives smart-attach: pass `{ kind: 'job', jobId }` from a
+// Job surface to auto-tag the call to that Job; the default `{ kind:
+// 'contact' }` leaves it untagged (re-tag after the fact).
+
+interface ClickToCallProps {
+  e164: string | null | undefined;
+  // Smart-attach source. Defaults to a Contact-card call (untagged).
+  sourceContext?: unknown;
+  // Visible label. Defaults to "Call".
+  label?: string;
+  className?: string;
+}
+
+export function ClickToCall({
+  e164,
+  sourceContext = { kind: "contact" },
+  label = "Call",
+  className,
+}: ClickToCallProps) {
+  const [calling, setCalling] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!e164) return null;
+
+  async function place() {
+    if (calling) return;
+    setCalling(true);
+    setStatus(null);
+    setError(null);
+    try {
+      const res = await fetch("/api/phone/calls", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ outsideE164: e164, sourceContext }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        setError(body.error ?? `Call failed (${res.status})`);
+        return;
+      }
+      setStatus("Ringing your phone — answer to connect.");
+    } catch {
+      setError("Could not place the call. Please try again.");
+    } finally {
+      setCalling(false);
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => void place()}
+        disabled={calling}
+        className={
+          className ??
+          "inline-flex items-center gap-1 text-[var(--brand-primary)] hover:underline disabled:opacity-50"
+        }
+      >
+        <Phone size={12} aria-hidden /> {calling ? "Calling…" : label}
+      </button>
+      {status ? (
+        <span role="status" className="text-xs text-muted-foreground">
+          {status}
+        </span>
+      ) : null}
+      {error ? (
+        <span role="alert" className="text-xs text-red-600 dark:text-red-400">
+          {error}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/src/components/phone/compose-call-modal.test.tsx
+++ b/src/components/phone/compose-call-modal.test.tsx
@@ -1,0 +1,104 @@
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — Job-page Call compose.
+//
+// Opened by the Job-page Call button. Picks one of the Job's Contacts and
+// places an outbound bridge call with sourceContext { kind: 'job', jobId },
+// so smart-attach auto-tags the call to this Job — no chip prompt. There is
+// no message body; a call needs only a recipient.
+
+import { it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { ComposeCallModal } from "./compose-call-modal";
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch as never;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const contacts = [
+  { id: "c-1", name: "Alice Homeowner", phone: "+15551110000" },
+  { id: "c-2", name: "Bob Adjuster", phone: "+15552220000" },
+];
+
+it("renders nothing when closed", () => {
+  const { container } = render(
+    <ComposeCallModal
+      open={false}
+      onClose={() => {}}
+      jobId="job-9"
+      contacts={contacts}
+    />,
+  );
+  expect(container.firstChild).toBeNull();
+});
+
+it("places a Job-tagged call to the chosen contact and closes", async () => {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 201,
+    json: async () => ({ id: "call-1", twilio_call_sid: "CA-1", status: "queued" }),
+  });
+  const onClose = vi.fn();
+  const onPlaced = vi.fn();
+
+  render(
+    <ComposeCallModal
+      open
+      onClose={onClose}
+      onPlaced={onPlaced}
+      jobId="job-9"
+      contacts={contacts}
+    />,
+  );
+
+  // Pick the adjuster, then place the call.
+  fireEvent.change(screen.getByLabelText(/recipient/i), {
+    target: { value: "c-2" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: /call/i }));
+
+  await waitFor(() => {
+    const post = mockFetch.mock.calls.find(
+      ([u, init]) =>
+        String(u).endsWith("/api/phone/calls") &&
+        (init as RequestInit | undefined)?.method === "POST",
+    );
+    expect(post).toBeDefined();
+    const body = JSON.parse((post![1] as RequestInit).body as string);
+    expect(body).toMatchObject({
+      outsideE164: "+15552220000",
+      sourceContext: { kind: "job", jobId: "job-9" },
+    });
+  });
+
+  await waitFor(() => expect(onPlaced).toHaveBeenCalled());
+  expect(onClose).toHaveBeenCalled();
+});
+
+it("surfaces the server error and stays open when the call is refused", async () => {
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 422,
+    json: async () => ({
+      error: "Add a mobile number to your profile before placing a call.",
+    }),
+  });
+  const onClose = vi.fn();
+
+  render(
+    <ComposeCallModal
+      open
+      onClose={onClose}
+      jobId="job-9"
+      contacts={contacts}
+    />,
+  );
+  fireEvent.click(screen.getByRole("button", { name: /call/i }));
+
+  await screen.findByText(/add a mobile number to your profile/i);
+  expect(onClose).not.toHaveBeenCalled();
+});

--- a/src/components/phone/compose-call-modal.tsx
+++ b/src/components/phone/compose-call-modal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+import { Phone, X } from "lucide-react";
+
+// PRD #304 — Nookleus Phone. Slice 10 (#314) — Job-page Call compose.
+//
+// Opened by the Job-page Call button with one of the Job's Contacts
+// pre-selected. Placing the call POSTs to /api/phone/calls with
+// sourceContext: { kind: 'job', jobId }, so smart-attach auto-tags the
+// outbound call to this Job — no tagging-chip prompt; on the Job page the
+// tag is definite. Mirrors ComposeTextModal, minus the message body (a call
+// needs only a recipient). NOT gated on A2P 10DLC — voice has no 10DLC
+// dependency.
+
+export interface ComposeCallContact {
+  id: string;
+  name: string;
+  phone: string | null;
+}
+
+export function ComposeCallModal({
+  open,
+  onClose,
+  jobId,
+  contacts,
+  onPlaced,
+}: {
+  open: boolean;
+  onClose: () => void;
+  jobId: string;
+  contacts: ComposeCallContact[];
+  onPlaced?: () => void;
+}) {
+  const [selectedId, setSelectedId] = useState(contacts[0]?.id ?? "");
+  const [calling, setCalling] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const selected = contacts.find((c) => c.id === selectedId) ?? contacts[0];
+
+  async function handleCall() {
+    if (calling || !selected?.phone) return;
+    setCalling(true);
+    setError(null);
+    const res = await fetch("/api/phone/calls", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        outsideE164: selected.phone,
+        // Smart-attach Job branch — the call is auto-tagged to this Job.
+        sourceContext: { kind: "job", jobId },
+      }),
+    });
+    setCalling(false);
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      setError(body.error ?? "Could not place the call. Please try again.");
+      return;
+    }
+    onPlaced?.();
+    onClose();
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Call a contact"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-card p-5 shadow-lg">
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="text-base font-semibold text-foreground">Call</h3>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-md p-1 text-muted-foreground hover:bg-accent"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <label className="mb-1 block text-xs font-medium text-muted-foreground">
+          To
+        </label>
+        {contacts.length > 1 ? (
+          <select
+            aria-label="Recipient"
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="mb-3 w-full rounded-md border border-border bg-background px-3 py-2 text-sm"
+          >
+            {contacts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <div className="mb-3 text-sm text-foreground">{selected?.name}</div>
+        )}
+
+        <p className="mb-3 text-xs text-muted-foreground">
+          Your own phone will ring first; answer to connect to the customer.
+          They&apos;ll see the Nookleus number, not your cell.
+        </p>
+
+        {error ? (
+          <p className="mb-3 text-xs text-destructive">{error}</p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleCall}
+            disabled={calling || !selected?.phone}
+            className="inline-flex items-center justify-center gap-1.5 rounded-md bg-[image:var(--gradient-primary)] px-3 py-1.5 text-sm font-medium text-white shadow-sm transition-colors hover:brightness-110 disabled:opacity-50"
+          >
+            <Phone size={14} />
+            {calling ? "Calling…" : "Call"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/phone/fake-twilio-client.test.ts
+++ b/src/lib/phone/fake-twilio-client.test.ts
@@ -15,7 +15,9 @@
 import { describe, it, expect } from "vitest";
 import { createFakeTwilioClient } from "./fake-twilio-client";
 import {
+  buildBridgeTwiml,
   listAvailableLocalNumbers,
+  placeBridgeCall,
   provisionNumber,
   releaseNumber,
   sendSms,
@@ -100,5 +102,25 @@ describe("createFakeTwilioClient — incomingPhoneNumbers(sid).remove (release)"
     const client = createFakeTwilioClient();
 
     await expect(releaseNumber(client, "PNfake")).resolves.toBeUndefined();
+  });
+});
+
+describe("createFakeTwilioClient — calls.create (outbound bridge call, #314)", () => {
+  it("returns a CA-prefixed SID and 'queued' status", async () => {
+    const client = createFakeTwilioClient();
+
+    const result = await placeBridgeCall(client, {
+      from: "+15125550000",
+      to: "+15129990000",
+      twiml: buildBridgeTwiml({
+        customerE164: "+15551234567",
+        callerId: "+15125550000",
+      }),
+      statusCallback: "https://example.com/voice-status",
+    });
+
+    expect(result.sid).toMatch(/^CA/);
+    expect(result.sid.length).toBeGreaterThan(2);
+    expect(result.status).toBe("queued");
   });
 });

--- a/src/lib/phone/fake-twilio-client.ts
+++ b/src/lib/phone/fake-twilio-client.ts
@@ -111,5 +111,24 @@ export function createFakeTwilioClient(): TwilioClientLike {
         };
       },
     },
+    // Slice 10 (#314) — outbound bridge call. Mirrors Twilio's
+    // `calls.create`: a CA-prefixed SID and an initial 'queued' status. The
+    // demo provider never actually rings a phone; the voice-status webhook
+    // can be driven by the dev simulate route to advance the lifecycle.
+    calls: {
+      async create(_opts: {
+        from: string;
+        to: string;
+        twiml: string;
+        statusCallback?: string;
+        statusCallbackEvent?: string[];
+        statusCallbackMethod?: string;
+      }) {
+        return {
+          sid: `CA${fakeSidTail()}`,
+          status: "queued",
+        };
+      },
+    },
   };
 }

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -12,9 +12,11 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  buildBridgeTwiml,
   buildVoiceTwiml,
   createTwilioClient,
   listAvailableLocalNumbers,
+  placeBridgeCall,
   provisionNumber,
   releaseNumber,
   sendSms,
@@ -27,10 +29,13 @@ function fakeClient(opts: {
   removeImpl?: () => Promise<void>;
   messageCreateResult?: { sid: string; status: string };
   messageCreateImpl?: (params: unknown) => Promise<unknown>;
+  callCreateResult?: { sid: string; status: string };
+  callCreateImpl?: (params: unknown) => Promise<unknown>;
   listSpy?: ReturnType<typeof vi.fn>;
   createSpy?: ReturnType<typeof vi.fn>;
   removeSpy?: ReturnType<typeof vi.fn>;
   messageCreateSpy?: ReturnType<typeof vi.fn>;
+  callCreateSpy?: ReturnType<typeof vi.fn>;
 }): TwilioClientLike {
   const list = opts.listSpy ?? vi.fn(async () => opts.listResult ?? []);
   const create =
@@ -43,6 +48,12 @@ function fakeClient(opts: {
       opts.messageCreateImpl ??
         (async () => opts.messageCreateResult ?? { sid: "SMabc", status: "queued" }),
     );
+  const callCreate =
+    opts.callCreateSpy ??
+    vi.fn(
+      opts.callCreateImpl ??
+        (async () => opts.callCreateResult ?? { sid: "CAabc", status: "queued" }),
+    );
   // Twilio SDK shape: `incomingPhoneNumbers` is callable (sid) → resource AND
   // has a `.create` method. We replicate that surface here so the helper
   // can stay byte-identical between fake and real client.
@@ -54,6 +65,7 @@ function fakeClient(opts: {
     availablePhoneNumbers: (_country: string) => ({ local: { list } }),
     incomingPhoneNumbers,
     messages: { create: messageCreate },
+    calls: { create: callCreate },
   } as TwilioClientLike;
 }
 
@@ -428,5 +440,152 @@ describe("buildVoiceTwiml — voicemail", () => {
     expect(xml).toContain("<Record");
     // No dial leg — the call goes straight to the recorder.
     expect(xml).not.toContain("<Dial");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 10 (#314) — outbound bridge call. `buildBridgeTwiml` is the inline
+// TwiML Twilio executes when the Crew Lead answers their cell: it dials the
+// customer with the Nookleus number presented as caller ID, so the customer
+// NEVER sees the Crew Lead's real cell. This is the caller-ID-spoofing safety
+// property the whole slice rests on. Pure (Twilio SDK's twiml.VoiceResponse
+// for correct XML escaping; no network).
+// ---------------------------------------------------------------------------
+describe("buildBridgeTwiml — outbound bridge (#314)", () => {
+  it("dials the customer as a <Number> with the Nookleus number as caller ID", () => {
+    const xml = buildBridgeTwiml({
+      customerE164: "+15551234567",
+      callerId: "+15125550000",
+    });
+    expect(xml).toContain("<Dial");
+    // The customer's caller ID is the Nookleus number — not the crew lead's cell.
+    expect(xml).toContain('callerId="+15125550000"');
+    expect(xml).toContain("<Number>+15551234567</Number>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 10 (#314) — placeBridgeCall. Rings the Crew Lead's cell (`to`) from
+// the Nookleus number (`from`), executing the inline bridge `twiml` on answer.
+// Returns the outer-leg CallSid + initial status; the route stores that SID so
+// the voice-status webhook can advance the call through its state machine.
+// Mirrors sendSms: E.164 guards before the SDK, errors propagate to the caller.
+// ---------------------------------------------------------------------------
+describe("placeBridgeCall", () => {
+  it("dispatches a Twilio call (cell FROM the Nookleus number, inline bridge twiml) and returns SID + status", async () => {
+    const callCreateSpy = vi.fn(async () => ({ sid: "CAxyz", status: "queued" }));
+    const client = fakeClient({ callCreateSpy });
+
+    const result = await placeBridgeCall(client, {
+      from: "+15125550000",
+      to: "+15129990000",
+      twiml: '<Response><Dial callerId="+15125550000"><Number>+15551234567</Number></Dial></Response>',
+      statusCallback: "https://example.com/voice-status",
+    });
+
+    expect(callCreateSpy).toHaveBeenCalledTimes(1);
+    const payload = (callCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      from: "+15125550000",
+      to: "+15129990000",
+      twiml:
+        '<Response><Dial callerId="+15125550000"><Number>+15551234567</Number></Dial></Response>',
+      statusCallback: "https://example.com/voice-status",
+    });
+    expect(result).toEqual({ sid: "CAxyz", status: "queued" });
+  });
+
+  it("requests the full event list so ringing/answered transitions reach the webhook (not just 'completed')", async () => {
+    // Twilio's default statusCallbackEvent is ['completed'] only. Without the
+    // intermediate events the in-flight thread row would jump straight from
+    // queued to completed — never showing ringing / in-progress. Pin that
+    // placeBridgeCall opts into the whole lifecycle whenever a callback is set.
+    const callCreateSpy = vi.fn(async () => ({ sid: "CAa", status: "queued" }));
+    const client = fakeClient({ callCreateSpy });
+
+    await placeBridgeCall(client, {
+      from: "+15125550000",
+      to: "+15129990000",
+      twiml: "<Response><Dial><Number>+15551234567</Number></Dial></Response>",
+      statusCallback: "https://example.com/voice-status",
+    });
+
+    const payload = (callCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    const events = payload.statusCallbackEvent as string[];
+    expect(events).toEqual(
+      expect.arrayContaining(["initiated", "ringing", "answered", "completed"]),
+    );
+  });
+
+  it("omits statusCallback (and the event list) when no callback URL is provided", async () => {
+    const callCreateSpy = vi.fn(async () => ({ sid: "CAa", status: "queued" }));
+    const client = fakeClient({ callCreateSpy });
+
+    await placeBridgeCall(client, {
+      from: "+15125550000",
+      to: "+15129990000",
+      twiml: "<Response><Dial><Number>+15551234567</Number></Dial></Response>",
+    });
+
+    const payload = (callCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).not.toHaveProperty("statusCallback");
+    expect(payload).not.toHaveProperty("statusCallbackEvent");
+  });
+
+  it("rejects when from is not E.164 (caller-ID safety — never dial from a non-owned number shape)", async () => {
+    const client = fakeClient({});
+    await expect(
+      placeBridgeCall(client, {
+        from: "5125550000",
+        to: "+15129990000",
+        twiml: "<Response/>",
+      }),
+    ).rejects.toThrow(/from.*E\.164/);
+  });
+
+  it("rejects when to is not E.164", async () => {
+    const client = fakeClient({});
+    await expect(
+      placeBridgeCall(client, {
+        from: "+15125550000",
+        to: "5129990000",
+        twiml: "<Response/>",
+      }),
+    ).rejects.toThrow(/to.*E\.164/);
+  });
+
+  it("rejects when twiml is empty (a bridge call with no dial leg is a programming error)", async () => {
+    const client = fakeClient({});
+    await expect(
+      placeBridgeCall(client, {
+        from: "+15125550000",
+        to: "+15129990000",
+        twiml: "",
+      }),
+    ).rejects.toThrow(/twiml/i);
+  });
+
+  it("propagates errors from the SDK (caller surfaces as 5xx)", async () => {
+    const client = fakeClient({
+      callCreateImpl: async () => {
+        throw new Error("twilio: 21215 geo-permission not enabled");
+      },
+    });
+    await expect(
+      placeBridgeCall(client, {
+        from: "+15125550000",
+        to: "+15129990000",
+        twiml: "<Response><Dial><Number>+15551234567</Number></Dial></Response>",
+      }),
+    ).rejects.toThrow(/21215/);
   });
 });

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -64,6 +64,19 @@ export interface TwilioClientLike {
       mediaUrl?: string[];
     }): Promise<{ sid: string; status: string }>;
   };
+  // Slice 10 (#314) — outbound bridge calling. We use the inline-`twiml`
+  // form (TwiML executed on answer) rather than a hosted `url`, so the
+  // customer number never transits a webhook URL.
+  calls: {
+    create(opts: {
+      from: string;
+      to: string;
+      twiml: string;
+      statusCallback?: string;
+      statusCallbackEvent?: string[];
+      statusCallbackMethod?: string;
+    }): Promise<{ sid: string; status: string }>;
+  };
 }
 
 // US 3-digit area codes only. Twilio enforces the same; failing fast here
@@ -307,4 +320,104 @@ export function buildVoiceTwiml(
     vr.record({});
   }
   return vr.toString();
+}
+
+// ---------------------------------------------------------------------------
+// Slice 10 (#314) — outbound bridge call. The Crew Lead clicks Call; Twilio
+// rings their own cell first (a call FROM the Nookleus number), and when they
+// answer, executes the TwiML below to bridge them to the customer. The
+// customer's caller ID is the Nookleus number — the Crew Lead's real cell is
+// never exposed. This is the caller-ID-spoofing safety property of the slice.
+//
+// We pass this TwiML INLINE on `calls.create({ twiml })` rather than hosting a
+// webhook the call fetches: no customer number transits a URL, no extra
+// signature-validated endpoint, and no answer-before-insert race. twilio-client
+// is the only file allowed to import twilio, so the builder lives here.
+// ---------------------------------------------------------------------------
+export interface BridgeTwimlInput {
+  // The customer's number to dial once the Crew Lead answers.
+  customerE164: string;
+  // The Nookleus number presented to the customer as caller ID.
+  callerId: string;
+}
+
+export function buildBridgeTwiml(input: BridgeTwimlInput): string {
+  const vr = new twilio.twiml.VoiceResponse();
+  const dial = vr.dial({ callerId: input.callerId });
+  dial.number(input.customerE164);
+  return vr.toString();
+}
+
+export interface PlaceBridgeCallParams {
+  // The Nookleus number. Caller ID the Crew Lead's cell sees on the leg
+  // Twilio places to them, and (in the bridge twiml) the caller ID the
+  // customer sees. Must be a Twilio-owned number.
+  from: string;
+  // The Crew Lead's own cell — rung first.
+  to: string;
+  // The inline bridge TwiML (from buildBridgeTwiml) executed on answer.
+  twiml: string;
+  // Our voice-status webhook; Twilio POSTs call-state transitions there.
+  statusCallback?: string;
+}
+
+export interface PlaceBridgeCallResult {
+  sid: string;
+  status: string;
+}
+
+/**
+ * Place the outbound bridge call. Rings `to` (the Crew Lead's cell) from
+ * `from` (the Nookleus number); on answer Twilio executes the inline
+ * `twiml` to dial the customer. Returns the outer-leg CallSid + initial
+ * status (typically `'queued'`) — the route stores the SID so the
+ * voice-status webhook can advance the row through ringing → in_progress →
+ * completed.
+ *
+ * E.164 guards mirror sendSms: reject obviously-wrong numbers before the
+ * network round-trip. Errors from the SDK propagate so the route can
+ * surface them as a 502.
+ */
+export async function placeBridgeCall(
+  client: TwilioClientLike,
+  params: PlaceBridgeCallParams,
+): Promise<PlaceBridgeCallResult> {
+  if (!E164_RE.test(params.from)) {
+    throw new Error(
+      `twilio-client: placeBridgeCall from "${params.from}" must be E.164 (e.g. +15125551234)`,
+    );
+  }
+  if (!E164_RE.test(params.to)) {
+    throw new Error(
+      `twilio-client: placeBridgeCall to "${params.to}" must be E.164 (e.g. +15125551234)`,
+    );
+  }
+  if (!params.twiml) {
+    throw new Error("twilio-client: placeBridgeCall requires non-empty twiml");
+  }
+  const payload: {
+    from: string;
+    to: string;
+    twiml: string;
+    statusCallback?: string;
+    statusCallbackEvent?: string[];
+  } = {
+    from: params.from,
+    to: params.to,
+    twiml: params.twiml,
+  };
+  if (params.statusCallback) {
+    payload.statusCallback = params.statusCallback;
+    // Twilio's default is ['completed'] only. Opt into the whole lifecycle
+    // so the row advances ringing → in-progress → completed in the thread,
+    // not a single jump from queued to completed.
+    payload.statusCallbackEvent = [
+      "initiated",
+      "ringing",
+      "answered",
+      "completed",
+    ];
+  }
+  const created = await client.calls.create(payload);
+  return { sid: created.sid, status: created.status };
 }

--- a/src/lib/phone/use-phone-sync.test.ts
+++ b/src/lib/phone/use-phone-sync.test.ts
@@ -243,3 +243,127 @@ describe("usePhoneSync — onMessageUpdate (re-tag)", () => {
     );
   });
 });
+
+// Slice 10 (#314) — outbound bridge calling. The Phone-tab thread shows an
+// in-flight indicator for an outbound call and must flip it live as the
+// status-callback webhook advances the `phone_calls` row (queued → ringing →
+// in_progress → completed). That's a `phone_calls` UPDATE; a brand-new call
+// (e.g. one this user placed from another device, or an inbound ring) is a
+// `phone_calls` INSERT. The hook grows two optional callbacks — `onNewCall`
+// (INSERT) and `onCallUpdate` (UPDATE) — that register additional
+// subscriptions only when supplied. Callers that pass neither (the Job-page
+// section) keep exactly their phone_messages subscriptions.
+describe("usePhoneSync — phone_calls (outbound bridge call, #314)", () => {
+  function findCall(
+    ch: FakeChannel,
+    event: "INSERT" | "UPDATE",
+  ): [unknown, Record<string, unknown>, (p: { new: Record<string, unknown> }) => void] | undefined {
+    return ch.on.mock.calls.find(
+      (c) =>
+        (c[1] as Record<string, unknown>).table === "phone_calls" &&
+        (c[1] as Record<string, unknown>).event === event,
+    ) as never;
+  }
+
+  it("registers a phone_calls INSERT subscription and fires onNewCall with the row", () => {
+    const supabase = fakeSupabase();
+    const onNewCall = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+        onNewCall,
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    const reg = findCall(ch, "INSERT");
+    expect(reg).toBeDefined();
+    expect(reg![1]).toEqual(
+      expect.objectContaining({
+        event: "INSERT",
+        schema: "public",
+        table: "phone_calls",
+        filter: "organization_id=eq.org-1",
+      }),
+    );
+
+    act(() => {
+      reg![2]({
+        new: {
+          id: "call-1",
+          organization_id: "org-1",
+          conversation_id: "conv-1",
+          direction: "out",
+          status: "queued",
+        },
+      });
+    });
+    expect(onNewCall).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "call-1", status: "queued" }),
+    );
+  });
+
+  it("registers a phone_calls UPDATE subscription and fires onCallUpdate with the row", () => {
+    const supabase = fakeSupabase();
+    const onCallUpdate = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+        onCallUpdate,
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    const reg = findCall(ch, "UPDATE");
+    expect(reg).toBeDefined();
+    expect(reg![1]).toEqual(
+      expect.objectContaining({
+        event: "UPDATE",
+        schema: "public",
+        table: "phone_calls",
+        filter: "organization_id=eq.org-1",
+      }),
+    );
+
+    act(() => {
+      reg![2]({
+        new: {
+          id: "call-1",
+          organization_id: "org-1",
+          conversation_id: "conv-1",
+          direction: "out",
+          status: "completed",
+          duration_seconds: 30,
+        },
+      });
+    });
+    expect(onCallUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "call-1", status: "completed" }),
+    );
+  });
+
+  it("registers no phone_calls subscription when neither call callback is supplied", () => {
+    const supabase = fakeSupabase();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+        onMessageUpdate: vi.fn(),
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    const callRegs = ch.on.mock.calls.filter(
+      (c) => (c[1] as Record<string, unknown>).table === "phone_calls",
+    );
+    expect(callRegs).toHaveLength(0);
+  });
+});

--- a/src/lib/phone/use-phone-sync.ts
+++ b/src/lib/phone/use-phone-sync.ts
@@ -28,6 +28,22 @@ interface PhoneMessageRow {
   [key: string]: unknown;
 }
 
+// Slice 10 (#314) — a phone_calls row as it arrives over realtime. The
+// status-callback webhook UPDATEs status / duration_seconds / ended_at as
+// Twilio advances the call; a fresh call (placed elsewhere, or inbound) is
+// an INSERT. Shape is intentionally loose — callers read what they need.
+interface PhoneCallRow {
+  id: string;
+  organization_id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  status: string | null;
+  duration_seconds: number | null;
+  started_at: string;
+  ended_at: string | null;
+  [key: string]: unknown;
+}
+
 export interface UsePhoneSyncInput {
   supabase: SupabaseClient;
   // The active org. Null while loading or when the user is logged out;
@@ -40,28 +56,49 @@ export interface UsePhoneSyncInput {
   // caller, which only cares about new arrivals — so no UPDATE subscription
   // is registered there and its behavior is unchanged.
   onMessageUpdate?: (row: PhoneMessageRow) => void;
+  // Slice 10 (#314) — optional. When provided, the hook also subscribes to
+  // `phone_calls` INSERTs (a new call placed elsewhere or an inbound ring).
+  onNewCall?: (row: PhoneCallRow) => void;
+  // Slice 10 (#314) — optional. When provided, the hook also subscribes to
+  // `phone_calls` UPDATEs so the Phone-tab thread's in-flight call indicator
+  // advances live (queued → ringing → in_progress → completed) as the
+  // status-callback webhook stamps the row. Callers that pass neither call
+  // callback register no phone_calls subscription at all.
+  onCallUpdate?: (row: PhoneCallRow) => void;
 }
 
 export function usePhoneSync(input: UsePhoneSyncInput): void {
   const onNewMessageRef = useRef(input.onNewMessage);
   const onMessageUpdateRef = useRef(input.onMessageUpdate);
+  const onNewCallRef = useRef(input.onNewCall);
+  const onCallUpdateRef = useRef(input.onCallUpdate);
   // useLayoutEffect (or useEffect — either works since the effect runs
   // before the next event-loop tick that fires the subscription handler)
   // keeps the ref read-only during render, satisfying react-hooks/refs.
   useLayoutEffect(() => {
     onNewMessageRef.current = input.onNewMessage;
     onMessageUpdateRef.current = input.onMessageUpdate;
-  }, [input.onNewMessage, input.onMessageUpdate]);
+    onNewCallRef.current = input.onNewCall;
+    onCallUpdateRef.current = input.onCallUpdate;
+  }, [
+    input.onNewMessage,
+    input.onMessageUpdate,
+    input.onNewCall,
+    input.onCallUpdate,
+  ]);
 
   const { supabase, organizationId } = input;
-  // Whether to register the UPDATE subscription is decided once per
-  // (org) effect run; toggling the callback's presence is rare and a
+  // Whether to register each optional subscription is decided once per
+  // (org) effect run; toggling a callback's presence is rare and a
   // remount-worthy change, so it gates the effect rather than living
   // behind the ref.
   const wantsUpdates = input.onMessageUpdate != null;
+  const wantsCallInsert = input.onNewCall != null;
+  const wantsCallUpdate = input.onCallUpdate != null;
 
   useEffect(() => {
     if (!organizationId) return;
+    const orgFilter = `organization_id=eq.${organizationId}`;
     let channel = supabase
       .channel(`phone-messages-${organizationId}`)
       .on(
@@ -70,7 +107,7 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
           event: "INSERT",
           schema: "public",
           table: "phone_messages",
-          filter: `organization_id=eq.${organizationId}`,
+          filter: orgFilter,
         },
         (payload: { new: PhoneMessageRow }) => {
           onNewMessageRef.current(payload.new);
@@ -84,10 +121,42 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
           event: "UPDATE",
           schema: "public",
           table: "phone_messages",
-          filter: `organization_id=eq.${organizationId}`,
+          filter: orgFilter,
         },
         (payload: { new: PhoneMessageRow }) => {
           onMessageUpdateRef.current?.(payload.new);
+        },
+      );
+    }
+
+    // Slice 10 (#314) — outbound-call realtime. Same channel, additional
+    // postgres_changes registrations on `phone_calls`, only when wanted.
+    if (wantsCallInsert) {
+      channel = channel.on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "phone_calls",
+          filter: orgFilter,
+        },
+        (payload: { new: PhoneCallRow }) => {
+          onNewCallRef.current?.(payload.new);
+        },
+      );
+    }
+
+    if (wantsCallUpdate) {
+      channel = channel.on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "phone_calls",
+          filter: orgFilter,
+        },
+        (payload: { new: PhoneCallRow }) => {
+          onCallUpdateRef.current?.(payload.new);
         },
       );
     }
@@ -97,5 +166,11 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
     return () => {
       subscribed.unsubscribe();
     };
-  }, [supabase, organizationId, wantsUpdates]);
+  }, [
+    supabase,
+    organizationId,
+    wantsUpdates,
+    wantsCallInsert,
+    wantsCallUpdate,
+  ]);
 }


### PR DESCRIPTION
## Slice 10 (#314) — Outbound bridge calling (Layer 1)

A Crew Lead clicks **Call** (Job page, Contact card, Adjuster card, Phone-tab thread, Contacts list). Twilio rings the crew lead's **own cell** (`user_profiles.phone`); on answer the inline bridge TwiML dials the customer with `callerId` = a Nookleus-owned org number.

### Security property (the whole point of the bridge)
The crew lead's real cell is **only** the `to` of the first leg — it is never the `callerId`, never put in a URL, and never written to the `phone_calls` row. `buildBridgeTwiml({ customerE164, callerId })` has no parameter through which the cell could leak; the persisted row records the logical Nookleus → customer call.

### Architecture (approved)
- **Inline TwiML** via `calls.create({ twiml })` — no bridge webhook, no PII in URLs.
- **New `POST /api/phone/calls`** mirroring `POST /api/phone/messages`; lifecycle tracked by the existing `voice-status` webhook keyed on `CallSid` (no new webhook).
- **`view_phone` gate only** — voice carries no A2P 10DLC dependency, so Call is live wherever the Phone tab is, flag on or off.

Refusal gates, cheapest first, Twilio last: body 400 → resolve customer E.164 (404/400) → owned-number rule (422) → profile-cell gate (422) → TCPA opt-out (403) → **Twilio dispatch before any DB write** (502) → insert `phone_calls` (201).

### Surfaces
Call button + `click-to-call` wired on all five surfaces; Job-page Call posts `sourceContext { kind:'job', jobId }` (auto-tag); Phone-tab/Contact-card post untagged.

### Tests
TDD throughout. Full phone suite green (458 tests / 45 files). `tsc` clean for all #314 code (only the pre-existing pg-integration baseline remains). Includes a realtime-race regression test: the optimistic in-flight row now dedupes against the INSERT echo so a call never shows twice.

### No migration
Reuses the `phone_calls` table + `voice-status` webhook from prior slices. No schema change.

### Follow-ups (out of scope — pre-existing, shared with the SMS route)
Adversarial review surfaced two latent issues in code shared with `POST /api/phone/messages` (#311), deliberately **not** fixed here to keep this slice tight and avoid silently changing SMS behavior. Filing a tracking issue:
- `decideJobTag` outbound + exactly-1-active-job returns `auto` where the locked spec says `prompt` (latent; no outbound chip UI consumes it yet).
- `{ kind:'job' }` `jobId` is not validated against the caller's org before dispatch (happy path always sends a valid in-org id; crafted requests could orphan a call or write a cross-org tag that RLS already masks on read).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)
