### PR TITLE
feat(phone): voicemail + auto-transcription (#313)

### DIFF
--- a/src/app/api/phone/conversations/[id]/calls/route.test.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.test.ts
@@ -99,4 +99,90 @@ describe("GET /api/phone/conversations/[id]/calls", () => {
       }),
     ]);
   });
+
+  // Slice 9 (#313) — a call that went to voicemail carries its recording +
+  // transcript inline. Supabase embeds the related phone_voicemails row(s)
+  // under the embed key; the route flattens the (0-or-1, UNIQUE per call)
+  // result to a single `voicemail` field so the client gets a clean
+  // `voicemail | null` rather than a PostgREST array.
+  it("flattens an embedded voicemail onto the call as `voicemail`", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      {
+        id: "call-vm",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "in",
+        status: "no_answer",
+        duration_seconds: 18,
+        started_at: "2026-05-27T10:00:00Z",
+        ended_at: "2026-05-27T10:00:18Z",
+        // PostgREST returns the embed as an array (FK on the child table).
+        phone_voicemails: [
+          {
+            id: "vm-1",
+            audio_storage_path: "org-1/rec-1.mp3",
+            transcript: "Hi, please call me back about the roof.",
+            transcript_status: "ready",
+            duration_seconds: 12,
+          },
+        ],
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].voicemail).toEqual({
+      id: "vm-1",
+      audio_storage_path: "org-1/rec-1.mp3",
+      transcript: "Hi, please call me back about the roof.",
+      transcript_status: "ready",
+      duration_seconds: 12,
+    });
+    // The raw PostgREST embed key is gone — the client sees only `voicemail`.
+    expect("phone_voicemails" in body[0]).toBe(false);
+  });
+
+  it("sets voicemail to null for a call with no recording", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      {
+        id: "call-plain",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "out",
+        status: "completed",
+        duration_seconds: 30,
+        started_at: "2026-05-27T11:00:00Z",
+        ended_at: "2026-05-27T11:00:30Z",
+        phone_voicemails: [],
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].voicemail).toBeNull();
+  });
 });

--- a/src/app/api/phone/conversations/[id]/calls/route.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.ts
@@ -12,9 +12,27 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 // is untouched. RLS (migration-312) enforces the ADR 0003 matrix; the route
 // is a thin pass-through — a caller who cannot see a row simply doesn't get
 // it back.
+//
+// Slice 9 (#313) — each call also embeds its voicemail (recording +
+// transcript). The embed runs under the same User-client RLS, so a row the
+// caller can't see is simply absent. PostgREST returns the embed as an array
+// keyed off the child FK; since phone_voicemails is UNIQUE per call we
+// flatten it to a single `voicemail | null` for the client.
 
 const FIELDS =
-  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at";
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at, phone_voicemails(id, audio_storage_path, transcript, transcript_status, duration_seconds)";
+
+// Flatten PostgREST's embed array (0-or-1 row, UNIQUE per call) into a single
+// `voicemail` field, dropping the raw embed key.
+function flattenVoicemail(row: Record<string, unknown>): Record<string, unknown> {
+  const { phone_voicemails, ...call } = row as {
+    phone_voicemails?: unknown;
+  } & Record<string, unknown>;
+  const voicemail = Array.isArray(phone_voicemails)
+    ? (phone_voicemails[0] ?? null)
+    : (phone_voicemails ?? null);
+  return { ...call, voicemail };
+}
 
 export const GET = withRequestContext(
   { permission: "view_phone" },
@@ -28,6 +46,9 @@ export const GET = withRequestContext(
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
-    return NextResponse.json(data ?? []);
+    const calls = ((data ?? []) as Record<string, unknown>[]).map(
+      flattenVoicemail,
+    );
+    return NextResponse.json(calls);
   },
 );

--- a/src/app/api/phone/recordings/route.test.ts
+++ b/src/app/api/phone/recordings/route.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+// PRD #304 — Nookleus Phone. Slice 9 (#313).
+//
+// Tests for the voicemail-recording signed-URL route. The thread renders a
+// voicemail's audio in an <audio> element; the browser needs a short-lived
+// public URL for the stored MP3. Mirrors GET /api/phone/attachments —
+// view_phone gated, service-client signing, cross-org reads refused at the
+// path level (objects live under `{org}/...` in the phone-recordings bucket).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const ORG = "org-1";
+const routeCtx = { params: Promise.resolve({}) };
+
+function getRequest(path: string): Request {
+  return new Request(
+    `http://test/api/phone/recordings?path=${encodeURIComponent(path)}`,
+  );
+}
+
+// Service-client fake exposing only storage.createSignedUrl, recording the
+// bucket + path it was asked to sign.
+function makeService() {
+  const signed: Array<{ bucket: string; path: string }> = [];
+  return {
+    signed,
+    client: {
+      storage: {
+        from(bucket: string) {
+          return {
+            async createSignedUrl(path: string) {
+              signed.push({ bucket, path });
+              return {
+                data: { signedUrl: `https://signed/${bucket}/${path}` },
+                error: null,
+              };
+            },
+          };
+        },
+      },
+    },
+  };
+}
+
+function authed(userId: string, role: "admin" | "crew_lead" | "crew_member") {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({
+      user: { id: userId },
+      tables: memberTables({
+        userId,
+        role,
+        grants: role === "crew_member" ? [] : ["view_phone"],
+      }),
+    }) as never,
+  );
+}
+
+function unauthed() {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient({ user: null }) as never,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue(ORG);
+});
+
+describe("GET /api/phone/recordings — signed URL", () => {
+  it("401 when unauthenticated", async () => {
+    unauthed();
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(getRequest("org-1/rec.mp3"), routeCtx);
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when caller lacks view_phone (crew_member)", async () => {
+    authed("u-cm", "crew_member");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(getRequest("org-1/rec.mp3"), routeCtx);
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when no path is given", async () => {
+    authed("u-1", "crew_lead");
+    vi.mocked(createServiceClient).mockReturnValue(makeService().client as never);
+    const res = await GET(
+      new Request("http://test/api/phone/recordings"),
+      routeCtx,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("404 for a path outside the caller's organization", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+    const res = await GET(getRequest("org-OTHER/secret.mp3"), routeCtx);
+    expect(res.status).toBe(404);
+    // Never even attempted to sign a cross-org object.
+    expect(svc.signed).toHaveLength(0);
+  });
+
+  it("returns a signed URL on the phone-recordings bucket for an in-org path", async () => {
+    authed("u-1", "crew_lead");
+    const svc = makeService();
+    vi.mocked(createServiceClient).mockReturnValue(svc.client as never);
+    const res = await GET(getRequest("org-1/rec.mp3"), routeCtx);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe("https://signed/phone-recordings/org-1/rec.mp3");
+    expect(svc.signed).toEqual([
+      { bucket: "phone-recordings", path: "org-1/rec.mp3" },
+    ]);
+  });
+});

--- a/src/app/api/phone/recordings/route.ts
+++ b/src/app/api/phone/recordings/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import {
+  signedUrlForPhoneRecording,
+  type PhoneRecordingStorageClient,
+} from "@/lib/phone/recordings-storage";
+
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — voicemail-recording signed URL.
+//
+// Thread render needs a short-lived public URL for a stored voicemail MP3 so
+// the <audio> element can play it. Mirrors GET /api/phone/attachments: it is
+// view_phone gated and signs through the Service client, but cross-org reads
+// are refused at the path level — every recording lives under `{org}/...` in
+// the phone-recordings bucket, so a path outside the caller's Organization
+// prefix is a 404 (we never even ask Storage to sign it).
+
+const SIGNED_URL_TTL_SECONDS = 600; // 10 minutes
+
+export const GET = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx) => {
+    if (!ctx.orgId) {
+      return NextResponse.json(
+        { error: "No active organization" },
+        { status: 403 },
+      );
+    }
+    const path = new URL(request.url).searchParams.get("path");
+    if (!path) {
+      return NextResponse.json({ error: "path is required" }, { status: 400 });
+    }
+    if (!path.startsWith(`${ctx.orgId}/`)) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    try {
+      const url = await signedUrlForPhoneRecording(
+        ctx.serviceClient as unknown as PhoneRecordingStorageClient,
+        path,
+        SIGNED_URL_TTL_SECONDS,
+      );
+      return NextResponse.json({ url });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Not found";
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+  },
+);

--- a/src/app/api/phone/voicemails/[id]/route.test.ts
+++ b/src/app/api/phone/voicemails/[id]/route.test.ts
@@ -1,0 +1,384 @@
+// PRD #304 — Nookleus Phone. Slice 10 (#313) — delete-voicemail route.
+//
+// DELETE /api/phone/voicemails/[id]
+// canManage-gated (mirrors numbers/[id]/release): Shared is admin-only,
+// Personal is owner-or-admin. The number kind/owner is resolved by joining
+// the voicemail → its parent call → conversation → phone_number through the
+// Service client, exactly like the re-tag route.
+//
+// Ordering: Twilio first, DB second (then a best-effort Storage cleanup).
+// Twilio's recording is the retention-relevant thing (PRD #304 story 54) — a
+// successful Twilio hard-delete + DB-write failure is recoverable (admin
+// retries; Twilio's remove of an already-removed SID errors cleanly). The
+// reverse — row gone, recording still on Twilio — silently keeps a recording
+// Nookleus believes it deleted, so we refuse to touch the DB until Twilio
+// confirms (502 on Twilio failure leaves the row untouched).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+const deleteRecordingMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  deleteRecording: (...args: unknown[]) => deleteRecordingMock(...args),
+  createTwilioClient: () => ({}),
+}));
+
+import { DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const idParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const VOICEMAIL_ROW = {
+  id: "vm-1",
+  organization_id: "org-1",
+  phone_call_id: "call-1",
+  twilio_recording_sid: "REabc",
+  audio_storage_path: "org-1/rec-1.mp3",
+};
+const CALL_ROW = {
+  id: "call-1",
+  organization_id: "org-1",
+  conversation_id: "conv-1",
+};
+const CONVERSATION_ROW = {
+  id: "conv-1",
+  organization_id: "org-1",
+  phone_number_id: "num-1",
+};
+// Shared number — admin-only manage.
+const SHARED_NUMBER = {
+  id: "num-1",
+  organization_id: "org-1",
+  kind: "shared" as const,
+  user_id: null,
+};
+
+// A Service client over the 4 tables the route joins, with spies on the
+// voicemail-row delete and the Storage-object remove so a test can assert
+// ordering (the DB delete must NOT fire when Twilio errors) and cleanup.
+function instrumentedService(
+  overrides: {
+    voicemail?: Record<string, unknown> | null;
+    number?: Record<string, unknown>;
+  } = {},
+) {
+  const voicemail =
+    overrides.voicemail === undefined ? VOICEMAIL_ROW : overrides.voicemail;
+  const tables: Record<string, Record<string, unknown>[]> = {
+    phone_voicemails: voicemail ? [voicemail] : [],
+    phone_calls: [CALL_ROW],
+    phone_conversations: [CONVERSATION_ROW],
+    phone_numbers: [overrides.number ?? SHARED_NUMBER],
+  };
+  const svc = fakeServiceClient({ tables }) as unknown as {
+    from: (table: string) => Record<string, unknown>;
+    storage: unknown;
+  };
+  const deleteSpy = vi.fn();
+  const removeSpy = vi.fn(async () => ({ data: [], error: null }));
+  const origFrom = svc.from.bind(svc);
+  svc.from = (table: string) => {
+    const builder = origFrom(table) as Record<string, unknown> & {
+      delete: (...a: unknown[]) => unknown;
+    };
+    if (table === "phone_voicemails") {
+      const origDelete = builder.delete.bind(builder);
+      builder.delete = (...a: unknown[]) => {
+        deleteSpy(...a);
+        return origDelete(...a);
+      };
+    }
+    return builder;
+  };
+  svc.storage = {
+    from: () => ({
+      remove: removeSpy,
+      async download() {
+        return { data: null, error: { message: "not found" } };
+      },
+      async upload() {
+        return { data: null, error: null };
+      },
+    }),
+  };
+  return { svc, deleteSpy, removeSpy };
+}
+
+function serviceReturns(svc: unknown) {
+  vi.mocked(createServiceClient).mockReturnValue(svc as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  serviceReturns(instrumentedService().svc);
+  deleteRecordingMock.mockResolvedValue(undefined);
+});
+
+describe("DELETE /api/phone/voicemails/[id]", () => {
+  it("admin deletes a Shared voicemail: hard-deletes the Twilio recording, then 200", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteRecordingMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "REabc",
+    );
+  });
+
+  it("403 when the caller lacks view_phone (permission gate, before any lookup)", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("view_phone holder who is not an admin cannot delete a Shared voicemail: 403, no Twilio remove, DB untouched", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "lead-1" },
+      tables: memberTables({
+        userId: "lead-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("404 when the voicemail does not exist", async () => {
+    const { svc } = instrumentedService({ voicemail: null });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+  });
+
+  it("404 when the voicemail belongs to another org (no cross-org reach)", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      voicemail: { ...VOICEMAIL_ROW, organization_id: "org-2" },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("Twilio failure → 502 and the DB row is left untouched", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    deleteRecordingMock.mockRejectedValue(new Error("Twilio 500"));
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("voicemail with no Twilio recording sid: skips the Twilio hop, still deletes + 200", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      voicemail: { ...VOICEMAIL_ROW, twilio_recording_sid: null },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("Personal-number owner (non-admin) can delete their own voicemail", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      number: {
+        id: "num-1",
+        organization_id: "org-1",
+        kind: "personal" as const,
+        user_id: "owner-1",
+      },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "owner-1" },
+      tables: memberTables({
+        userId: "owner-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("non-owner non-admin cannot delete someone else's Personal voicemail: 403", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      number: {
+        id: "num-1",
+        organization_id: "org-1",
+        kind: "personal" as const,
+        user_id: "owner-1",
+      },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "intruder-1" },
+      tables: memberTables({
+        userId: "intruder-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("also removes the stored audio copy from the phone-recordings bucket", async () => {
+    const { svc, removeSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(removeSpy).toHaveBeenCalledWith(["org-1/rec-1.mp3"]);
+  });
+
+  it("storage cleanup failure does not fail the delete (best-effort): still 200", async () => {
+    const { svc, removeSpy, deleteSpy } = instrumentedService();
+    removeSpy.mockRejectedValueOnce(new Error("storage offline"));
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("voicemail with no stored audio path: skips storage cleanup, still 200", async () => {
+    const { svc, removeSpy } = instrumentedService({
+      voicemail: { ...VOICEMAIL_ROW, audio_storage_path: null },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("vm-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/phone/voicemails/[id]/route.ts
+++ b/src/app/api/phone/voicemails/[id]/route.ts
@@ -1,0 +1,155 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { canManage } from "@/lib/phone/phone-event-access";
+import { createTwilioClient, deleteRecording } from "@/lib/phone/twilio-client";
+import { PHONE_RECORDINGS_BUCKET } from "@/lib/phone/recordings-storage";
+
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — delete a voicemail.
+//
+// DELETE /api/phone/voicemails/[id]
+//
+// Flow (mirrors numbers/[id]/release — Twilio first, DB second):
+//   1. Look up the voicemail via the Service client (RLS bypassed). A
+//      voicemail carries no kind/owner of its own, so resolve the parent
+//      call → conversation → phone_number to learn them — the same join the
+//      re-tag route walks.
+//   2. Run `canManage` against the (caller, number): Shared is admin-only,
+//      Personal is owner-or-admin (ADR 0003/0005). Cross-org callers are
+//      denied as 404 (privacy-preserving, same convention as release); wrong
+//      role inside the org is 403.
+//   3. Twilio first: hard-delete the recording. A transient Twilio error
+//      returns 502 and leaves the DB row untouched — the admin retries. The
+//      reverse (row gone, recording still on Twilio) silently keeps a
+//      recording Nookleus believes it deleted, so we refuse to touch the DB
+//      until Twilio confirms. deleteRecording is idempotent: a retry whose
+//      recording was already hard-deleted (Twilio 404) is treated as success
+//      and falls through to the DB delete, so a prior Twilio-success +
+//      DB-failure can't strand the row in a 502 loop. A voicemail with no
+//      twilio_recording_sid (demo / already gone) skips the Twilio hop.
+//   4. Delete the phone_voicemails row.
+
+interface VoicemailRow {
+  id: string;
+  organization_id: string;
+  phone_call_id: string;
+  twilio_recording_sid: string | null;
+  audio_storage_path: string | null;
+}
+
+interface CallRow {
+  id: string;
+  organization_id: string;
+  conversation_id: string;
+}
+
+interface ConversationRow {
+  id: string;
+  organization_id: string;
+  phone_number_id: string;
+}
+
+interface PhoneNumberRow {
+  id: string;
+  organization_id: string;
+  kind: "shared" | "personal";
+  user_id: string | null;
+}
+
+export const DELETE = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    const { data: vm } = await ctx.serviceClient!
+      .from("phone_voicemails")
+      .select(
+        "id, organization_id, phone_call_id, twilio_recording_sid, audio_storage_path",
+      )
+      .eq("id", id)
+      .maybeSingle<VoicemailRow>();
+    if (!vm || vm.organization_id !== ctx.orgId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Resolve the number kind / owner so canManage can apply the ADR 0003
+    // matrix: voicemail → call → conversation → number.
+    const { data: call } = await ctx.serviceClient!
+      .from("phone_calls")
+      .select("id, organization_id, conversation_id")
+      .eq("id", vm.phone_call_id)
+      .maybeSingle<CallRow>();
+    if (!call) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { data: conv } = await ctx.serviceClient!
+      .from("phone_conversations")
+      .select("id, organization_id, phone_number_id")
+      .eq("id", call.conversation_id)
+      .maybeSingle<ConversationRow>();
+    if (!conv) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { data: num } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .select("id, organization_id, kind, user_id")
+      .eq("id", conv.phone_number_id)
+      .maybeSingle<PhoneNumberRow>();
+    if (!num) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const allowed = canManage(
+      {
+        userId: ctx.userId,
+        organizationId: ctx.orgId ?? "",
+        role: ctx.role,
+      },
+      {
+        kind: num.kind,
+        organizationId: num.organization_id,
+        userId: num.user_id,
+      },
+    );
+    if (!allowed) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    // Twilio first. A null sid (demo voicemail / already gone) skips the hop.
+    if (vm.twilio_recording_sid) {
+      try {
+        await deleteRecording(createTwilioClient(), vm.twilio_recording_sid);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Twilio error";
+        return NextResponse.json(
+          { error: `Twilio: ${message}` },
+          { status: 502 },
+        );
+      }
+    }
+
+    const { error } = await ctx.serviceClient!
+      .from("phone_voicemails")
+      .delete()
+      .eq("id", id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Best-effort: drop the Nookleus storage copy so a deleted voicemail
+    // leaves no playable audio. The row is already gone and Twilio's
+    // recording is hard-deleted, so a storage hiccup here is cosmetic — the
+    // object is orphaned, not exposed (private bucket, no row to sign it).
+    // Don't let it fail the request.
+    if (vm.audio_storage_path) {
+      try {
+        await ctx.serviceClient!.storage
+          .from(PHONE_RECORDINGS_BUCKET)
+          .remove([vm.audio_storage_path]);
+      } catch {
+        // swallow — orphaned object, retryable out-of-band
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/phone/webhook/transcription-completed/route.test.ts
+++ b/src/app/api/phone/webhook/transcription-completed/route.test.ts
@@ -1,0 +1,220 @@
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — transcription-completed webhook.
+//
+// Twilio POSTs here when the <Record transcribe> auto-transcription finishes
+// (the inbound-voice webhook wires this as the recording's transcribeCallback).
+// The callback carries:
+//   RecordingSid       — matches the `twilio_recording_sid` on phone_voicemails
+//   TranscriptionText   — the transcript (present when status is 'completed')
+//   TranscriptionStatus — 'completed' | 'failed'
+//
+// The route updates the voicemail row matched by RecordingSid: on success
+// transcript = TranscriptionText, transcript_status = 'ready'; on failure
+// transcript_status = 'failed' (transcript stays null) — slice 6.
+//
+// Unauthenticated; gated solely by X-Twilio-Signature. Service-client UPDATE —
+// no auth user, so RLS would otherwise refuse.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  validateTwilioSignature: (...args: unknown[]) => validateSignatureMock(...args),
+}));
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+type Row = Record<string, unknown>;
+
+function makeServiceClient() {
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+
+  function builder(table: string) {
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingUpdate: Row | null = null;
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.then = (resolve: (v: { data: unknown; error: null }) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      return resolve({ data: [], error: null });
+    };
+    return b;
+  }
+
+  return { client: { from: builder }, updates };
+}
+
+function trForm(opts: {
+  RecordingSid?: string;
+  TranscriptionText?: string;
+  TranscriptionStatus?: string;
+}): Request {
+  const params = new URLSearchParams();
+  if (opts.RecordingSid !== undefined) params.set("RecordingSid", opts.RecordingSid);
+  if (opts.TranscriptionText !== undefined)
+    params.set("TranscriptionText", opts.TranscriptionText);
+  if (opts.TranscriptionStatus !== undefined)
+    params.set("TranscriptionStatus", opts.TranscriptionStatus);
+  return new Request("http://test/api/phone/webhook/transcription-completed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid",
+    },
+    body: params.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+describe("POST /api/phone/webhook/transcription-completed — ready (tracer)", () => {
+  it("sets transcript + transcript_status='ready' on the voicemail matched by RecordingSid", async () => {
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({
+        RecordingSid: "RE-1",
+        TranscriptionText: "Hi, please call me back about the roof.",
+        TranscriptionStatus: "completed",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_voicemails");
+    expect(upd).toBeDefined();
+    expect(upd!.filters).toMatchObject({ twilio_recording_sid: "RE-1" });
+    expect(upd!.patch).toMatchObject({
+      transcript: "Hi, please call me back about the roof.",
+      transcript_status: "ready",
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/transcription-completed — failed", () => {
+  it("sets transcript_status='failed' and leaves transcript null when TranscriptionStatus is 'failed'", async () => {
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({
+        RecordingSid: "RE-1",
+        // Twilio may still send a partial/garbage TranscriptionText on failure;
+        // we must NOT persist it.
+        TranscriptionText: "garbled partial",
+        TranscriptionStatus: "failed",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_voicemails");
+    expect(upd!.filters).toMatchObject({ twilio_recording_sid: "RE-1" });
+    expect(upd!.patch).toMatchObject({
+      transcript: null,
+      transcript_status: "failed",
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/transcription-completed — non-failed statuses default to ready", () => {
+  it("a 'completed' callback with no TranscriptionText lands transcript null at status 'ready' (not 'failed')", async () => {
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({ RecordingSid: "RE-1", TranscriptionStatus: "completed" }),
+    );
+
+    expect(res.status).toBe(200);
+    const upd = updates.find((u) => u.table === "phone_voicemails");
+    expect(upd!.patch).toMatchObject({
+      transcript: null,
+      transcript_status: "ready",
+    });
+  });
+
+  it("never marks 'failed' unless TranscriptionStatus is the exact 'failed' sentinel (absent / typo'd → ready)", async () => {
+    // The failed branch keys off the literal 'failed'. An absent status, or a
+    // typo like 'Failed'/'error', must NOT discard a transcript that actually
+    // completed — it lands 'ready' with the text preserved.
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    for (const TranscriptionStatus of [undefined, "Failed", "error"]) {
+      const res = await POST(
+        trForm({
+          RecordingSid: "RE-1",
+          TranscriptionText: "real transcript",
+          TranscriptionStatus,
+        }),
+      );
+      expect(res.status).toBe(200);
+    }
+
+    expect(updates).toHaveLength(3);
+    for (const upd of updates) {
+      expect(upd.patch).toMatchObject({
+        transcript: "real transcript",
+        transcript_status: "ready",
+      });
+    }
+  });
+});
+
+describe("POST /api/phone/webhook/transcription-completed — signature + guards", () => {
+  it("returns 403 when the Twilio signature is invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({ RecordingSid: "RE-1", TranscriptionText: "x", TranscriptionStatus: "completed" }),
+    );
+
+    expect(res.status).toBe(403);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("returns 400 when RecordingSid is missing (no lookup key)", async () => {
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({ TranscriptionText: "x", TranscriptionStatus: "completed" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(updates).toHaveLength(0);
+  });
+
+  it("returns 200 when RecordingSid matches no voicemail (UPDATE matches zero rows)", async () => {
+    const { client, updates } = makeServiceClient();
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      trForm({ RecordingSid: "RE-unknown", TranscriptionText: "x", TranscriptionStatus: "completed" }),
+    );
+
+    expect(res.status).toBe(200);
+    // The UPDATE still runs (matching zero rows); 200 so Twilio stops retrying.
+    expect(updates).toHaveLength(1);
+  });
+});

--- a/src/app/api/phone/webhook/transcription-completed/route.ts
+++ b/src/app/api/phone/webhook/transcription-completed/route.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { validateTwilioSignature } from "@/lib/phone/twilio-client";
+
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — transcription-completed webhook.
+//
+// Twilio POSTs here when the <Record transcribe> auto-transcription finishes
+// (the inbound-voice webhook wires this as the recording's transcribeCallback).
+// The callback carries RecordingSid (matches twilio_recording_sid on
+// phone_voicemails), TranscriptionText, and TranscriptionStatus
+// ('completed' | 'failed'). We advance the voicemail row matched by
+// RecordingSid: on success transcript = TranscriptionText and
+// transcript_status = 'ready'; the failure path lands in slice 6.
+//
+// The UPDATE matches by twilio_recording_sid — an unknown SID matches zero
+// rows and still 200s (silent drop, no Twilio retry storm). Unauthenticated;
+// gated solely by X-Twilio-Signature. Service-client UPDATE — no auth user.
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const recordingSid = params.RecordingSid;
+  if (!recordingSid) {
+    return new Response("RecordingSid required", { status: 400 });
+  }
+
+  // On a failed transcription, persist the 'failed' status and DROP any
+  // partial/garbage TranscriptionText Twilio may still include — transcript
+  // stays null so the UI shows "transcript unavailable", not noise.
+  const failed = params.TranscriptionStatus === "failed";
+  const patch: Record<string, unknown> = failed
+    ? { transcript: null, transcript_status: "failed" }
+    : { transcript: params.TranscriptionText ?? null, transcript_status: "ready" };
+
+  const supabase = createServiceClient();
+  await supabase
+    .from("phone_voicemails")
+    .update(patch)
+    .eq("twilio_recording_sid", recordingSid);
+
+  return new Response("", { status: 200 });
+}

--- a/src/app/api/phone/webhook/voice-inbound/route.test.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.test.ts
@@ -22,7 +22,7 @@
 // the REAL buildVoiceTwiml + decideShared + routeInbound + ingestInboundCall
 // run, so the TwiML and persistence are asserted end-to-end.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const validateSignatureMock = vi.fn();
 vi.mock("@/lib/phone/twilio-client", async (importOriginal) => {
@@ -174,6 +174,10 @@ beforeEach(() => {
   validateSignatureMock.mockReturnValue(true);
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
 describe("POST /api/phone/webhook/voice-inbound — ring-all (tracer)", () => {
   it("dials every selected member's cell and writes a ringing phone_calls row", async () => {
     const { client, inserts } = makeServiceClient(ringAllTables());
@@ -286,6 +290,34 @@ describe("POST /api/phone/webhook/voice-inbound — voicemail / unconfigured", (
     expect(xml).not.toContain("<Dial");
     // The inbound attempt is still persisted.
     expect(inserts.find((i) => i.table === "phone_calls")).toBeDefined();
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — voicemail callbacks (#313)", () => {
+  it("wires the voicemail-completed + transcription-completed webhook URLs from env into the <Record>", async () => {
+    vi.stubEnv(
+      "PHONE_VOICEMAIL_CALLBACK_URL",
+      "https://app.test/api/phone/webhook/voicemail-completed",
+    );
+    vi.stubEnv(
+      "PHONE_TRANSCRIPTION_CALLBACK_URL",
+      "https://app.test/api/phone/webhook/transcription-completed",
+    );
+    const tables = ringAllTables();
+    tables.phone_numbers[0].inbound_rule = null; // Shared, no rule → voicemail.
+    const { client } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(xml).toContain(
+      'recordingStatusCallback="https://app.test/api/phone/webhook/voicemail-completed"',
+    );
+    expect(xml).toContain('transcribe="true"');
+    expect(xml).toContain(
+      'transcribeCallback="https://app.test/api/phone/webhook/transcription-completed"',
+    );
   });
 });
 

--- a/src/app/api/phone/webhook/voice-inbound/route.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.ts
@@ -199,7 +199,16 @@ export async function POST(request: NextRequest | Request): Promise<Response> {
     }
   }
 
-  const twiml = buildVoiceTwiml(result, { callerId: toE164 });
+  // Slice 9 (#313) — voicemail callback URLs. Passed on every call (the
+  // builder ignores them in the dial branches); the <Record> verb in the
+  // voicemail branch posts the finished recording to voicemail-completed and
+  // the auto-transcription to transcription-completed. Fully-qualified URLs
+  // from env, mirroring PHONE_STATUS_CALLBACK_URL for outbound SMS.
+  const twiml = buildVoiceTwiml(result, {
+    callerId: toE164,
+    recordingStatusCallback: process.env.PHONE_VOICEMAIL_CALLBACK_URL || undefined,
+    transcribeCallback: process.env.PHONE_TRANSCRIPTION_CALLBACK_URL || undefined,
+  });
 
   // 4. Persist the ringing call row, threaded on the conversation.
   await ingestInboundCall({

--- a/src/app/api/phone/webhook/voicemail-completed/route.test.ts
+++ b/src/app/api/phone/webhook/voicemail-completed/route.test.ts
@@ -1,0 +1,329 @@
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — voicemail-completed webhook.
+//
+// Twilio POSTs here when an inbound call's <Record> verb finishes (the
+// inbound-voice webhook sets this as the recording's recordingStatusCallback).
+// The callback carries:
+//   CallSid           — matches the `twilio_call_sid` we stored on phone_calls
+//   RecordingSid      — Twilio's handle for the recording (RE...)
+//   RecordingUrl      — the Twilio-hosted media URL
+//   RecordingDuration — length in seconds
+//
+// The route looks up the parent phone_calls row by CallSid (to inherit its
+// org + id) and inserts a phone_voicemails row with transcript_status
+// 'pending'. The transcript lands later via the transcription-completed
+// webhook. Unauthenticated; gated solely by X-Twilio-Signature. Service-client
+// writes — no auth user, so RLS would otherwise refuse.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  validateTwilioSignature: (...args: unknown[]) => validateSignatureMock(...args),
+}));
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+type Row = Record<string, unknown>;
+
+function makeServiceClient(
+  seed: Record<string, Row[]>,
+  opts: { uploadError?: { message: string } } = {},
+) {
+  const tables: Record<string, Row[]> = {
+    phone_calls: [],
+    phone_voicemails: [],
+    ...seed,
+  };
+  const inserts: { table: string; row: Row; onConflict?: string }[] = [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+  const uploads: { path: string; options: unknown }[] = [];
+
+  function builder(table: string) {
+    let rows = tables[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opt?: { onConflict?: string }) => {
+      pendingInsert = row;
+      inserts.push({ table, row, onConflict: opt?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.then = (resolve: (v: { data: unknown; error: null }) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      if (pendingInsert) return resolve({ data: null, error: null });
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  const storage = {
+    from: (_bucket: string) => ({
+      upload: async (path: string, _body: unknown, uploadOpts: unknown) => {
+        uploads.push({ path, options: uploadOpts });
+        return { data: opts.uploadError ? null : { path }, error: opts.uploadError ?? null };
+      },
+      createSignedUrl: async (path: string) => ({
+        data: { signedUrl: `https://signed.example/${path}` },
+        error: null,
+      }),
+    }),
+  };
+
+  return { client: { from: builder, storage }, tables, inserts, updates, uploads };
+}
+
+function vmForm(opts: {
+  CallSid?: string;
+  RecordingSid?: string;
+  RecordingUrl?: string;
+  RecordingDuration?: string;
+}): Request {
+  const params = new URLSearchParams();
+  if (opts.CallSid !== undefined) params.set("CallSid", opts.CallSid);
+  if (opts.RecordingSid !== undefined) params.set("RecordingSid", opts.RecordingSid);
+  if (opts.RecordingUrl !== undefined) params.set("RecordingUrl", opts.RecordingUrl);
+  if (opts.RecordingDuration !== undefined)
+    params.set("RecordingDuration", opts.RecordingDuration);
+  return new Request("http://test/api/phone/webhook/voicemail-completed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid",
+    },
+    body: params.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/phone/webhook/voicemail-completed — persist (tracer)", () => {
+  it("inserts a pending phone_voicemails row keyed to the parent call (by CallSid)", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      vmForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+        RecordingDuration: "12",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const ins = inserts.find((i) => i.table === "phone_voicemails");
+    expect(ins).toBeDefined();
+    expect(ins!.row).toMatchObject({
+      phone_call_id: "call-1",
+      organization_id: "org-1",
+      twilio_recording_sid: "RE-1",
+      twilio_recording_url: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      duration_seconds: 12,
+      transcript_status: "pending",
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/voicemail-completed — signature + guards", () => {
+  it("returns 403 when the Twilio signature is invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client, inserts } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(vmForm({ CallSid: "CA-1", RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(403);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("returns 400 when CallSid is missing", async () => {
+    const { client, inserts } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(vmForm({ RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(400);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("returns 200 and inserts nothing when CallSid matches no call (silent drop)", async () => {
+    const { client, inserts } = makeServiceClient({ phone_calls: [] });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      vmForm({ CallSid: "CA-unknown", RecordingSid: "RE-1" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(inserts.find((i) => i.table === "phone_voicemails")).toBeUndefined();
+  });
+
+  it("is idempotent — upserts on the phone_call_id unique key so a Twilio retry can't violate it", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(vmForm({ CallSid: "CA-1", RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(200);
+    const ins = inserts.find((i) => i.table === "phone_voicemails");
+    expect(ins).toBeDefined();
+    // The unique key is phone_call_id; a duplicate recordingStatusCallback
+    // must conflict-drop, not throw.
+    expect(ins!.onConflict).toBe("phone_call_id");
+  });
+});
+
+describe("POST /api/phone/webhook/voicemail-completed — audio copy", () => {
+  it("fetches the Twilio recording, uploads it to phone-recordings, and sets audio_storage_path", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([4, 5, 6]).buffer,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, updates, uploads } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      vmForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // Fetched Twilio's MP3 variant.
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String((fetchMock.mock.calls[0] as unknown[])[0])).toBe(
+      "https://api.twilio.com/2010-04-01/Recordings/RE-1.mp3",
+    );
+    // Uploaded under the org prefix.
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].path).toMatch(/^org-1\/[0-9a-f-]+\.mp3$/);
+    // audio_storage_path patched onto the voicemail row by phone_call_id.
+    const upd = updates.find((u) => u.table === "phone_voicemails");
+    expect(upd).toBeDefined();
+    expect(upd!.filters).toMatchObject({ phone_call_id: "call-1" });
+    expect(upd!.patch.audio_storage_path).toEqual(uploads[0].path);
+  });
+
+  it("skips the copy on a Twilio redelivery whose voicemail already has audio_storage_path (no orphan upload)", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([4, 5, 6]).buffer,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, uploads, updates } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+      // First delivery already copied the audio.
+      phone_voicemails: [
+        {
+          phone_call_id: "call-1",
+          organization_id: "org-1",
+          audio_storage_path: "org-1/already-copied.mp3",
+        },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      vmForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    // recordings-storage mints a fresh UUID per upload, so re-copying would
+    // orphan the first object in the bucket and clobber the stored path.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(uploads).toHaveLength(0);
+    expect(
+      updates.find(
+        (u) =>
+          u.table === "phone_voicemails" && "audio_storage_path" in u.patch,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("swallows a copy failure — the row still persists pending with no audio_storage_path update", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, inserts, updates } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      vmForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    // The webhook still 200s (no Twilio retry storm) and the pending row was
+    // written; only the audio_storage_path patch is skipped.
+    expect(res.status).toBe(200);
+    expect(inserts.find((i) => i.table === "phone_voicemails")).toBeDefined();
+    expect(
+      updates.find(
+        (u) =>
+          u.table === "phone_voicemails" &&
+          "audio_storage_path" in u.patch,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/app/api/phone/webhook/voicemail-completed/route.ts
+++ b/src/app/api/phone/webhook/voicemail-completed/route.ts
@@ -1,0 +1,135 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { validateTwilioSignature } from "@/lib/phone/twilio-client";
+import { uploadPhoneRecording } from "@/lib/phone/recordings-storage";
+
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — voicemail-completed webhook.
+//
+// Twilio POSTs here when an inbound call's <Record> verb finishes (the
+// inbound-voice webhook wires this as the recording's recordingStatusCallback).
+// The callback carries CallSid (the parent call), RecordingSid / RecordingUrl
+// (Twilio's handle + media URL), and RecordingDuration. We look up the parent
+// phone_calls row by CallSid to inherit its org + id, then insert a
+// phone_voicemails row at transcript_status 'pending'. The transcript fills in
+// later via the transcription-completed webhook; the audio is copied into the
+// phone-recordings bucket in a later step.
+//
+// Unauthenticated; gated solely by X-Twilio-Signature. Service-client writes —
+// the webhook has no auth user, so RLS would otherwise refuse the insert.
+
+// Fetch the recording's MP3 from Twilio. Twilio serves the WAV at the bare
+// RecordingUrl and an MP3 at the `.mp3` suffix; we store the smaller,
+// browser-playable MP3. Authenticated with the account credentials in case
+// the recording is access-protected.
+async function fetchRecordingMp3(recordingUrl: string): Promise<Uint8Array> {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const headers: Record<string, string> = {};
+  if (accountSid && authToken) {
+    headers.Authorization =
+      "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+  }
+  const res = await fetch(`${recordingUrl}.mp3`, { headers });
+  if (!res.ok) {
+    throw new Error(`twilio recording fetch failed: ${res.status}`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const callSid = params.CallSid;
+  if (!callSid) {
+    return new Response("CallSid required", { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  // Look up the parent call to inherit its org + id. Unknown CallSid → 200
+  // silent drop so Twilio stops retrying (the call may predate this feature
+  // or have been deleted).
+  const { data: call } = await supabase
+    .from("phone_calls")
+    .select("id, organization_id")
+    .eq("twilio_call_sid", callSid)
+    .maybeSingle<{ id: string; organization_id: string }>();
+
+  if (!call) {
+    return new Response("", { status: 200 });
+  }
+
+  const durationRaw = params.RecordingDuration;
+  let duration_seconds: number | null = null;
+  if (durationRaw !== undefined && durationRaw !== "") {
+    const seconds = Number.parseInt(durationRaw, 10);
+    if (Number.isFinite(seconds)) duration_seconds = seconds;
+  }
+
+  // Upsert on the phone_call_id unique key: a Twilio retry of the same
+  // recordingStatusCallback must conflict-drop, not raise a unique violation
+  // (which would 500 and trigger further Twilio retries).
+  await supabase.from("phone_voicemails").upsert(
+    {
+      organization_id: call.organization_id,
+      phone_call_id: call.id,
+      twilio_recording_sid: params.RecordingSid ?? null,
+      twilio_recording_url: params.RecordingUrl ?? null,
+      duration_seconds,
+      transcript_status: "pending",
+    },
+    { onConflict: "phone_call_id", ignoreDuplicates: true },
+  );
+
+  // A Twilio retry of the same recordingStatusCallback conflict-drops the
+  // upsert above (ignoreDuplicates). If the FIRST delivery already copied the
+  // audio, the copy below must NOT run again: uploadPhoneRecording mints a
+  // fresh UUID per call (upsert:false), so a re-copy would orphan the original
+  // object in the bucket and clobber the stored path. A copy that previously
+  // FAILED left audio_storage_path null, so a retry still gets to finish it.
+  // (Narrow residual: two callbacks racing before either copies will each
+  // upload once — Twilio spaces its retries, so this isn't observed.)
+  const { data: existing } = await supabase
+    .from("phone_voicemails")
+    .select("audio_storage_path")
+    .eq("phone_call_id", call.id)
+    .maybeSingle<{ audio_storage_path: string | null }>();
+
+  if (existing?.audio_storage_path) {
+    return new Response("", { status: 200 });
+  }
+
+  // Copy the audio out of Twilio into the org-scoped phone-recordings bucket so
+  // playback outlives Twilio's media retention and deletion is under our
+  // control (PRD #304 story 54). A copy failure is SWALLOWED: the voicemail row
+  // already persists at 'pending', so we 200 (no Twilio retry storm) and leave
+  // audio_storage_path null — a later Twilio redelivery retries the copy.
+  const recordingUrl = params.RecordingUrl;
+  if (recordingUrl) {
+    try {
+      const bytes = await fetchRecordingMp3(recordingUrl);
+      const { storagePath } = await uploadPhoneRecording(supabase, {
+        orgId: call.organization_id,
+        bytes,
+      });
+      await supabase
+        .from("phone_voicemails")
+        .update({ audio_storage_path: storagePath })
+        .eq("phone_call_id", call.id);
+    } catch (err) {
+      console.error("voicemail-completed: audio copy failed", err);
+    }
+  }
+
+  return new Response("", { status: 200 });
+}

--- a/src/app/phone/page.test.tsx
+++ b/src/app/phone/page.test.tsx
@@ -24,11 +24,13 @@ vi.mock("@/lib/supabase/get-active-org", () => ({
 // Slice 4 — PhonePageClient instantiates the browser Supabase client for
 // the realtime subscription. The tests don't exercise realtime; this stub
 // keeps `createClient()` from reading process.env at module-eval time.
+// The realtime hook chains `.on()` once per subscription (phone_messages
+// INSERT, message UPDATE, phone_calls INSERT/UPDATE since slice 10, and
+// phone_voicemails UPDATE since slice 9), so `.on()` must return the channel
+// itself to stay chainable — a non-chainable stub breaks the moment a second
+// `.on()` fires.
 vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
-    // The realtime hook chains `.on()` once per subscription (phone_messages
-    // INSERT, plus phone_calls INSERT/UPDATE since slice 10), so `.on()` must
-    // return the channel itself to stay chainable.
     channel: () => {
       const ch: {
         on: () => typeof ch;

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -14,20 +14,34 @@
 // no-op `supabase` via the supabase module's `createClient`.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 
+// Capture the realtime subscription handlers usePhoneSync registers so tests
+// can simulate a postgres_changes event arriving. Chainable `.on()` mirrors
+// the real Supabase channel (the hook chains multiple subscriptions).
+const realtime = vi.hoisted(() => ({
+  handlers: [] as Array<{
+    config: { table?: string; event?: string };
+    handler: (payload: { new: Record<string, unknown> }) => void;
+  }>,
+}));
 vi.mock("@/lib/supabase", () => ({
   createClient: () => ({
     // The realtime hook chains `.on()` once per subscription (phone_messages
-    // INSERT, plus phone_calls INSERT/UPDATE since slice 10), so `.on()` must
-    // return the channel itself to stay chainable.
+    // INSERT, message UPDATE, phone_calls INSERT/UPDATE since slice 10, and
+    // phone_voicemails UPDATE since slice 9). `.on()` captures each handler so
+    // a test can fire a postgres_changes event, and returns the channel to
+    // stay chainable.
     channel: () => {
-      const ch: {
-        on: () => typeof ch;
-        subscribe: () => { unsubscribe: () => void };
-        unsubscribe: () => void;
-      } = {
-        on: () => ch,
+      const ch = {
+        on: (
+          _event: string,
+          config: { table?: string; event?: string },
+          handler: (payload: { new: Record<string, unknown> }) => void,
+        ) => {
+          realtime.handlers.push({ config, handler });
+          return ch;
+        },
         subscribe: () => ({ unsubscribe: () => undefined }),
         unsubscribe: () => undefined,
       };
@@ -35,6 +49,15 @@ vi.mock("@/lib/supabase", () => ({
     },
   }),
 }));
+
+// Fire a phone_voicemails UPDATE through the handler usePhoneSync registered.
+function emitVoicemailUpdate(row: Record<string, unknown>) {
+  const entry = realtime.handlers.find(
+    (h) => h.config?.table === "phone_voicemails" && h.config?.event === "UPDATE",
+  );
+  if (!entry) throw new Error("no phone_voicemails UPDATE subscription registered");
+  act(() => entry.handler({ new: row }));
+}
 
 const searchParamsMock = vi.fn<() => URLSearchParams>();
 vi.mock("next/navigation", () => ({
@@ -53,6 +76,7 @@ const mockFetch = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
+  realtime.handlers.length = 0;
   // Use globalThis to type-narrow as `unknown`, then cast at the
   // assignment site. Avoids the `any` lint hit on the `global.fetch =`
   // shorthand.
@@ -1314,5 +1338,228 @@ describe("PhonePageClient — call events (#312)", () => {
     // placeholder").
     fireEvent.click(callRow);
     expect(await screen.findByText(/slice 11/i)).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 9 (#313) — voicemail render.
+//
+// A call that went to voicemail carries its recording + transcript inline on
+// the call (the /calls route flattens the embed to `call.voicemail`). When the
+// transcript is ready the thread shows the transcript text and an <audio>
+// player; the player's src is a short-lived signed URL fetched from
+// /api/phone/recordings. Pending/failed transcript states land in slice 8.
+// ---------------------------------------------------------------------------
+
+describe("PhonePageClient — voicemail render (#313)", () => {
+  function setupThread(opts: {
+    messages?: Array<Record<string, unknown>>;
+    calls?: Array<Record<string, unknown>>;
+    recordingUrl?: string;
+  }) {
+    mockFetch.mockImplementation(async (input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const path = url.replace(/^https?:\/\/[^/]+/, "");
+      if (path === "/api/phone/conversations/conv-1/messages") {
+        return { ok: true, status: 200, json: async () => opts.messages ?? [] };
+      }
+      if (path === "/api/phone/conversations/conv-1/calls") {
+        return { ok: true, status: 200, json: async () => opts.calls ?? [] };
+      }
+      if (path.startsWith("/api/phone/recordings")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            url: opts.recordingUrl ?? "https://signed/rec.mp3",
+          }),
+        };
+      }
+      throw new Error(`unmocked fetch: ${path}`);
+    });
+  }
+
+  const voicemailCall = (voicemail: Record<string, unknown> | null) => ({
+    id: "call-vm",
+    conversation_id: "conv-1",
+    direction: "in",
+    status: "no_answer",
+    duration_seconds: 18,
+    started_at: "2026-05-27T10:00:00Z",
+    ended_at: "2026-05-27T10:00:18Z",
+    voicemail,
+  });
+
+  it("renders the transcript text of a ready voicemail inline in the thread", async () => {
+    setupThread({
+      calls: [
+        voicemailCall({
+          id: "vm-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          transcript: "Hi, please call me back about the roof.",
+          transcript_status: "ready",
+          duration_seconds: 12,
+        }),
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    expect(
+      await screen.findByText(/please call me back about the roof/i),
+    ).toBeDefined();
+  });
+
+  it("renders an <audio> player whose src is the signed recording URL", async () => {
+    setupThread({
+      recordingUrl: "https://signed/phone-recordings/org-1/rec-1.mp3",
+      calls: [
+        voicemailCall({
+          id: "vm-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          transcript: "Call me back.",
+          transcript_status: "ready",
+          duration_seconds: 12,
+        }),
+      ],
+    });
+
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    // The player resolves its src from the signed-URL endpoint, keyed on the
+    // voicemail's storage path.
+    await waitFor(() => {
+      const audio = container.querySelector("audio");
+      expect(audio?.getAttribute("src")).toBe(
+        "https://signed/phone-recordings/org-1/rec-1.mp3",
+      );
+    });
+    const signedCall = mockFetch.mock.calls.find(([input]) =>
+      String(input).includes("/api/phone/recordings"),
+    );
+    expect(signedCall).toBeDefined();
+    expect(String(signedCall![0])).toContain(
+      `path=${encodeURIComponent("org-1/rec-1.mp3")}`,
+    );
+  });
+
+  it("shows a transcribing indicator while the transcript is pending", async () => {
+    setupThread({
+      calls: [
+        voicemailCall({
+          id: "vm-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          // Recorded, but the transcription webhook hasn't landed yet.
+          transcript: null,
+          transcript_status: "pending",
+          duration_seconds: 12,
+        }),
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    expect(await screen.findByText(/transcribing/i)).toBeDefined();
+  });
+
+  it("shows 'Transcript unavailable' when transcription failed, with the player still present", async () => {
+    setupThread({
+      calls: [
+        voicemailCall({
+          id: "vm-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          // Transcription failed — transcript stays null (the webhook drops
+          // any partial text), so the audio is still playable but there is no
+          // transcript to show.
+          transcript: null,
+          transcript_status: "failed",
+          duration_seconds: 12,
+        }),
+      ],
+    });
+
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    expect(await screen.findByText(/transcript unavailable/i)).toBeDefined();
+    // The recording is still playable even though transcription failed.
+    expect(container.querySelector("audio")).not.toBeNull();
+    // No transcribing spinner once we know it failed.
+    expect(screen.queryByText(/transcribing/i)).toBeNull();
+  });
+
+  it("flips a pending voicemail to its transcript live on a realtime UPDATE", async () => {
+    setupThread({
+      calls: [
+        voicemailCall({
+          id: "vm-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          transcript: null,
+          transcript_status: "pending",
+          duration_seconds: 12,
+        }),
+      ],
+    });
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[
+          convo({ id: "conv-1", contact_id: "c-1", contact_name: "Alice" }),
+        ]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /alice/i }));
+
+    // Starts in the transcribing state…
+    expect(await screen.findByText(/transcribing/i)).toBeDefined();
+
+    // …the transcription-completed webhook UPDATEs the phone_voicemails row;
+    // realtime delivers it and the open thread flips to the transcript text.
+    emitVoicemailUpdate({
+      id: "vm-1",
+      organization_id: "org-1",
+      phone_call_id: "call-vm",
+      audio_storage_path: "org-1/rec-1.mp3",
+      transcript: "Roof is leaking, call me.",
+      transcript_status: "ready",
+      duration_seconds: 12,
+    });
+
+    expect(
+      await screen.findByText(/roof is leaking, call me/i),
+    ).toBeDefined();
+    expect(screen.queryByText(/transcribing/i)).toBeNull();
   });
 });

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -61,6 +61,20 @@ interface PhoneMessage {
   media_urls?: PhoneAttachmentRef[];
 }
 
+// Slice 9 (#313) — the voicemail recorded for an unanswered call, flattened
+// onto the call by the /calls route. `transcript_status` drives the UI:
+// 'pending' (recorded, transcript not back yet), 'ready' (transcript shown),
+// 'failed' (transcript unavailable). `audio_storage_path` is the stored MP3
+// the <audio> player signs a URL for; it can lag the row briefly while the
+// copy-from-Twilio finishes.
+interface PhoneVoicemail {
+  id: string;
+  audio_storage_path: string | null;
+  transcript: string | null;
+  transcript_status: "pending" | "ready" | "failed";
+  duration_seconds: number | null;
+}
+
 // Slice 8 (#312) — a voice call in the thread. Threads on the same
 // conversation as the messages; `started_at` is its timeline anchor.
 // `status`/`duration_seconds` are null until the status-callback webhook
@@ -73,6 +87,8 @@ interface PhoneCall {
   duration_seconds: number | null;
   started_at: string;
   ended_at: string | null;
+  // Slice 9 (#313) — present when the call went to voicemail.
+  voicemail?: PhoneVoicemail | null;
 }
 
 // Slice 6 (#310) — a staged attachment in the compose strip. Either the
@@ -564,6 +580,29 @@ export function PhonePageClient({
                 status: row.status,
                 duration_seconds: row.duration_seconds,
                 ended_at: row.ended_at,
+              }
+            : c,
+        ),
+      );
+    },
+    // Slice 9 (#313) — the transcription-completed webhook UPDATEs the
+    // voicemail row after the call already rendered. Patch the matching call
+    // in the open thread so "Transcribing…" flips to the transcript (or the
+    // failed state) live. A row for a call not in the current thread is a
+    // no-op (map finds no match).
+    onVoicemailUpdate: (row) => {
+      setCalls((prev) =>
+        prev.map((c) =>
+          c.id === row.phone_call_id
+            ? {
+                ...c,
+                voicemail: {
+                  id: row.id,
+                  audio_storage_path: row.audio_storage_path,
+                  transcript: row.transcript,
+                  transcript_status: row.transcript_status,
+                  duration_seconds: row.duration_seconds,
+                },
               }
             : c,
         ),
@@ -1079,13 +1118,15 @@ function formatDuration(seconds: number): string {
 }
 
 // Slice 8 (#312) — a voice call rendered inline in the thread, centered
-// like a system row (distinct from the left/right message bubbles).
+// like a system row (distinct from the left/right message bubbles). Slice 9
+// (#313) — when the call went to voicemail, its recording + transcript render
+// inline beneath the call pill.
 function CallRow({ call, onOpen }: { call: PhoneCall; onOpen: () => void }) {
   const incoming = call.direction === "in";
   const label = incoming ? "Incoming call" : "Outgoing call";
   const DirectionIcon = incoming ? PhoneIncoming : PhoneOutgoing;
   return (
-    <div className="flex justify-center">
+    <div className="flex flex-col items-center gap-1">
       <button
         type="button"
         onClick={onOpen}
@@ -1104,6 +1145,61 @@ function CallRow({ call, onOpen }: { call: PhoneCall; onOpen: () => void }) {
           })}
         </span>
       </button>
+      {call.voicemail ? <VoicemailBlock voicemail={call.voicemail} /> : null}
     </div>
+  );
+}
+
+// Slice 9 (#313) — the voicemail recording + transcript shown under a call.
+// The transcript renders synchronously from the call payload; the audio
+// player fetches a short-lived signed URL for the stored MP3 (mirrors
+// MessageAttachment). Pending/failed transcript states land in slice 8.
+function VoicemailBlock({ voicemail }: { voicemail: PhoneVoicemail }) {
+  return (
+    <div className="w-full max-w-sm rounded-lg border border-border bg-background p-2 text-xs">
+      {voicemail.audio_storage_path ? (
+        <VoicemailPlayer storagePath={voicemail.audio_storage_path} />
+      ) : null}
+      {voicemail.transcript_status === "ready" && voicemail.transcript ? (
+        <p className="mt-1 text-foreground">{voicemail.transcript}</p>
+      ) : null}
+      {voicemail.transcript_status === "pending" ? (
+        <p className="mt-1 italic text-muted-foreground">Transcribing…</p>
+      ) : null}
+      {voicemail.transcript_status === "failed" ? (
+        <p className="mt-1 italic text-muted-foreground">
+          Transcript unavailable
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// Slice 9 (#313) — <audio> player for a stored voicemail. Fetches a signed URL
+// for the MP3 on mount (same signed-URL pattern as MessageAttachment) and
+// renders a native audio control once it resolves.
+function VoicemailPlayer({ storagePath }: { storagePath: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/recordings?path=${encodeURIComponent(storagePath)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storagePath]);
+  return (
+    <audio
+      controls
+      src={url ?? undefined}
+      aria-label="Voicemail recording"
+      className="w-full"
+    />
   );
 }

--- a/src/lib/phone/fake-twilio-client.test.ts
+++ b/src/lib/phone/fake-twilio-client.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect } from "vitest";
 import { createFakeTwilioClient } from "./fake-twilio-client";
 import {
   buildBridgeTwiml,
+  deleteRecording,
   listAvailableLocalNumbers,
   placeBridgeCall,
   provisionNumber,
@@ -122,5 +123,13 @@ describe("createFakeTwilioClient — calls.create (outbound bridge call, #314)",
     expect(result.sid).toMatch(/^CA/);
     expect(result.sid.length).toBeGreaterThan(2);
     expect(result.status).toBe("queued");
+  });
+});
+
+describe("createFakeTwilioClient — recordings(sid).remove (voicemail delete)", () => {
+  it("resolves with no error (no-op)", async () => {
+    const client = createFakeTwilioClient();
+
+    await expect(deleteRecording(client, "REfake")).resolves.toBeUndefined();
   });
 });

--- a/src/lib/phone/fake-twilio-client.ts
+++ b/src/lib/phone/fake-twilio-client.ts
@@ -97,6 +97,13 @@ export function createFakeTwilioClient(): TwilioClientLike {
       },
     }),
     incomingPhoneNumbers,
+    // recordings(sid).remove() → resolves (no-op). Demo voicemails have no real
+    // Twilio recording to hard-delete; the deletion path still runs end-to-end.
+    recordings: (_sid: string) => ({
+      async remove() {
+        return undefined;
+      },
+    }),
     messages: {
       async create(_opts: {
         from: string;

--- a/src/lib/phone/recordings-storage.test.ts
+++ b/src/lib/phone/recordings-storage.test.ts
@@ -1,0 +1,126 @@
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — voice-recordings bucket I/O.
+//
+// The bucket layer behind voicemail playback. Pure shape + thin I/O over the
+// Supabase Storage client, mirroring attachments-storage (slice 6). Org-scoping
+// is enforced by the path prefix `{organization_id}/` and double-checked by the
+// read policy on the phone-recordings bucket (migration-313). Voicemail audio
+// is stored as MP3 (browser-playable in <audio>, smaller than Twilio's WAV).
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  PHONE_RECORDINGS_BUCKET,
+  phoneRecordingPath,
+  uploadPhoneRecording,
+  signedUrlForPhoneRecording,
+} from "./recordings-storage";
+
+function makeBucketFake() {
+  const uploads: Array<{
+    path: string;
+    body: unknown;
+    options: { contentType?: string; upsert?: boolean } | undefined;
+  }> = [];
+  const signed: string[] = [];
+  const bucket = {
+    upload: vi.fn(
+      async (
+        path: string,
+        body: unknown,
+        options?: { contentType?: string; upsert?: boolean },
+      ) => {
+        uploads.push({ path, body, options });
+        return { data: { path }, error: null };
+      },
+    ),
+    createSignedUrl: vi.fn(async (path: string) => {
+      signed.push(path);
+      return { data: { signedUrl: `https://signed.example/${path}` }, error: null };
+    }),
+  };
+  const client = {
+    storage: { from: vi.fn(() => bucket) },
+  } as const;
+  return { client, bucket, uploads, signed };
+}
+
+describe("phoneRecordingPath", () => {
+  it("returns {org}/{uuid}.{ext}", () => {
+    expect(phoneRecordingPath("org-1", "abc-uuid", "mp3")).toBe(
+      "org-1/abc-uuid.mp3",
+    );
+  });
+});
+
+describe("PHONE_RECORDINGS_BUCKET", () => {
+  it("is the documented bucket name", () => {
+    expect(PHONE_RECORDINGS_BUCKET).toBe("phone-recordings");
+  });
+});
+
+describe("uploadPhoneRecording", () => {
+  it("uploads MP3 audio to the phone-recordings bucket and returns the storage path", async () => {
+    const { client, bucket, uploads } = makeBucketFake();
+
+    const result = await uploadPhoneRecording(client, {
+      orgId: "org-1",
+      bytes: new Uint8Array([1, 2, 3]),
+    });
+
+    expect(client.storage.from).toHaveBeenCalledWith("phone-recordings");
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].path).toMatch(/^org-1\/[0-9a-f-]+\.mp3$/);
+    expect(uploads[0].options).toEqual({
+      contentType: "audio/mpeg",
+      upsert: false,
+    });
+    expect(result.storagePath).toEqual(uploads[0].path);
+    expect(bucket.upload).toHaveBeenCalledOnce();
+  });
+
+  it("throws when the bucket returns an error", async () => {
+    const client = {
+      storage: {
+        from: () => ({
+          upload: async () => ({ data: null, error: { message: "bucket boom" } }),
+        }),
+      },
+    } as const;
+
+    await expect(
+      uploadPhoneRecording(client as never, {
+        orgId: "org-1",
+        bytes: new Uint8Array([1]),
+      }),
+    ).rejects.toThrow(/bucket boom/);
+  });
+});
+
+describe("signedUrlForPhoneRecording", () => {
+  it("mints a signed URL for the path on the phone-recordings bucket", async () => {
+    const { client, signed } = makeBucketFake();
+
+    const url = await signedUrlForPhoneRecording(client, "org-1/abc.mp3", 60);
+
+    expect(client.storage.from).toHaveBeenCalledWith("phone-recordings");
+    expect(signed).toEqual(["org-1/abc.mp3"]);
+    expect(url).toBe("https://signed.example/org-1/abc.mp3");
+  });
+
+  it("throws when the signing call fails", async () => {
+    const client = {
+      storage: {
+        from: () => ({
+          createSignedUrl: async () => ({
+            data: null,
+            error: { message: "not found" },
+          }),
+        }),
+      },
+    } as const;
+
+    await expect(
+      signedUrlForPhoneRecording(client as never, "org-x/missing.mp3", 60),
+    ).rejects.toThrow(/not found/);
+  });
+});

--- a/src/lib/phone/recordings-storage.ts
+++ b/src/lib/phone/recordings-storage.ts
@@ -1,0 +1,83 @@
+// PRD #304 — Nookleus Phone. Slice 9 (#313) — voice-recordings bucket I/O.
+//
+// Owns the `phone-recordings` bucket (migration-313): path shape + upload +
+// signed-URL minting, mirroring attachments-storage (slice 6). Org-scoping is
+// enforced at the path level — every object lives under `{organization_id}/` —
+// and double-enforced by the Storage read policy installed alongside the
+// bucket. Voicemail audio is copied out of Twilio as MP3 so it outlives
+// Twilio's media retention and plays directly in the browser <audio> element.
+
+export const PHONE_RECORDINGS_BUCKET = "phone-recordings";
+
+// Voicemail audio is always stored as MP3 (we fetch Twilio's `.mp3` variant).
+const RECORDING_EXT = "mp3";
+const RECORDING_CONTENT_TYPE = "audio/mpeg";
+
+// Structural slice of the Supabase Storage client — only the calls these
+// helpers make.
+interface StorageError {
+  message: string;
+}
+interface BucketClient {
+  upload(
+    path: string,
+    body: Buffer | Uint8Array | ArrayBuffer,
+    options?: { contentType?: string; upsert?: boolean },
+  ): Promise<{ data: unknown; error: StorageError | null }>;
+  createSignedUrl(
+    path: string,
+    expiresIn: number,
+  ): Promise<{ data: { signedUrl: string } | null; error: StorageError | null }>;
+}
+export interface PhoneRecordingStorageClient {
+  storage: { from(bucket: string): BucketClient };
+}
+
+// {organization_id}/{uuid}.{ext} — flat under the org id (Phone has no
+// per-conversation sweep), matching phoneAttachmentPath.
+export function phoneRecordingPath(
+  orgId: string,
+  uuid: string,
+  ext: string,
+): string {
+  return `${orgId}/${uuid}.${ext}`;
+}
+
+export interface UploadRecordingParams {
+  orgId: string;
+  bytes: Buffer | Uint8Array;
+}
+
+export async function uploadPhoneRecording(
+  client: PhoneRecordingStorageClient,
+  params: UploadRecordingParams,
+): Promise<{ storagePath: string }> {
+  const uuid = crypto.randomUUID();
+  const storagePath = phoneRecordingPath(params.orgId, uuid, RECORDING_EXT);
+  const { error } = await client.storage
+    .from(PHONE_RECORDINGS_BUCKET)
+    .upload(storagePath, params.bytes, {
+      contentType: RECORDING_CONTENT_TYPE,
+      upsert: false,
+    });
+  if (error) {
+    throw new Error(`Failed to upload phone recording: ${error.message}`);
+  }
+  return { storagePath };
+}
+
+export async function signedUrlForPhoneRecording(
+  client: PhoneRecordingStorageClient,
+  storagePath: string,
+  expiresInSeconds: number,
+): Promise<string> {
+  const { data, error } = await client.storage
+    .from(PHONE_RECORDINGS_BUCKET)
+    .createSignedUrl(storagePath, expiresInSeconds);
+  if (error || !data) {
+    throw new Error(
+      `Failed to sign phone recording URL: ${error?.message ?? "no url"}`,
+    );
+  }
+  return data.signedUrl;
+}

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -15,6 +15,7 @@ import {
   buildBridgeTwiml,
   buildVoiceTwiml,
   createTwilioClient,
+  deleteRecording,
   listAvailableLocalNumbers,
   placeBridgeCall,
   provisionNumber,
@@ -31,17 +32,22 @@ function fakeClient(opts: {
   messageCreateImpl?: (params: unknown) => Promise<unknown>;
   callCreateResult?: { sid: string; status: string };
   callCreateImpl?: (params: unknown) => Promise<unknown>;
+  recordingRemoveImpl?: () => Promise<void>;
   listSpy?: ReturnType<typeof vi.fn>;
   createSpy?: ReturnType<typeof vi.fn>;
   removeSpy?: ReturnType<typeof vi.fn>;
   messageCreateSpy?: ReturnType<typeof vi.fn>;
   callCreateSpy?: ReturnType<typeof vi.fn>;
+  recordingRemoveSpy?: ReturnType<typeof vi.fn>;
 }): TwilioClientLike {
   const list = opts.listSpy ?? vi.fn(async () => opts.listResult ?? []);
   const create =
     opts.createSpy ??
     vi.fn(async () => opts.createResult ?? { sid: "PNxxx", phoneNumber: "+15555550100" });
   const remove = opts.removeSpy ?? vi.fn(opts.removeImpl ?? (async () => undefined));
+  const recordingRemove =
+    opts.recordingRemoveSpy ??
+    vi.fn(opts.recordingRemoveImpl ?? (async () => undefined));
   const messageCreate =
     opts.messageCreateSpy ??
     vi.fn(
@@ -64,6 +70,9 @@ function fakeClient(opts: {
   return {
     availablePhoneNumbers: (_country: string) => ({ local: { list } }),
     incomingPhoneNumbers,
+    // `recordings` mirrors `incomingPhoneNumbers`'s single-resource callable
+    // shape: `client.recordings(sid).remove()` hard-deletes the recording.
+    recordings: (_sid: string) => ({ remove: recordingRemove }),
     messages: { create: messageCreate },
     calls: { create: callCreate },
   } as TwilioClientLike;
@@ -183,6 +192,57 @@ describe("releaseNumber", () => {
   it("rejects an empty sid (programming-error guard)", async () => {
     const client = fakeClient({});
     await expect(releaseNumber(client, "")).rejects.toThrow(/sid/i);
+  });
+});
+
+// Slice 10 (#313) — voicemail deletion. Deleting a voicemail hard-deletes the
+// recording on Twilio's side (PRD #304 story 54 — Nookleus owns retention).
+// `deleteRecording` mirrors `releaseNumber`: a thin wrapper over the SDK's
+// `client.recordings(sid).remove()` that the canManage-gated DELETE route
+// calls before removing the DB row.
+describe("deleteRecording", () => {
+  it("invokes the Twilio remove() on the named recording sid", async () => {
+    const recordingRemoveSpy = vi.fn(async () => undefined);
+    const client = fakeClient({ recordingRemoveSpy });
+
+    await deleteRecording(client, "REabc");
+
+    expect(recordingRemoveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates non-not-found errors from the SDK (caller surfaces them as 502)", async () => {
+    const client = fakeClient({
+      recordingRemoveImpl: async () => {
+        throw Object.assign(new Error("twilio: 503 service unavailable"), {
+          status: 503,
+        });
+      },
+    });
+
+    await expect(deleteRecording(client, "REzzz")).rejects.toThrow(/503/);
+  });
+
+  it("treats Twilio's already-deleted recording (404 / code 20404) as success so a DELETE retry can clear the orphaned DB row", async () => {
+    // Scenario: a prior DELETE hard-deleted the recording on Twilio, then the
+    // DB row-delete failed (500). The admin retries; Twilio now 404s the
+    // remove() of the already-gone recording. deleteRecording must swallow it
+    // (resolve) so the route falls through to clear the row, instead of
+    // 502-looping forever on a recording that no longer exists.
+    const recordingRemoveSpy = vi.fn(async () => {
+      throw Object.assign(new Error("The requested resource was not found"), {
+        status: 404,
+        code: 20404,
+      });
+    });
+    const client = fakeClient({ recordingRemoveSpy });
+
+    await expect(deleteRecording(client, "REgone")).resolves.toBeUndefined();
+    expect(recordingRemoveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an empty sid (programming-error guard)", async () => {
+    const client = fakeClient({});
+    await expect(deleteRecording(client, "")).rejects.toThrow(/sid/i);
   });
 });
 
@@ -587,5 +647,49 @@ describe("placeBridgeCall", () => {
         twiml: "<Response><Dial><Number>+15551234567</Number></Dial></Response>",
       }),
     ).rejects.toThrow(/21215/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 9 (#313) — Voicemail + auto-transcription. The voicemail branch of
+// buildVoiceTwiml grows the <Record> callback wiring: Twilio posts the
+// finished recording to the voicemail-completed webhook (recordingStatusCallback)
+// and the auto-transcription to the transcription-completed webhook
+// (transcribeCallback). The two callback URLs are injected through
+// VoiceTwimlOptions so the route supplies them from env (mirroring
+// PHONE_STATUS_CALLBACK_URL for SMS) and the builder stays pure.
+// ---------------------------------------------------------------------------
+describe("buildVoiceTwiml — voicemail recording callbacks (#313)", () => {
+  it("wires <Record recordingStatusCallback> to the voicemail-completed URL", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "voicemail" },
+      {
+        recordingStatusCallback:
+          "https://app.example.com/api/phone/webhook/voicemail-completed",
+      },
+    );
+    expect(xml).toContain(
+      'recordingStatusCallback="https://app.example.com/api/phone/webhook/voicemail-completed"',
+    );
+  });
+
+  it("enables transcription and wires <Record transcribeCallback> to the transcription-completed URL", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "voicemail" },
+      {
+        transcribeCallback:
+          "https://app.example.com/api/phone/webhook/transcription-completed",
+      },
+    );
+    expect(xml).toContain('transcribe="true"');
+    expect(xml).toContain(
+      'transcribeCallback="https://app.example.com/api/phone/webhook/transcription-completed"',
+    );
+  });
+
+  it("plays a beep and caps the recording length (voicemail UX defaults, no options needed)", () => {
+    const xml = buildVoiceTwiml({ kind: "voicemail" });
+    expect(xml).toContain('playBeep="true"');
+    expect(xml).toContain('maxLength="120"');
   });
 });

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -55,6 +55,12 @@ export interface TwilioClientLike {
       phoneNumber: string;
     }>;
   };
+  // Slice 10 (#313) — voicemail deletion. The SDK's `recordings` is the same
+  // callable-single-resource shape: `client.recordings(sid).remove()` issues
+  // Twilio's hard-delete of the recording media.
+  recordings(sid: string): {
+    remove(): Promise<unknown>;
+  };
   messages: {
     create(opts: {
       from: string;
@@ -146,6 +152,43 @@ export async function releaseNumber(
     throw new Error("twilio-client: releaseNumber called with empty sid");
   }
   await client.incomingPhoneNumbers(sid).remove();
+}
+
+/**
+ * Hard-delete a recording on Twilio's side. Slice 10 (#313): deleting a
+ * voicemail removes the Twilio recording media (PRD #304 story 54 — Nookleus
+ * owns retention, and the playable copy lives in our own Storage bucket). Like
+ * `releaseNumber`, this does Twilio only; the call site decides ordering — we
+ * delete on Twilio first so a billing/retention-relevant remove cannot be lost
+ * behind a DB-write failure.
+ */
+export async function deleteRecording(
+  client: TwilioClientLike,
+  sid: string,
+): Promise<void> {
+  if (!sid) {
+    throw new Error("twilio-client: deleteRecording called with empty sid");
+  }
+  try {
+    await client.recordings(sid).remove();
+  } catch (err) {
+    // Idempotent: Twilio 404s a remove() of an already-deleted recording
+    // (HTTP 404 / error code 20404). Treat that as success so a DELETE retry
+    // — after a prior Twilio-success + DB-write failure — can fall through to
+    // clear the orphaned row, instead of 502-looping on a recording that no
+    // longer exists. Re-throw any other (transient / auth) error so the route
+    // still surfaces a 502 and leaves the DB row untouched.
+    if (isRecordingAlreadyGone(err)) return;
+    throw err;
+  }
+}
+
+// Twilio's RestException carries the HTTP `status` and a numeric Twilio
+// `code`; an already-deleted recording surfaces as 404 / 20404.
+function isRecordingAlreadyGone(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { status?: unknown; code?: unknown };
+  return e.status === 404 || e.code === 20404;
 }
 
 export interface SendSmsParams {
@@ -283,12 +326,29 @@ export interface VoiceTwimlOptions {
   // the team member's phone shows the business number (not the outside
   // caller) and a call-back rings the Nookleus number.
   callerId?: string;
+  // Slice 9 (#313) — voicemail recording callbacks. When the decision is
+  // voicemail, the <Record> verb posts the finished recording here (Twilio's
+  // RecordingSid / RecordingUrl / RecordingDuration + the CallSid). The route
+  // supplies the voicemail-completed webhook URL from env; omitted in the
+  // dial branches.
+  recordingStatusCallback?: string;
+  // Slice 9 (#313) — auto-transcription callback. When set, the <Record>
+  // verb requests Twilio's auto-transcription (transcribe="true") and posts
+  // the result here (Twilio's TranscriptionText / TranscriptionStatus +
+  // RecordingSid). The route supplies the transcription-completed webhook URL
+  // from env; transcription is off when this is omitted.
+  transcribeCallback?: string;
 }
 
 // Spoken when an inbound call falls through to voicemail and no custom
 // greeting is configured for the number.
 const DEFAULT_VOICEMAIL_GREETING =
   "You've reached us. Please leave a message after the tone and we'll get back to you.";
+
+// Voicemail UX defaults applied to every <Record>. The beep cues the caller
+// to start speaking; the cap bounds Twilio recording/storage cost and matches
+// a typical voicemail length (2 minutes).
+const VOICEMAIL_MAX_LENGTH_SECONDS = 120;
 
 /**
  * Build the inbound-call TwiML for a `decideShared` decision. Each decision
@@ -317,7 +377,18 @@ export function buildVoiceTwiml(
     dial.number(decision.cell);
   } else {
     vr.say(DEFAULT_VOICEMAIL_GREETING);
-    vr.record({});
+    const record: NonNullable<Parameters<typeof vr.record>[0]> = {
+      playBeep: true,
+      maxLength: VOICEMAIL_MAX_LENGTH_SECONDS,
+    };
+    if (opts.recordingStatusCallback) {
+      record.recordingStatusCallback = opts.recordingStatusCallback;
+    }
+    if (opts.transcribeCallback) {
+      record.transcribe = true;
+      record.transcribeCallback = opts.transcribeCallback;
+    }
+    vr.record(record);
   }
   return vr.toString();
 }

--- a/src/lib/phone/use-phone-sync.test.ts
+++ b/src/lib/phone/use-phone-sync.test.ts
@@ -257,7 +257,13 @@ describe("usePhoneSync — phone_calls (outbound bridge call, #314)", () => {
   function findCall(
     ch: FakeChannel,
     event: "INSERT" | "UPDATE",
-  ): [unknown, Record<string, unknown>, (p: { new: Record<string, unknown> }) => void] | undefined {
+  ):
+    | [
+        unknown,
+        Record<string, unknown>,
+        (p: { new: Record<string, unknown> }) => void,
+      ]
+    | undefined {
     return ch.on.mock.calls.find(
       (c) =>
         (c[1] as Record<string, unknown>).table === "phone_calls" &&
@@ -365,5 +371,93 @@ describe("usePhoneSync — phone_calls (outbound bridge call, #314)", () => {
       (c) => (c[1] as Record<string, unknown>).table === "phone_calls",
     );
     expect(callRegs).toHaveLength(0);
+  });
+});
+
+// Slice 9 (#313) — voicemail transcription lands asynchronously: the
+// transcription-completed webhook UPDATEs the phone_voicemails row long after
+// the call row first rendered. The open thread must flip "Transcribing…" to
+// the transcript text in realtime, so the hook grows an optional
+// `onVoicemailUpdate` callback that registers a subscription on
+// `phone_voicemails` UPDATEs for the active org. Callers that don't want it
+// (Job-page Messages) pass none and register no such subscription.
+describe("usePhoneSync — onVoicemailUpdate (#313)", () => {
+  it("registers a phone_voicemails UPDATE subscription and fires onVoicemailUpdate with the updated row", () => {
+    const supabase = fakeSupabase();
+    const onVoicemailUpdate = vi.fn();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+        onVoicemailUpdate,
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    expect(ch.on).toHaveBeenCalledWith(
+      "postgres_changes",
+      expect.objectContaining({
+        event: "UPDATE",
+        schema: "public",
+        table: "phone_voicemails",
+        filter: "organization_id=eq.org-1",
+      }),
+      expect.any(Function),
+    );
+
+    // Find the voicemail-UPDATE handler (not the phone_messages INSERT) and
+    // simulate the transcription-completed webhook's UPDATE arriving.
+    const vmCall = ch.on.mock.calls.find(
+      (c) =>
+        (c[1] as { table?: string }).table === "phone_voicemails" &&
+        (c[1] as { event?: string }).event === "UPDATE",
+    );
+    expect(vmCall).toBeDefined();
+    const handler = vmCall![2] as (payload: {
+      new: Record<string, unknown>;
+    }) => void;
+
+    act(() => {
+      handler({
+        new: {
+          id: "vm-1",
+          organization_id: "org-1",
+          phone_call_id: "call-1",
+          audio_storage_path: "org-1/rec-1.mp3",
+          transcript: "Call me back.",
+          transcript_status: "ready",
+          duration_seconds: 12,
+        },
+      });
+    });
+
+    expect(onVoicemailUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "vm-1",
+        phone_call_id: "call-1",
+        transcript: "Call me back.",
+        transcript_status: "ready",
+      }),
+    );
+  });
+
+  it("registers no phone_voicemails subscription when onVoicemailUpdate is omitted", () => {
+    const supabase = fakeSupabase();
+
+    renderHook(() =>
+      usePhoneSync({
+        supabase: supabase as never,
+        organizationId: "org-1",
+        onNewMessage: vi.fn(),
+      }),
+    );
+
+    const ch = supabase.channels[0];
+    const vmCall = ch.on.mock.calls.find(
+      (c) => (c[1] as { table?: string }).table === "phone_voicemails",
+    );
+    expect(vmCall).toBeUndefined();
   });
 });

--- a/src/lib/phone/use-phone-sync.ts
+++ b/src/lib/phone/use-phone-sync.ts
@@ -44,6 +44,19 @@ interface PhoneCallRow {
   [key: string]: unknown;
 }
 
+// Slice 9 (#313) — a phone_voicemails row as it arrives on a realtime UPDATE
+// (the transcription-completed webhook fills transcript + flips status).
+export interface PhoneVoicemailRow {
+  id: string;
+  organization_id: string;
+  phone_call_id: string;
+  audio_storage_path: string | null;
+  transcript: string | null;
+  transcript_status: "pending" | "ready" | "failed";
+  duration_seconds: number | null;
+  [key: string]: unknown;
+}
+
 export interface UsePhoneSyncInput {
   supabase: SupabaseClient;
   // The active org. Null while loading or when the user is logged out;
@@ -65,6 +78,11 @@ export interface UsePhoneSyncInput {
   // status-callback webhook stamps the row. Callers that pass neither call
   // callback register no phone_calls subscription at all.
   onCallUpdate?: (row: PhoneCallRow) => void;
+  // Slice 9 (#313) — optional. When provided, the hook also subscribes to
+  // `phone_voicemails` UPDATEs so a transcript that lands after the call row
+  // rendered (the transcription-completed webhook) flips "Transcribing…" to
+  // the text in realtime. The Job-page Messages caller omits it.
+  onVoicemailUpdate?: (row: PhoneVoicemailRow) => void;
 }
 
 export function usePhoneSync(input: UsePhoneSyncInput): void {
@@ -72,6 +90,7 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
   const onMessageUpdateRef = useRef(input.onMessageUpdate);
   const onNewCallRef = useRef(input.onNewCall);
   const onCallUpdateRef = useRef(input.onCallUpdate);
+  const onVoicemailUpdateRef = useRef(input.onVoicemailUpdate);
   // useLayoutEffect (or useEffect — either works since the effect runs
   // before the next event-loop tick that fires the subscription handler)
   // keeps the ref read-only during render, satisfying react-hooks/refs.
@@ -80,11 +99,13 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
     onMessageUpdateRef.current = input.onMessageUpdate;
     onNewCallRef.current = input.onNewCall;
     onCallUpdateRef.current = input.onCallUpdate;
+    onVoicemailUpdateRef.current = input.onVoicemailUpdate;
   }, [
     input.onNewMessage,
     input.onMessageUpdate,
     input.onNewCall,
     input.onCallUpdate,
+    input.onVoicemailUpdate,
   ]);
 
   const { supabase, organizationId } = input;
@@ -95,6 +116,7 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
   const wantsUpdates = input.onMessageUpdate != null;
   const wantsCallInsert = input.onNewCall != null;
   const wantsCallUpdate = input.onCallUpdate != null;
+  const wantsVoicemailUpdates = input.onVoicemailUpdate != null;
 
   useEffect(() => {
     if (!organizationId) return;
@@ -161,6 +183,23 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
       );
     }
 
+    // Slice 9 (#313) — voicemail transcript realtime. A transcript that
+    // lands after the call row rendered arrives as a phone_voicemails UPDATE.
+    if (wantsVoicemailUpdates) {
+      channel = channel.on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "phone_voicemails",
+          filter: orgFilter,
+        },
+        (payload: { new: PhoneVoicemailRow }) => {
+          onVoicemailUpdateRef.current?.(payload.new);
+        },
+      );
+    }
+
     const subscribed = channel.subscribe();
 
     return () => {
@@ -172,5 +211,6 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
     wantsUpdates,
     wantsCallInsert,
     wantsCallUpdate,
+    wantsVoicemailUpdates,
   ]);
 }

--- a/supabase/migration-313-phone-voicemails.sql
+++ b/supabase/migration-313-phone-voicemails.sql
@@ -1,0 +1,185 @@
+-- issue #313 (PRD #304, ADR 0005) — phone_voicemails + phone-recordings
+-- Storage bucket.
+--
+-- Purpose:   The voicemail table for Nookleus Phone. One row per voicemail
+--            recording left when an inbound call falls through to the
+--            <Record> verb (a Personal number always voicemails; a Shared
+--            number voicemails when its inbound rule resolves to voicemail).
+--            The voicemail-completed webhook inserts the row at
+--            recording-end (transcript_status='pending'), keyed to its
+--            parent phone_calls row via Twilio's CallSid; the
+--            transcription-completed webhook later fills `transcript` and
+--            flips `transcript_status` to 'ready' (or 'failed').
+--
+--            The recording audio is copied out of Twilio into the
+--            org-scoped `phone-recordings` Storage bucket so playback
+--            outlives Twilio's media retention and deletion is under
+--            Nookleus's control (PRD #304 story 54). audio_storage_path is
+--            that Nookleus-hosted copy; twilio_recording_url is the original
+--            Twilio URL (kept for provenance / re-fetch).
+--
+-- Shape:     One voicemail per call — UNIQUE(phone_call_id). A single
+--            <Record> verb yields exactly one recording, so the parent call
+--            is the natural key. twilio_recording_sid is stored (not just
+--            the URL) so the delete path can hard-delete on Twilio by SID
+--            without parsing it back out of the URL. No updated_at / update
+--            trigger — like phone_calls and phone_messages, a voicemail
+--            row's lifecycle is webhook-written status transitions, not a
+--            generic updated_at. transcript is NULL until the transcription
+--            webhook lands; transcript_status drives the UI (pending →
+--            spinner, ready → text, failed → "transcript unavailable").
+--
+-- RLS:       phone_voicemails SELECT DELEGATES to phone_calls visibility: a
+--            voicemail is visible exactly when its PARENT call is. The policy
+--            is `organization_id = active_organization_id() AND EXISTS(select 1
+--            from phone_calls call where call.id = phone_call_id)` — and
+--            because RLS DOES apply to phone_calls inside a policy subquery,
+--            that EXISTS is true iff phone_calls_select admits the parent call.
+--            So the full ADR 0005 matrix (Shared tagged/untagged team-visible,
+--            Personal owner-visible, Job-tagged visible to whoever can see the
+--            Job) is INHERITED from phone_calls_select rather than restated —
+--            and self-heals when that policy changes.
+--
+--            Do NOT re-express the matrix here by joining phone_numbers /
+--            phone_conversations and nesting the job_tag test inside that
+--            join's WHERE. RLS filters the Personal number + conversation rows
+--            out of the subquery for a non-owner, so the join comes back empty
+--            and the nested job_tag escape hatch never fires — a Job-tagged
+--            Personal voicemail would be wrongly hidden from the team (the
+--            migration-313 smoke test pins exactly this). phone_calls_select
+--            avoids the trap by lifting job_tag to a TOP-LEVEL OR branch that
+--            never touches the number join; delegation inherits that fix for
+--            free. Like phone_calls the policy does NOT check view_phone — the
+--            feature gate is applied at the route via withRequestContext.
+--
+--            There is no authenticated INSERT / UPDATE / DELETE policy.
+--            Every write path is the Service client: the voicemail-completed
+--            and transcription-completed webhooks (no auth user) and the
+--            canManage-gated DELETE route (serviceClient: true, mirroring
+--            numbers/[id]/release). RLS is ENABLED so the table is otherwise
+--            locked — the only user-facing path is the SELECT join the
+--            conversation Calls route issues on the User client.
+--
+-- Indexes:   UNIQUE(phone_call_id) doubles as the lookup index for the
+--            conversation Calls route's nested embed and the
+--            voicemail-completed insert's conflict target.
+--            idx_phone_voicemails_twilio_recording_sid — the
+--            transcription-completed webhook looks a row up by RecordingSid
+--            to attach the transcript; partial on non-null sid.
+--
+-- Bucket:    phone-recordings — a private Storage bucket, org-prefixed
+--            ({organization_id}/{uuid}.{ext}), mirroring phone-attachments
+--            (migration-310). Its own bucket (not phone-attachments) so
+--            voice recordings carry their own retention lifecycle (PRD #304
+--            story 54) and slice-11 call recordings reuse it. The read
+--            policy is Organization-scoped defense-in-depth: even a direct
+--            client read sees only objects under the caller's Active
+--            Organization prefix. All real I/O runs through the
+--            recordings-storage helpers on the Service client.
+--
+-- Depends on: schema.sql (organizations, jobs), migration-308
+--            (phone_conversations), migration-312 (phone_calls),
+--            `nookleus.active_organization_id()`, and
+--            migration-313-fix-phone-event-select-job-tag-visibility.sql
+--            (the smoke test below asserts the lifted Job-tag visibility
+--            branch on phone_calls_select; apply that fix first). NB: this
+--            file shares the `migration-313-` prefix with that fix — they are
+--            independent migrations, apply both.
+--
+-- Smoke test: supabase/migration-313-smoke-test.sql exercises every cell of
+--            the ADR 0005 matrix on phone_voicemails through the parent
+--            call, mirroring migration-312-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. phone_voicemails. One row per voicemail recording, on a phone_calls row.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_voicemails (
+  id                    uuid primary key default gen_random_uuid(),
+  organization_id       uuid not null references public.organizations(id) on delete cascade,
+  -- The voicemail's parent call. UNIQUE: one voicemail per call (a single
+  -- <Record> verb yields one recording). on delete cascade — a voicemail
+  -- has no meaning without its call.
+  phone_call_id         uuid not null references public.phone_calls(id) on delete cascade,
+  -- Twilio's RecordingSid. The delete path hard-deletes the recording on
+  -- Twilio by this SID; the transcription-completed webhook keys on it to
+  -- attach the transcript.
+  twilio_recording_sid  text,
+  -- The original Twilio media URL (provenance / re-fetch). Playback uses the
+  -- Nookleus-hosted copy below, not this.
+  twilio_recording_url  text,
+  -- The Nookleus-hosted copy in the phone-recordings bucket
+  -- ({organization_id}/{uuid}.{ext}). NULL if the copy failed (the row still
+  -- persists — see the voicemail-completed webhook).
+  audio_storage_path    text,
+  -- Recording length in seconds (Twilio's RecordingDuration).
+  duration_seconds      integer,
+  -- The transcript text. NULL until the transcription-completed webhook
+  -- lands (or permanently NULL on a failed transcription).
+  transcript            text,
+  -- Drives the UI. 'pending' at insert; the transcription webhook flips it
+  -- to 'ready' (transcript filled) or 'failed' (transcript stays NULL).
+  transcript_status     text not null default 'pending'
+                          check (transcript_status in ('pending', 'ready', 'failed')),
+  created_at            timestamptz not null default now(),
+  unique (phone_call_id)
+);
+
+create index if not exists idx_phone_voicemails_twilio_recording_sid
+  on public.phone_voicemails (twilio_recording_sid)
+  where twilio_recording_sid is not null;
+
+-- ---------------------------------------------------------------------------
+-- 2. phone-recordings Storage bucket (private; signed URLs only). Mirrors
+--    phone-attachments (migration-310). Object paths:
+--    {organization_id}/{uuid}.{ext}
+-- ---------------------------------------------------------------------------
+insert into storage.buckets (id, name, public)
+values ('phone-recordings', 'phone-recordings', false)
+on conflict (id) do nothing;
+
+-- Organization-scoped read policy. The first path segment is the
+-- organization id; a member may read only objects under their own Active
+-- Organization prefix.
+drop policy if exists "phone_recordings_org_members_read" on storage.objects;
+create policy "phone_recordings_org_members_read"
+  on storage.objects for select
+  using (
+    bucket_id = 'phone-recordings'
+    and (storage.foldername(name))[1] = nookleus.active_organization_id()::text
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS. SELECT delegates to phone_calls visibility — a voicemail is visible
+--    exactly when its parent call is (see the RLS note in the header for why
+--    delegation rather than a restated OR-tree). No authenticated INSERT /
+--    UPDATE / DELETE policy: every write is the Service client (webhooks + the
+--    canManage-gated DELETE route).
+-- ---------------------------------------------------------------------------
+alter table public.phone_voicemails enable row level security;
+
+drop policy if exists phone_voicemails_select on public.phone_voicemails;
+create policy phone_voicemails_select on public.phone_voicemails
+  for select to authenticated
+  using (
+    -- Fast org guard / defense-in-depth: the voicemail's own org must match the
+    -- caller's Active Organization.
+    organization_id = nookleus.active_organization_id()
+    -- Inherit the parent call's visibility. RLS applies to phone_calls inside
+    -- this subquery, so the EXISTS is true iff phone_calls_select admits the
+    -- parent call — the whole Shared/Personal/Job matrix, one hop out.
+    and exists (
+      select 1
+        from public.phone_calls call
+       where call.id = phone_voicemails.phone_call_id
+    )
+  );
+
+-- ROLLBACK ---
+-- drop policy if exists phone_voicemails_select on public.phone_voicemails;
+-- alter table public.phone_voicemails disable row level security;
+-- drop policy if exists "phone_recordings_org_members_read" on storage.objects;
+-- delete from storage.buckets where id = 'phone-recordings';
+-- drop index if exists public.idx_phone_voicemails_twilio_recording_sid;
+-- drop table if exists public.phone_voicemails;

--- a/supabase/migration-313-smoke-test.sql
+++ b/supabase/migration-313-smoke-test.sql
@@ -1,0 +1,225 @@
+-- issue #313 (PRD #304, ADR 0005) — phone_voicemails access-matrix smoke
+-- test.
+--
+-- Purpose:   Verify that the migration-313 phone_voicemails RLS policy
+--            encodes every cell of the ADR 0005 read-path matrix at the
+--            database — reached through the PARENT call — in the SAME shape
+--            migration-312-smoke-test.sql pins for phone_calls. A voicemail
+--            is visible exactly when its parent call is, so the matrix is
+--            identical; the seed hangs one voicemail off each of the four
+--            matrix-covering calls and asserts the same visible sets.
+--
+--            Matrix exercised (phone_voicemails SELECT, via parent call):
+--              - Shared untagged          → every same-org member sees
+--              - Shared Job-tagged        → every same-org member sees
+--              - Personal untagged, owner → owner sees
+--              - Personal untagged, other → hidden (incl. admin)
+--              - Personal Job-tagged, any → sees (Job-visible team)
+--              - Cross-org caller         → never sees
+--
+-- Shape:     One transaction, rolled back at the end. Service-role seeds two
+--            orgs, four users, two phone_numbers (Shared + Personal), two
+--            conversations, one Job, four phone_calls covering the matrix,
+--            and one phone_voicemail per call. Each assertion block sets the
+--            JWT claims, switches to `authenticated`, runs a SELECT, and
+--            asserts the row-count + (where it discriminates) the visible
+--            set via string_agg over the voicemail transcript label.
+--
+-- Run:       Via Supabase MCP `execute_sql` against the target project.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed. Service-role bypass for orgs / users / memberships.
+--      Org 1: smoke-313-org-1
+--        User A — admin
+--        User B — crew_lead (non-owner of any Personal number)
+--        User C — crew_lead (owner of the Personal number)
+--      Org 2: smoke-313-org-2
+--        User D — admin
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('31300000-0000-0000-0000-000000000001', 'smoke-313-org-1', 'smoke-313-org-1'),
+  ('31300000-0000-0000-0000-000000000002', 'smoke-313-org-2', 'smoke-313-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('31300000-0000-0000-0000-000000000010', 'smoke-313-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31300000-0000-0000-0000-000000000011', 'smoke-313-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31300000-0000-0000-0000-000000000012', 'smoke-313-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31300000-0000-0000-0000-000000000013', 'smoke-313-d@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('31300000-0000-0000-0000-000000000010', '31300000-0000-0000-0000-000000000001', 'admin'),
+  ('31300000-0000-0000-0000-000000000011', '31300000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31300000-0000-0000-0000-000000000012', '31300000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31300000-0000-0000-0000-000000000013', '31300000-0000-0000-0000-000000000002', 'admin');
+
+-- Two phone numbers in org-1: one Shared, one Personal owned by User C.
+insert into public.phone_numbers
+  (id, organization_id, twilio_sid, e164, kind, user_id)
+values
+  ('31300000-0000-0000-0000-0000000000a1', '31300000-0000-0000-0000-000000000001',
+   'PN-smoke313-shared', '+15125550100', 'shared', null),
+  ('31300000-0000-0000-0000-0000000000a2', '31300000-0000-0000-0000-000000000001',
+   'PN-smoke313-personal', '+15125550101', 'personal',
+   '31300000-0000-0000-0000-000000000012');
+
+-- Two conversations — one on each number.
+insert into public.phone_conversations
+  (id, organization_id, phone_number_id, outside_e164)
+values
+  ('31300000-0000-0000-0000-0000000000b1', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000a1', '+15551110101'),
+  ('31300000-0000-0000-0000-0000000000b2', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000a2', '+15551110102');
+
+-- One Job in org-1 for the Job-tagged cases. Contact is a placeholder.
+insert into public.contacts (id, organization_id, full_name)
+values ('31300000-0000-0000-0000-0000000000c1',
+        '31300000-0000-0000-0000-000000000001', 'smoke-313-contact');
+
+insert into public.jobs
+  (id, organization_id, contact_id, damage_type, property_address)
+values
+  ('31300000-0000-0000-0000-0000000000d1', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000c1', 'water', '1 smoke st');
+
+-- Four calls cover the matrix.
+--   call1: Shared, untagged
+--   call2: Shared, tagged (job d1)
+--   call3: Personal (owner C), untagged
+--   call4: Personal (owner C), tagged (job d1)
+insert into public.phone_calls
+  (id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, job_tag)
+values
+  ('31300000-0000-0000-0000-0000000000f1', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'CA-smoke313-1', 'no_answer', null),
+  ('31300000-0000-0000-0000-0000000000f2', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'CA-smoke313-2', 'no_answer',
+   '31300000-0000-0000-0000-0000000000d1'),
+  ('31300000-0000-0000-0000-0000000000f3', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'CA-smoke313-3', 'no_answer', null),
+  ('31300000-0000-0000-0000-0000000000f4', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'CA-smoke313-4', 'no_answer',
+   '31300000-0000-0000-0000-0000000000d1');
+
+-- One voicemail per call. `transcript` carries the matrix label so the
+-- assertions can string_agg the visible set (mirrors phone_calls.twilio_call_sid).
+insert into public.phone_voicemails
+  (id, organization_id, phone_call_id, twilio_recording_sid, transcript, transcript_status)
+values
+  ('31300000-0000-0000-0000-000000000091', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000f1', 'RE-smoke313-1', 'shared-untagged', 'ready'),
+  ('31300000-0000-0000-0000-000000000092', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000f2', 'RE-smoke313-2', 'shared-tagged', 'ready'),
+  ('31300000-0000-0000-0000-000000000093', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000f3', 'RE-smoke313-3', 'personal-untagged', 'ready'),
+  ('31300000-0000-0000-0000-000000000094', '31300000-0000-0000-0000-000000000001',
+   '31300000-0000-0000-0000-0000000000f4', 'RE-smoke313-4', 'personal-tagged', 'ready');
+
+-- ---------------------------------------------------------------------------
+-- 1. User A (admin, org-1) — sees Shared-untagged, Shared-tagged,
+--    Personal-tagged (Job-visible), but NOT Personal-untagged (admin
+--    cannot read untagged Personal content per ADR 0005).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31300000-0000-0000-0000-000000000010","active_organization_id":"31300000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(transcript, ',' order by transcript)
+    into v_count, v_ids
+    from public.phone_voicemails;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-313 smoke (case 1: admin): expected 3 visible voicemails, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-313 smoke (case 1: admin): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-313 smoke (case 1: admin) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. User B (crew_lead, org-1, NOT owner of any Personal number) — sees
+--    Shared-untagged, Shared-tagged, Personal-tagged, NOT Personal-untagged.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31300000-0000-0000-0000-000000000011","active_organization_id":"31300000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(transcript, ',' order by transcript)
+    into v_count, v_ids
+    from public.phone_voicemails;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-313 smoke (case 2: crew_lead non-owner): expected 3 visible voicemails, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-313 smoke (case 2: crew_lead non-owner): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-313 smoke (case 2: crew_lead non-owner) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. User C (crew_lead, org-1, OWNER of Personal +15125550101) — sees all 4.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31300000-0000-0000-0000-000000000012","active_organization_id":"31300000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_voicemails;
+
+  reset role;
+
+  if v_count <> 4 then
+    raise exception 'migration-313 smoke (case 3: Personal owner): expected 4 visible voicemails, got %', v_count;
+  end if;
+  raise notice 'migration-313 smoke (case 3: Personal owner) — sees all 4 of own + Shared rows';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. User D (admin, org-2) — cross-org. Should see 0 voicemails.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31300000-0000-0000-0000-000000000013","active_organization_id":"31300000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_voicemails;
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-313 smoke (case 4: cross-org admin): expected 0 visible voicemails, got %', v_count;
+  end if;
+  raise notice 'migration-313 smoke (case 4: cross-org admin) — sees nothing';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Done.
+-- ---------------------------------------------------------------------------
+rollback;


### PR DESCRIPTION
Closes #313. PRD #304 — Nookleus Phone, slice 9 (voicemail + auto-transcription).

## What this ships
A missed inbound call records a voicemail; Twilio transcribes it; the thread renders audio + transcript with a realtime "ready" update; the recording can be hard-deleted.

- **migration-313-phone-voicemails**: `phone_voicemails` table (one row per voicemail, on a `phone_calls` row, `unique (phone_call_id)`) + a **private** `phone-recordings` bucket with an org-scoped read policy. SELECT RLS delegates parent-call visibility via `EXISTS` on `phone_calls`; all writes go through the Service client.
- **voice-inbound webhook**: a missed call → `no_answer` + a child voicemail row.
- **voicemail-completed webhook**: copies Twilio's audio into Nookleus storage so playback survives Twilio's own retention delete.
- **transcription-completed webhook**: stores transcript → `ready`; `failed` → `failed` + "transcription unavailable" UI.
- **thread UI**: `<audio>` + transcript; realtime UPDATE pushes the ready state.
- **DELETE `/api/phone/voicemails/[id]`**: Twilio hard-delete **first** (a transient 502 leaves the DB untouched), then the row delete, then best-effort storage cleanup. Shared = admin-only, Personal = owner-or-admin (ADR 0003/0005); cross-org → 404.
- **recordings-storage** helpers + a signed-URL recordings route; **fake-twilio-client** `recordings(sid).remove()` no-op for demo mode.

## Pre-merge adversarial review — 5 gaps fixed (TDD)
A 6-dimension review of the integrated diff confirmed 5 real gaps (no high-severity / no security or privacy exposure). All fixed here, each test-first:

1. **(medium) Retry orphans a storage object.** `voicemail-completed` ran the audio-copy unconditionally; a Twilio redelivery conflict-drops the upsert but `uploadPhoneRecording` mints a fresh UUID per call, so the re-copy orphaned the first object and clobbered the stored path. Now reads back `audio_storage_path` after the upsert and skips the copy when it's already set (a *failed* copy left it null, so a retry still completes). Test replays a second delivery and asserts no re-upload.
2. **(low) Misleading comment** in `voicemail-completed` referenced a "later job can re-copy" that doesn't exist — reworded to "a later Twilio redelivery retries the copy."
3. **(low) DELETE retry 502-loop.** A prior Twilio-success + DB-write-failure left the row; the retry re-called `remove()` on the now-deleted recording → Twilio 404 → 502 → row never clearable. `deleteRecording` now treats Twilio not-found (HTTP 404 / code 20404) as success and falls through to the DB delete; genuine transient errors still propagate to a 502. Tests cover both branches.
4. **(low) transcription-completed status handling** is intentional but was untested — added two characterization tests: a `completed` callback with no `TranscriptionText` → `{ transcript: null, transcript_status: 'ready' }`, and an absent/typo'd status never marks `failed` (only the exact `'failed'` sentinel does).
5. **(nit) Migration header** now records its dependency on `migration-313-fix-phone-event-select-job-tag-visibility.sql` and the shared-prefix caveat.

## ⚠️ Migration filename overlap
`supabase/migration-313-phone-voicemails.sql` shares the `migration-313-` prefix with `migration-313-fix-phone-event-select-job-tag-visibility.sql` already on `main` (PR #510). They are **independent** migrations — apply **both**, fix first. The smoke test (`migration-313-smoke-test.sql`) asserts the lifted Job-tag visibility branch from that fix.

## Verification
- `vitest run`: **2530 passed / 4 failed** — the 4 are the pre-existing `estimate-drag-end.test.tsx` `localStorage.getItem` env failures (baseline), not regressions; +4 over baseline are this PR's new tests.
- `tsc --noEmit`: **13 errors**, all pre-existing `tests/integration/*.pg.test.ts` (`embedded-postgres`/`pg`) — baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
