### PR TITLE
feat(photo-viewer): Duplicate — clean same-Job copy (#519)

### DIFF
--- a/src/app/api/jobs/[id]/photos/[photoId]/duplicate/route.test.ts
+++ b/src/app/api/jobs/[id]/photos/[photoId]/duplicate/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../../../../__test-utils__/request-context-fakes";
+
+const paramsFor = { params: Promise.resolve({ id: "job-1", photoId: "p-1" }) };
+
+type Row = Record<string, unknown>;
+
+interface Recorders {
+  copies: { bucket: string; from: string; to: string }[];
+  rpcs: { fn: string; args: Record<string, unknown> }[];
+}
+
+// Build the authed-client fake the wrapper authenticates against, with the
+// Storage `.copy()` and `.rpc()` surfaces this route needs recorded so a test
+// can assert exactly what it copied and which RPC it called.
+function mockCaller(opts: {
+  user: { id: string } | null;
+  grants?: string[];
+  photos?: Row[];
+  copyError?: { message: string } | null;
+  duplicated?: Row;
+}): Recorders {
+  const rec: Recorders = { copies: [], rpcs: [] };
+  const client = fakeUserClient({
+    user: opts.user,
+    tables: opts.user
+      ? memberTables({
+          userId: opts.user.id,
+          role: "member",
+          grants: opts.grants ?? [],
+          extraTables: {
+            photos:
+              opts.photos ??
+              [{ id: "p-1", job_id: "job-1", storage_path: "org-1/job-1/p-1.jpg" }],
+          },
+        })
+      : undefined,
+  });
+
+  (client as unknown as { storage: unknown }).storage = {
+    from(bucket: string) {
+      return {
+        async copy(from: string, to: string) {
+          rec.copies.push({ bucket, from, to });
+          return { data: opts.copyError ? null : { path: to }, error: opts.copyError ?? null };
+        },
+      };
+    },
+  };
+  (client as unknown as { rpc: unknown }).rpc = async (
+    fn: string,
+    args: Record<string, unknown>,
+  ) => {
+    rec.rpcs.push({ fn, args });
+    return {
+      data: opts.duplicated ?? { id: "p-2", job_id: "job-1", storage_path: args.p_new_storage_path },
+      error: null,
+    };
+  };
+
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+  return rec;
+}
+
+function postRequest() {
+  return new Request("http://test", { method: "POST" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/jobs/[id]/photos/[photoId]/duplicate (gated on edit_jobs)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockCaller({ user: null });
+    const res = await POST(postRequest(), paramsFor);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller holds only view_jobs", async () => {
+    mockCaller({ user: { id: "u1" }, grants: ["view_jobs"] });
+    const res = await POST(postRequest(), paramsFor);
+    expect(res.status).toBe(403);
+  });
+
+  it("copies the clean original to a fresh path and delegates the row insert to duplicate_photo", async () => {
+    const rec = mockCaller({
+      user: { id: "u1" },
+      grants: ["edit_jobs"],
+      // The source has been drawn on; the duplicate must copy the ORIGINAL,
+      // never the annotation render.
+      photos: [
+        {
+          id: "p-1",
+          job_id: "job-1",
+          storage_path: "org-1/job-1/p-1.jpg",
+          annotated_path: "org-1/job-1/p-1-annotated.png",
+        },
+      ],
+    });
+
+    const res = await POST(postRequest(), paramsFor);
+
+    expect(res.status).toBe(201);
+
+    // Copied the clean original (storage_path), never the annotated render,
+    // into the photos bucket at a fresh org/job-scoped path with the original's
+    // extension.
+    expect(rec.copies).toHaveLength(1);
+    const copy = rec.copies[0];
+    expect(copy.bucket).toBe("photos");
+    expect(copy.from).toBe("org-1/job-1/p-1.jpg");
+    expect(copy.to).not.toBe("org-1/job-1/p-1-annotated.png");
+    expect(copy.to).toMatch(/^org-1\/job-1\/.+\.jpg$/);
+
+    // Handed the SAME fresh path to the deep module, keyed by the source id.
+    expect(rec.rpcs).toHaveLength(1);
+    expect(rec.rpcs[0].fn).toBe("duplicate_photo");
+    expect(rec.rpcs[0].args).toEqual({
+      p_source_photo_id: "p-1",
+      p_new_storage_path: copy.to,
+    });
+
+    // Answers with the new Photo row.
+    expect(await res.json()).toMatchObject({ id: "p-2", job_id: "job-1" });
+  });
+
+  it("returns 404 and neither copies nor inserts when the photo is not in the Job", async () => {
+    const rec = mockCaller({
+      user: { id: "u1" },
+      grants: ["edit_jobs"],
+      photos: [
+        { id: "p-1", job_id: "another-job", storage_path: "org-1/another/p-1.jpg" },
+      ],
+    });
+
+    const res = await POST(postRequest(), paramsFor);
+
+    expect(res.status).toBe(404);
+    expect(rec.copies).toHaveLength(0);
+    expect(rec.rpcs).toHaveLength(0);
+  });
+});

--- a/src/app/api/jobs/[id]/photos/[photoId]/duplicate/route.ts
+++ b/src/app/api/jobs/[id]/photos/[photoId]/duplicate/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+
+// POST /api/jobs/[id]/photos/[photoId]/duplicate — Duplicate (clean same-Job
+// copy, #519). Copies the clean ORIGINAL blob to a fresh path, then hands that
+// path to the `duplicate_photo` deep module, which writes the new Photo row and
+// re-links its tags. The annotation render is never copied — a duplicate is a
+// clean original. Gated on `edit_jobs`; the Job scope (+ RLS) confirms the
+// caller owns the Photo.
+export const POST = withRequestContext(
+  { permission: "edit_jobs" },
+  async (
+    _request,
+    ctx,
+    { params }: { params: Promise<{ id: string; photoId: string }> },
+  ) => {
+    const { id: jobId, photoId } = await params;
+    const supabase = ctx.supabase;
+
+    const { data: source, error: fetchErr } = await supabase
+      .from("photos")
+      .select("storage_path")
+      .eq("job_id", jobId)
+      .eq("id", photoId)
+      .maybeSingle();
+    if (fetchErr) return apiDbError(fetchErr.message, "POST duplicate select");
+    if (!source) {
+      return NextResponse.json({ error: "Photo not found" }, { status: 404 });
+    }
+
+    // Copy the clean original to a fresh org/job-scoped path so the duplicate
+    // owns an independent object — deleting or annotating one never touches the
+    // other. The extension follows the original.
+    const ext = source.storage_path.split(".").pop() || "jpg";
+    const newPath = `${ctx.orgId}/${jobId}/${randomUUID()}.${ext}`;
+    const { error: copyErr } = await supabase.storage
+      .from("photos")
+      .copy(source.storage_path, newPath);
+    if (copyErr) return apiDbError(copyErr.message, "POST duplicate copy");
+
+    // The deep module writes the new row + re-links tags, returning the copy.
+    const { data: duplicated, error: rpcErr } = await supabase.rpc(
+      "duplicate_photo",
+      { p_source_photo_id: photoId, p_new_storage_path: newPath },
+    );
+    if (rpcErr) return apiDbError(rpcErr.message, "POST duplicate insert");
+
+    return NextResponse.json(duplicated, { status: 201 });
+  },
+);

--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -664,6 +664,73 @@ describe("PhotoViewer — Share / Save to device (⋯ More)", () => {
   });
 });
 
+describe("PhotoViewer — Duplicate (⋯ More)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ id: "p2", job_id: "job-1" }),
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to the duplicate endpoint for the current Photo, then refetches and toasts", async () => {
+    const { photo, onUpdated } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /duplicate/i }));
+    });
+
+    // The clean same-Job copy is the endpoint's job (Storage copy + new row +
+    // tag re-link); the viewer only kicks it off for the current Photo.
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/jobs/${photo.job_id}/photos/${photo.id}/duplicate`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    // The grid refetches so the new copy shows up, and the user is told.
+    expect(onUpdated).toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/duplicat/i));
+    // The ⋯ menu closes after the action.
+    expect(screen.queryByRole("button", { name: /duplicate/i })).toBeNull();
+  });
+
+  it("is offered for a video too (it copies the original file)", async () => {
+    renderViewer({ photos: [makePhoto({ media_type: "video", storage_path: "job-1/clip.mp4" })] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+
+    expect(screen.queryByRole("button", { name: /duplicate/i })).toBeTruthy();
+  });
+
+  it("warns and does not refetch when the duplicate request fails", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, json: async () => ({ error: "nope" }) });
+    const { onUpdated } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /duplicate/i }));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/duplicat/i));
+    expect(onUpdated).not.toHaveBeenCalled();
+  });
+});
+
 describe("PhotoViewer — Cover indicator", () => {
   it("shows a Cover badge when the current Photo is the Job's cover", async () => {
     const photo = makePhoto();

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -42,6 +42,7 @@ import {
   MoreHorizontal,
   Share2,
   ArrowDownToLine,
+  Copy,
   Star,
   ChevronLeft,
   ChevronRight,
@@ -341,6 +342,7 @@ export default function PhotoViewer({
   // Which export, if any, is in flight — so the chosen ⋯ menu entry shows a
   // spinner and both stay disabled until the share/download settles.
   const [exporting, setExporting] = useState<null | "share" | "save">(null);
+  const [duplicating, setDuplicating] = useState(false);
 
   async function fetchTags(photoId: string) {
     const supabase = createClient();
@@ -579,6 +581,28 @@ export default function PhotoViewer({
       );
     }
     setExporting(null);
+    setMoreOpen(false);
+  }
+
+  // Duplicate makes a clean same-Job copy of the Photo (#519). The work — copy
+  // the clean original blob, insert the new row, re-link the tags — lives behind
+  // the duplicate endpoint + deep module (never the drawings); the viewer kicks
+  // it off and refetches so the fresh copy lands in the Job's grid.
+  async function handleDuplicate() {
+    if (!currentPhoto) return;
+    setDuplicating(true);
+    try {
+      const res = await fetch(
+        `/api/jobs/${currentPhoto.job_id}/photos/${currentPhoto.id}/duplicate`,
+        { method: "POST" },
+      );
+      if (!res.ok) throw new Error("duplicate failed");
+      toast.success("Photo duplicated.");
+      onUpdated();
+    } catch {
+      toast.error("Failed to duplicate photo.");
+    }
+    setDuplicating(false);
     setMoreOpen(false);
   }
 
@@ -879,6 +903,19 @@ export default function PhotoViewer({
                 <ArrowDownToLine size={14} />
               )}
               Save to device
+            </button>
+            <button
+              type="button"
+              onClick={handleDuplicate}
+              disabled={duplicating}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-[#1A1A1A] hover:bg-gray-100 rounded-md transition-colors disabled:opacity-60 disabled:hover:bg-transparent"
+            >
+              {duplicating ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Copy size={14} />
+              )}
+              Duplicate
             </button>
           </div>
         )}

--- a/supabase/migration-519-duplicate-photo.sql
+++ b/supabase/migration-519-duplicate-photo.sql
@@ -1,0 +1,55 @@
+-- Issue #519 — Duplicate (clean same-Job copy).
+--
+-- `duplicate_photo` is the deep module behind the viewer's Duplicate ⋯ More
+-- action: it makes a fresh Photo row from a source, in the SAME Job. The
+-- endpoint copies the clean ORIGINAL blob in Storage (never the drawings) to a
+-- new path and hands that path in; this function writes the new row and
+-- re-links the source's tags. Caption and Before/After (role + pairing) carry
+-- over; the duplicate is a clean original, so it never inherits the annotation
+-- render. Returns the new row so the endpoint can answer with it.
+
+CREATE OR REPLACE FUNCTION public.duplicate_photo(
+  p_source_photo_id uuid,
+  p_new_storage_path text
+)
+ RETURNS photos
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  v_src photos%ROWTYPE;
+  v_new photos%ROWTYPE;
+BEGIN
+  SELECT * INTO v_src FROM photos WHERE id = p_source_photo_id;
+  IF v_src.id IS NULL THEN
+    RAISE EXCEPTION 'photo_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  -- annotated_path is omitted on purpose: the duplicate is a clean original,
+  -- so it never inherits the source's annotation render. client_capture_id is
+  -- omitted too — it is a per-capture idempotency key, and a duplicate is not a
+  -- fresh capture. created_at defaults to now() so the copy sorts to the top of
+  -- the Job's grid (ordered by created_at DESC).
+  INSERT INTO photos (
+    job_id, organization_id, storage_path, caption,
+    before_after_role, before_after_pair_id,
+    media_type, file_size, width, height, taken_by, taken_at
+  )
+  VALUES (
+    v_src.job_id, v_src.organization_id, p_new_storage_path, v_src.caption,
+    v_src.before_after_role, v_src.before_after_pair_id,
+    v_src.media_type, v_src.file_size, v_src.width, v_src.height,
+    v_src.taken_by, v_src.taken_at
+  )
+  RETURNING * INTO v_new;
+
+  -- Re-apply the source's tags to the copy (same tag + org, new photo).
+  INSERT INTO photo_tag_assignments (organization_id, photo_id, tag_id)
+  SELECT organization_id, v_new.id, tag_id
+    FROM photo_tag_assignments
+   WHERE photo_id = v_src.id;
+
+  RETURN v_new;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.duplicate_photo(uuid, text) TO authenticated;

--- a/tests/integration/duplicate-photo-schema.sql
+++ b/tests/integration/duplicate-photo-schema.sql
@@ -1,0 +1,64 @@
+-- Self-contained schema for the embedded-postgres duplicate_photo harness
+-- (#519). Loaded by duplicate-photo.pg.test.ts into a throwaway cluster.
+--
+-- This is NOT the Supabase stack: there is no PostgREST, no RLS, and none of
+-- the anon/authenticated/service_role grants the shared schema-photos.sql
+-- carries. It is the smallest schema that lets the LIVE migration-519 function
+-- run: the three photo tables it reads/writes, with the columns it touches,
+-- typed to match the prod shape (supabase/schema-photos.sql).
+--
+-- Deliberate divergences from prod, all safe because the RPC never depends on
+-- them:
+--   * photos drops the NOT NULL job_id FK and the organization_id FK — a
+--     fixture is just a bare photo row, no org/job chain to seed.
+--   * before_after_pair_id is FK-LESS — duplicating an "after" copies its pair
+--     link verbatim; a self-referential FK would force every fixture to also
+--     seed the partner row just to exercise the copy.
+
+-- gen_random_uuid() is core since PG 13; keep pgcrypto too for older binaries.
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Photos: the function reads the source row and writes the duplicate. Columns
+-- and CHECKs mirror prod (schema-photos.sql §1) minus the org/job/pair FKs.
+CREATE TABLE photos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  job_id uuid NOT NULL,
+  storage_path text NOT NULL,
+  annotated_path text,
+  caption text,
+  taken_at timestamptz,
+  taken_by text NOT NULL DEFAULT 'Eric',
+  media_type text NOT NULL DEFAULT 'photo'
+    CHECK (media_type IN ('photo', 'video')),
+  file_size integer,
+  width integer,
+  height integer,
+  before_after_pair_id uuid,
+  before_after_role text
+    CHECK (before_after_role IN ('before', 'after')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL,
+  uploaded_from text NOT NULL DEFAULT 'web',
+  client_capture_id text
+);
+
+-- Tags: read only to satisfy the assignment FK when a fixture seeds tags.
+CREATE TABLE photo_tags (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  color text NOT NULL DEFAULT '#2B5EA7',
+  created_by text NOT NULL DEFAULT 'Eric',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL
+);
+
+-- Tag assignments: the join the function re-inserts for the duplicate. The
+-- UNIQUE(photo_id, tag_id) mirrors prod so a double-link would be rejected.
+CREATE TABLE photo_tag_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  photo_id uuid NOT NULL REFERENCES photos(id) ON DELETE CASCADE,
+  tag_id uuid NOT NULL REFERENCES photo_tags(id) ON DELETE CASCADE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  organization_id uuid NOT NULL,
+  UNIQUE(photo_id, tag_id)
+);

--- a/tests/integration/duplicate-photo.pg.test.ts
+++ b/tests/integration/duplicate-photo.pg.test.ts
@@ -1,0 +1,295 @@
+// Issue #519 — Duplicate (clean same-Job copy). Integration test for the
+// `duplicate_photo` RPC (the deep module behind the Duplicate ⋯ More action),
+// driven against a real Postgres via the embedded-postgres harness. The
+// endpoint copies the clean original blob in Storage and hands the new path to
+// this function, which writes the new Photo row + re-links its tags.
+//
+// Mirrors the embedded-postgres pattern in apply-template.pg.test.ts: boot a
+// throwaway cluster in beforeAll, load the focused schema + the LIVE
+// migration-519 function, drive queries through a raw pg client.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import { randomUUID } from "node:crypto";
+
+import EmbeddedPostgres from "embedded-postgres";
+import type { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SCHEMA_SQL = readFileSync(
+  join(process.cwd(), "tests", "integration", "duplicate-photo-schema.sql"),
+  "utf8",
+);
+const MIGRATION_SQL = readFileSync(
+  join(process.cwd(), "supabase", "migration-519-duplicate-photo.sql"),
+  "utf8",
+);
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+let pgServer: EmbeddedPostgres;
+let dataDir: string;
+let client: Client;
+
+const TEST_DB = "duplicate_photo_test";
+
+beforeAll(async () => {
+  dataDir = mkdtempSync(join(tmpdir(), "nookleus-pg-"));
+  pgServer = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    port: await freePort(),
+    user: "postgres",
+    password: "postgres",
+    persistent: false,
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+
+  await pgServer.initialise();
+  await pgServer.start();
+  await pgServer.createDatabase(TEST_DB);
+
+  client = pgServer.getPgClient(TEST_DB);
+  await client.connect();
+
+  await client.query(
+    "DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated; END IF; END $$;",
+  );
+  await client.query(SCHEMA_SQL);
+  await client.query(MIGRATION_SQL);
+}, 120_000);
+
+afterAll(async () => {
+  if (client) await client.end().catch(() => {});
+  if (pgServer) await pgServer.stop().catch(() => {});
+  if (dataDir) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp-dir cleanup */
+    }
+  }
+});
+
+interface PhotoRow {
+  id: string;
+  job_id: string;
+  storage_path: string;
+  annotated_path: string | null;
+  caption: string | null;
+  taken_at: string | null;
+  taken_by: string;
+  media_type: string;
+  file_size: number | null;
+  width: number | null;
+  height: number | null;
+  before_after_pair_id: string | null;
+  before_after_role: string | null;
+  organization_id: string;
+  uploaded_from: string;
+  client_capture_id: string | null;
+}
+
+/** Seed one source Photo, returning its row. Overrides patch the defaults. */
+async function seedPhoto(
+  fields: Partial<PhotoRow> & { job_id?: string; organization_id?: string } = {},
+): Promise<PhotoRow> {
+  const row = {
+    job_id: fields.job_id ?? randomUUID(),
+    organization_id: fields.organization_id ?? randomUUID(),
+    storage_path: fields.storage_path ?? `org/job/${randomUUID()}.jpg`,
+    annotated_path: fields.annotated_path ?? null,
+    caption: fields.caption ?? null,
+    taken_at: fields.taken_at ?? null,
+    taken_by: fields.taken_by ?? "Eric",
+    media_type: fields.media_type ?? "photo",
+    file_size: fields.file_size ?? null,
+    width: fields.width ?? null,
+    height: fields.height ?? null,
+    before_after_pair_id: fields.before_after_pair_id ?? null,
+    before_after_role: fields.before_after_role ?? null,
+    uploaded_from: fields.uploaded_from ?? "web",
+    client_capture_id: fields.client_capture_id ?? null,
+  };
+  const { rows } = await client.query<PhotoRow>(
+    `INSERT INTO photos (
+       job_id, organization_id, storage_path, annotated_path, caption,
+       taken_at, taken_by, media_type, file_size, width, height,
+       before_after_pair_id, before_after_role, uploaded_from, client_capture_id
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+     RETURNING *`,
+    [
+      row.job_id, row.organization_id, row.storage_path, row.annotated_path, row.caption,
+      row.taken_at, row.taken_by, row.media_type, row.file_size, row.width, row.height,
+      row.before_after_pair_id, row.before_after_role, row.uploaded_from, row.client_capture_id,
+    ],
+  );
+  return rows[0];
+}
+
+/** Seed a tag in an org and return its id. */
+async function seedTag(orgId: string, name: string): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    "INSERT INTO photo_tags (organization_id, name) VALUES ($1, $2) RETURNING id",
+    [orgId, name],
+  );
+  return rows[0].id;
+}
+
+/** Assign a tag to a photo. */
+async function assignTag(orgId: string, photoId: string, tagId: string): Promise<void> {
+  await client.query(
+    "INSERT INTO photo_tag_assignments (organization_id, photo_id, tag_id) VALUES ($1, $2, $3)",
+    [orgId, photoId, tagId],
+  );
+}
+
+/** The tag ids assigned to a photo. */
+async function tagIdsOf(photoId: string): Promise<string[]> {
+  const { rows } = await client.query<{ tag_id: string }>(
+    "SELECT tag_id FROM photo_tag_assignments WHERE photo_id = $1 ORDER BY tag_id",
+    [photoId],
+  );
+  return rows.map((r) => r.tag_id);
+}
+
+/** Call the function under test, returning the new Photo row. */
+async function duplicatePhoto(sourceId: string, newPath: string): Promise<PhotoRow> {
+  const { rows } = await client.query<PhotoRow>(
+    "SELECT * FROM duplicate_photo($1, $2)",
+    [sourceId, newPath],
+  );
+  return rows[0];
+}
+
+describe("duplicate_photo — new row in the same Job", () => {
+  it("inserts exactly one new Photo row in the source's Job", async () => {
+    const source = await seedPhoto();
+    const newPath = `org/job/${randomUUID()}.jpg`;
+
+    const copy = await duplicatePhoto(source.id, newPath);
+
+    // A distinct row…
+    expect(copy.id).not.toBe(source.id);
+    // …in the same Job…
+    expect(copy.job_id).toBe(source.job_id);
+    expect(copy.organization_id).toBe(source.organization_id);
+    // …carrying the path the endpoint copied the clean original to.
+    expect(copy.storage_path).toBe(newPath);
+
+    // Exactly one new row landed in that Job (source + copy).
+    const { rows } = await client.query<{ count: string }>(
+      "SELECT COUNT(*)::text AS count FROM photos WHERE job_id = $1",
+      [source.job_id],
+    );
+    expect(Number(rows[0].count)).toBe(2);
+  });
+});
+
+describe("duplicate_photo — preserves the Photo's fields", () => {
+  it("carries the caption over to the copy", async () => {
+    const source = await seedPhoto({ caption: "Roof damage to NE corner" });
+
+    const copy = await duplicatePhoto(source.id, `org/job/${randomUUID()}.jpg`);
+
+    expect(copy.caption).toBe("Roof damage to NE corner");
+  });
+
+  it("keeps the Before/After role and its pairing link", async () => {
+    const partnerId = randomUUID();
+    const source = await seedPhoto({
+      before_after_role: "after",
+      before_after_pair_id: partnerId,
+    });
+
+    const copy = await duplicatePhoto(source.id, `org/job/${randomUUID()}.jpg`);
+
+    expect(copy.before_after_role).toBe("after");
+    expect(copy.before_after_pair_id).toBe(partnerId);
+  });
+});
+
+describe("duplicate_photo — clean original, never the drawings", () => {
+  it("copies as a clean original: the given path, and annotated_path is NULL even when the source was drawn on", async () => {
+    const source = await seedPhoto({
+      storage_path: "org/job/original.jpg",
+      annotated_path: "org/job/original-annotated.png",
+    });
+    const newPath = `org/job/${randomUUID()}.jpg`;
+
+    const copy = await duplicatePhoto(source.id, newPath);
+
+    // The duplicate points at the freshly-copied original, not the source's
+    // path and never the annotation render.
+    expect(copy.storage_path).toBe(newPath);
+    expect(copy.annotated_path).toBeNull();
+  });
+
+  it("preserves the media kind and dimensions so a duplicated video stays a playable video", async () => {
+    const source = await seedPhoto({
+      media_type: "video",
+      storage_path: "org/job/clip.mp4",
+      file_size: 1_048_576,
+      width: 1920,
+      height: 1080,
+      taken_by: "Jordan",
+      taken_at: "2026-05-01T15:30:00.000Z",
+    });
+
+    const copy = await duplicatePhoto(source.id, "org/job/clip-copy.mp4");
+
+    expect(copy.media_type).toBe("video");
+    expect(copy.width).toBe(1920);
+    expect(copy.height).toBe(1080);
+    expect(copy.file_size).toBe(1_048_576);
+    expect(copy.taken_by).toBe("Jordan");
+    expect(new Date(copy.taken_at as string).toISOString()).toBe(
+      "2026-05-01T15:30:00.000Z",
+    );
+  });
+});
+
+describe("duplicate_photo — re-links the source's tags", () => {
+  it("assigns the copy the same tags (ids + org) the source carried", async () => {
+    const orgId = randomUUID();
+    const source = await seedPhoto({ organization_id: orgId });
+    const roof = await seedTag(orgId, "Roof");
+    const water = await seedTag(orgId, "Water Damage");
+    await assignTag(orgId, source.id, roof);
+    await assignTag(orgId, source.id, water);
+
+    const copy = await duplicatePhoto(source.id, `org/job/${randomUUID()}.jpg`);
+
+    // The copy carries exactly the source's tags — same ids…
+    expect(await tagIdsOf(copy.id)).toEqual([roof, water].sort());
+    // …each stamped with the same organization.
+    const { rows } = await client.query<{ organization_id: string }>(
+      "SELECT organization_id FROM photo_tag_assignments WHERE photo_id = $1",
+      [copy.id],
+    );
+    expect(rows.every((r) => r.organization_id === orgId)).toBe(true);
+    // The source keeps its own assignments untouched.
+    expect(await tagIdsOf(source.id)).toEqual([roof, water].sort());
+  });
+
+  it("leaves the copy untagged when the source had no tags", async () => {
+    const source = await seedPhoto();
+
+    const copy = await duplicatePhoto(source.id, `org/job/${randomUUID()}.jpg`);
+
+    expect(await tagIdsOf(copy.id)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #519.

## What this does

Adds **Duplicate** to the photo viewer's ⋯ More menu. Duplicating makes a fresh copy of the Photo **in the same Job** from the clean **original** image (never the drawings), keeping the caption + **Before/After** (role and pairing) and re-applying the same tags. The copy lands at the top of the Job's grid (fresh `created_at`).

## How it's built

- **Deep module** — [`supabase/migration-519-duplicate-photo.sql`](../blob/519-photo-viewer-duplicate/supabase/migration-519-duplicate-photo.sql): a `duplicate_photo(p_source_photo_id, p_new_storage_path)` PL/pgSQL function (the repo's convention for DB logic, like `apply_template_to_estimate`). Inserts one new `photos` row in the same job/org with `annotated_path = NULL` (clean original), copies the source's caption / role / pairing / media metadata, then re-inserts its `photo_tag_assignments`. `client_capture_id` is dropped (it's a per-capture idempotency key, not a duplicate).
- **Endpoint** — `POST /api/jobs/[id]/photos/[photoId]/duplicate`, gated on `edit_jobs`. Scopes the source to the Job, Storage-`copy()`s the **clean original** to a fresh `{org}/{job}/{uuid}.{ext}` path (an independent object — deleting/annotating one never touches the other), calls the deep module, returns the new row. Mirrors the existing contract-template duplicate route.
- **Viewer** — a Duplicate ⋯ More entry (offered for **photos and videos**) that POSTs the endpoint and refetches so the copy appears in the grid.

## Decisions
- Keeps **both** the Before/After role **and** the pairing link (`before_after_pair_id`).
- Duplicate is available for **videos** too (it copies the original file).

## Acceptance criteria
- [x] Duplicate creates a new Photo in the same Job from the clean original (no drawings)
- [x] The copy keeps the caption, Before/After role, and the same tags
- [x] The copy appears in the Job's photo grid
- [x] A duplicate-photo deep module performs the copy / insert / tag-relink; a new endpoint wraps it
- [x] Integration test verifies: original (not annotated) copied, caption + tags preserved, same Job, one new Photo row + matching tag assignments
- [x] No new test failures beyond the known-red baseline

## Tests (TDD, red→green per slice)
- `tests/integration/duplicate-photo.pg.test.ts` — **7** tests (embedded-postgres, `npm run test:pg`): same-job row, caption, role + pairing, clean-original/no-drawings + media fidelity, tag re-link, no-tags guard.
- `…/duplicate/route.test.ts` — **4** tests: 401/403 gate, clean-original copy + RPC + 201, 404 when not in Job.
- `photo-viewer.test.tsx` — **3** new tests: POST + refetch + toast, offered for video, error path.

Verification: pg 7/7 · photos route tests 14/14 · viewer suite 56/56 · `tsc --noEmit` 0 errors · ESLint 0 errors.

## Note for deploy
`duplicate_photo` ships as a migration — run `supabase/migration-519-duplicate-photo.sql` against the database. The endpoint's `storage.copy` runs on the user client (matching the viewer's existing photos-bucket ops); worth a quick smoke once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)