### PR TITLE
fix(phone): outbound smart-attach prompts, not auto-tags, on a single active job (#530)

### DIFF
--- a/src/app/api/phone/calls/route.test.ts
+++ b/src/app/api/phone/calls/route.test.ts
@@ -577,7 +577,11 @@ describe("POST /api/phone/calls — smart-attach", () => {
     expect(body.smartAttach).toMatchObject({ kind: "auto", jobId: "job-77" });
   });
 
-  it("auto-tags a Contact-card call when the contact has exactly one Active job", async () => {
+  it("leaves a Contact-card call untagged and offers a chip even when the contact has exactly one Active job (#530)", async () => {
+    // The locked rule is "Outbound from Phone tab / Contact card → prompt
+    // chips." A single Active job must NOT be auto-tagged on an outbound
+    // call — the row persists job_tag null and the 201 echoes a prompt with
+    // the one candidate so the UI can offer it. Before #530 this auto-tagged.
     authed("user-1", "crew_lead");
     const { client, inserts } = makeServiceClient({
       phone_numbers: [SHARED_NUM_ROW],
@@ -610,7 +614,12 @@ describe("POST /api/phone/calls — smart-attach", () => {
 
     expect(res.status).toBe(201);
     const callInsert = inserts.find((i) => i.table === "phone_calls");
-    expect(callInsert?.row).toMatchObject({ job_tag: "job-5" });
+    expect(callInsert?.row).toMatchObject({ job_tag: null });
+    const body = await res.json();
+    expect(body.smartAttach.kind).toBe("prompt");
+    expect(body.smartAttach.candidates).toEqual([
+      { jobId: "job-5", label: "JOB-005" },
+    ]);
   });
 
   it("leaves the row untagged and offers chips when the contact has 2+ Active jobs", async () => {

--- a/src/app/api/phone/messages/route.test.ts
+++ b/src/app/api/phone/messages/route.test.ts
@@ -741,6 +741,64 @@ describe("POST /api/phone/messages — Job-page auto-tag (#311)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 7b. Outbound smart-attach prompt on a single Active job (#530)
+//
+// A Phone-tab / Contact-card send must never auto-tag, even when the contact
+// has exactly one Active job — the locked rule is "Outbound from Phone tab /
+// Contact card → prompt chips." Before #530 the single-job case fell through
+// to the inbound auto-tag branch and silently tagged the text to that Job.
+// The row persists job_tag null; the 201 echoes smartAttach:prompt with the
+// one candidate so the UI can offer the chip.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/messages — outbound prompt on a single Active job (#530)", () => {
+  it("persists job_tag null and echoes smartAttach:prompt for a phone-tab send to a contact with exactly one Active job", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      phone_conversations: [
+        {
+          id: "conv-530",
+          organization_id: ORG,
+          phone_number_id: "num-shared",
+          outside_e164: "+15550003333",
+          contact_id: "contact-22",
+        },
+      ],
+      jobs: [
+        {
+          id: "job-7",
+          organization_id: ORG,
+          contact_id: "contact-22",
+          job_number: "JOB-007",
+          status: "in_progress",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        conversationId: "conv-530",
+        body: "quick question",
+        sourceContext: "phone-tab",
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.smartAttach.kind).toBe("prompt");
+    expect(body.smartAttach.candidates).toEqual([
+      { jobId: "job-7", label: "JOB-007" },
+    ]);
+    // The text is persisted UNTAGGED — the chip is offered, not applied.
+    const msgInsert = inserts.find((i) => i.table === "phone_messages");
+    expect(msgInsert?.row.job_tag).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 8. GET — Job-page Messages read (slice 7 / #311)
 //
 // The Job-page Messages (N) section reads every text/MMS tagged to a Job

--- a/src/lib/phone/smart-attach.test.ts
+++ b/src/lib/phone/smart-attach.test.ts
@@ -181,4 +181,76 @@ describe("decideJobTag — outbound branches (PRD #304, Job-page Text #311)", ()
       }),
     ).toEqual({ kind: "untagged" });
   });
+
+  it("outbound from the Phone tab with exactly one Active job PROMPTS, never auto-tags (#530)", () => {
+    // The locked rule is "Outbound from Phone tab / Contact card → prompt
+    // chips." The single-Active-job auto-tag is INBOUND-only: an outbound
+    // send must never silently attribute itself to the contact's lone Job —
+    // a false attribution (a personal text landing on a Job's timeline) is
+    // worse than one click. Before #530 this fell through to the inbound
+    // branch and returned { kind:'auto' }.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "phone-tab" },
+        contactId: CONTACT_ID,
+        activeJobs: [job("job-1", "WTR-2026-0001")],
+      }),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [{ jobId: "job-1", label: "WTR-2026-0001" }],
+    });
+  });
+
+  it("outbound from a Contact card with exactly one Active job PROMPTS, never auto-tags (#530)", () => {
+    // Same locked rule as the Phone tab — the Contact card is the other
+    // outbound non-Job source. One Active job still prompts; the crew lead
+    // picks the Job (or none) rather than the system guessing.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "contact-card" },
+        contactId: CONTACT_ID,
+        activeJobs: [job("job-1", "WTR-2026-0001")],
+      }),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [{ jobId: "job-1", label: "WTR-2026-0001" }],
+    });
+  });
+
+  it("outbound from the Phone tab with two Active jobs PROMPTS with both candidates", () => {
+    // 2+ Active jobs already prompted before #530; pinned here so the AC2
+    // "2+ still returns prompt" guarantee survives the inbound/outbound split.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "phone-tab" },
+        contactId: CONTACT_ID,
+        activeJobs: [
+          job("job-1", "WTR-2026-0001"),
+          job("job-2", "FYR-2026-0005"),
+        ],
+      }),
+    ).toEqual({
+      kind: "prompt",
+      candidates: [
+        { jobId: "job-1", label: "WTR-2026-0001" },
+        { jobId: "job-2", label: "FYR-2026-0005" },
+      ],
+    });
+  });
+
+  it("outbound from a Contact card with zero Active jobs stays untagged", () => {
+    // AC2: outbound with no Active jobs still returns untagged (nothing to
+    // prompt for) — the empty-jobs branch is shared with inbound.
+    expect(
+      decideJobTag({
+        direction: "out",
+        sourceContext: { kind: "contact-card" },
+        contactId: CONTACT_ID,
+        activeJobs: [],
+      }),
+    ).toEqual({ kind: "untagged" });
+  });
 });

--- a/src/lib/phone/smart-attach.ts
+++ b/src/lib/phone/smart-attach.ts
@@ -67,7 +67,13 @@ export function decideJobTag(input: SmartAttachInput): SmartAttachDecision {
   if (input.activeJobs.length === 0) {
     return { kind: "untagged" };
   }
-  if (input.activeJobs.length === 1) {
+  // A single Active job auto-tags ONLY for inbound. An outbound send from the
+  // Phone tab / Contact card must prompt even here — the locked rule is
+  // "Outbound from Phone tab / Contact card → prompt chips" (#530). The
+  // Job-page outbound source (kind:'job') already returned above, so any
+  // outbound reaching this point is a non-Job source that must never
+  // auto-tag: a false attribution is worse than the friction of one click.
+  if (input.direction === "in" && input.activeJobs.length === 1) {
     return { kind: "auto", jobId: input.activeJobs[0].id };
   }
   return {


### PR DESCRIPTION
Closes #530.

## What & why
Outbound smart-attach from the **Phone tab** or a **Contact card** must not silently auto-tag a call/text to a Job. `decideJobTag` was falling through to the inbound branch for `direction:'out'` + `phone-tab`/`contact-card` + exactly one active job, returning `{ kind:'auto' }` and tagging without asking — contrary to the locked rule *"Outbound from Phone tab / Contact card → prompt chips."*

The single-Active-job auto-tag is now gated on `direction === 'in'`. Outbound non-Job sources fall through to `{ kind:'prompt' }`. Both routes already mapped any non-`auto` decision to `job_tag = null`, so the 1-active-job phone-tab/contact-card send is now persisted **untagged** and the 201 echoes `smartAttach: { kind:'prompt' }`. Job-page (`kind:'job'`) and all inbound behavior are unchanged.

Rendering the outbound chip picker is a separate future slice and explicitly out of scope here, per the issue.

## Acceptance criteria
- [x] `decideJobTag` out + phone-tab/contact-card + exactly one active job → `prompt`
- [x] Outbound 0 jobs → `untagged`; 2+ → `prompt`
- [x] All inbound paths unchanged (1→auto, 2+→prompt, 0/unknown→untagged)
- [x] `{ kind:'job', jobId }` outbound → `auto` (Job-page button)
- [x] `POST /api/phone/calls` and `/api/phone/messages` persist `job_tag = null` and echo `smartAttach:{kind:'prompt'}` for the 1-active-job case
- [x] Covered by the smart-attach unit test and both route test files

## Tests
- Built TDD: RED→GREEN tracer, then vertical slices.
- **91/91** across the smart-attach unit suite, both route tests, and every inbound consumer (route-inbound, sms-inbound, simulate-inbound, lifecycle).
- `tsc --noEmit` clean · `eslint` clean.
- Independent adversarial review (2 agents): all 6 ACs covered, no broken consumer/type/test; CONTEXT.md and the module header already describe this behavior.

## Follow-up (not in this slice)
The compose-strip hint *"This message will be smart-attached when sent."* (src/app/phone/phone-page-client.tsx:953-957) now over-promises for the single-active-job Phone-tab case; fold the copy into the deferred outbound-chip slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)