### PR TITLE
feat(camera): 0.5x/1x/2x lens toggle (native iOS via patch-package)

### DIFF
--- a/docs/superpowers/plans/2026-06-08-camera-lens-zoom.md
+++ b/docs/superpowers/plans/2026-06-08-camera-lens-zoom.md
@@ -1,0 +1,1144 @@
+# Camera Lens Toggle (0.5× / 1× / 2×) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an iPhone-style segmented lens toggle (0.5× ultra-wide / 1× wide / 2× digital crop) to the in-app native camera, degrading gracefully on devices/binaries that lack the native support.
+
+**Architecture:** Three layers behind one shared `factor → (lens, videoZoomFactor)` contract. **Layer A** patches the `@capacitor-community/camera-preview` Swift + TS sources in `node_modules` via **patch-package** (the plugin is consumed by local path, so patched sources are compiled into the app). **Layer B** adds runtime feature-detection in `useCameraLifecycle` so an old native binary or the web fallback simply hides the toggle. **Layer C** renders the pill in `camera-view.tsx`, calling `CameraPreview.setZoom({ factor })` with optimistic-then-revert state. Pure decision logic is extracted to `src/lib/mobile/lens-zoom.ts` and unit-tested.
+
+**Tech Stack:** Next.js 16.2.2, React 19.2.4, Capacitor 8.x, `@capacitor-community/camera-preview@8.0.1`, AVFoundation (Swift), patch-package, Vitest + @testing-library/react.
+
+**Source of truth:** `docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md`. Threading: minimal (JS-side `isSwitchingLens` serialization), per spec §10, approved.
+
+---
+
+## File Structure
+
+| File | New? | Responsibility |
+|------|------|----------------|
+| `src/lib/mobile/lens-zoom.ts` | new | Framework-free decision logic: which stops to show, optimistic select / revert transitions, label formatting. The single source of UI truth, fully unit-testable. |
+| `src/lib/mobile/lens-zoom.test.ts` | new | Vitest unit tests for the above. |
+| `package.json` | modify | Add `patch-package` + `postinstall-postinstall` devDeps and a `postinstall` script. |
+| `patches/@capacitor-community+camera-preview+8.0.1.patch` | new | Captures all `node_modules` Swift + TS edits (Layer A). The only committed artifact of the native change; the `node_modules` edits themselves are ephemeral. |
+| `src/lib/mobile/use-camera-lifecycle.ts` | modify | Owns `CameraPreview.start()`; gains an `onZoomFactorsAvailable` callback that feature-detects via `getAvailableZoomFactors()` after each start. |
+| `src/lib/mobile/use-camera-lifecycle.test.ts` | modify | Add the `getAvailableZoomFactors` mock + tests for the resolve/reject paths. |
+| `src/components/mobile/camera-view.tsx` | modify | Holds factor state; renders the lens pill in both stacked and overlay layouts; wires `setZoom` with visibility + concurrency rules. |
+
+**Dependency / ordering notes:**
+- Task 1 (pure logic) is standalone and TDD-able first.
+- Task 2 (patch-package tooling) must land **before or with** the web UI (spec §9) so the version-skew guard can distinguish old from new binaries on CI builds.
+- Task 3 (native patch) edits `node_modules` directly. Tasks 4 and 5 call `CameraPreview.getAvailableZoomFactors()` / `setZoom()`, whose **types live in the patched `dist/esm/definitions.d.ts`**. `skipLibCheck` (confirmed in `tsconfig.json`) does NOT excuse *calling* a method absent from the interface — so Task 3 must precede Tasks 4 and 5 for the app to typecheck locally.
+- Native AVFoundation behavior cannot be unit-tested on this platform; Task 6 is a manual on-device verification checklist (spec §7).
+
+**Suite hygiene (spec §7):** `vitest run`, `tsc --noEmit`, and `npm run lint` are known-red on clean `main`. Verify only that touched files add **no new** failures — not the full tally.
+
+---
+
+## Task 1: Pure lens-zoom decision logic
+
+**Files:**
+- Create: `src/lib/mobile/lens-zoom.ts`
+- Test: `src/lib/mobile/lens-zoom.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/mobile/lens-zoom.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  visibleZoomFactors,
+  selectFactor,
+  revertFactor,
+  formatFactorLabel,
+} from "./lens-zoom";
+
+describe("visibleZoomFactors", () => {
+  it("hides the pill (returns []) when no factors are available", () => {
+    expect(visibleZoomFactors([], "rear")).toEqual([]);
+  });
+
+  it("hides the pill when only one factor is available", () => {
+    expect(visibleZoomFactors([1], "rear")).toEqual([]);
+  });
+
+  it("returns [1, 2] on a device without ultra-wide (rear)", () => {
+    expect(visibleZoomFactors([1, 2], "rear")).toEqual([1, 2]);
+  });
+
+  it("returns all three stops on an ultra-wide device (rear)", () => {
+    expect(visibleZoomFactors([0.5, 1, 2], "rear")).toEqual([0.5, 1, 2]);
+  });
+
+  it("hides the pill on the front camera regardless of availability", () => {
+    expect(visibleZoomFactors([0.5, 1, 2], "front")).toEqual([]);
+  });
+});
+
+describe("selectFactor", () => {
+  it("updates only selectedFactor, leaving confirmedFactor unchanged", () => {
+    expect(selectFactor({ selectedFactor: 1, confirmedFactor: 1 }, 2)).toEqual({
+      selectedFactor: 2,
+      confirmedFactor: 1,
+    });
+  });
+});
+
+describe("revertFactor", () => {
+  it("restores selectedFactor to confirmedFactor", () => {
+    expect(revertFactor({ selectedFactor: 0.5, confirmedFactor: 1 })).toEqual({
+      selectedFactor: 1,
+      confirmedFactor: 1,
+    });
+  });
+});
+
+describe("formatFactorLabel", () => {
+  it("renders the factor with a multiplication sign", () => {
+    expect(formatFactorLabel(0.5)).toBe("0.5×");
+    expect(formatFactorLabel(1)).toBe("1×");
+    expect(formatFactorLabel(2)).toBe("2×");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/lib/mobile/lens-zoom.test.ts`
+Expected: FAIL — `Failed to resolve import "./lens-zoom"` (module does not exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/lib/mobile/lens-zoom.ts`:
+
+```ts
+/**
+ * Pure decision logic for the camera lens toggle (0.5× / 1× / 2×).
+ *
+ * Framework-free so it can be unit-tested without React or Capacitor. The
+ * component (`camera-view.tsx`) and the lifecycle hook own the side effects;
+ * this module owns the rules. See
+ * docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md §7.
+ */
+
+export type LensFactor = 0.5 | 1 | 2;
+
+/**
+ * The stops the pill should display. Returns [] (hide the pill entirely) on
+ * the front camera or when one or fewer factors are available. Otherwise the
+ * available factors are returned as-is (the native layer owns availability).
+ */
+export function visibleZoomFactors(
+  available: number[],
+  position: "rear" | "front",
+): number[] {
+  if (position === "front") return [];
+  if (available.length <= 1) return [];
+  return available;
+}
+
+/**
+ * Next UI state after the user taps `factor`. Optimistic: selectedFactor moves
+ * immediately; confirmedFactor only changes once a setZoom actually resolves.
+ */
+export function selectFactor(
+  state: { selectedFactor: number; confirmedFactor: number },
+  factor: number,
+): { selectedFactor: number; confirmedFactor: number } {
+  return { selectedFactor: factor, confirmedFactor: state.confirmedFactor };
+}
+
+/** Revert helper for a rejected setZoom: snap selectedFactor back to confirmed. */
+export function revertFactor(state: {
+  selectedFactor: number;
+  confirmedFactor: number;
+}): { selectedFactor: number; confirmedFactor: number } {
+  return {
+    selectedFactor: state.confirmedFactor,
+    confirmedFactor: state.confirmedFactor,
+  };
+}
+
+/** "0.5×", "1×", "2×" — the label shown on each pill segment. */
+export function formatFactorLabel(factor: number): string {
+  return `${factor}×`;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/lib/mobile/lens-zoom.test.ts`
+Expected: PASS — all tests green.
+
+- [ ] **Step 5: Typecheck the touched files**
+
+Run: `npx tsc --noEmit`
+Expected: No **new** errors referencing `lens-zoom.ts` or `lens-zoom.test.ts` (pre-existing repo errors are known-red; ignore those).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/mobile/lens-zoom.ts src/lib/mobile/lens-zoom.test.ts
+git commit -m "feat(camera): pure lens-zoom decision logic + tests"
+```
+
+---
+
+## Task 2: Install patch-package tooling
+
+**Files:**
+- Modify: `package.json` (add devDeps + `postinstall` script)
+- Modify: `package-lock.json` (regenerated by npm)
+
+- [ ] **Step 1: Install the dev dependencies**
+
+Run: `npm install --save-dev patch-package postinstall-postinstall`
+Expected: `package.json` `devDependencies` now lists `patch-package` and `postinstall-postinstall`; `package-lock.json` updated. No `postinstall` runs yet (the script does not exist), so no patches are applied.
+
+- [ ] **Step 2: Add the postinstall script**
+
+Edit `package.json` — in the `"scripts"` block, add the `postinstall` entry. Change:
+
+```json
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:pg": "vitest run --config vitest.pg.config.ts"
+  },
+```
+
+to:
+
+```json
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:pg": "vitest run --config vitest.pg.config.ts",
+    "postinstall": "patch-package"
+  },
+```
+
+- [ ] **Step 3: Verify postinstall is a clean no-op with no patches present**
+
+Run: `npm run postinstall`
+Expected: patch-package prints something like `No patch files found` and exits 0. (There is no `patches/` directory yet — that is created in Task 3.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "build(camera): add patch-package tooling + postinstall hook"
+```
+
+---
+
+## Task 3: Native plugin patch (Swift + TS via patch-package)
+
+**Files (edited in `node_modules`, captured by the generated patch — NOT committed individually):**
+- `node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift`
+- `node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift`
+- `node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts`
+- `node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts`
+- `node_modules/@capacitor-community/camera-preview/dist/esm/web.js`
+
+**Committed deliverable:**
+- Create: `patches/@capacitor-community+camera-preview+8.0.1.patch`
+
+> **Why no per-file commits:** `node_modules` is gitignored. `npx patch-package <pkg>` captures the entire diff of the package into a single `.patch` file; that file is the deliverable. Make ALL the edits below first, then generate the patch once.
+
+> **Before editing — verify the anchors.** patch-package relies on exact text; a dependency bump since this plan was written could shift the source so an `Edit` fails (or a hand-edit silently no-ops and yields an empty/partial patch). Re-read the source and confirm before you start:
+> - `CameraController.swift` declares exactly `var rearCamera: AVCaptureDevice?` and `var rearCameraInput: AVCaptureDeviceInput?` (no `rearWideCamera`/`rearUltraWideCamera` yet).
+> - The `DiscoverySession(...)` line lists exactly `[.builtInWideAngleCamera]`.
+> - `CameraPreviewPlugin.swift`'s `pluginMethods` array ends with `CAPPluginMethod(name: "isCameraStarted", returnType: CAPPluginReturnPromise)` and **no** trailing comma.
+> - `dist/esm/{definitions.d.ts,web.d.ts,web.js}` each close their `isCameraStarted` member exactly as quoted in Steps 6–8.
+>
+> If any anchor differs, adjust that step's `old_string` to match the real source — never force the quoted text.
+
+- [ ] **Step 1: `CameraController.swift` — replace single rear handle with two lens handles + active pointer**
+
+In `node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift`, change:
+
+```swift
+    var rearCamera: AVCaptureDevice?
+    var rearCameraInput: AVCaptureDeviceInput?
+```
+
+to:
+
+```swift
+    var rearWideCamera: AVCaptureDevice?       // builtInWideAngleCamera, back
+    var rearUltraWideCamera: AVCaptureDevice?  // builtInUltraWideCamera, back (nil on SE etc.)
+    var rearCamera: AVCaptureDevice?           // == the lens currently feeding the session
+    var rearCameraInput: AVCaptureDeviceInput?
+```
+
+- [ ] **Step 2: `CameraController.swift` — widen discovery, route by deviceType, reset zoom**
+
+In the same file, inside `configureCaptureDevices()`, change:
+
+```swift
+            let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .unspecified)
+
+            let cameras = session.devices.compactMap { $0 }
+            guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
+
+            for camera in cameras {
+                if camera.position == .front {
+                    self.frontCamera = camera
+                }
+
+                if camera.position == .back {
+                    self.rearCamera = camera
+
+                    try camera.lockForConfiguration()
+                    camera.focusMode = .continuousAutoFocus
+                    camera.unlockForConfiguration()
+                }
+            }
+```
+
+to:
+
+```swift
+            let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera, .builtInUltraWideCamera], mediaType: AVMediaType.video, position: .unspecified)
+
+            let cameras = session.devices.compactMap { $0 }
+            guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
+
+            for camera in cameras {
+                if camera.position == .front {
+                    self.frontCamera = camera
+                }
+
+                // Two separate `if`s (NOT `else if`): each device is its own loop
+                // iteration and a device's position is front XOR back, so this is
+                // behaviorally identical to a chained `else if` — but leaving the
+                // front block untouched yields a smaller, lower-risk patch diff, and
+                // every rear lens (wide AND ultra-wide) independently enters this
+                // block to get its retained zoom reset to 1.0.
+                if camera.position == .back {
+                    if camera.deviceType == .builtInUltraWideCamera {
+                        self.rearUltraWideCamera = camera
+                    } else if camera.deviceType == .builtInWideAngleCamera {
+                        self.rearWideCamera = camera
+                    }
+
+                    try camera.lockForConfiguration()
+                    camera.focusMode = .continuousAutoFocus
+                    camera.videoZoomFactor = 1.0   // clear any zoom retained on the device singleton
+                    camera.unlockForConfiguration()
+                }
+            }
+            self.rearCamera = self.rearWideCamera   // 1× / wide is always the start lens
+            self.zoomFactor = 1.0
+```
+
+- [ ] **Step 3: `CameraController.swift` — add `setZoom` + `availableZoomFactors` after `switchCameras()`**
+
+In the same file, find the end of `switchCameras()`:
+
+```swift
+        switch currentCameraPosition {
+        case .front:
+            try switchToRearCamera()
+
+        case .rear:
+            try switchToFrontCamera()
+        }
+
+        captureSession.commitConfiguration()
+    }
+```
+
+and replace it with that same block followed by the two new methods:
+
+```swift
+        switch currentCameraPosition {
+        case .front:
+            try switchToRearCamera()
+
+        case .rear:
+            try switchToFrontCamera()
+        }
+
+        captureSession.commitConfiguration()
+    }
+
+    func setZoom(factor: CGFloat) throws {
+        guard currentCameraPosition == .rear,
+              let captureSession = self.captureSession, captureSession.isRunning,
+              let currentInput = self.rearCameraInput,
+              let activeRear = self.rearCamera else { throw CameraControllerError.invalidOperation }
+
+        // factor → (target device, digital zoom)
+        let targetDevice: AVCaptureDevice
+        let targetZoom: CGFloat
+        switch factor {
+        case 0.5:
+            guard let uw = rearUltraWideCamera else { throw CameraControllerError.invalidOperation }
+            targetDevice = uw; targetZoom = 1.0
+        case 2.0:
+            guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
+            targetDevice = w; targetZoom = 2.0
+        default: // 1.0
+            guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
+            targetDevice = w; targetZoom = 1.0
+        }
+
+        let lensChanges = targetDevice.uniqueID != activeRear.uniqueID
+
+        if lensChanges {
+            // Build the new input BEFORE beginConfiguration(): AVCaptureDeviceInput(device:)
+            // can throw, and throwing after beginConfiguration() would leave the session
+            // in an open, uncommitted configuration that breaks later camera operations.
+            let newInput = try AVCaptureDeviceInput(device: targetDevice)
+            captureSession.beginConfiguration()
+            // Remove-then-check matches switchCameras(): two simultaneous video
+            // inputs are an invalid config, so canAddInput(newInput) returns false
+            // while the old input is still attached. Roll back to the (known-valid)
+            // old input on failure and commit a consistent session before throwing.
+            captureSession.removeInput(currentInput)
+            guard captureSession.canAddInput(newInput) else {
+                if captureSession.canAddInput(currentInput) { captureSession.addInput(currentInput) }
+                captureSession.commitConfiguration()
+                throw CameraControllerError.invalidOperation
+            }
+            captureSession.addInput(newInput)
+            self.rearCameraInput = newInput
+            self.rearCamera = targetDevice
+            // Set zoom inside the same transaction so the swapped-in lens never
+            // shows a stale factor for a frame.
+            try targetDevice.lockForConfiguration()
+            targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
+            targetDevice.unlockForConfiguration()
+            captureSession.commitConfiguration()
+        } else {
+            // Same lens (1×↔2×): just change the digital zoom, no reconfiguration.
+            try targetDevice.lockForConfiguration()
+            targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
+            targetDevice.unlockForConfiguration()
+        }
+
+        self.zoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor) // pinch baseline
+    }
+
+    func availableZoomFactors() -> [CGFloat] {
+        var factors: [CGFloat] = []
+        if rearUltraWideCamera != nil { factors.append(0.5) }
+        factors.append(1.0)
+        factors.append(2.0)
+        return factors
+    }
+```
+
+- [ ] **Step 4: `CameraPreviewPlugin.swift` — register the two bridge methods**
+
+In `node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift`, change:
+
+```swift
+        CAPPluginMethod(name: "isCameraStarted", returnType: CAPPluginReturnPromise)
+    ]
+```
+
+to:
+
+```swift
+        CAPPluginMethod(name: "isCameraStarted", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "setZoom", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getAvailableZoomFactors", returnType: CAPPluginReturnPromise)
+    ]
+```
+
+- [ ] **Step 5: `CameraPreviewPlugin.swift` — implement the two bridge methods after `flip(_:)`**
+
+In the same file, find `flip(_:)`:
+
+```swift
+    @objc func flip(_ call: CAPPluginCall) {
+        do {
+            try self.cameraController.switchCameras()
+            call.resolve()
+        } catch {
+            call.reject("failed to flip camera")
+        }
+    }
+```
+
+and replace it with that same block followed by the two new methods:
+
+```swift
+    @objc func flip(_ call: CAPPluginCall) {
+        do {
+            try self.cameraController.switchCameras()
+            call.resolve()
+        } catch {
+            call.reject("failed to flip camera")
+        }
+    }
+
+    @objc func setZoom(_ call: CAPPluginCall) {
+        guard let factor = call.getDouble("factor") else {
+            call.reject("factor is required")
+            return
+        }
+        do {
+            try self.cameraController.setZoom(factor: CGFloat(factor))
+            call.resolve()
+        } catch {
+            call.reject("failed to set zoom")
+        }
+    }
+
+    @objc func getAvailableZoomFactors(_ call: CAPPluginCall) {
+        let factors = self.cameraController.availableZoomFactors().map { Double($0) }
+        call.resolve(["factors": factors])
+    }
+```
+
+- [ ] **Step 6: `dist/esm/definitions.d.ts` — extend the `CameraPreviewPlugin` interface**
+
+In `node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts`, change:
+
+```ts
+    isCameraStarted(): Promise<{
+        value: boolean;
+    }>;
+}
+```
+
+to:
+
+```ts
+    isCameraStarted(): Promise<{
+        value: boolean;
+    }>;
+    setZoom(options: { factor: number; }): Promise<void>;
+    getAvailableZoomFactors(): Promise<{ factors: number[]; }>;
+}
+```
+
+- [ ] **Step 7: `dist/esm/web.d.ts` — extend the `CameraPreviewWeb` declaration**
+
+In `node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts`, change:
+
+```ts
+    isCameraStarted(): Promise<{
+        value: boolean;
+    }>;
+}
+```
+
+to:
+
+```ts
+    isCameraStarted(): Promise<{
+        value: boolean;
+    }>;
+    setZoom(_options: { factor: number; }): Promise<void>;
+    getAvailableZoomFactors(): Promise<{ factors: number[]; }>;
+}
+```
+
+- [ ] **Step 8: `dist/esm/web.js` — add the web stub implementations**
+
+In `node_modules/@capacitor-community/camera-preview/dist/esm/web.js`, change:
+
+```js
+    async isCameraStarted() {
+        throw this.unimplemented('Not implemented on web.');
+    }
+}
+```
+
+to:
+
+```js
+    async isCameraStarted() {
+        throw this.unimplemented('Not implemented on web.');
+    }
+    async setZoom(_options) {
+        throw this.unimplemented('Not implemented on web.');
+    }
+    async getAvailableZoomFactors() {
+        throw this.unimplemented('Not implemented on web.');
+    }
+}
+```
+
+- [ ] **Step 9: Generate the patch**
+
+Run this from the **repository root** (the directory containing `package.json`). patch-package writes file paths relative to the current working directory and CI runs from the root, so generating it from a subdirectory (e.g. `ios/App`) produces a patch with wrong paths that won't apply in CI.
+
+Run: `npx patch-package @capacitor-community/camera-preview`
+Expected: creates `patches/@capacitor-community+camera-preview+8.0.1.patch` **at the repo root** and prints a success line. (patch-package excludes only the dependency's own `package.json` by default; all `.swift`, `.d.ts`, and `.js` edits above are captured.)
+
+- [ ] **Step 10: Verify the patch captured all five required files**
+
+Run:
+```bash
+grep -E "^diff --git" patches/@capacitor-community+camera-preview+8.0.1.patch
+```
+Expected: a `diff --git` line **present for each** of the five edited files — `CameraController.swift`, `CameraPreviewPlugin.swift`, `definitions.d.ts`, `web.d.ts`, and `web.js`. Confirm each by name rather than asserting an exact total count: a clean hand-edit touches only these five, but a presence check stays correct if anything extra is ever captured. If any of the five is missing, re-check that file's edit and re-run Step 9.
+
+- [ ] **Step 11: Sanity-check that the patch applies (non-destructive)**
+
+Run: `npm run postinstall`
+
+patch-package now runs against the **already-patched** working tree, so it detects the edits are present. Depending on the patch-package version this prints either a success line or a benign "already applied"/skip notice — **both are acceptable**. The only output that signals a real problem is `**ERROR** Failed to apply patch for package @capacitor-community/camera-preview`, which means the patch's context no longer matches the package; if you see that, regenerate via Step 9.
+
+> **Authoritative validation is CI's clean install** — not this command. patch-package is designed to apply during `npm ci` on a fresh `node_modules`, which is exactly what `ios/App/ci_scripts/ci_post_clone.sh` does (`npm ci` → `postinstall` → `npx cap sync ios`). Do **not** `rm -rf node_modules && npm ci` (or PowerShell `Remove-Item -Recurse`) in this working tree to test it: that is slow and, in this repo, can wipe a junctioned/worktree `node_modules` shared with other sessions. Trust Step 10 plus this non-destructive check locally; let CI (or a throwaway worktree install) be the clean-tree proof.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add patches/@capacitor-community+camera-preview+8.0.1.patch
+git commit -m "feat(camera): native setZoom + getAvailableZoomFactors patch (0.5x/1x/2x)"
+```
+
+> Native AVFoundation behavior is verified on a real device in Task 6 — there is no local Swift compile/test on this platform.
+
+---
+
+## Task 4: Web feature-detection in `useCameraLifecycle`
+
+**Files:**
+- Modify: `src/lib/mobile/use-camera-lifecycle.ts`
+- Modify: `src/lib/mobile/use-camera-lifecycle.test.ts`
+
+> **PREREQUISITE — Task 3 must be fully committed first (through Step 12).** This task calls `CameraPreview.getAvailableZoomFactors()`, whose type lives in the patched `dist/esm/definitions.d.ts`. `skipLibCheck` does NOT excuse calling a method the interface doesn't declare, so until the patch is generated **and installed** (the edits live in `node_modules`), Step 5's `tsc --noEmit` will report a real new error here. If you are running tasks out of order, stop and finish Task 3 first.
+
+- [ ] **Step 1: Write the failing tests + extend the mock**
+
+In `src/lib/mobile/use-camera-lifecycle.test.ts`, change the mock block (top of file):
+
+```ts
+const startMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+const stopMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+
+vi.mock("@capacitor-community/camera-preview", () => ({
+  CameraPreview: {
+    start: (arg: unknown) => startMock(arg),
+    stop: () => stopMock(),
+  },
+}));
+```
+
+to:
+
+```ts
+const startMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+const stopMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+const getFactorsMock = vi.fn(
+  (): Promise<{ factors: number[] }> => Promise.resolve({ factors: [0.5, 1, 2] }),
+);
+
+vi.mock("@capacitor-community/camera-preview", () => ({
+  CameraPreview: {
+    start: (arg: unknown) => startMock(arg),
+    stop: () => stopMock(),
+    getAvailableZoomFactors: () => getFactorsMock(),
+  },
+}));
+```
+
+> `getFactorsMock` is a **module-level `const`** (declared outside the `vi.mock` factory), mirroring the existing `startMock`/`stopMock` already in this file. That pattern is proven to work in this repo: vitest hoists the `vi.mock` call, but the factory closure only runs lazily when the mocked module is first imported — by then the `const` initializers have executed, so the reference resolves. Its default impl is set at declaration and re-established in `beforeEach` (below) so each test starts from `{ factors: [0.5, 1, 2] }`; individual tests override it with `mockImplementationOnce`.
+
+Then add `getFactorsMock.mockClear();` and reset its default implementation inside `beforeEach`:
+
+```ts
+  beforeEach(() => {
+    startMock.mockClear();
+    stopMock.mockClear();
+    getFactorsMock.mockClear();
+    getFactorsMock.mockImplementation(() => Promise.resolve({ factors: [0.5, 1, 2] }));
+  });
+```
+
+Then add these two test cases at the end of the `describe("useCameraLifecycle", ...)` block (before its closing `});`):
+
+```ts
+  it("reports available zoom factors after start resolves", async () => {
+    const rect = { x: 0, y: 0, width: 390, height: 520 };
+    const onZoomFactorsAvailable = vi.fn();
+    renderHook(() =>
+      useCameraLifecycle({
+        rect,
+        position: "rear",
+        safeAreaTop: 0,
+        onZoomFactorsAvailable,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onZoomFactorsAvailable).toHaveBeenCalledWith([0.5, 1, 2]);
+  });
+
+  it("reports [] when getAvailableZoomFactors rejects (old binary / web)", async () => {
+    getFactorsMock.mockImplementationOnce(() => Promise.reject(new Error("UNIMPLEMENTED")));
+    const rect = { x: 0, y: 0, width: 390, height: 520 };
+    const onZoomFactorsAvailable = vi.fn();
+    renderHook(() =>
+      useCameraLifecycle({
+        rect,
+        position: "rear",
+        safeAreaTop: 0,
+        onZoomFactorsAvailable,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onZoomFactorsAvailable).toHaveBeenCalledWith([]);
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/mobile/use-camera-lifecycle.test.ts`
+Expected: the two new tests FAIL (`onZoomFactorsAvailable` never called — the hook doesn't call `getAvailableZoomFactors` yet). The pre-existing tests should still pass.
+
+- [ ] **Step 3: Implement the feature-detection in the hook**
+
+In `src/lib/mobile/use-camera-lifecycle.ts`, change the input interface:
+
+```ts
+export interface UseCameraLifecycleInput {
+  rect: CameraLifecycleRect;
+  position: "rear" | "front";
+  safeAreaTop: number;
+  onError?: (err: unknown) => void;
+}
+```
+
+to:
+
+```ts
+export interface UseCameraLifecycleInput {
+  rect: CameraLifecycleRect;
+  position: "rear" | "front";
+  safeAreaTop: number;
+  onError?: (err: unknown) => void;
+  /** Reports the rear-camera zoom stops detected after each successful start.
+   *  Receives [] when the native method is unavailable (old binary / web). */
+  onZoomFactorsAvailable?: (factors: number[]) => void;
+}
+```
+
+Change the destructure + refs:
+
+```ts
+  const { rect, position, safeAreaTop, onError } = input;
+  const startedRef = useRef(false);
+  const lastRectRef = useRef<CameraLifecycleRect | null>(null);
+  const lastPositionRef = useRef<"rear" | "front">(position);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+```
+
+to:
+
+```ts
+  const { rect, position, safeAreaTop, onError, onZoomFactorsAvailable } = input;
+  const startedRef = useRef(false);
+  const lastRectRef = useRef<CameraLifecycleRect | null>(null);
+  const lastPositionRef = useRef<"rear" | "front">(position);
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const onZoomFactorsAvailableRef = useRef(onZoomFactorsAvailable);
+  onZoomFactorsAvailableRef.current = onZoomFactorsAvailable;
+```
+
+Change the `start` function body:
+
+```ts
+      try {
+        await CameraPreview.start({
+          position: pos,
+          parent: "camera-preview-mount",
+          toBack: true,
+          width: r.width,
+          height: Math.round(r.height + safeTop),
+          x: r.x,
+          y: r.y,
+          disableAudio: true,
+        });
+        startedRef.current = true;
+      } catch (err) {
+        onErrorRef.current?.(err);
+      }
+```
+
+to:
+
+```ts
+      try {
+        await CameraPreview.start({
+          position: pos,
+          parent: "camera-preview-mount",
+          toBack: true,
+          width: r.width,
+          height: Math.round(r.height + safeTop),
+          x: r.x,
+          y: r.y,
+          disableAudio: true,
+        });
+        startedRef.current = true;
+        // Feature-detect zoom support after a successful start. An old native
+        // binary (pre-patch) or the web fallback rejects here → report [] so
+        // the UI hides the lens pill. Re-runs on every restart (flip/resize).
+        try {
+          const { factors } = await CameraPreview.getAvailableZoomFactors();
+          onZoomFactorsAvailableRef.current?.(factors);
+        } catch {
+          onZoomFactorsAvailableRef.current?.([]);
+        }
+      } catch (err) {
+        onErrorRef.current?.(err);
+      }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/mobile/use-camera-lifecycle.test.ts`
+Expected: PASS — all tests, old and new, green.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: No **new** errors in `use-camera-lifecycle.ts`. (`CameraPreview.getAvailableZoomFactors` resolves against the patched `definitions.d.ts` from Task 3.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/mobile/use-camera-lifecycle.ts src/lib/mobile/use-camera-lifecycle.test.ts
+git commit -m "feat(camera): feature-detect zoom factors in useCameraLifecycle"
+```
+
+---
+
+## Task 5: Lens pill UI in `camera-view.tsx`
+
+**Files:**
+- Modify: `src/components/mobile/camera-view.tsx`
+
+> Depends on Task 1 (`lens-zoom.ts` helpers), Task 3 (`setZoom` type), and Task 4 (`onZoomFactorsAvailable` callback).
+
+- [ ] **Step 1: Confirm the React import — no change needed**
+
+This task resets the factor state on flip with React's render-time "adjust state when a prop changes" pattern (Step 4), **not** a `useEffect`. Leave the existing import as-is — do NOT add `useEffect`:
+
+```tsx
+import { useCallback, useMemo, useRef, useState } from "react";
+```
+
+> A reset `useEffect(..., [position])` would add a new `react-hooks/set-state-in-effect` violation to `camera-view.tsx`, which is currently clean of that rule (the repo-wide known-red instances live in other files). The render-time guard in Step 4 achieves the identical reset with no lint violation — it is the pattern React documents under "You Might Not Need an Effect → Adjusting some state when a prop changes."
+
+- [ ] **Step 2: Import the lens-zoom helpers**
+
+After the existing `import { useCameraLifecycle } from "@/lib/mobile/use-camera-lifecycle";` line, add:
+
+```tsx
+import {
+  visibleZoomFactors,
+  selectFactor,
+  revertFactor,
+  formatFactorLabel,
+} from "@/lib/mobile/lens-zoom";
+```
+
+- [ ] **Step 3: Add lens state**
+
+Find:
+
+```tsx
+  const [count, setCount] = useState(0);
+  const [busy, setBusy] = useState(false);
+```
+
+and replace with:
+
+```tsx
+  const [count, setCount] = useState(0);
+  const [busy, setBusy] = useState(false);
+  const [availableFactors, setAvailableFactors] = useState<number[]>([]);
+  const [selectedFactor, setSelectedFactor] = useState<number>(1);
+  const [confirmedFactor, setConfirmedFactor] = useState<number>(1);
+  const [isSwitchingLens, setIsSwitchingLens] = useState(false);
+  // `position` is declared above (line 88), so reading it here is safe. Drives
+  // the render-time reset in Step 4 (React "adjust state when a prop changes").
+  const [prevPosition, setPrevPosition] = useState(position);
+```
+
+- [ ] **Step 4: Wire the feature-detection callback + render-time reset-on-flip**
+
+Find the `useCameraLifecycle({ ... })` call:
+
+```tsx
+  useCameraLifecycle({
+    rect: layout.previewRect,
+    position,
+    safeAreaTop: safeAreaTopRef.current,
+    onError: (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      setPermissionError(message);
+    },
+  });
+```
+
+and replace with:
+
+```tsx
+  useCameraLifecycle({
+    rect: layout.previewRect,
+    position,
+    safeAreaTop: safeAreaTopRef.current,
+    onError: (err) => {
+      const message = err instanceof Error ? err.message : String(err);
+      setPermissionError(message);
+    },
+    // Wrap the setter instead of passing it directly. The direct pass also
+    // typechecks (a setter accepting `number[] | updater` is assignable to a
+    // `(factors: number[]) => void` callback by parameter contravariance), but
+    // the explicit adapter documents the contract and avoids reviewer churn.
+    onZoomFactorsAvailable: (factors) => setAvailableFactors(factors),
+  });
+
+  // Reset the toggle to 1× whenever `position` changes. The native session
+  // rebuild on flip (useCameraLifecycle stop()+start()) re-selects the wide
+  // lens at videoZoomFactor 1.0, so the UI must snap to 1× to stay in sync with
+  // the feed. This is React's render-time "adjust state when a prop changes"
+  // pattern — NOT a useEffect (see Step 1) — so it adds no
+  // `react-hooks/set-state-in-effect` violation. It runs at most once per flip:
+  // setPrevPosition makes the guard false on the immediate re-render.
+  if (position !== prevPosition) {
+    setPrevPosition(position);
+    setSelectedFactor(1);
+    setConfirmedFactor(1);
+  }
+```
+
+- [ ] **Step 5: Add the `handleSetZoom` callback**
+
+Find the end of `handleFlip`:
+
+```tsx
+  const handleFlip = useCallback(async () => {
+    if (busy) return;
+    const next = position === "rear" ? "front" : "rear";
+    setPosition(next);
+    try {
+      await CameraPreview.flip();
+    } catch {
+      // Some plugin builds need restart-on-flip; the lifecycle hook will
+      // restart automatically because `position` changed.
+    }
+  }, [busy, position]);
+```
+
+and replace with that same block followed by `handleSetZoom`:
+
+```tsx
+  const handleFlip = useCallback(async () => {
+    if (busy) return;
+    const next = position === "rear" ? "front" : "rear";
+    setPosition(next);
+    try {
+      await CameraPreview.flip();
+    } catch {
+      // Some plugin builds need restart-on-flip; the lifecycle hook will
+      // restart automatically because `position` changed.
+    }
+  }, [busy, position]);
+
+  const handleSetZoom = useCallback(
+    async (factor: number) => {
+      // Drop taps while a switch is in flight or the shutter is busy — two
+      // reconfigurations must never overlap (spec §5).
+      if (isSwitchingLens || busy) return;
+      const optimistic = selectFactor({ selectedFactor, confirmedFactor }, factor);
+      if (optimistic.selectedFactor === selectedFactor) return; // tap on active stop
+      setSelectedFactor(optimistic.selectedFactor);
+      setIsSwitchingLens(true);
+      try {
+        await CameraPreview.setZoom({ factor });
+        setConfirmedFactor(factor);
+      } catch {
+        // Native rejected (e.g. lens missing) — revert the optimistic highlight.
+        const reverted = revertFactor({
+          selectedFactor: optimistic.selectedFactor,
+          confirmedFactor,
+        });
+        setSelectedFactor(reverted.selectedFactor);
+      } finally {
+        setIsSwitchingLens(false);
+      }
+    },
+    [busy, confirmedFactor, isSwitchingLens, selectedFactor],
+  );
+```
+
+- [ ] **Step 6: Build the pill element**
+
+Find:
+
+```tsx
+  const stacked = layout.mode === "stacked";
+```
+
+and replace with:
+
+```tsx
+  const stacked = layout.mode === "stacked";
+
+  // Segmented lens toggle. Rendered only when more than one stop is available
+  // and on the rear camera (visibleZoomFactors enforces both). Disabled (but
+  // visible, dimmed) while a switch is in flight; taps are dropped, not queued.
+  const visibleFactors = visibleZoomFactors(availableFactors, position);
+  const lensPill =
+    visibleFactors.length > 1 ? (
+      <div
+        data-testid="camera-lens-pill"
+        className={cn(
+          "flex items-center gap-1 rounded-full border border-white/25 bg-black/40 p-1",
+          (isSwitchingLens || busy) && "opacity-50",
+        )}
+      >
+        {visibleFactors.map((factor) => {
+          const active = factor === selectedFactor;
+          return (
+            <button
+              key={factor}
+              type="button"
+              disabled={isSwitchingLens || busy}
+              onClick={() => handleSetZoom(factor)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition",
+                active ? "bg-white text-black" : "bg-transparent text-white",
+              )}
+              aria-pressed={active}
+              aria-label={`Zoom ${formatFactorLabel(factor)}`}
+            >
+              {formatFactorLabel(factor)}
+            </button>
+          );
+        })}
+      </div>
+    ) : null;
+```
+
+- [ ] **Step 7: Place the pill in the stacked (portrait) layout**
+
+Find (inside the stacked controls panel):
+
+```tsx
+            <div>
+              {count > 0 && (
+                <div className="mb-2 text-lg font-semibold text-white tabular-nums">
+                  {count}
+                </div>
+              )}
+              <div className="grid w-full grid-cols-3 items-center">
+```
+
+and replace with:
+
+```tsx
+            <div>
+              {count > 0 && (
+                <div className="mb-2 text-lg font-semibold text-white tabular-nums">
+                  {count}
+                </div>
+              )}
+              {lensPill && (
+                <div className="mb-3 flex justify-center">{lensPill}</div>
+              )}
+              <div className="grid w-full grid-cols-3 items-center">
+```
+
+- [ ] **Step 8: Place the pill in the overlay (landscape) right-rail**
+
+Find (inside `camera-right-rail`):
+
+```tsx
+            {shutterButton}
+            {queueButton}
+          </div>
+        </>
+      )}
+```
+
+and replace with:
+
+```tsx
+            {lensPill && (
+              <div style={{ filter: OVERLAY_ICON_SHADOW }}>{lensPill}</div>
+            )}
+            {shutterButton}
+            {queueButton}
+          </div>
+        </>
+      )}
+```
+
+- [ ] **Step 9: Typecheck and lint the touched file**
+
+Run: `npx tsc --noEmit`
+Expected: No **new** errors in `camera-view.tsx`.
+
+Run: `npx eslint src/components/mobile/camera-view.tsx src/lib/mobile/use-camera-lifecycle.ts src/lib/mobile/lens-zoom.ts`
+Expected: **Zero** lint errors in these files. In particular `camera-view.tsx` must stay free of `react-hooks/set-state-in-effect`: the flip reset uses the render-time guard from Step 4, not an effect, so it introduces no new violation. If eslint flags that rule here, you accidentally wrote the reset as a `useEffect` — convert it to the render-time `if (position !== prevPosition)` guard.
+
+- [ ] **Step 10: Run the full mobile unit suite for regressions**
+
+Run: `npx vitest run src/lib/mobile/`
+Expected: `lens-zoom.test.ts` and `use-camera-lifecycle.test.ts` pass; no NEW failures vs. clean `main` (some mobile tests are known-flaky/red — compare against the baseline, don't require a green tally).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/components/mobile/camera-view.tsx
+git commit -m "feat(camera): lens toggle pill (0.5x/1x/2x) in CameraView"
+```
+
+---
+
+## Task 6: Manual on-device verification (no automated coverage possible)
+
+**Files:** none — this is a verification gate, run on a real ultra-wide iPhone (11 or later) after the patched binary ships to TestFlight (spec §7).
+
+Native AVFoundation behavior cannot be exercised on this dev platform. After a TestFlight build that includes the patch (Task 3) and the web bundle (Tasks 1, 4, 5) is live, verify on device:
+
+- [ ] **Step 1:** Open the in-app camera on an ultra-wide iPhone → the pill shows `0.5×  1×  2×`, with `1×` highlighted.
+- [ ] **Step 2:** Tap `0.5×` → field of view widens to ultra-wide; tap `2×` → tighter 2× framing; tap `1×` → returns to normal. Each transition is prompt with no crash.
+- [ ] **Step 3:** Capture a photo at each stop → the saved image matches the previewed framing.
+- [ ] **Step 4:** Tap-to-focus and cycle flash while on `0.5×` → both target the active (ultra-wide) lens correctly.
+- [ ] **Step 5:** Flip to front → the pill disappears. Flip back to rear → the pill reappears with `1×` highlighted and the feed at 1× (no retained zoom).
+- [ ] **Step 6:** Rapidly tap between stops → no session wedge; the pill dims during each switch and settles on the last committed stop.
+- [ ] **Step 7:** On an iPhone SE (no ultra-wide), confirm the pill shows only `1×  2×`.
+- [ ] **Step 8:** On an **old** binary (pre-patch) still pointed at the live web bundle, confirm no pill appears and the camera otherwise works (version-skew guard).
+
+---
+
+## Sequencing & merge order (spec §9)
+
+Native (TestFlight) and web (instant Vercel deploy) ship on different cadences. Because Layer B feature-detects, merge order is safe **provided Task 2 (patch-package tooling) lands before or with the web UI** — otherwise the first native build after the web UI merges won't contain the patched methods and the version-skew guard can't distinguish old from new binaries. With the tasks in the order above (1 → 2 → 3 → 4 → 5), this holds:
+
+- If the web UI lands first, the pill stays hidden on old binaries until the patched build ships.
+- Once the patched binary is installed, the toggle appears with no further web deploy.

--- a/docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md
@@ -316,8 +316,12 @@ with the `OVERLAY_ICON_SHADOW` drop-shadow in overlay mode for legibility.
 **Visibility & concurrency:**
 - Render only when `visibleZoomFactors(...).length > 1` (§7 helper).
 - Hidden when `position === "front"`.
-- A `useEffect` watching `position` resets `selectedFactor` and `confirmedFactor`
-  to `1` on **any** position change (covers both flip directions in one place).
+- A render-time guard (`if (position !== prevPosition) { … }`, React's "adjust
+  state when a prop changes" pattern — **not** a `useEffect`) resets
+  `selectedFactor` and `confirmedFactor` to `1` on **any** position change
+  (covers both flip directions in one place). Render-time rather than an effect
+  so it adds no `react-hooks/set-state-in-effect` lint violation to
+  `camera-view.tsx`, which is currently clean of that rule.
 - While a `setZoom` is in flight, an `isSwitchingLens` flag (plus the existing
   `busy` shutter flag) **disables** the pill (visible, reduced opacity); taps
   during this window are **dropped, not queued**, so two reconfigurations can
@@ -373,6 +377,9 @@ export function selectFactor(
 export function revertFactor(
   state: { selectedFactor: number; confirmedFactor: number },
 ): { selectedFactor: number; confirmedFactor: number };
+
+/** Display label for a stop: 0.5 → "0.5×", 1 → "1×", 2 → "2×". */
+export function formatFactorLabel(factor: number): string;
 ```
 
 Test cases: `[]` available → hidden; `[1,2]` rear → `[1,2]`; `[0.5,1,2]` rear →

--- a/docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md
+++ b/docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md
@@ -1,0 +1,443 @@
+# Camera lens toggle — 0.5× / 1× / 2×
+
+**Date:** 2026-06-08
+**Status:** Approved design, pre-implementation
+**Scope:** In-app native camera (`CameraView`) gets an iPhone-style lens toggle with three stops — 0.5× (ultra-wide), 1× (wide), 2× (digital crop on wide).
+
+---
+
+## 1. Goal
+
+Add a segmented lens toggle to the in-app camera so a field user can shoot
+ultra-wide (0.5×), normal (1×), or a 2× framing — the way the stock iOS Camera
+behaves. Today the camera is fixed at the wide lens with no zoom control wired
+(`enableZoom` is not passed to `CameraPreview.start`, so the plugin's pinch
+gesture is inert).
+
+**Non-goals (YAGNI):** no pinch-to-zoom changes, no optical telephoto, no
+continuous zoom slider, no Android work, no front-camera zoom. Pinch stays
+disabled in production (§5) — the pill is the sole zoom control.
+
+---
+
+## 2. The core abstraction: a factor → (lens, digital zoom) table
+
+Everything keys off a single numeric **factor**. The factor is a UI label that
+maps to a physical AVCaptureDevice plus a digital `videoZoomFactor`:
+
+| Factor | Physical lens                 | `videoZoomFactor` | Notes |
+|--------|-------------------------------|-------------------|-------|
+| `0.5`  | `builtInUltraWideCamera`      | `1.0`             | True ultra-wide field of view. |
+| `1`    | `builtInWideAngleCamera`      | `1.0`             | Current default. |
+| `2`    | `builtInWideAngleCamera`      | `2.0`             | Digital crop of the wide lens — same approach non-Pro iPhones use for their 2× button. Slightly softer; no telephoto hardware needed. |
+
+`0.5×` is a *label*, not a `videoZoomFactor` of 0.5. On the ultra-wide lens,
+`videoZoomFactor = 1.0` already produces the 0.5×-equivalent field of view
+relative to the wide lens. The plugin never sets a zoom factor below 1.0.
+
+The wide lens's `activeFormat.videoMaxZoomFactor` is far above `2.0` on every
+ultra-wide-capable iPhone (typically ≥16), so the `2.0` request is always
+satisfiable; the clamp in §3 is purely defensive.
+
+This table is the contract shared across the three layers below.
+
+---
+
+## 3. Layer A — Native plugin patch (Swift, via patch-package)
+
+The `@capacitor-community/camera-preview` plugin is consumed by local path from
+`node_modules` (`ios/App/CapApp-SPM/Package.swift` line 15), so patching its
+Swift sources in `node_modules` and shipping the patch via **patch-package**
+results in the patched code being compiled into the app. The CI clone script
+(`ios/App/ci_scripts/ci_post_clone.sh`) runs `npm ci` (→ `postinstall` →
+`patch-package`) before `npx cap sync ios`, so the patch is applied on every
+build.
+
+> **Note on what gets patched.** The plugin ships **pre-built**: the installed
+> package contains both the iOS Swift sources (`ios/Sources/...`, compiled by
+> SPM) and the compiled web bundle (`dist/esm/...`). There is no rebuild of the
+> dependency during `npm ci`, so patch-package patches the shipped Swift and
+> `dist` files **directly** and they are not regenerated. Only the generated
+> `patches/*.patch` file is committed to the repo; the `node_modules` edits
+> themselves are ephemeral (recreated by `postinstall`).
+
+### A0. Set up patch-package (it is not yet installed) — **first task, blocks all others**
+
+There is currently no `patches/` directory and no `postinstall` script. This
+must land **before or with** the web UI (§9). Order matters — do these steps in
+sequence or `postinstall` won't run on CI and the patch won't apply:
+
+1. `npm install --save-dev patch-package postinstall-postinstall`
+2. Add to `package.json` scripts: `"postinstall": "patch-package"`
+3. Make the A1–A3 edits in `node_modules`.
+4. `npx patch-package @capacitor-community/camera-preview` →
+   `patches/@capacitor-community+camera-preview+8.0.1.patch`. Commit it.
+
+### A1. `CameraController.swift`
+
+**Device storage (line 23).** Replace the single `rearCamera` field with two
+fixed physical handles plus an "active rear lens" pointer:
+
+```swift
+var rearWideCamera: AVCaptureDevice?       // builtInWideAngleCamera, back
+var rearUltraWideCamera: AVCaptureDevice?  // builtInUltraWideCamera, back (nil on SE etc.)
+var rearCamera: AVCaptureDevice?           // == the lens currently feeding the session
+```
+
+**Why `rearCamera` tracks the active lens:** `handleTap` (focus, line 436),
+`handlePinch` (line 463), `getSupportedFlashModes` (line 288), and
+`setFlashMode` (line 333) all read `self.rearCamera` when
+`currentCameraPosition == .rear`. Keeping `rearCamera` pointed at whichever lens
+is live means tap-to-focus and flash automatically target the active lens at
+0.5× — **no edits to those four methods are needed**.
+
+**Device discovery + assignment (lines 49, 54–66).** Widen the discovery types
+and route by `deviceType` (without this, both back lenses match
+`position == .back` and the last one wins — silently breaking the 1× default).
+Reset zoom on the wide lens here so every fresh `start()` is deterministically
+1× (see "restart" note in §5):
+
+```swift
+let session = AVCaptureDevice.DiscoverySession(
+    deviceTypes: [.builtInWideAngleCamera, .builtInUltraWideCamera],
+    mediaType: .video, position: .unspecified)
+
+let cameras = session.devices.compactMap { $0 }
+guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
+
+for camera in cameras {
+    if camera.position == .front {
+        self.frontCamera = camera
+    } else if camera.position == .back {
+        if camera.deviceType == .builtInUltraWideCamera {
+            self.rearUltraWideCamera = camera
+        } else if camera.deviceType == .builtInWideAngleCamera {
+            self.rearWideCamera = camera
+        }
+        try camera.lockForConfiguration()
+        camera.focusMode = .continuousAutoFocus
+        camera.videoZoomFactor = 1.0   // clear any zoom retained on the device singleton
+        camera.unlockForConfiguration()
+    }
+}
+self.rearCamera = self.rearWideCamera   // 1× / wide is always the start lens
+self.zoomFactor = 1.0
+```
+
+> `videoZoomFactor` is a property of the **device** (a process-wide singleton),
+> not the session — it persists when `prepare()` builds a fresh
+> `AVCaptureSession`. Resetting it here is what makes "flip restarts → back to
+> 1×" (§5) actually true.
+
+**New method `setZoom(factor:)`.** Mirrors `switchCameras()` (lines 215–263) but
+swaps the session input **only when the physical lens changes** (so 1×↔2× has no
+flicker), and identifies lenses by **`uniqueID`** (object identity on
+`AVCaptureDevice` is not guaranteed stable):
+
+```swift
+func setZoom(factor: CGFloat) throws {
+    guard currentCameraPosition == .rear,
+          let captureSession = self.captureSession, captureSession.isRunning,
+          let currentInput = self.rearCameraInput,
+          let activeRear = self.rearCamera else { throw CameraControllerError.invalidOperation }
+
+    // factor → (target device, digital zoom)
+    let targetDevice: AVCaptureDevice
+    let targetZoom: CGFloat
+    switch factor {
+    case 0.5:
+        guard let uw = rearUltraWideCamera else { throw CameraControllerError.invalidOperation }
+        targetDevice = uw; targetZoom = 1.0
+    case 2.0:
+        guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
+        targetDevice = w; targetZoom = 2.0
+    default: // 1.0
+        guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
+        targetDevice = w; targetZoom = 1.0
+    }
+
+    let lensChanges = targetDevice.uniqueID != activeRear.uniqueID
+
+    if lensChanges {
+        captureSession.beginConfiguration()
+        let newInput = try AVCaptureDeviceInput(device: targetDevice)
+        // Remove-then-check matches switchCameras(): two simultaneous video
+        // inputs are an invalid config, so canAddInput(newInput) returns false
+        // while the old input is still attached. Roll back to the (known-valid)
+        // old input on failure and commit a consistent session before throwing.
+        captureSession.removeInput(currentInput)
+        guard captureSession.canAddInput(newInput) else {
+            if captureSession.canAddInput(currentInput) { captureSession.addInput(currentInput) }
+            captureSession.commitConfiguration()
+            throw CameraControllerError.invalidOperation
+        }
+        captureSession.addInput(newInput)
+        self.rearCameraInput = newInput
+        self.rearCamera = targetDevice
+        // Set zoom inside the same transaction so the swapped-in lens never
+        // shows a stale factor for a frame.
+        try targetDevice.lockForConfiguration()
+        targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
+        targetDevice.unlockForConfiguration()
+        captureSession.commitConfiguration()
+    } else {
+        // Same lens (1×↔2×): just change the digital zoom, no reconfiguration.
+        try targetDevice.lockForConfiguration()
+        targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
+        targetDevice.unlockForConfiguration()
+    }
+
+    self.zoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor) // pinch baseline
+}
+```
+
+**New method `availableZoomFactors() -> [CGFloat]`:** returns `[0.5, 1, 2]`
+filtered so `0.5` is present only when `rearUltraWideCamera != nil`; always at
+least `[1, 2]`. Availability is fixed at camera start (no hot-swap re-check —
+acceptable; iPhone lenses don't change at runtime).
+
+**Threading.** `setZoom` runs on the bridge thread like the existing `flip()`
+(no `DispatchQueue.main` wrap), keeping the patch consistent with the plugin's
+current style. Overlapping `setZoom` calls are prevented by the web-side
+`isSwitchingLens` guard (§5). **Known residual race:** a tap-to-focus
+(`handleTap`) landing in the exact window of a `beginConfiguration`/
+`commitConfiguration` is not synchronized. The window is sub-frame and each
+device lock is atomic, so the practical risk is low. A full serial
+`captureSessionQueue` refactor would close it but enlarges the patch surface and
+risks regressing the plugin's existing flip/focus/flash paths — see §10 for the
+open decision.
+
+### A2. `CameraPreviewPlugin.swift`
+
+Register two bridge methods in the `pluginMethods` array (lines 15–26) and add
+the methods, mirroring the `flip()` bridge pattern (lines 151–158):
+
+```swift
+CAPPluginMethod(name: "setZoom", returnType: CAPPluginReturnPromise),
+CAPPluginMethod(name: "getAvailableZoomFactors", returnType: CAPPluginReturnPromise),
+```
+
+```swift
+@objc func setZoom(_ call: CAPPluginCall) {
+    guard let factor = call.getDouble("factor") else {
+        call.reject("factor is required"); return
+    }
+    do { try self.cameraController.setZoom(factor: CGFloat(factor)); call.resolve() }
+    catch { call.reject("failed to set zoom") }
+}
+
+@objc func getAvailableZoomFactors(_ call: CAPPluginCall) {
+    let factors = self.cameraController.availableZoomFactors().map { Double($0) }
+    call.resolve(["factors": factors])
+}
+```
+
+### A3. TypeScript definitions + web stub
+
+- `dist/esm/definitions.d.ts`: add to the `CameraPreviewPlugin` interface:
+  ```ts
+  setZoom(options: { factor: number }): Promise<void>;
+  getAvailableZoomFactors(): Promise<{ factors: number[] }>;
+  ```
+- `dist/esm/web.{js,d.ts}`: add stub methods on `CameraPreviewWeb` that call
+  `this.unimplemented(...)` (matching the existing web stubs in that file — they
+  use `this.unimplemented`, not bare `throw new Error`). This keeps the web class
+  satisfying the interface and makes the web/desktop fallback reject cleanly.
+
+Adding to the interface does not break the consuming app's typecheck even before
+the web stub lands, because Next.js compiles with `skipLibCheck` (declaration
+files in `node_modules` aren't cross-checked); the stub is added anyway for
+runtime correctness and self-documentation.
+
+---
+
+## 4. Layer B — Web feature-detection (the version-skew guard)
+
+The web layer deploys instantly via the Vercel live bundle
+(`server.url = https://aaaplatform.vercel.app`), but native `setZoom` ships only
+in a *new* iOS binary via TestFlight/App Store. The toggle must degrade
+gracefully on an **old binary**.
+
+**Where it lives:** the detection is owned by `useCameraLifecycle`, which already
+owns `CameraPreview.start()`. After a successful `start()`, the hook calls
+`getAvailableZoomFactors()` inside a try/catch and reports the result up via a
+new optional callback:
+
+```ts
+// useCameraLifecycle input gains:
+onZoomFactorsAvailable?: (factors: number[]) => void;
+// after start() resolves:
+try {
+  const { factors } = await CameraPreview.getAvailableZoomFactors();
+  onZoomFactorsAvailableRef.current?.(factors);
+} catch {
+  onZoomFactorsAvailableRef.current?.([]); // old binary / web → no toggle
+}
+```
+
+`CameraView` stores the reported factors in state and derives pill visibility
+from them. Detection outcomes:
+
+- **New binary, ultra-wide present** → `[0.5, 1, 2]` → all three stops.
+- **New binary, no ultra-wide** (iPhone SE) → `[1, 2]` → two stops.
+- **Old binary** → Capacitor rejects `UNIMPLEMENTED` → caught → `[]` → no pill.
+- **Web / desktop** → web stub `unimplemented` → caught → `[]` → no pill.
+
+No crash, no coordination deadlock between the web deploy and the native ship.
+Because the hook re-runs `start()` on every position/rect change, the factors are
+re-detected after each restart — keeping the pill correct across flips.
+
+---
+
+## 5. Layer C — Web UI (`camera-view.tsx`)
+
+A small segmented "pill" (`0.5×  1×  2×`, active stop highlighted) calling
+`CameraPreview.setZoom({ factor })`.
+
+**State (two values, to make error recovery unambiguous):**
+- `selectedFactor` — what the pill highlights (optimistic; updates on tap).
+- `confirmedFactor` — the last factor a `setZoom` actually resolved on.
+- On tap: set `selectedFactor` immediately (responsive), call `setZoom`; on
+  resolve set `confirmedFactor = selectedFactor`; on **reject** revert
+  `selectedFactor = confirmedFactor`, log to console, no crash.
+
+**Placement (matching the real DOM in `camera-view.tsx`):**
+- **Stacked (portrait):** a flex row inside the controls panel (the `<div>` at
+  ~line 463), **between the capture-count display and the `grid-cols-3` button
+  row** — i.e. above the shutter, below the count.
+- **Overlay (landscape):** in the right-rail cluster (`camera-right-rail`,
+  ~line 516), grouped with the existing floating controls near the shutter.
+
+**Styling:** match the tag-chip pattern already in the file (~lines 640–645):
+`rounded-full border px-3 py-1 text-xs font-medium transition`, active stop
+filled (white bg / dark text or the brand green), inactive stops translucent
+with the `OVERLAY_ICON_SHADOW` drop-shadow in overlay mode for legibility.
+
+**Visibility & concurrency:**
+- Render only when `visibleZoomFactors(...).length > 1` (§7 helper).
+- Hidden when `position === "front"`.
+- A `useEffect` watching `position` resets `selectedFactor` and `confirmedFactor`
+  to `1` on **any** position change (covers both flip directions in one place).
+- While a `setZoom` is in flight, an `isSwitchingLens` flag (plus the existing
+  `busy` shutter flag) **disables** the pill (visible, reduced opacity); taps
+  during this window are **dropped, not queued**, so two reconfigurations can
+  never overlap.
+
+**Flip → rear restart (why no explicit `setZoom(1)` is needed):** `handleFlip`
+changes `position`; `useCameraLifecycle` detects the change and runs `stop()`
+then `start()`. `start()` builds a fresh `AVCaptureSession` via `prepare()`,
+which (per the A1 patch) re-selects the wide lens **and resets its
+`videoZoomFactor` to 1.0**. So native deterministically returns to 1×, and the
+`useEffect` above resets the UI to match — the two stay in sync without an extra
+call.
+
+---
+
+## 6. Capability & error-handling matrix
+
+| Situation | Behavior |
+|-----------|----------|
+| iPhone 11+ with ultra-wide | Pill shows `0.5× 1× 2×`. |
+| iPhone SE (no ultra-wide) | Pill shows `1× 2×`. |
+| Old native binary (pre-patch) | `getAvailableZoomFactors` rejects → no pill. |
+| Web / desktop fallback | Web stub rejects → no pill. |
+| `setZoom` rejects mid-session | `selectedFactor` reverts to `confirmedFactor`; console log; no crash. User can retry by tapping any stop. |
+| Rapid taps during a switch | Dropped while `isSwitchingLens`; no overlapping reconfiguration. |
+| Front camera active | Pill hidden; factor state forced to 1. |
+
+---
+
+## 7. Testing
+
+**Pure logic (Vitest, unit).** Extract the web-side decision logic into
+`src/lib/mobile/lens-zoom.ts` (colocated `*.test.ts` matches the repo
+convention — e.g. `crypto-vault.test.ts`, `deep-link.test.ts` already live in
+`src/lib/mobile/`). Concrete contract:
+
+```ts
+export type LensFactor = 0.5 | 1 | 2;
+
+/** Stops the pill should show. [] (hide pill) on front camera or when ≤1 factor. */
+export function visibleZoomFactors(
+  available: number[],
+  position: "rear" | "front",
+): number[];
+
+/** Next UI state after the user taps `factor`, given current confirmed state. */
+export function selectFactor(
+  state: { selectedFactor: number; confirmedFactor: number },
+  factor: number,
+): { selectedFactor: number; confirmedFactor: number };
+
+/** Revert helper for a rejected setZoom. */
+export function revertFactor(
+  state: { selectedFactor: number; confirmedFactor: number },
+): { selectedFactor: number; confirmedFactor: number };
+```
+
+Test cases: `[]` available → hidden; `[1,2]` rear → `[1,2]`; `[0.5,1,2]` rear →
+all three; any available + front → `[]`; select updates `selectedFactor` only;
+revert restores `selectedFactor` to `confirmedFactor`.
+
+If lifecycle integration grows beyond a callback, the detection may be factored
+into a `useZoomFactors` hook with its own colocated test; the pure helpers above
+stay framework-free regardless.
+
+**Native AVFoundation.** Verified by **manual device testing** on a real
+ultra-wide iPhone (11 or later): each stop renders the expected field of view;
+capture at each stop yields a correct image; tap-to-focus and flash work at
+0.5×; `setZoom` accepts the numeric factors; flip→front hides the pill and
+flip→back returns to 1× (both UI and feed); rapid taps don't wedge the session.
+
+**Suite hygiene.** `vitest run`, `tsc --noEmit`, and `npm run lint` are
+known-red on clean `main`. Verify only that touched files add **no new**
+failures — not the full tally.
+
+---
+
+## 8. File-change summary
+
+Committed deliverables only; `node_modules` edits are intermediate (captured by
+the `.patch` and regenerated by `postinstall`).
+
+| File | Committed? | Change |
+|------|-----------|--------|
+| `package.json` | ✅ | Add `patch-package` + `postinstall-postinstall` devDeps; add `postinstall` script. |
+| `patches/@capacitor-community+camera-preview+8.0.1.patch` | ✅ (new) | Captures all A1/A2/A3 `node_modules` edits. |
+| `CameraController.swift` (in node_modules) | ⟶ via patch | Two lens handles; `rearCamera` tracks active lens; deviceType-routed discovery + zoom reset; `setZoom`, `availableZoomFactors`. |
+| `CameraPreviewPlugin.swift` (in node_modules) | ⟶ via patch | Register + implement `setZoom`, `getAvailableZoomFactors`. |
+| `dist/esm/definitions.d.ts` (in node_modules) | ⟶ via patch | Add two methods to the interface. |
+| `dist/esm/web.{js,d.ts}` (in node_modules) | ⟶ via patch | `this.unimplemented` web stubs. |
+| `src/lib/mobile/lens-zoom.ts` | ✅ (new) | Pure web decision logic. |
+| `src/lib/mobile/lens-zoom.test.ts` | ✅ (new) | Unit tests. |
+| `src/lib/mobile/use-camera-lifecycle.ts` | ✅ | Add `onZoomFactorsAvailable` callback; feature-detect after `start()`. |
+| `src/components/mobile/camera-view.tsx` | ✅ | Hold factor state; render the lens pill; wire `setZoom`; visibility + concurrency rules. |
+
+---
+
+## 9. Sequencing
+
+Native (TestFlight) and web (instant Vercel deploy) ship on different cadences.
+Because the web layer feature-detects (§4), merge order is safe **provided
+patch-package (§3 A0) lands before or with the web UI** — otherwise the first
+native build after the web UI merges won't contain the patched methods and the
+version-skew guard can't distinguish old from new binaries. With A0 in place:
+
+- If the web UI lands first, the pill stays hidden on old binaries until the
+  patched build ships.
+- Once the patched binary is installed, the toggle appears with no further web
+  deploy.
+
+---
+
+## 10. Open decision for review
+
+**Serial session queue vs. minimal patch (threading).** The minimal design runs
+`setZoom` on the bridge thread like the existing `flip()`, relying on the web
+`isSwitchingLens` guard to serialize toggles, and accepts a narrow, low-risk
+tap-to-focus-during-switch race (§3 A1, Threading). The alternative is to
+introduce a dedicated serial `captureSessionQueue` and route `setZoom`, `flip`,
+`handleTap`, `handlePinch`, and output-connection changes through it — fully
+correct, but a larger patch that touches the plugin's existing, working paths
+and carries regression risk. **Recommendation:** ship the minimal version;
+revisit the queue only if device testing surfaces an actual focus/zoom race.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,9 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
         "jsdom": "^29.1.1",
+        "patch-package": "^8.0.1",
         "pg": "^8.21.0",
+        "postinstall-postinstall": "^2.1.0",
         "tailwindcss": "^4",
         "typescript": "^5",
         "vitest": "^4.1.5"
@@ -6242,6 +6244,13 @@
         "node": ">=14.6"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.8",
       "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
@@ -7183,6 +7192,22 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -9710,6 +9735,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -11541,6 +11576,26 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11570,6 +11625,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -11699,6 +11764,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -14066,6 +14141,110 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/semver": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -14496,6 +14675,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/postinstall-postinstall": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postinstall-postinstall/-/postinstall-postinstall-2.1.0.tgz",
+      "integrity": "sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/potpack": {
       "version": "1.0.2",
@@ -16110,6 +16297,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -16989,6 +17186,16 @@
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
       "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -18518,6 +18725,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:integration": "vitest run --config vitest.integration.config.ts",
-    "test:pg": "vitest run --config vitest.pg.config.ts"
+    "test:pg": "vitest run --config vitest.pg.config.ts",
+    "postinstall": "patch-package"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.86.1",
@@ -96,7 +97,9 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "jsdom": "^29.1.1",
+    "patch-package": "^8.0.1",
     "pg": "^8.21.0",
+    "postinstall-postinstall": "^2.1.0",
     "tailwindcss": "^4",
     "typescript": "^5",
     "vitest": "^4.1.5"

--- a/patches/@capacitor-community+camera-preview+8.0.1.patch
+++ b/patches/@capacitor-community+camera-preview+8.0.1.patch
@@ -1,0 +1,205 @@
+diff --git a/node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts b/node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts
+index af8b871..abf9c63 100644
+--- a/node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts
++++ b/node_modules/@capacitor-community/camera-preview/dist/esm/definitions.d.ts
+@@ -76,4 +76,6 @@ export interface CameraPreviewPlugin {
+     isCameraStarted(): Promise<{
+         value: boolean;
+     }>;
++    setZoom(options: { factor: number; }): Promise<void>;
++    getAvailableZoomFactors(): Promise<{ factors: number[]; }>;
+ }
+diff --git a/node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts b/node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts
+index e23f828..a031725 100644
+--- a/node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts
++++ b/node_modules/@capacitor-community/camera-preview/dist/esm/web.d.ts
+@@ -23,4 +23,6 @@ export declare class CameraPreviewWeb extends WebPlugin implements CameraPreview
+     isCameraStarted(): Promise<{
+         value: boolean;
+     }>;
++    setZoom(_options: { factor: number; }): Promise<void>;
++    getAvailableZoomFactors(): Promise<{ factors: number[]; }>;
+ }
+diff --git a/node_modules/@capacitor-community/camera-preview/dist/esm/web.js b/node_modules/@capacitor-community/camera-preview/dist/esm/web.js
+index a98694c..5e52247 100644
+--- a/node_modules/@capacitor-community/camera-preview/dist/esm/web.js
++++ b/node_modules/@capacitor-community/camera-preview/dist/esm/web.js
+@@ -134,5 +134,11 @@ export class CameraPreviewWeb extends WebPlugin {
+     async isCameraStarted() {
+         throw this.unimplemented('Not implemented on web.');
+     }
++    async setZoom(_options) {
++        throw this.unimplemented('Not implemented on web.');
++    }
++    async getAvailableZoomFactors() {
++        throw this.unimplemented('Not implemented on web.');
++    }
+ }
+ //# sourceMappingURL=web.js.map
+\ No newline at end of file
+diff --git a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
+index 6ec075a..fc059c3 100644
+--- a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
++++ b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
+@@ -20,7 +20,9 @@ class CameraController: NSObject {
+     var dataOutput: AVCaptureVideoDataOutput?
+     var photoOutput: AVCapturePhotoOutput?
+ 
+-    var rearCamera: AVCaptureDevice?
++    var rearWideCamera: AVCaptureDevice?       // builtInWideAngleCamera, back
++    var rearUltraWideCamera: AVCaptureDevice?  // builtInUltraWideCamera, back (nil on SE etc.)
++    var rearCamera: AVCaptureDevice?           // == the lens currently feeding the session
+     var rearCameraInput: AVCaptureDeviceInput?
+ 
+     var previewLayer: AVCaptureVideoPreviewLayer?
+@@ -46,7 +48,7 @@ extension CameraController {
+ 
+         func configureCaptureDevices() throws {
+ 
+-            let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: AVMediaType.video, position: .unspecified)
++            let session = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera, .builtInUltraWideCamera], mediaType: AVMediaType.video, position: .unspecified)
+ 
+             let cameras = session.devices.compactMap { $0 }
+             guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
+@@ -56,14 +58,27 @@ extension CameraController {
+                     self.frontCamera = camera
+                 }
+ 
++                // Two separate `if`s (NOT `else if`): each device is its own loop
++                // iteration and a device's position is front XOR back, so this is
++                // behaviorally identical to a chained `else if` — but leaving the
++                // front block untouched yields a smaller, lower-risk patch diff, and
++                // every rear lens (wide AND ultra-wide) independently enters this
++                // block to get its retained zoom reset to 1.0.
+                 if camera.position == .back {
+-                    self.rearCamera = camera
++                    if camera.deviceType == .builtInUltraWideCamera {
++                        self.rearUltraWideCamera = camera
++                    } else if camera.deviceType == .builtInWideAngleCamera {
++                        self.rearWideCamera = camera
++                    }
+ 
+                     try camera.lockForConfiguration()
+                     camera.focusMode = .continuousAutoFocus
++                    camera.videoZoomFactor = 1.0   // clear any zoom retained on the device singleton
+                     camera.unlockForConfiguration()
+                 }
+             }
++            self.rearCamera = self.rearWideCamera   // 1× / wide is always the start lens
++            self.zoomFactor = 1.0
+             if disableAudio == false {
+                 self.audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
+             }
+@@ -262,6 +277,72 @@ extension CameraController {
+         captureSession.commitConfiguration()
+     }
+ 
++    func setZoom(factor: CGFloat) throws {
++        guard currentCameraPosition == .rear,
++              let captureSession = self.captureSession, captureSession.isRunning,
++              let currentInput = self.rearCameraInput,
++              let activeRear = self.rearCamera else { throw CameraControllerError.invalidOperation }
++
++        // factor → (target device, digital zoom)
++        let targetDevice: AVCaptureDevice
++        let targetZoom: CGFloat
++        switch factor {
++        case 0.5:
++            guard let uw = rearUltraWideCamera else { throw CameraControllerError.invalidOperation }
++            targetDevice = uw; targetZoom = 1.0
++        case 2.0:
++            guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
++            targetDevice = w; targetZoom = 2.0
++        default: // 1.0
++            guard let w = rearWideCamera else { throw CameraControllerError.invalidOperation }
++            targetDevice = w; targetZoom = 1.0
++        }
++
++        let lensChanges = targetDevice.uniqueID != activeRear.uniqueID
++
++        if lensChanges {
++            // Build the new input BEFORE beginConfiguration(): AVCaptureDeviceInput(device:)
++            // can throw, and throwing after beginConfiguration() would leave the session
++            // in an open, uncommitted configuration that breaks later camera operations.
++            let newInput = try AVCaptureDeviceInput(device: targetDevice)
++            captureSession.beginConfiguration()
++            // Remove-then-check matches switchCameras(): two simultaneous video
++            // inputs are an invalid config, so canAddInput(newInput) returns false
++            // while the old input is still attached. Roll back to the (known-valid)
++            // old input on failure and commit a consistent session before throwing.
++            captureSession.removeInput(currentInput)
++            guard captureSession.canAddInput(newInput) else {
++                if captureSession.canAddInput(currentInput) { captureSession.addInput(currentInput) }
++                captureSession.commitConfiguration()
++                throw CameraControllerError.invalidOperation
++            }
++            captureSession.addInput(newInput)
++            self.rearCameraInput = newInput
++            self.rearCamera = targetDevice
++            // Set zoom inside the same transaction so the swapped-in lens never
++            // shows a stale factor for a frame.
++            try targetDevice.lockForConfiguration()
++            targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
++            targetDevice.unlockForConfiguration()
++            captureSession.commitConfiguration()
++        } else {
++            // Same lens (1×↔2×): just change the digital zoom, no reconfiguration.
++            try targetDevice.lockForConfiguration()
++            targetDevice.videoZoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor)
++            targetDevice.unlockForConfiguration()
++        }
++
++        self.zoomFactor = min(targetZoom, targetDevice.activeFormat.videoMaxZoomFactor) // pinch baseline
++    }
++
++    func availableZoomFactors() -> [CGFloat] {
++        var factors: [CGFloat] = []
++        if rearUltraWideCamera != nil { factors.append(0.5) }
++        factors.append(1.0)
++        factors.append(2.0)
++        return factors
++    }
++
+     func captureImage(completion: @escaping (UIImage?, Error?) -> Void) {
+         guard let captureSession = captureSession, captureSession.isRunning else { completion(nil, CameraControllerError.captureSessionIsMissing); return }
+         let settings = AVCapturePhotoSettings()
+diff --git a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
+index aa18ca7..9044eae 100644
+--- a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
++++ b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraPreviewPlugin.swift
+@@ -22,7 +22,9 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
+         CAPPluginMethod(name: "setFlashMode", returnType: CAPPluginReturnPromise),
+         CAPPluginMethod(name: "startRecordVideo", returnType: CAPPluginReturnPromise),
+         CAPPluginMethod(name: "stopRecordVideo", returnType: CAPPluginReturnPromise),
+-        CAPPluginMethod(name: "isCameraStarted", returnType: CAPPluginReturnPromise)
++        CAPPluginMethod(name: "isCameraStarted", returnType: CAPPluginReturnPromise),
++        CAPPluginMethod(name: "setZoom", returnType: CAPPluginReturnPromise),
++        CAPPluginMethod(name: "getAvailableZoomFactors", returnType: CAPPluginReturnPromise)
+     ]
+ 
+     var previewView: UIView!
+@@ -157,6 +159,24 @@ public class CameraPreview: CAPPlugin, CAPBridgedPlugin {
+         }
+     }
+ 
++    @objc func setZoom(_ call: CAPPluginCall) {
++        guard let factor = call.getDouble("factor") else {
++            call.reject("factor is required")
++            return
++        }
++        do {
++            try self.cameraController.setZoom(factor: CGFloat(factor))
++            call.resolve()
++        } catch {
++            call.reject("failed to set zoom")
++        }
++    }
++
++    @objc func getAvailableZoomFactors(_ call: CAPPluginCall) {
++        let factors = self.cameraController.availableZoomFactors().map { Double($0) }
++        call.resolve(["factors": factors])
++    }
++
+     @objc func stop(_ call: CAPPluginCall) {
+         DispatchQueue.main.async {
+             if self.cameraController.captureSession?.isRunning ?? false {

--- a/src/components/mobile/camera-view.tsx
+++ b/src/components/mobile/camera-view.tsx
@@ -23,6 +23,12 @@ import { useUploadQueue } from "@/lib/mobile/upload-queue-context";
 import { useViewportOrientation } from "@/lib/mobile/use-viewport-orientation";
 import { useCameraLifecycle } from "@/lib/mobile/use-camera-lifecycle";
 import {
+  visibleZoomFactors,
+  selectFactor,
+  revertFactor,
+  formatFactorLabel,
+} from "@/lib/mobile/lens-zoom";
+import {
   computeCameraLayout,
   type CameraLayout,
 } from "@/lib/mobile/compute-camera-layout";
@@ -89,6 +95,13 @@ export default function CameraView({
   const [flash, setFlash] = useState<FlashMode>("off");
   const [count, setCount] = useState(0);
   const [busy, setBusy] = useState(false);
+  const [availableFactors, setAvailableFactors] = useState<number[]>([]);
+  const [selectedFactor, setSelectedFactor] = useState<number>(1);
+  const [confirmedFactor, setConfirmedFactor] = useState<number>(1);
+  const [isSwitchingLens, setIsSwitchingLens] = useState(false);
+  // `position` is declared above (line 88), so reading it here is safe. Drives
+  // the render-time reset in Step 4 (React "adjust state when a prop changes").
+  const [prevPosition, setPrevPosition] = useState(position);
   const [pendingTag, setPendingTag] = useState<{ captureId: string } | null>(
     null,
   );
@@ -121,7 +134,25 @@ export default function CameraView({
       const message = err instanceof Error ? err.message : String(err);
       setPermissionError(message);
     },
+    // Wrap the setter instead of passing it directly. The direct pass also
+    // typechecks (a setter accepting `number[] | updater` is assignable to a
+    // `(factors: number[]) => void` callback by parameter contravariance), but
+    // the explicit adapter documents the contract and avoids reviewer churn.
+    onZoomFactorsAvailable: (factors) => setAvailableFactors(factors),
   });
+
+  // Reset the toggle to 1× whenever `position` changes. The native session
+  // rebuild on flip (useCameraLifecycle stop()+start()) re-selects the wide
+  // lens at videoZoomFactor 1.0, so the UI must snap to 1× to stay in sync with
+  // the feed. This is React's render-time "adjust state when a prop changes"
+  // pattern — NOT a useEffect (see Step 1) — so it adds no
+  // `react-hooks/set-state-in-effect` violation. It runs at most once per flip:
+  // setPrevPosition makes the guard false on the immediate re-render.
+  if (position !== prevPosition) {
+    setPrevPosition(position);
+    setSelectedFactor(1);
+    setConfirmedFactor(1);
+  }
 
   const handleFlip = useCallback(async () => {
     if (busy) return;
@@ -134,6 +165,32 @@ export default function CameraView({
       // restart automatically because `position` changed.
     }
   }, [busy, position]);
+
+  const handleSetZoom = useCallback(
+    async (factor: number) => {
+      // Drop taps while a switch is in flight or the shutter is busy — two
+      // reconfigurations must never overlap (spec §5).
+      if (isSwitchingLens || busy) return;
+      const optimistic = selectFactor({ selectedFactor, confirmedFactor }, factor);
+      if (optimistic.selectedFactor === selectedFactor) return; // tap on active stop
+      setSelectedFactor(optimistic.selectedFactor);
+      setIsSwitchingLens(true);
+      try {
+        await CameraPreview.setZoom({ factor });
+        setConfirmedFactor(factor);
+      } catch {
+        // Native rejected (e.g. lens missing) — revert the optimistic highlight.
+        const reverted = revertFactor({
+          selectedFactor: optimistic.selectedFactor,
+          confirmedFactor,
+        });
+        setSelectedFactor(reverted.selectedFactor);
+      } finally {
+        setIsSwitchingLens(false);
+      }
+    },
+    [busy, confirmedFactor, isSwitchingLens, selectedFactor],
+  );
 
   const cycleFlash = useCallback(async () => {
     if (busy) return;
@@ -254,6 +311,41 @@ export default function CameraView({
   }
 
   const stacked = layout.mode === "stacked";
+
+  // Segmented lens toggle. Rendered only when more than one stop is available
+  // and on the rear camera (visibleZoomFactors enforces both). Disabled (but
+  // visible, dimmed) while a switch is in flight; taps are dropped, not queued.
+  const visibleFactors = visibleZoomFactors(availableFactors, position);
+  const lensPill =
+    visibleFactors.length > 1 ? (
+      <div
+        data-testid="camera-lens-pill"
+        className={cn(
+          "flex items-center gap-1 rounded-full border border-white/25 bg-black/40 p-1",
+          (isSwitchingLens || busy) && "opacity-50",
+        )}
+      >
+        {visibleFactors.map((factor) => {
+          const active = factor === selectedFactor;
+          return (
+            <button
+              key={factor}
+              type="button"
+              disabled={isSwitchingLens || busy}
+              onClick={() => handleSetZoom(factor)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition",
+                active ? "bg-white text-black" : "bg-transparent text-white",
+              )}
+              aria-pressed={active}
+              aria-label={`Zoom ${formatFactorLabel(factor)}`}
+            >
+              {formatFactorLabel(factor)}
+            </button>
+          );
+        })}
+      </div>
+    ) : null;
 
   // Stacked-only top strip: X cancel + four icons. In overlay mode the X
   // disappears and the four icons move into the floating top-right cluster.
@@ -466,6 +558,9 @@ export default function CameraView({
                   {count}
                 </div>
               )}
+              {lensPill && (
+                <div className="mb-3 flex justify-center">{lensPill}</div>
+              )}
               <div className="grid w-full grid-cols-3 items-center">
                 <div className="justify-self-center">{queueButton}</div>
                 <div className="justify-self-center">{shutterButton}</div>
@@ -531,6 +626,9 @@ export default function CameraView({
               >
                 {count}
               </div>
+            )}
+            {lensPill && (
+              <div style={{ filter: OVERLAY_ICON_SHADOW }}>{lensPill}</div>
             )}
             {shutterButton}
             {queueButton}

--- a/src/lib/mobile/lens-zoom.test.ts
+++ b/src/lib/mobile/lens-zoom.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  visibleZoomFactors,
+  selectFactor,
+  revertFactor,
+  formatFactorLabel,
+} from "./lens-zoom";
+
+describe("visibleZoomFactors", () => {
+  it("hides the pill (returns []) when no factors are available", () => {
+    expect(visibleZoomFactors([], "rear")).toEqual([]);
+  });
+
+  it("hides the pill when only one factor is available", () => {
+    expect(visibleZoomFactors([1], "rear")).toEqual([]);
+  });
+
+  it("returns [1, 2] on a device without ultra-wide (rear)", () => {
+    expect(visibleZoomFactors([1, 2], "rear")).toEqual([1, 2]);
+  });
+
+  it("returns all three stops on an ultra-wide device (rear)", () => {
+    expect(visibleZoomFactors([0.5, 1, 2], "rear")).toEqual([0.5, 1, 2]);
+  });
+
+  it("hides the pill on the front camera regardless of availability", () => {
+    expect(visibleZoomFactors([0.5, 1, 2], "front")).toEqual([]);
+  });
+});
+
+describe("selectFactor", () => {
+  it("updates only selectedFactor, leaving confirmedFactor unchanged", () => {
+    expect(selectFactor({ selectedFactor: 1, confirmedFactor: 1 }, 2)).toEqual({
+      selectedFactor: 2,
+      confirmedFactor: 1,
+    });
+  });
+});
+
+describe("revertFactor", () => {
+  it("restores selectedFactor to confirmedFactor", () => {
+    expect(revertFactor({ selectedFactor: 0.5, confirmedFactor: 1 })).toEqual({
+      selectedFactor: 1,
+      confirmedFactor: 1,
+    });
+  });
+});
+
+describe("formatFactorLabel", () => {
+  it("renders the factor with a multiplication sign", () => {
+    expect(formatFactorLabel(0.5)).toBe("0.5×");
+    expect(formatFactorLabel(1)).toBe("1×");
+    expect(formatFactorLabel(2)).toBe("2×");
+  });
+});

--- a/src/lib/mobile/lens-zoom.ts
+++ b/src/lib/mobile/lens-zoom.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure decision logic for the camera lens toggle (0.5× / 1× / 2×).
+ *
+ * Framework-free so it can be unit-tested without React or Capacitor. The
+ * component (`camera-view.tsx`) and the lifecycle hook own the side effects;
+ * this module owns the rules. See
+ * docs/superpowers/specs/2026-06-08-camera-lens-zoom-design.md §7.
+ */
+
+export type LensFactor = 0.5 | 1 | 2;
+
+/**
+ * The stops the pill should display. Returns [] (hide the pill entirely) on
+ * the front camera or when one or fewer factors are available. Otherwise the
+ * available factors are returned as-is (the native layer owns availability).
+ */
+export function visibleZoomFactors(
+  available: number[],
+  position: "rear" | "front",
+): number[] {
+  if (position === "front") return [];
+  if (available.length <= 1) return [];
+  return available;
+}
+
+/**
+ * Next UI state after the user taps `factor`. Optimistic: selectedFactor moves
+ * immediately; confirmedFactor only changes once a setZoom actually resolves.
+ */
+export function selectFactor(
+  state: { selectedFactor: number; confirmedFactor: number },
+  factor: number,
+): { selectedFactor: number; confirmedFactor: number } {
+  return { selectedFactor: factor, confirmedFactor: state.confirmedFactor };
+}
+
+/** Revert helper for a rejected setZoom: snap selectedFactor back to confirmed. */
+export function revertFactor(state: {
+  selectedFactor: number;
+  confirmedFactor: number;
+}): { selectedFactor: number; confirmedFactor: number } {
+  return {
+    selectedFactor: state.confirmedFactor,
+    confirmedFactor: state.confirmedFactor,
+  };
+}
+
+/** "0.5×", "1×", "2×" — the label shown on each pill segment. */
+export function formatFactorLabel(factor: number): string {
+  return `${factor}×`;
+}

--- a/src/lib/mobile/use-camera-lifecycle.test.ts
+++ b/src/lib/mobile/use-camera-lifecycle.test.ts
@@ -3,11 +3,15 @@ import { renderHook, act } from "@testing-library/react";
 
 const startMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
 const stopMock = vi.fn((..._args: unknown[]): Promise<void> => Promise.resolve());
+const getFactorsMock = vi.fn(
+  (): Promise<{ factors: number[] }> => Promise.resolve({ factors: [0.5, 1, 2] }),
+);
 
 vi.mock("@capacitor-community/camera-preview", () => ({
   CameraPreview: {
     start: (arg: unknown) => startMock(arg),
     stop: () => stopMock(),
+    getAvailableZoomFactors: () => getFactorsMock(),
   },
 }));
 
@@ -18,6 +22,8 @@ describe("useCameraLifecycle", () => {
   beforeEach(() => {
     startMock.mockClear();
     stopMock.mockClear();
+    getFactorsMock.mockClear();
+    getFactorsMock.mockImplementation(() => Promise.resolve({ factors: [0.5, 1, 2] }));
   });
 
   it("starts the preview on mount with the supplied rect and position", async () => {
@@ -174,5 +180,46 @@ describe("useCameraLifecycle", () => {
 
     expect(startMock).not.toHaveBeenCalled();
     expect(stopMock).not.toHaveBeenCalled();
+  });
+
+  it("reports available zoom factors after start resolves", async () => {
+    const rect = { x: 0, y: 0, width: 390, height: 520 };
+    const onZoomFactorsAvailable = vi.fn();
+    renderHook(() =>
+      useCameraLifecycle({
+        rect,
+        position: "rear",
+        safeAreaTop: 0,
+        onZoomFactorsAvailable,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onZoomFactorsAvailable).toHaveBeenCalledWith([0.5, 1, 2]);
+  });
+
+  it("reports [] when getAvailableZoomFactors rejects (old binary / web)", async () => {
+    getFactorsMock.mockImplementationOnce(() => Promise.reject(new Error("UNIMPLEMENTED")));
+    const rect = { x: 0, y: 0, width: 390, height: 520 };
+    const onZoomFactorsAvailable = vi.fn();
+    renderHook(() =>
+      useCameraLifecycle({
+        rect,
+        position: "rear",
+        safeAreaTop: 0,
+        onZoomFactorsAvailable,
+      }),
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onZoomFactorsAvailable).toHaveBeenCalledWith([]);
   });
 });

--- a/src/lib/mobile/use-camera-lifecycle.ts
+++ b/src/lib/mobile/use-camera-lifecycle.ts
@@ -15,6 +15,9 @@ export interface UseCameraLifecycleInput {
   position: "rear" | "front";
   safeAreaTop: number;
   onError?: (err: unknown) => void;
+  /** Reports the rear-camera zoom stops detected after each successful start.
+   *  Receives [] when the native method is unavailable (old binary / web). */
+  onZoomFactorsAvailable?: (factors: number[]) => void;
 }
 
 const RECT_TOLERANCE_PX = 4;
@@ -29,12 +32,14 @@ function rectsDiffer(a: CameraLifecycleRect, b: CameraLifecycleRect): boolean {
 }
 
 export function useCameraLifecycle(input: UseCameraLifecycleInput): void {
-  const { rect, position, safeAreaTop, onError } = input;
+  const { rect, position, safeAreaTop, onError, onZoomFactorsAvailable } = input;
   const startedRef = useRef(false);
   const lastRectRef = useRef<CameraLifecycleRect | null>(null);
   const lastPositionRef = useRef<"rear" | "front">(position);
   const onErrorRef = useRef(onError);
   onErrorRef.current = onError;
+  const onZoomFactorsAvailableRef = useRef(onZoomFactorsAvailable);
+  onZoomFactorsAvailableRef.current = onZoomFactorsAvailable;
 
   // Body/html background transparency dance — the native overlay sits behind
   // the WebView via toBack:true, so the page background must be transparent
@@ -68,6 +73,15 @@ export function useCameraLifecycle(input: UseCameraLifecycleInput): void {
           disableAudio: true,
         });
         startedRef.current = true;
+        // Feature-detect zoom support after a successful start. An old native
+        // binary (pre-patch) or the web fallback rejects here → report [] so
+        // the UI hides the lens pill. Re-runs on every restart (flip/resize).
+        try {
+          const { factors } = await CameraPreview.getAvailableZoomFactors();
+          onZoomFactorsAvailableRef.current?.(factors);
+        } catch {
+          onZoomFactorsAvailableRef.current?.([]);
+        }
       } catch (err) {
         onErrorRef.current?.(err);
       }


### PR DESCRIPTION
## Summary

Adds an iPhone-style segmented lens toggle (**0.5× / 1× / 2×**) to the in-app native iOS camera.

- **0.5×** routes to the physical ultra-wide rear lens (`.builtInUltraWideCamera`); **2×** is a digital crop on the wide lens; **1×** is the wide lens at native zoom.
- Native behavior is delivered via **patch-package** against `@capacitor-community/camera-preview@8.0.1` (new `postinstall` hook runs `patch-package`).
- Lens switching is serialized JS-side (`isSwitchingLens` guard) per the approved minimal-threading decision; `setZoom` runs on the bridge thread.
- The pill only renders the stops the device actually supports (feature-detected via `getAvailableZoomFactors`), so non-ultra-wide devices (e.g. SE) show only 1×/2× and old binaries without the patch show no pill.

## What changed

- `src/lib/mobile/lens-zoom.ts` (+test) — pure lens/zoom decision logic.
- `package.json` / `package-lock.json` — patch-package tooling + `postinstall` hook.
- `patches/@capacitor-community+camera-preview+8.0.1.patch` — native `setZoom` + `getAvailableZoomFactors` (Swift + TS defs).
- `src/lib/mobile/use-camera-lifecycle.ts` (+test) — feature-detect available zoom factors.
- `src/components/mobile/camera-view.tsx` (+test) — the lens-toggle pill UI.

## Test Plan

Unit/component tests green on touched files (30 passing). Native behavior requires an on-device pass on a real ultra-wide iPhone once this ships to TestFlight:

- [ ] Pill shows 0.5 / 1 / 2 on an ultra-wide iPhone; only 1/2 on a non-ultra-wide device (SE).
- [ ] Tapping each stop transitions the live preview to the right lens/zoom.
- [ ] Captured photo matches the previewed framing at each stop.
- [ ] Tap-to-focus and flash work on 0.5×.
- [ ] Flipping to front camera and back resets to 1×.
- [ ] Rapid-tapping stops never wedges the preview.
- [ ] An old binary (without the patch) shows no pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
