### PR TITLE
fix(camera): guard ultra-wide focusMode — stop crash on camera open (Build 298 regression)

### DIFF
--- a/patches/@capacitor-community+camera-preview+8.0.1.patch
+++ b/patches/@capacitor-community+camera-preview+8.0.1.patch
@@ -38,7 +38,7 @@ index a98694c..5e52247 100644
  //# sourceMappingURL=web.js.map
 \ No newline at end of file
 diff --git a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
-index 6ec075a..fc059c3 100644
+index 6ec075a..95ea58c 100644
 --- a/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
 +++ b/node_modules/@capacitor-community/camera-preview/ios/Sources/CameraPreviewPlugin/CameraController.swift
 @@ -20,7 +20,9 @@ class CameraController: NSObject {
@@ -61,7 +61,7 @@ index 6ec075a..fc059c3 100644
  
              let cameras = session.devices.compactMap { $0 }
              guard !cameras.isEmpty else { throw CameraControllerError.noCamerasAvailable }
-@@ -56,14 +58,27 @@ extension CameraController {
+@@ -56,14 +58,35 @@ extension CameraController {
                      self.frontCamera = camera
                  }
  
@@ -80,7 +80,16 @@ index 6ec075a..fc059c3 100644
 +                    }
  
                      try camera.lockForConfiguration()
-                     camera.focusMode = .continuousAutoFocus
+-                    camera.focusMode = .continuousAutoFocus
++                    // Guard focusMode: many ultra-wide lenses (iPhone 11/12 and the
++                    // non-Pro models through 14) are FIXED-FOCUS. Setting an unsupported
++                    // focusMode raises an uncatchable NSInvalidArgumentException (an Obj-C
++                    // exception — Swift try/catch does NOT catch it), which hard-crashes
++                    // the app on camera open the moment the ultra-wide lens is enumerated.
++                    // Mirrors the isFocusModeSupported guard already used in handleTap().
++                    if camera.isFocusModeSupported(.continuousAutoFocus) {
++                        camera.focusMode = .continuousAutoFocus
++                    }
 +                    camera.videoZoomFactor = 1.0   // clear any zoom retained on the device singleton
                      camera.unlockForConfiguration()
                  }
@@ -90,7 +99,7 @@ index 6ec075a..fc059c3 100644
              if disableAudio == false {
                  self.audioDevice = AVCaptureDevice.default(for: AVMediaType.audio)
              }
-@@ -262,6 +277,72 @@ extension CameraController {
+@@ -262,6 +285,72 @@ extension CameraController {
          captureSession.commitConfiguration()
      }
  


### PR DESCRIPTION
## Summary

Hotfix for a **crash on camera open** introduced in #535 (TestFlight Build 298).

The lens-zoom patch added `.builtInUltraWideCamera` to the AVFoundation discovery session, so `configureCaptureDevices()` now iterates the ultra-wide lens and set `focusMode = .continuousAutoFocus` on it **unconditionally**. Most iPhone ultra-wide lenses (iPhone 11/12 and non-Pro 13/14) are **fixed-focus** — setting an unsupported focus mode raises an **uncatchable** `NSInvalidArgumentException` (an Obj-C exception that Swift `try`/`catch` doesn't catch), hard-crashing the app the instant the camera opens. SE-class phones (no ultra-wide) and Pro models (AF-capable ultra-wide) were unaffected — which is why it hit the crew's mid-range iPhones.

**Fix:** guard the set with `isFocusModeSupported(.continuousAutoFocus)` — the same pattern already used in `handleTap()` — and regenerate the committed patch-package patch.

## Why this is the complete fix

A 4-lens adversarial audit of the full patch confirmed this is the **only** unguarded device-mode setter on the camera-open path. The other items it surfaced are not the open crash:

- **videoZoomFactor lower-bound** — can't underflow on the *physical* lenses we use (`minAvailableVideoZoomFactor == 1.0`; we only request 0.5/1/2). The risk only exists on *virtual* multi-cam devices, which we don't use.
- **`rearWideCamera` nil path** — impossible on any shipping iPhone (all have a rear wide lens) and already soft-guarded downstream in `configureDeviceInputs`.
- **setZoom threading / reconfig** — only reachable on lens-*tap*, not open, and mirrors the upstream `switchCameras()` pattern.

## Test plan

- [x] `patches/@capacitor-community+camera-preview+8.0.1.patch` regenerated from fixed source — diff is the guard only
- [x] Camera feature tests green (`lens-zoom` + `use-camera-lifecycle`, 16/16)
- [ ] Vercel preview build passes (validates the patch-package `postinstall` applies cleanly)
- [ ] On-device: camera opens without crashing on a fixed-focus ultra-wide iPhone (11/12/non-Pro 13/14); 0.5×/1×/2× toggle still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
