### PR TITLE
feat(photo-viewer): Share + Save to device (#518)

### DIFF
--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -95,7 +95,16 @@ vi.mock("sonner", () => ({
   toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }),
 }));
 
+// The platform share/download plumbing is its own tested seam (#518); the
+// viewer's job is only to call it with the right version + filename + mode, so
+// mock it and assert the hand-off.
+vi.mock("@/lib/share/share-or-download", () => ({
+  shareOrDownloadFile: vi.fn(async () => {}),
+}));
+
 import { toast } from "sonner";
+import { shareOrDownloadFile } from "@/lib/share/share-or-download";
+import { exportVersion } from "@/lib/jobs/photo-export-version";
 import PhotoViewer from "./photo-viewer";
 
 function makePhoto(overrides: Partial<Photo> = {}): Photo {
@@ -574,6 +583,84 @@ describe("PhotoViewer — Set as cover (⋯ More)", () => {
       name: /cover photo/i,
     }) as HTMLButtonElement;
     expect(entry.disabled).toBe(true);
+  });
+});
+
+describe("PhotoViewer — Share / Save to device (⋯ More)", () => {
+  it("Save to device hands the displayed version + filename to the plumbing in save mode", async () => {
+    const { photo } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save to device/i }));
+    });
+
+    expect(shareOrDownloadFile).toHaveBeenCalledWith({
+      ...exportVersion(photo, SUPABASE_URL, "save"),
+      mode: "save",
+    });
+  });
+
+  it("Share opens the share sheet with the displayed version in share mode", async () => {
+    const { photo } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /share/i }));
+    });
+
+    expect(shareOrDownloadFile).toHaveBeenCalledWith({
+      ...exportVersion(photo, SUPABASE_URL, "share"),
+      mode: "share",
+    });
+  });
+
+  it("acts on the annotated render when the Photo has been drawn on", async () => {
+    const annotated = makePhoto({
+      annotated_path: "job-1/p1-annotated.png",
+      caption: "Roof",
+    });
+    renderViewer({ photos: [annotated] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save to device/i }));
+    });
+
+    // The displayed version is the annotated copy: its URL, and a name carrying
+    // the render's .png extension.
+    const arg = vi.mocked(shareOrDownloadFile).mock.calls[0][0];
+    expect(arg.url).toBe(photoUrl(annotated, SUPABASE_URL, "full"));
+    expect(arg.filename).toBe("Roof.png");
+  });
+
+  it("closes the ⋯ menu after an export", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    expect(
+      screen.queryByRole("button", { name: /save to device/i }),
+    ).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /save to device/i }));
+    });
+
+    expect(
+      screen.queryByRole("button", { name: /save to device/i }),
+    ).toBeNull();
   });
 });
 

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -14,6 +14,8 @@ import {
   indexAfterDelete,
 } from "@/lib/jobs/photo-viewer-navigation";
 import { mediaCapabilities } from "@/lib/jobs/photo-media-capabilities";
+import { exportVersion } from "@/lib/jobs/photo-export-version";
+import { shareOrDownloadFile } from "@/lib/share/share-or-download";
 import {
   FIT,
   ZOOM_STEP,
@@ -38,6 +40,8 @@ import {
   RotateCcw,
   X,
   MoreHorizontal,
+  Share2,
+  ArrowDownToLine,
   Star,
   ChevronLeft,
   ChevronRight,
@@ -334,6 +338,9 @@ export default function PhotoViewer({
   const [hasOriginalBackup, setHasOriginalBackup] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const [settingCover, setSettingCover] = useState(false);
+  // Which export, if any, is in flight — so the chosen ⋯ menu entry shows a
+  // spinner and both stay disabled until the share/download settles.
+  const [exporting, setExporting] = useState<null | "share" | "save">(null);
 
   async function fetchTags(photoId: string) {
     const supabase = createClient();
@@ -554,6 +561,25 @@ export default function PhotoViewer({
     }
     toast.success("Cover photo updated.");
     onUpdated();
+  }
+
+  // Share / Save to device act on the displayed version (annotated when drawn
+  // on, else the original) — the pure export-version rule picks the file + name,
+  // and the shared platform recipe opens the device share sheet or downloads,
+  // falling back to a download where the Web Share API isn't available.
+  async function handleExport(intent: "share" | "save") {
+    if (!currentPhoto) return;
+    setExporting(intent);
+    try {
+      const version = exportVersion(currentPhoto, supabaseUrl, intent);
+      await shareOrDownloadFile({ ...version, mode: intent });
+    } catch {
+      toast.error(
+        intent === "share" ? "Failed to share photo." : "Failed to save photo.",
+      );
+    }
+    setExporting(null);
+    setMoreOpen(false);
   }
 
   // Delete is deferred behind an Undo window (#515). Confirming hides the Photo
@@ -827,6 +853,32 @@ export default function PhotoViewer({
                 <Star size={14} />
               )}
               {isCover ? "Cover photo" : "Set as cover"}
+            </button>
+            <button
+              type="button"
+              onClick={() => handleExport("share")}
+              disabled={exporting !== null}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-[#1A1A1A] hover:bg-gray-100 rounded-md transition-colors disabled:opacity-60 disabled:hover:bg-transparent"
+            >
+              {exporting === "share" ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Share2 size={14} />
+              )}
+              Share
+            </button>
+            <button
+              type="button"
+              onClick={() => handleExport("save")}
+              disabled={exporting !== null}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-[#1A1A1A] hover:bg-gray-100 rounded-md transition-colors disabled:opacity-60 disabled:hover:bg-transparent"
+            >
+              {exporting === "save" ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <ArrowDownToLine size={14} />
+              )}
+              Save to device
             </button>
           </div>
         )}

--- a/src/lib/jobs/photo-export-version.test.ts
+++ b/src/lib/jobs/photo-export-version.test.ts
@@ -1,0 +1,123 @@
+// Issue #518 — the pure rule for which version of a Photo an export acts on
+// (the displayed image: annotated when drawings exist, else the original) and
+// what the exported file is named. Free of React/DOM so the version + filename
+// choice is verified in one place; the viewer's Share / Save to device entries
+// and the platform share/download plumbing read this.
+
+import { describe, it, expect } from "vitest";
+import type { Photo } from "@/lib/types";
+import { exportVersion } from "./photo-export-version";
+import { photoUrl } from "./photo-url";
+
+const SUPABASE_URL = "https://example.supabase.co";
+
+// A Photo with the fields the export rule reads: the two paths (to pick the
+// displayed version + its extension) and the caption (for a friendly filename).
+function photo(over: Partial<Photo> = {}): Photo {
+  return {
+    id: "p1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    storage_path: "job-1/IMG_1234.jpg",
+    annotated_path: null,
+    caption: null,
+    taken_at: null,
+    taken_by: "Eric",
+    media_type: "photo",
+    file_size: null,
+    width: null,
+    height: null,
+    before_after_pair_id: null,
+    before_after_role: null,
+    created_at: "2026-05-01T00:00:00Z",
+    uploaded_from: "web",
+    client_capture_id: null,
+    ...over,
+  };
+}
+
+describe("exportVersion — share acts on the displayed original when undrawn", () => {
+  it("resolves the original's full URL and a caption-based filename", () => {
+    const p = photo({ caption: "Kitchen before" });
+    const result = exportVersion(p, SUPABASE_URL, "share");
+
+    // The displayed version of an un-annotated Photo is its original, resolved
+    // through the one place Photo URLs are built (ADR 0008).
+    expect(result.url).toBe(photoUrl(p, SUPABASE_URL, "full"));
+    // Friendly name from the caption; extension matches the exported file.
+    expect(result.filename).toBe("Kitchen before.jpg");
+  });
+});
+
+describe("exportVersion — share acts on the annotated render when drawn on", () => {
+  it("resolves the annotated URL and an extension matching that render", () => {
+    const p = photo({
+      caption: "Kitchen before",
+      annotated_path: "job-1/IMG_1234-annotated.png",
+    });
+    const result = exportVersion(p, SUPABASE_URL, "share");
+
+    // The displayed version is now the annotated copy.
+    expect(result.url).toBe(photoUrl(p, SUPABASE_URL, "full"));
+    // The render is a PNG even though the original was a JPG — the extension
+    // must follow the exported version, not the stored original.
+    expect(result.filename).toBe("Kitchen before.png");
+  });
+});
+
+describe("exportVersion — names the file from the original when there is no caption", () => {
+  it("uses the original's basename (without its extension) as the stem", () => {
+    const p = photo({ caption: null, storage_path: "job-1/IMG_1234.jpg" });
+    const result = exportVersion(p, SUPABASE_URL, "share");
+
+    expect(result.filename).toBe("IMG_1234.jpg");
+  });
+
+  it("keeps the original's name even when it has been drawn on", () => {
+    // No caption + an annotation: the stem is still the original's name, while
+    // the extension is the render's (.png).
+    const p = photo({
+      caption: null,
+      storage_path: "job-1/IMG_1234.jpg",
+      annotated_path: "job-1/IMG_1234-annotated.png",
+    });
+
+    expect(exportVersion(p, SUPABASE_URL, "share").filename).toBe(
+      "IMG_1234.png",
+    );
+  });
+});
+
+describe("exportVersion — sanitizes the caption into a safe filename", () => {
+  it("replaces path-illegal characters in the caption", () => {
+    const p = photo({ caption: "Before/After: roof" });
+
+    expect(exportVersion(p, SUPABASE_URL, "share").filename).toBe(
+      "Before_After_ roof.jpg",
+    );
+  });
+});
+
+describe("exportVersion — save and share act on the same displayed version", () => {
+  it("returns the same url and filename for save as for share", () => {
+    const p = photo({
+      caption: "Kitchen before",
+      annotated_path: "job-1/IMG_1234-annotated.png",
+    });
+
+    expect(exportVersion(p, SUPABASE_URL, "save")).toEqual(
+      exportVersion(p, SUPABASE_URL, "share"),
+    );
+  });
+});
+
+describe("exportVersion — duplicate marks the copy in its filename", () => {
+  it("appends 'copy' to the stem so a duplicate doesn't shadow the original", () => {
+    const p = photo({ caption: "Kitchen before" });
+    const result = exportVersion(p, SUPABASE_URL, "duplicate");
+
+    // Same displayed version, but a distinct name.
+    expect(result.url).toBe(photoUrl(p, SUPABASE_URL, "full"));
+    expect(result.filename).toBe("Kitchen before copy.jpg");
+  });
+});

--- a/src/lib/jobs/photo-export-version.ts
+++ b/src/lib/jobs/photo-export-version.ts
@@ -1,0 +1,60 @@
+// Issue #518 — the pure rule for which version of a Photo an export acts on and
+// what the exported file is named. The "displayed version" is the annotated
+// image when drawings exist, otherwise the original (the same rule the viewer
+// shows). Kept free of React/DOM so the version + filename choice lives in one
+// tested place; the viewer's Share / Save to device entries and the platform
+// share/download plumbing read this.
+
+import type { Photo } from "@/lib/types";
+import { photoUrl, type PhotoUrlSource } from "./photo-url";
+
+/** What an export does with the chosen version — drives only the filename. */
+export type ExportIntent = "share" | "save" | "duplicate";
+
+export interface ExportVersion {
+  /** Fetchable URL of the version to export (the displayed image). */
+  url: string;
+  /** Human-meaningful download filename; extension matches the exported file. */
+  filename: string;
+}
+
+/** The subset of a Photo the export rule reads. */
+export type ExportablePhoto = Pick<Photo, "caption"> & PhotoUrlSource;
+
+export function exportVersion(
+  photo: ExportablePhoto,
+  supabaseUrl: string,
+  intent: ExportIntent,
+): ExportVersion {
+  const url = photoUrl(photo, supabaseUrl, "full");
+  // Extension follows the exported version: the annotation render is a PNG even
+  // when the original was a JPG, so read it off the displayed path.
+  const displayedPath = photo.annotated_path || photo.storage_path;
+  const ext = displayedPath.split(".").pop() ?? "jpg";
+  // Friendly stem: the caption when one is set, otherwise the original file's
+  // own name — never the "-annotated" render's — so a drawn-on Photo still
+  // exports under its original name.
+  const caption = photo.caption?.trim();
+  const base = caption ? sanitizeFilename(caption) : basename(photo.storage_path);
+  // A duplicate is a new file alongside the original, so it carries a distinct
+  // name; share / save export the displayed version under its own name.
+  const stem = intent === "duplicate" ? `${base} copy` : base;
+  return { url, filename: `${stem}.${ext}` };
+}
+
+/**
+ * Fold a caption into a filesystem-safe filename stem by dropping the characters
+ * no OS allows in a name. Unlike the contract PDF rule it keeps non-ASCII —
+ * `<a download>` and Web Share both carry UTF-8 names, so an accented caption
+ * survives intact.
+ */
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\\/:*?"<>|]/g, "_");
+}
+
+/** The file's own name within its storage path, with any extension dropped. */
+function basename(path: string): string {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(0, dot) : name;
+}

--- a/src/lib/share/share-or-download.test.ts
+++ b/src/lib/share/share-or-download.test.ts
@@ -1,0 +1,214 @@
+// Issue #518 — the platform plumbing behind the Photo viewer's Share / Save to
+// device entries. Fetches the chosen image as a blob, then either opens the
+// native share sheet (Web Share with a File) or downloads it, per mode and
+// platform. Same recipe the contract PDF download uses; verified here against
+// stubbed navigator / fetch / DOM.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { shareOrDownloadFile } from "./share-or-download";
+
+// --- Environment stubs --------------------------------------------------------
+// jsdom ships none of Web Share, object-URL minting, or matchMedia, so each test
+// drives them explicitly. Defaults: a plain desktop browser tab that can fetch
+// the image but has no share sheet.
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let clickSpy: ReturnType<typeof vi.spyOn>;
+// The `download` attribute of the anchor the last download clicked, captured off
+// the spy's `this` (without aliasing the element, which eslint forbids).
+let clickedDownload: string | undefined;
+let origCreateObjectURL: typeof URL.createObjectURL;
+let origRevokeObjectURL: typeof URL.revokeObjectURL;
+
+function setMatchMedia(standalone: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: standalone,
+      media: query,
+      addEventListener() {},
+      removeEventListener() {},
+    }),
+  });
+}
+
+/** Install (or, with undefined, withhold) the Web Share API. */
+function setWebShare(opts: {
+  canShare?: (data: { files: File[] }) => boolean;
+  share?: (data: { files: File[] }) => Promise<void>;
+}) {
+  Object.defineProperty(navigator, "canShare", {
+    configurable: true,
+    writable: true,
+    value: opts.canShare,
+  });
+  Object.defineProperty(navigator, "share", {
+    configurable: true,
+    writable: true,
+    value: opts.share,
+  });
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () => ({
+    ok: true,
+    blob: async () => new Blob(["bytes"], { type: "image/png" }),
+  }));
+  vi.stubGlobal("fetch", fetchMock);
+
+  origCreateObjectURL = URL.createObjectURL;
+  origRevokeObjectURL = URL.revokeObjectURL;
+  URL.createObjectURL = vi.fn(() => "blob:mock-url");
+  URL.revokeObjectURL = vi.fn();
+
+  clickedDownload = undefined;
+  clickSpy = vi
+    .spyOn(HTMLAnchorElement.prototype, "click")
+    .mockImplementation(function (this: HTMLAnchorElement) {
+      clickedDownload = this.download;
+    });
+
+  setMatchMedia(false); // desktop browser tab
+  setWebShare({ canShare: undefined, share: undefined }); // no share sheet
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  clickSpy.mockRestore();
+  URL.createObjectURL = origCreateObjectURL;
+  URL.revokeObjectURL = origRevokeObjectURL;
+  delete (navigator as { standalone?: boolean }).standalone;
+  delete (window as { Capacitor?: unknown }).Capacitor;
+});
+
+describe("shareOrDownloadFile — share mode opens the native share sheet", () => {
+  it("fetches the image and shares it as a File when Web Share is available", async () => {
+    const share = vi.fn<(data: { files: File[] }) => Promise<void>>(
+      async () => {},
+    );
+    setWebShare({ canShare: () => true, share });
+
+    await shareOrDownloadFile({
+      url: "https://cdn.example/photos/job-1/IMG_1234.png",
+      filename: "Kitchen before.png",
+      mode: "share",
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://cdn.example/photos/job-1/IMG_1234.png",
+    );
+    expect(share).toHaveBeenCalledTimes(1);
+    const shared = share.mock.calls[0][0];
+    expect(shared.files[0]).toBeInstanceOf(File);
+    expect(shared.files[0].name).toBe("Kitchen before.png");
+    // Shared, not downloaded.
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a download when the Web Share API isn't available", async () => {
+    // beforeEach leaves canShare / share undefined (a desktop browser tab).
+    await shareOrDownloadFile({
+      url: "https://cdn.example/photos/job-1/IMG_1234.png",
+      filename: "Kitchen before.png",
+      mode: "share",
+    });
+
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(clickedDownload).toBe("Kitchen before.png");
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});
+
+describe("shareOrDownloadFile — save mode downloads on a desktop browser", () => {
+  it("downloads rather than sharing even when a share sheet is available", async () => {
+    const share = vi.fn(async () => {});
+    setWebShare({ canShare: () => true, share }); // share sheet exists...
+    setMatchMedia(false); // ...but this is a plain browser tab, not a PWA
+
+    await shareOrDownloadFile({
+      url: "https://cdn.example/photos/job-1/IMG_1234.jpg",
+      filename: "IMG_1234.jpg",
+      mode: "save",
+    });
+
+    // A desktop "Save to device" is a download — the share sheet is for where
+    // the anchor download is broken (iOS PWA), not here.
+    expect(share).not.toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(clickedDownload).toBe("IMG_1234.jpg");
+  });
+
+  it("uses the share sheet inside a standalone PWA, where the anchor is broken", async () => {
+    const share = vi.fn(async () => {});
+    setWebShare({ canShare: () => true, share });
+    setMatchMedia(true); // installed PWA
+
+    await shareOrDownloadFile({
+      url: "https://cdn.example/photos/job-1/IMG_1234.jpg",
+      filename: "IMG_1234.jpg",
+      mode: "save",
+    });
+
+    expect(share).toHaveBeenCalledOnce();
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("shareOrDownloadFile — handles share-sheet outcomes", () => {
+  it("treats the user dismissing the sheet (AbortError) as a no-op", async () => {
+    const abort = Object.assign(new Error("cancelled"), { name: "AbortError" });
+    const share = vi.fn(async () => {
+      throw abort;
+    });
+    setWebShare({ canShare: () => true, share });
+
+    // Must not reject, and must not silently download behind the dismissal.
+    await expect(
+      shareOrDownloadFile({
+        url: "https://cdn.example/photos/job-1/IMG_1234.png",
+        filename: "Kitchen before.png",
+        mode: "share",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a download when the share sheet errors for real", async () => {
+    const share = vi.fn(async () => {
+      throw new Error("share failed");
+    });
+    setWebShare({ canShare: () => true, share });
+
+    await shareOrDownloadFile({
+      url: "https://cdn.example/photos/job-1/IMG_1234.png",
+      filename: "Kitchen before.png",
+      mode: "share",
+    });
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    expect(clickedDownload).toBe("Kitchen before.png");
+  });
+
+  it("rejects when the image can't be fetched", async () => {
+    // A complete-looking response that merely reports failure: the helper must
+    // check `ok` rather than blindly reading the body.
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      blob: async () => new Blob(["Not found"], { type: "text/plain" }),
+    });
+
+    await expect(
+      shareOrDownloadFile({
+        url: "https://cdn.example/photos/job-1/missing.png",
+        filename: "missing.png",
+        mode: "share",
+      }),
+    ).rejects.toThrow();
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/share/share-or-download.ts
+++ b/src/lib/share/share-or-download.ts
@@ -1,0 +1,82 @@
+// Issue #518 — fetch an image and hand it to the device: open the native share
+// sheet (Web Share with a File) or download it. The same recipe the contract
+// PDF download uses, extracted so the Photo viewer's Share / Save to device
+// entries can reuse it. Kept as a plain async function (reads browser globals at
+// call time) so it's driven from one tested place.
+
+/** How the caller wants the file delivered. */
+export type ShareMode = "share" | "save";
+
+export interface ShareOrDownloadOptions {
+  /** URL of the already-resolved version to deliver (see exportVersion). */
+  url: string;
+  /** The name the delivered file should carry. */
+  filename: string;
+  /** `share` prefers the share sheet; `save` downloads (sheet only where the
+   *  download anchor is broken — iOS PWA / Capacitor). */
+  mode: ShareMode;
+}
+
+export async function shareOrDownloadFile({
+  url,
+  filename,
+  mode,
+}: ShareOrDownloadOptions): Promise<void> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+  const blob = await res.blob();
+  const file = new File([blob], filename, { type: blob.type });
+
+  // Share always prefers the sheet; Save downloads, reaching for the sheet only
+  // inside an installed shell where the <a download> anchor silently fails.
+  const preferShare =
+    mode === "share" ? canShareFile(file) : inStandaloneApp() && canShareFile(file);
+
+  if (preferShare) {
+    try {
+      await navigator.share({ files: [file] });
+      return;
+    } catch (err) {
+      // The user dismissing the sheet isn't a failure — nothing more to do. A
+      // real share error still owes the user the file, so fall through to the
+      // download.
+      if ((err as DOMException)?.name === "AbortError") return;
+    }
+  }
+
+  downloadBlob(blob, filename);
+}
+
+/** Whether the device can share this file through the Web Share API. */
+function canShareFile(file: File): boolean {
+  return navigator.canShare?.({ files: [file] }) === true;
+}
+
+/**
+ * Whether we're running inside an installed shell — a standalone PWA, an iOS
+ * Add-to-Home-Screen page, or a Capacitor WKWebView — where tapping a download
+ * anchor navigates the SPA to the file instead of saving it.
+ */
+function inStandaloneApp(): boolean {
+  if (typeof window === "undefined") return false;
+  const cap = (window as Window & {
+    Capacitor?: { isNativePlatform?: () => boolean };
+  }).Capacitor;
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    (window.navigator as Navigator & { standalone?: boolean }).standalone === true ||
+    cap?.isNativePlatform?.() === true
+  );
+}
+
+/** Save a blob to disk via a synthetic, self-cleaning download anchor. */
+function downloadBlob(blob: Blob, filename: string): void {
+  const objectUrl = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = objectUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(objectUrl);
+}


### PR DESCRIPTION
## What

Adds **Share** and **Save to device** to the Photo viewer's ⋯ More menu (slice 5 of PRD #511). Both act on the **displayed** version of the Photo — the annotated render when drawings exist, otherwise the original.

Closes #518.

## How (three tested layers, built with TDD)

1. **Pure module** — `src/lib/jobs/photo-export-version.ts`
   `exportVersion(photo, supabaseUrl, intent)` → `{ url, filename }`. Encodes the version choice (annotated-when-drawn, reusing the `photoUrl` seam) and the filename: caption when set (sanitized) else the original's name, extension following the *exported* version (an annotated JPG exports as `.png`). `duplicate` appends ` copy`; `share`/`save` are version-equivalent. No React/DOM. **7 unit tests.**

2. **Share helper** — `src/lib/share/share-or-download.ts`
   `shareOrDownloadFile({ url, filename, mode })` — the extracted PWA / Capacitor → Web Share → `<a download>` recipe (the same one `DownloadPdfButton` uses). `share` prefers the sheet; `save` downloads except inside an installed shell where the anchor is broken. **7 unit tests** covering the platform matrix, AbortError dismissal, real-error fallback, and failed-fetch.

3. **Viewer wiring** — `src/components/photo-viewer.tsx`
   Two ⋯ More menu entries feeding the displayed version + filename into the plumbing. **4 component tests** (hand-off in each mode, annotated-version case, menu closes).

## Acceptance criteria

- [x] Share opens the device share sheet with the image file
- [x] Save to device saves the displayed version locally
- [x] Both use the annotated image when drawings exist, otherwise the original
- [x] Pure export-version module (share / save / **duplicate**) covered by unit tests
- [x] Falls back to a download when the Web Share API isn't available
- [x] Share and Save entries appear in the ⋯ More menu (no viewport gating — desktop and phone)
- [x] No new test failures beyond the known-red baseline (baseline is 0)

## Decisions baked in

- The toolbar **Download** (pristine original) is kept alongside **Save to device** (displayed version) — they serve different needs.
- `DownloadPdfButton` is **left untouched**; the new helper encodes the same recipe, ready for the 3 contract call sites to converge onto in a follow-up.

## Verification

- 67/67 tests across the three files pass · ESLint clean on new files · `tsc --noEmit` 0 errors project-wide.

## Note for device QA

Share fetches the displayed image from the cross-origin Supabase public URL to build the `File`, relying on the storage bucket's CORS allowing GET (the same URL already loads as the `<img src>`). Worth a quick check on a real phone before closing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
