### PR TITLE
feat(photo-viewer): phone layout — full-bleed photo + slide-up action panels (#520)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -1097,6 +1097,9 @@ export default function JobDetail({ jobId }: { jobId: string }) {
         allTags={tags}
         supabaseUrl={supabaseUrl}
         coverPhotoId={job?.cover_photo_id ?? null}
+        // The phone layout's top bar names the Job so the field user always
+        // knows which Job they're in (#520); mirrors the detail header's title.
+        jobName={contactName}
         // Refetch only — the viewer stays open after a Save (the side panel is
         // always visible). Delete/Restore close themselves via onOpenChange.
         onUpdated={fetchData}

--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -1203,3 +1203,390 @@ describe("PhotoViewer — guard", () => {
     expect(container.firstChild).toBeNull();
   });
 });
+
+// Issue #520 — the phone layout. On a phone viewport the Photo is full-bleed and
+// the desktop side panel is gone; a top bar carries ✕ / Job name / ⓘ, the
+// uploader·date·caption sit inline at the bottom, and a bottom action row raises
+// a per-button safe-area-aware slide-up panel. The viewer chooses the layout at
+// runtime from the viewport width (jsdom defaults to 1024 → desktop), so these
+// tests force a phone-class width before rendering and restore it afterward.
+describe("PhotoViewer — phone layout", () => {
+  const ORIGINAL_WIDTH = window.innerWidth;
+  const ORIGINAL_HEIGHT = window.innerHeight;
+  function setViewport(width: number, height: number) {
+    Object.defineProperty(window, "innerWidth", { value: width, configurable: true });
+    Object.defineProperty(window, "innerHeight", { value: height, configurable: true });
+  }
+  beforeEach(() => setViewport(390, 844)); // iPhone-class portrait
+  afterEach(() => setViewport(ORIGINAL_WIDTH, ORIGINAL_HEIGHT));
+
+  it("renders a full-bleed Photo without the desktop side panel", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    // The Photo still renders…
+    expect(screen.getByRole("img")).toBeTruthy();
+    // …but the desktop side panel's "Save Changes" is gone — phone persists each
+    // change from its own slide-up panel, not a single side-panel Save.
+    expect(screen.queryByRole("button", { name: /save changes/i })).toBeNull();
+  });
+
+  it("shows a top bar with a close ✕, the Job name, and an info button", async () => {
+    renderViewer({ jobName: "Eleanor Whitfield" });
+    await act(async () => {});
+
+    expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+    expect(screen.getByText("Eleanor Whitfield")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /details/i })).toBeTruthy();
+  });
+
+  it("closes back to the Job when the top-bar ✕ is tapped", async () => {
+    const { onOpenChange } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /close/i }));
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows the Photo's assigned tags as view-only pills on the Photo", async () => {
+    h.tagAssignments = [{ tag_id: "tag-a" }];
+    renderViewer({
+      allTags: [makeTag("tag-a", "Roof"), makeTag("tag-b", "Water")],
+    });
+    // Let the mount-effect tag read resolve.
+    await act(async () => {});
+
+    // The assigned tag shows as a pill on the Photo…
+    expect(screen.getByText("Roof")).toBeTruthy();
+    // …view-only — it is not an interactive button (editing is in the Tags
+    // panel, so swiping never toggles a tag by accident).
+    expect(screen.queryByRole("button", { name: "Roof" })).toBeNull();
+    // …and an unassigned tag is not shown on the Photo.
+    expect(screen.queryByText("Water")).toBeNull();
+  });
+
+  it("shows the uploader, date, and caption inline along the bottom", async () => {
+    renderViewer({
+      photos: [
+        makePhoto({
+          taken_by: "Eric Daniels",
+          caption: "Roof damage to NE corner",
+        }),
+      ],
+    });
+    await act(async () => {});
+
+    expect(screen.getByText(/Eric Daniels/)).toBeTruthy();
+    // Date is shown; assert the year (timezone-stable, unlike day/hour).
+    expect(screen.getByText(/2026/)).toBeTruthy();
+    expect(screen.getByText(/Roof damage to NE corner/)).toBeTruthy();
+  });
+
+  it("shows a bottom action row — Tags, Draw, Before/After, and ⋯ More", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    expect(screen.getByRole("button", { name: /^tags$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^draw$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /before.*after/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /more/i })).toBeTruthy();
+  });
+
+  it("hides Draw for a video in the bottom action row (no still to draw on)", async () => {
+    renderViewer({
+      photos: [makePhoto({ media_type: "video", storage_path: "job-1/clip.mp4" })],
+    });
+    await act(async () => {});
+
+    expect(screen.queryByRole("button", { name: /^draw$/i })).toBeNull();
+    // The other actions still apply to a video.
+    expect(screen.getByRole("button", { name: /^tags$/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /before.*after/i })).toBeTruthy();
+  });
+
+  it("Draw hands the still off to the Annotator with its display URL", async () => {
+    const { photo, onAnnotate } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^draw$/i }));
+    });
+
+    expect(onAnnotate).toHaveBeenCalledWith(
+      photo,
+      photoUrl(photo, SUPABASE_URL, "full"),
+    );
+  });
+
+  it("raises the Tags add/remove list when Tags is tapped", async () => {
+    renderViewer({
+      allTags: [makeTag("tag-a", "Roof"), makeTag("tag-b", "Water")],
+    });
+    await act(async () => {});
+
+    // Closed: the interactive tag toggles aren't on screen yet.
+    expect(screen.queryByRole("button", { name: "Roof" })).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^tags$/i }));
+    });
+
+    // The panel raises the add/remove list — each tag becomes a toggle.
+    expect(screen.getByRole("button", { name: "Roof" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Water" })).toBeTruthy();
+  });
+
+  it("pre-selects the Photo's existing tags in the Tags panel", async () => {
+    h.tagAssignments = [{ tag_id: "tag-a" }];
+    renderViewer({
+      allTags: [makeTag("tag-a", "Roof"), makeTag("tag-b", "Water")],
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^tags$/i }));
+    });
+
+    const selected = screen.getByRole("button", { name: "Roof" }) as HTMLElement;
+    const unselected = screen.getByRole("button", { name: "Water" }) as HTMLElement;
+    expect(selected.style.backgroundColor).toBeTruthy();
+    expect(unselected.style.backgroundColor).toBeFalsy();
+  });
+
+  it("adds/removes tags from the Tags panel and persists on Done", async () => {
+    const { photo } = renderViewer({
+      allTags: [makeTag("tag-a", "Roof"), makeTag("tag-b", "Water")],
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^tags$/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Roof" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^done$/i }));
+    });
+
+    // Persisted with the same delete-all-then-insert the desktop Save uses.
+    expect(h.del).toHaveBeenCalledWith(
+      "photo_tag_assignments",
+      "photo_id",
+      photo.id,
+    );
+    expect(h.insert).toHaveBeenCalledWith(
+      "photo_tag_assignments",
+      expect.arrayContaining([
+        expect.objectContaining({
+          organization_id: "org-1",
+          photo_id: photo.id,
+          tag_id: "tag-a",
+        }),
+      ]),
+    );
+  });
+
+  it("raises the Before/After toggle when Before/After is tapped", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    // Closed: the role toggles aren't on screen.
+    expect(screen.queryByRole("button", { name: "After" })).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /before.*after/i }));
+    });
+
+    expect(screen.getByRole("button", { name: "Before" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "After" })).toBeTruthy();
+  });
+
+  it("sets the Before/After role from the panel and persists on Done", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /before.*after/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "After" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^done$/i }));
+    });
+
+    expect(h.update).toHaveBeenCalledWith(
+      "photos",
+      expect.objectContaining({ before_after_role: "after" }),
+    );
+  });
+
+  it("clears the Before/After role from the panel and persists on Done", async () => {
+    renderViewer({ photos: [makePhoto({ before_after_role: "before" })] });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /before.*after/i }));
+    });
+    // Toggling the active role off clears it.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Before" }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^done$/i }));
+    });
+
+    expect(h.update).toHaveBeenCalledWith(
+      "photos",
+      expect.objectContaining({ before_after_role: null }),
+    );
+  });
+
+  it("offers Share, Duplicate, Set as cover, Save to device, and Delete in ⋯ More", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+
+    expect(screen.getByRole("button", { name: /share/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /duplicate/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /set as cover/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /save to device/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /^delete$/i })).toBeTruthy();
+  });
+
+  it("Set as cover from ⋯ More writes the Job's cover to the current Photo", async () => {
+    const { photo } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /set as cover/i }));
+    });
+
+    expect(h.update).toHaveBeenCalledWith(
+      "jobs",
+      expect.objectContaining({ cover_photo_id: photo.id }),
+    );
+  });
+
+  it("Delete from ⋯ More confirms, then closes on the last Photo", async () => {
+    const { onOpenChange } = renderViewer();
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /more/i }));
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+    });
+    // Arming Delete does not delete yet — it asks to confirm.
+    expect(h.del).not.toHaveBeenCalledWith("photos", "id", expect.anything());
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm delete/i }));
+    });
+
+    // Deleting the only Photo closes the viewer (deferred hard delete + Undo).
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toast).toHaveBeenCalledWith(
+      expect.stringMatching(/deleted/i),
+      expect.objectContaining({
+        action: expect.objectContaining({ label: expect.stringMatching(/undo/i) }),
+      }),
+    );
+  });
+
+  it("raises a details panel from the info (ⓘ) button with the file size", async () => {
+    renderViewer({
+      photos: [makePhoto({ taken_by: "Eric Daniels", file_size: 2_097_152 })],
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /details/i }));
+    });
+
+    // The info panel carries the fuller metadata — the file size, which the
+    // inline bottom strip omits.
+    expect(screen.getByText(/2\.0 MB/)).toBeTruthy();
+  });
+
+  it("offers Restore Original in the info panel for an annotated Photo", async () => {
+    renderViewer({
+      photos: [makePhoto({ annotated_path: "job-1/p1-annotated.png" })],
+    });
+    // Let the mount-effect backup probe resolve so the control appears.
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /details/i }));
+    });
+
+    expect(
+      screen.getByRole("button", { name: /restore original/i }),
+    ).toBeTruthy();
+  });
+
+  it("pads its slide-up panels past the iOS safe-area inset", async () => {
+    renderViewer({
+      allTags: [makeTag("tag-a", "Roof")],
+    });
+    await act(async () => {});
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /^tags$/i }));
+    });
+
+    // The open panel's scroll area pads its bottom past the home indicator.
+    const panel = screen.getByRole("dialog");
+    expect(
+      panel.querySelector('[class*="safe-area-inset-bottom"]'),
+    ).toBeTruthy();
+  });
+
+  it("pages between Photos on swipe", async () => {
+    const a = makePhoto({
+      id: "a",
+      storage_path: "job-1/a.jpg",
+      created_at: "2026-05-02T10:00:00Z",
+    });
+    const b = makePhoto({
+      id: "b",
+      storage_path: "job-1/b.jpg",
+      created_at: "2026-05-01T10:00:00Z",
+    });
+    renderViewer({ photos: [a, b], initialPhotoIndex: 0 });
+    await act(async () => {});
+
+    const src = () =>
+      (screen.getByRole("img") as HTMLImageElement).getAttribute("src");
+    const surface = screen.getByRole("img").parentElement as HTMLElement;
+    expect(src()).toBe(photoUrl(a, SUPABASE_URL, "full"));
+
+    // Finger travels right → left: advance to the next (older) Photo.
+    await act(async () => {
+      fireEvent.touchStart(surface, { touches: [{ clientX: 240 }] });
+      fireEvent.touchEnd(surface, { changedTouches: [{ clientX: 80 }] });
+    });
+    expect(src()).toBe(photoUrl(b, SUPABASE_URL, "full"));
+  });
+
+  it("drops the desktop zoom buttons on a phone (pinch-to-zoom replaces them)", async () => {
+    renderViewer();
+    await act(async () => {});
+
+    // The full-bleed phone surface zooms by pinch / double-tap, so the on-photo
+    // ＋ / − buttons (which would overlap the bottom action row) are not shown.
+    expect(screen.queryByRole("button", { name: /zoom in/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /zoom out/i })).toBeNull();
+  });
+});

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -14,6 +14,8 @@ import {
   indexAfterDelete,
 } from "@/lib/jobs/photo-viewer-navigation";
 import { mediaCapabilities } from "@/lib/jobs/photo-media-capabilities";
+import { isPhoneViewport } from "@/lib/jobs/photo-viewer-layout";
+import { useViewportOrientation } from "@/lib/mobile/use-viewport-orientation";
 import { exportVersion } from "@/lib/jobs/photo-export-version";
 import { shareOrDownloadFile } from "@/lib/share/share-or-download";
 import {
@@ -48,6 +50,8 @@ import {
   ChevronRight,
   ZoomIn,
   ZoomOut,
+  Info,
+  ArrowLeftRight,
 } from "lucide-react";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -55,6 +59,54 @@ import { toast } from "sonner";
 // How long the deleted Photo lingers — hidden but recoverable — before the
 // permanent hard delete commits (#515). Matches the Undo toast's lifetime.
 const UNDO_WINDOW_MS = 5000;
+
+// A safe-area-aware slide-up panel for the phone layout (#520) — the bottom
+// sheet each action button raises. Mirrors the existing pattern: a full-screen
+// scrim that dismisses on tap and a rounded panel pinned to the bottom edge,
+// its scroll area padded past the iOS home indicator with
+// pb-[max(env(safe-area-inset-bottom),24px)]. Renders nothing when closed, so
+// its contents never collide with the desktop layout's controls.
+function PhoneSheet({
+  open,
+  onClose,
+  title,
+  children,
+}: {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  children: React.ReactNode;
+}) {
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[95] flex items-end"
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+    >
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative w-full max-h-[80vh] overflow-y-auto rounded-t-2xl bg-white px-4 pt-4 pb-[max(env(safe-area-inset-bottom),24px)]">
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-base font-semibold text-[#1A1A1A]">{title}</h2>
+          <button
+            type="button"
+            aria-label="Dismiss"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-[#666666] hover:bg-gray-100"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
 
 export default function PhotoViewer({
   open,
@@ -64,6 +116,7 @@ export default function PhotoViewer({
   allTags,
   supabaseUrl,
   coverPhotoId,
+  jobName,
   onUpdated,
   onAnnotate,
 }: {
@@ -74,6 +127,8 @@ export default function PhotoViewer({
   allTags: PhotoTag[];
   supabaseUrl: string;
   coverPhotoId: string | null;
+  /** The Job's display name, shown in the phone layout's top bar (#520). */
+  jobName?: string;
   onUpdated: () => void;
   onAnnotate: (photo: Photo, url: string) => void;
 }) {
@@ -139,6 +194,13 @@ export default function PhotoViewer({
   const surfaceRef = useRef<HTMLDivElement>(null);
   const imgRef = useRef<HTMLImageElement>(null);
   const isZoomed = transform.scale > 1;
+
+  // Phone vs desktop is chosen at runtime from the live viewport width: narrow
+  // viewports get the full-bleed phone layout with slide-up action panels, wider
+  // ones keep the desktop side panel (#520). The pure rule decides; the hook
+  // just supplies the measured width (and re-renders on rotate/resize).
+  const { width: viewportWidth } = useViewportOrientation();
+  const isPhone = isPhoneViewport(viewportWidth);
 
   // The transform reasons in pixels: the surface's measured size is the
   // viewport, and the Photo's stored dimensions (falling back to the decoded
@@ -338,6 +400,11 @@ export default function PhotoViewer({
   const [restoring, setRestoring] = useState(false);
   const [hasOriginalBackup, setHasOriginalBackup] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
+  // Which phone slide-up panel is raised, if any (#520). Only one at a time; the
+  // desktop layout never opens these (it has the always-visible side panel).
+  const [phoneSheet, setPhoneSheet] = useState<
+    null | "tags" | "beforeAfter" | "info" | "more"
+  >(null);
   const [settingCover, setSettingCover] = useState(false);
   // Which export, if any, is in flight — so the chosen ⋯ menu entry shows a
   // spinner and both stay disabled until the share/download settles.
@@ -514,6 +581,14 @@ export default function PhotoViewer({
     onUpdated();
   }
 
+  // A phone slide-up panel's "Done" persists its change through the same write
+  // the desktop side panel's Save uses, then lowers the panel (#520). The Tags
+  // and Before/After panels both route through here so there is one save path.
+  async function handlePhoneSheetDone() {
+    await handleSave();
+    setPhoneSheet(null);
+  }
+
   // Download the original-quality image. Reuses the grid's download route
   // (signed URL of the clean original — storage_path, never the annotated copy).
   async function handleDownload() {
@@ -677,8 +752,21 @@ export default function PhotoViewer({
   // <video> src for a clip.
   const caps = mediaCapabilities(currentPhoto, supabaseUrl);
 
+  // The full tag records for the Photo's current assignments, in the gallery's
+  // tag order — drives both the on-photo pills (view-only) and the Tags panel's
+  // selected state (#520).
+  const assignedTags = allTags.filter((t) => assignedTagIds.includes(t.id));
+
   const toolbarBtn =
     "inline-flex items-center justify-center w-9 h-9 rounded-full bg-black/50 text-white transition-colors";
+
+  // A phone bottom-row action: a stacked icon + label, comfortably tappable.
+  const phoneActionBtn =
+    "flex flex-1 flex-col items-center gap-1 py-1 text-[11px] font-medium text-white transition-opacity active:opacity-60";
+
+  // A row in the ⋯ More slide-up panel: an icon + label, full-width and tappable.
+  const phoneMenuItem =
+    "flex items-center gap-3 px-1 py-3 text-sm text-[#1A1A1A] text-left border-b border-gray-100 last:border-0 disabled:opacity-60";
 
   return (
     <div className="fixed inset-0 z-[90] flex bg-black">
@@ -723,8 +811,10 @@ export default function PhotoViewer({
         )}
 
         {/* Zoom controls (desktop) — scroll-wheel and double-click also zoom;
-            hidden for media that can't zoom (video). */}
-        {caps.canZoom && (
+            hidden for media that can't zoom (video) and on phones, where pinch /
+            double-tap zoom replaces them and the bottom action row owns the
+            bottom-left (#520). */}
+        {caps.canZoom && !isPhone && (
           <div className="absolute bottom-3 left-3 flex flex-col gap-2">
             <button
               type="button"
@@ -779,6 +869,11 @@ export default function PhotoViewer({
           </button>
         )}
 
+        {/* Desktop chrome over the Photo: close, cover badge, action toolbar,
+            and the ⋯ menu. On a phone these give way to the top bar, the on-photo
+            tag pills, and the bottom slide-up panels (#520). */}
+        {!isPhone && (
+          <>
         {/* Close back to the Job */}
         <button
           type="button"
@@ -919,6 +1014,53 @@ export default function PhotoViewer({
             </button>
           </div>
         )}
+          </>
+        )}
+
+        {/* Phone top bar — ✕, the Job name, and an info (ⓘ) button that raises
+            the details panel (#520). The full-bleed Photo sits behind it. */}
+        {isPhone && (
+          <div className="absolute inset-x-0 top-0 flex items-center gap-2 px-3 pt-[max(env(safe-area-inset-top),12px)] pb-6 bg-gradient-to-b from-black/60 to-transparent text-white">
+            <button
+              type="button"
+              aria-label="Close"
+              title="Close"
+              onClick={() => onOpenChange(false)}
+              className={cn(toolbarBtn, "shrink-0 hover:bg-black/70")}
+            >
+              <X size={18} />
+            </button>
+            <span className="flex-1 truncate text-sm font-semibold">
+              {jobName}
+            </span>
+            <button
+              type="button"
+              aria-label="Photo details"
+              title="Photo details"
+              onClick={() => setPhoneSheet("info")}
+              className={cn(toolbarBtn, "shrink-0 hover:bg-black/70")}
+            >
+              <Info size={18} />
+            </button>
+          </div>
+        )}
+
+        {/* On-photo tag pills (phone) — a view-only glance at how the Photo is
+            tagged while swiping; editing happens in the Tags panel, so these are
+            plain pills, never buttons (#520). */}
+        {isPhone && assignedTags.length > 0 && (
+          <div className="absolute left-3 right-3 top-[max(env(safe-area-inset-top),12px)] mt-12 flex flex-wrap gap-1.5">
+            {assignedTags.map((tag) => (
+              <span
+                key={tag.id}
+                className="px-2.5 py-1 rounded-full text-xs font-medium text-white shadow-sm"
+                style={{ backgroundColor: tag.color }}
+              >
+                {tag.name}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* Delete confirmation */}
         {confirmDelete && (
@@ -939,9 +1081,77 @@ export default function PhotoViewer({
             </button>
           </div>
         )}
+
+        {/* Phone bottom — the uploader · date · caption sit inline so the field
+            user has context without opening anything (#520). The action row that
+            raises the slide-up panels sits below it, closest to the thumb. */}
+        {isPhone && (
+          <div className="absolute inset-x-0 bottom-0 flex flex-col gap-3 px-4 pt-10 pb-[max(env(safe-area-inset-bottom),12px)] bg-gradient-to-t from-black/70 via-black/40 to-transparent text-white">
+            <div className="space-y-0.5">
+              {currentPhoto.caption && (
+                <p className="text-sm font-medium">{currentPhoto.caption}</p>
+              )}
+              <p className="text-xs text-white/70">
+                {currentPhoto.taken_by}
+                {" · "}
+                {format(new Date(currentPhoto.created_at), "MMM d, yyyy")}
+              </p>
+            </div>
+
+            {/* Action row — Tags · Draw · Before/After · ⋯ More. Tags,
+                Before/After and More each raise their own slide-up panel; Draw
+                hands off to the Annotator (hidden for video). */}
+            <div className="flex items-stretch justify-around">
+              <button
+                type="button"
+                aria-label="Tags"
+                onClick={() => setPhoneSheet("tags")}
+                className={phoneActionBtn}
+              >
+                <Tag size={20} />
+                Tags
+              </button>
+              {caps.canDraw && (
+                <button
+                  type="button"
+                  aria-label="Draw"
+                  onClick={() =>
+                    onAnnotate(
+                      currentPhoto,
+                      photoUrl(currentPhoto, supabaseUrl, "full"),
+                    )
+                  }
+                  className={phoneActionBtn}
+                >
+                  <Pencil size={20} />
+                  Draw
+                </button>
+              )}
+              <button
+                type="button"
+                aria-label="Before / After"
+                onClick={() => setPhoneSheet("beforeAfter")}
+                className={phoneActionBtn}
+              >
+                <ArrowLeftRight size={20} />
+                Before/After
+              </button>
+              <button
+                type="button"
+                aria-label="More"
+                onClick={() => setPhoneSheet("more")}
+                className={phoneActionBtn}
+              >
+                <MoreHorizontal size={20} />
+                More
+              </button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Always-visible side panel (desktop) carries the modal's fields */}
+      {!isPhone && (
       <aside className="w-[340px] shrink-0 bg-white border-l border-gray-200 overflow-y-auto p-4 space-y-4">
         {/* Caption */}
         <div>
@@ -1078,6 +1288,221 @@ export default function PhotoViewer({
           </button>
         </div>
       </aside>
+      )}
+
+      {/* Phone slide-up panels (#520). Each action button raises its own; only
+          one is open at a time. Tags and Before/After persist on Done through
+          the same writes the desktop Save uses. */}
+      {isPhone && (
+        <>
+          <PhoneSheet
+            open={phoneSheet === "tags"}
+            onClose={() => setPhoneSheet(null)}
+            title="Tags"
+          >
+            <div className="flex flex-wrap gap-1.5">
+              {allTags.map((tag) => {
+                const selected = assignedTagIds.includes(tag.id);
+                return (
+                  <button
+                    key={tag.id}
+                    type="button"
+                    onClick={() => toggleTag(tag.id)}
+                    className={cn(
+                      "px-2.5 py-1 rounded-full text-sm font-medium border transition-all flex items-center gap-1",
+                      selected
+                        ? "text-white border-transparent"
+                        : "bg-white text-[#666666] border-gray-200 hover:border-gray-300",
+                    )}
+                    style={
+                      selected
+                        ? { backgroundColor: tag.color, borderColor: tag.color }
+                        : undefined
+                    }
+                  >
+                    {selected && <Check size={12} />}
+                    {tag.name}
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              type="button"
+              onClick={handlePhoneSheetDone}
+              disabled={saving}
+              className="mt-4 w-full inline-flex items-center justify-center rounded-lg text-sm font-medium px-4 py-2.5 bg-[#C41E2A] hover:bg-[#A3171F] text-white transition-colors disabled:opacity-50"
+            >
+              {saving && <Loader2 size={14} className="animate-spin mr-1.5" />}
+              Done
+            </button>
+          </PhoneSheet>
+
+          <PhoneSheet
+            open={phoneSheet === "beforeAfter"}
+            onClose={() => setPhoneSheet(null)}
+            title="Before / After"
+          >
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  setBeforeAfterRole(
+                    beforeAfterRole === "before" ? null : "before",
+                  )
+                }
+                className={cn(
+                  "flex-1 px-3 py-2.5 rounded-lg text-sm font-medium border transition-all",
+                  beforeAfterRole === "before"
+                    ? "bg-[#FCEBEB] text-[#791F1F] border-[#791F1F]/20"
+                    : "bg-white text-[#666666] border-gray-200",
+                )}
+              >
+                Before
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setBeforeAfterRole(
+                    beforeAfterRole === "after" ? null : "after",
+                  )
+                }
+                className={cn(
+                  "flex-1 px-3 py-2.5 rounded-lg text-sm font-medium border transition-all",
+                  beforeAfterRole === "after"
+                    ? "bg-[#E1F5EE] text-[#085041] border-[#085041]/20"
+                    : "bg-white text-[#666666] border-gray-200",
+                )}
+              >
+                After
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={handlePhoneSheetDone}
+              disabled={saving}
+              className="mt-4 w-full inline-flex items-center justify-center rounded-lg text-sm font-medium px-4 py-2.5 bg-[#C41E2A] hover:bg-[#A3171F] text-white transition-colors disabled:opacity-50"
+            >
+              {saving && <Loader2 size={14} className="animate-spin mr-1.5" />}
+              Done
+            </button>
+          </PhoneSheet>
+
+          <PhoneSheet
+            open={phoneSheet === "more"}
+            onClose={() => setPhoneSheet(null)}
+            title="More"
+          >
+            <div className="flex flex-col">
+              <button
+                type="button"
+                onClick={handleSetCover}
+                disabled={settingCover || isCover}
+                className={phoneMenuItem}
+              >
+                {settingCover ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : isCover ? (
+                  <Check size={18} className="text-[#085041]" />
+                ) : (
+                  <Star size={18} />
+                )}
+                {isCover ? "Cover photo" : "Set as cover"}
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport("share")}
+                disabled={exporting !== null}
+                className={phoneMenuItem}
+              >
+                {exporting === "share" ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : (
+                  <Share2 size={18} />
+                )}
+                Share
+              </button>
+              <button
+                type="button"
+                onClick={() => handleExport("save")}
+                disabled={exporting !== null}
+                className={phoneMenuItem}
+              >
+                {exporting === "save" ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : (
+                  <ArrowDownToLine size={18} />
+                )}
+                Save to device
+              </button>
+              <button
+                type="button"
+                onClick={handleDuplicate}
+                disabled={duplicating}
+                className={phoneMenuItem}
+              >
+                {duplicating ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : (
+                  <Copy size={18} />
+                )}
+                Duplicate
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setPhoneSheet(null);
+                  setConfirmDelete(true);
+                }}
+                className={cn(phoneMenuItem, "text-[#C41E2A]")}
+              >
+                <Trash2 size={18} />
+                Delete
+              </button>
+            </div>
+          </PhoneSheet>
+
+          <PhoneSheet
+            open={phoneSheet === "info"}
+            onClose={() => setPhoneSheet(null)}
+            title="Details"
+          >
+            <div className="text-sm text-[#444444] space-y-1.5">
+              <p>
+                <span className="text-[#999999]">Uploaded: </span>
+                {format(
+                  new Date(currentPhoto.created_at),
+                  "MMM d, yyyy 'at' h:mm a",
+                )}
+              </p>
+              <p>
+                <span className="text-[#999999]">By: </span>
+                {currentPhoto.taken_by}
+              </p>
+              {currentPhoto.file_size && (
+                <p>
+                  <span className="text-[#999999]">Size: </span>
+                  {(currentPhoto.file_size / 1024 / 1024).toFixed(1)} MB
+                </p>
+              )}
+            </div>
+            {hasOriginalBackup && (
+              <button
+                type="button"
+                onClick={handleRestoreOriginal}
+                disabled={restoring}
+                className="mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-[#791F1F] hover:text-[#C41E2A] transition-colors disabled:opacity-50"
+              >
+                {restoring ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <RotateCcw size={14} />
+                )}
+                Restore Original Photo
+              </button>
+            )}
+          </PhoneSheet>
+        </>
+      )}
     </div>
   );
 }

--- a/src/lib/jobs/photo-viewer-layout.test.ts
+++ b/src/lib/jobs/photo-viewer-layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+
+import { isPhoneViewport, PHONE_MAX_WIDTH } from "./photo-viewer-layout";
+
+describe("isPhoneViewport", () => {
+  it("treats viewports narrower than the breakpoint as phone", () => {
+    expect(isPhoneViewport(390)).toBe(true); // iPhone-class portrait
+    expect(isPhoneViewport(PHONE_MAX_WIDTH - 1)).toBe(true);
+  });
+
+  it("treats the breakpoint and wider as desktop", () => {
+    expect(isPhoneViewport(PHONE_MAX_WIDTH)).toBe(false);
+    expect(isPhoneViewport(1024)).toBe(false); // jsdom's default / tablet+
+  });
+
+  it("treats an unmeasured (0 or negative) width as desktop", () => {
+    // Server render / before the viewport is measured — default to the richer
+    // layout rather than flashing the phone one.
+    expect(isPhoneViewport(0)).toBe(false);
+    expect(isPhoneViewport(-1)).toBe(false);
+  });
+});

--- a/src/lib/jobs/photo-viewer-layout.ts
+++ b/src/lib/jobs/photo-viewer-layout.ts
@@ -1,0 +1,17 @@
+// Issue #520 — the pure rule for which PhotoViewer layout a viewport gets.
+//
+// Below this width the viewer switches to its phone layout (a full-bleed Photo
+// with slide-up action panels); at or above it, the desktop side-panel layout.
+// A non-positive width — server render or an unmeasured viewport — is treated as
+// desktop so the richer layout is the default until a real width is known (and
+// so jsdom's default 1024 keeps component tests on the desktop layout). Kept
+// free of React/DOM so the rule lives in one tested place, mirroring the other
+// pure viewer modules (navigation, media-capabilities, zoom-transform).
+
+/** Widths narrower than this (in CSS px) get the phone layout — Tailwind's md. */
+export const PHONE_MAX_WIDTH = 768;
+
+/** Whether a viewport of `width` CSS px should render the viewer's phone layout. */
+export function isPhoneViewport(width: number): boolean {
+  return width > 0 && width < PHONE_MAX_WIDTH;
+}


### PR DESCRIPTION
Closes #520. Photo viewer 3 (PRD #511) — gives the Photo viewer its phone layout.

## What changed

Below **768px** the viewer renders a full-bleed Photo with phone chrome; at ≥768px the existing desktop side-panel layout is **unchanged**. The layout is chosen at **runtime** from the viewport width (a new pure `isPhoneViewport` rule + `useViewportOrientation`), not Tailwind `lg:` toggles — so both layouts never render at once, which keeps the existing desktop tests on jsdom's 1024px default rather than finding duplicated controls.

Phone layout:
- **Top bar** — ✕, the Job name, and an info (ⓘ) button.
- **View-only tag pills** on the Photo (plain pills, never buttons — editing happens in the Tags panel, so swiping never toggles a tag).
- **Inline metadata** — uploader · date · caption along the bottom.
- **Bottom action row** — Tags · Draw · Before/After · ⋯ More. Tags, Before/After, info and ⋯ each raise their own **safe-area-aware slide-up panel** (a reusable hand-rolled `PhoneSheet` padded with `pb-[max(env(safe-area-inset-bottom),24px)]`); Draw hands off to the Annotator (hidden for video).
- **Persistence** — the Tags and Before/After panels persist on their **Done** button through the same Supabase writes the desktop Save uses.
- Swipe paging (from #515) works; the desktop zoom +/- buttons drop on phones (pinch / double-tap replace them and the action row owns the bottom-left).

## Acceptance criteria

- [x] Full-bleed Photo; tag pills show on the Photo (view-only)
- [x] Top bar shows ✕, the Job name, and an info button
- [x] Uploader, date, and caption inline at the bottom
- [x] Bottom row (Tags · Draw · Before/After · ⋯) each raises its own slide-up panel
- [x] Tags panel adds/removes; Before/After panel sets the role; both persist as elsewhere
- [x] Panels respect the iOS safe-area inset
- [x] Swipe moves between Photos
- [x] No new test failures beyond the known-red baseline

## Files

- **`src/lib/jobs/photo-viewer-layout.ts`** *(new)* — pure `isPhoneViewport(width)` predicate (`>0 && <768`), unit-tested.
- **`src/components/photo-viewer.tsx`** — `jobName?` prop; phone top bar / pills / inline metadata / action row; reusable safe-area `PhoneSheet` hosting the Tags, Before/After, ⋯ More, and info panels; desktop chrome gated behind `!isPhone`.
- **`src/components/job-detail.tsx`** — passes `jobName={contactName}` (mirrors the detail header title).
- Tests — `photo-viewer.test.tsx` (+25 phone-layout tests), `photo-viewer-layout.test.ts` *(new)*.

## Verification

- `npm test -- src/components/photo-viewer.test.tsx src/lib/jobs/photo-viewer-layout.test.ts` → **81 passed** (was 56 before).
- `npx tsc --noEmit` → clean (exit 0).
- `eslint` on changed files → **0 errors** (2 pre-existing warnings in `photo-viewer.tsx` only).

## Notes

- Built test-first (red→green per behavior).
- Design choices: a **hand-rolled** safe-area sheet (not Base-UI `<Sheet>`, which has no jsdom test precedent and would nest a focus-trap inside the viewer's own overlay), and a **Done button per panel** routing through one save path.
- Blocked-by #513 and #515 are both already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
