### PR TITLE
feat(phone): validate {kind:'job'} jobId belongs to caller's org before Twilio dispatch (#531)

### DIFF
--- a/src/app/api/phone/calls/route.test.ts
+++ b/src/app/api/phone/calls/route.test.ts
@@ -559,6 +559,17 @@ describe("POST /api/phone/calls — smart-attach", () => {
     const { client, inserts } = makeServiceClient({
       phone_numbers: [SHARED_NUM_ROW],
       user_profiles: [CREW_PROFILE],
+      // The Job must exist in the caller's org — the #531 ownership gate
+      // refuses an unknown / cross-org id before Twilio.
+      jobs: [
+        {
+          id: "job-77",
+          organization_id: ORG,
+          contact_id: "contact-77",
+          job_number: "JOB-077",
+          status: "in_progress",
+        },
+      ],
     });
     vi.mocked(createServiceClient).mockReturnValue(client as never);
 
@@ -666,6 +677,78 @@ describe("POST /api/phone/calls — smart-attach", () => {
     const body = await res.json();
     expect(body.smartAttach.kind).toBe("prompt");
     expect(body.smartAttach.candidates).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8b. Job-ownership gate (#531) — a { kind:'job' } source writes jobId into
+//     job_tag, which carries a foreign key to jobs(id). A crafted cross-org
+//     or non-existent id must be refused with 422 BEFORE Twilio, and no row
+//     may be written. Otherwise: a non-existent id rings + bridges the call,
+//     then the FK insert fails into an orphan; a cross-org id succeeds and
+//     tags the row to another organization's Job. Defense in depth — the
+//     Job-page Call button only ever sends a valid in-org id.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — job-ownership gate (#531)", () => {
+  it("refuses with 422 and never calls Twilio when the jobId belongs to another org", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts, upserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      jobs: [
+        {
+          id: "job-x",
+          organization_id: "org-2",
+          contact_id: "contact-x",
+          job_number: "JOB-X",
+          status: "in_progress",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        sourceContext: { kind: "job", jobId: "job-x" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+    // "no DB row written" covers every mutation — the guard refuses BEFORE
+    // the conversation upsert, so not even a phone_conversations row appears.
+    expect(
+      upserts.find((u) => u.table === "phone_conversations"),
+    ).toBeUndefined();
+  });
+
+  it("refuses with 422 and never calls Twilio when the jobId does not exist (no orphan call)", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts, upserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      jobs: [], // no Job at all — a crafted / stale id
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        sourceContext: { kind: "job", jobId: "job-does-not-exist" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(placeBridgeCallMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+    expect(
+      upserts.find((u) => u.table === "phone_conversations"),
+    ).toBeUndefined();
   });
 });
 

--- a/src/app/api/phone/calls/route.ts
+++ b/src/app/api/phone/calls/route.ts
@@ -35,9 +35,12 @@ import {
 //      present as caller ID (owned-number safety; 422).
 //   4. Profile-cell gate — refuse if the caller has no cell to ring (422).
 //   5. TCPA opt-out — refuse before any Twilio call (403).
-//   6. Twilio dispatch BEFORE the DB write — we never want a phone_calls
+//   6. Job-ownership gate — if a `{ kind:'job' }` source is given, refuse
+//      unless the Job exists and belongs to the caller's org (#531; 422),
+//      before Twilio and before any DB write.
+//   7. Twilio dispatch BEFORE the DB write — we never want a phone_calls
 //      row claiming a dispatch that didn't happen (502 on Twilio error).
-//   7. Insert the phone_calls row (direction='out', initiated_by_user_id).
+//   8. Insert the phone_calls row (direction='out', initiated_by_user_id).
 //
 // The Twilio call lifecycle is tracked by the existing voice-status webhook
 // keyed on CallSid — generic over inbound/outbound, so the outbound row is
@@ -200,6 +203,29 @@ export const POST = withRequestContext(
       );
     }
 
+    // Job-ownership gate (#531). A `{ kind:'job' }` source writes its jobId
+    // into job_tag, which carries a foreign key to jobs(id). Confirm the Job
+    // exists AND belongs to the caller's org BEFORE Twilio and before any DB
+    // write — a single query filtered by id + organization_id refuses both a
+    // non-existent id (orphan call: rings, then the FK insert fails) and a
+    // cross-org id (a row tagged to another org's Job). The happy path never
+    // hits this: the Job-page Call button always sends a valid in-org id.
+    const source = parseSourceContext(body.sourceContext);
+    if (source.kind === "job") {
+      const { data: job } = await ctx.serviceClient!
+        .from("jobs")
+        .select("id, organization_id")
+        .eq("id", source.jobId)
+        .eq("organization_id", ctx.orgId)
+        .maybeSingle<{ id: string; organization_id: string }>();
+      if (!job) {
+        return NextResponse.json(
+          { error: "Job not found in this organization." },
+          { status: 422 },
+        );
+      }
+    }
+
     // Resolve the conversation_id we'll write under — upsert by
     // (phone_number_id, outside_e164), the natural key from migration-308.
     let conversationId: string;
@@ -231,8 +257,8 @@ export const POST = withRequestContext(
 
     // Smart-attach. A Job-page Call auto-tags to that Job; Phone-tab /
     // Contact-card calls are untagged. The rule is given the conversation's
-    // contact + their Active jobs for the non-Job sources.
-    const source = parseSourceContext(body.sourceContext);
+    // contact + their Active jobs for the non-Job sources. (`source` was
+    // parsed and ownership-checked above, before Twilio.)
     let activeJobs: ActiveJob[] = [];
     let contactId: string | null = null;
     if (source.kind === "phone-tab" || source.kind === "contact-card") {

--- a/src/app/api/phone/messages/route.test.ts
+++ b/src/app/api/phone/messages/route.test.ts
@@ -692,6 +692,17 @@ describe("POST /api/phone/messages — Job-page auto-tag (#311)", () => {
     authed("user-1", "crew_lead");
     const { client, inserts } = makeServiceClient({
       phone_numbers: [SHARED_NUM_ROW],
+      // The Job must exist in the caller's org — the #531 ownership gate
+      // refuses an unknown / cross-org id before Twilio.
+      jobs: [
+        {
+          id: "job-1",
+          organization_id: ORG,
+          contact_id: "contact-1",
+          job_number: "JOB-001",
+          status: "in_progress",
+        },
+      ],
     });
     vi.mocked(createServiceClient).mockReturnValue(client as never);
 
@@ -795,6 +806,78 @@ describe("POST /api/phone/messages — outbound prompt on a single Active job (#
     // The text is persisted UNTAGGED — the chip is offered, not applied.
     const msgInsert = inserts.find((i) => i.table === "phone_messages");
     expect(msgInsert?.row.job_tag).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7c. Job-ownership gate (#531) — a { kind:'job' } source writes jobId into
+//     job_tag, which carries a foreign key to jobs(id). A crafted cross-org
+//     or non-existent id must be refused with 422 BEFORE Twilio, and no row
+//     may be written. Otherwise: a non-existent id sends the text, then the
+//     FK insert fails into an orphan; a cross-org id succeeds and tags the
+//     row to another organization's Job. Defense in depth — the Job-page
+//     Text button only ever sends a valid in-org id.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/messages — job-ownership gate (#531)", () => {
+  it("refuses with 422 and never calls Twilio when the jobId belongs to another org", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts, upserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      jobs: [
+        {
+          id: "job-x",
+          organization_id: "org-2",
+          contact_id: "contact-x",
+          job_number: "JOB-X",
+          status: "in_progress",
+        },
+      ],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "On our way",
+        sourceContext: { kind: "job", jobId: "job-x" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(sendSmsMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_messages")).toBeUndefined();
+    // "no DB row written" covers every mutation — the guard refuses BEFORE
+    // the conversation upsert, so not even a phone_conversations row appears.
+    expect(
+      upserts.find((u) => u.table === "phone_conversations"),
+    ).toBeUndefined();
+  });
+
+  it("refuses with 422 and never calls Twilio when the jobId does not exist (no orphan send)", async () => {
+    authed("user-1", "crew_lead");
+    const { client, inserts, upserts } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      jobs: [], // no Job at all — a crafted / stale id
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        body: "On our way",
+        sourceContext: { kind: "job", jobId: "job-does-not-exist" },
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(422);
+    expect(sendSmsMock).not.toHaveBeenCalled();
+    expect(inserts.find((i) => i.table === "phone_messages")).toBeUndefined();
+    expect(
+      upserts.find((u) => u.table === "phone_conversations"),
+    ).toBeUndefined();
   });
 });
 

--- a/src/app/api/phone/messages/route.ts
+++ b/src/app/api/phone/messages/route.ts
@@ -270,6 +270,30 @@ export const POST = withRequestContext(
       );
     }
 
+    // Job-ownership gate (#531). A `{ kind:'job' }` source writes its jobId
+    // into job_tag, which carries a foreign key to jobs(id). Confirm the Job
+    // exists AND belongs to the caller's org BEFORE Twilio and before any DB
+    // write — a single query filtered by id + organization_id refuses both a
+    // non-existent id (orphan send: the text goes out, then the FK insert
+    // fails) and a cross-org id (a row tagged to another org's Job). The
+    // happy path never hits this: the Job-page Text button always sends a
+    // valid in-org id.
+    const source = parseSourceContext(body.sourceContext);
+    if (source.kind === "job") {
+      const { data: job } = await ctx.serviceClient!
+        .from("jobs")
+        .select("id, organization_id")
+        .eq("id", source.jobId)
+        .eq("organization_id", ctx.orgId)
+        .maybeSingle<{ id: string; organization_id: string }>();
+      if (!job) {
+        return NextResponse.json(
+          { error: "Job not found in this organization." },
+          { status: 422 },
+        );
+      }
+    }
+
     // Resolve the conversation_id we'll write under. Upsert by
     // (phone_number_id, outside_e164) — slice 4 wrote the unique
     // constraint on that pair.
@@ -302,8 +326,8 @@ export const POST = withRequestContext(
 
     // Smart-attach. Slice 5 only ever sees the outbound sources
     // 'phone-tab' / 'contact-card' (Job-page Text is slice 7). The rule
-    // covers all three.
-    const source = parseSourceContext(body.sourceContext);
+    // covers all three. (`source` was parsed and ownership-checked above,
+    // before Twilio.)
     let activeJobs: ActiveJob[] = [];
     let contactId: string | null = null;
     if (source.kind === "phone-tab" || source.kind === "contact-card") {


### PR DESCRIPTION
Closes #531.

## Problem

Both `POST /api/phone/calls` and `POST /api/phone/messages` accepted a `{ kind:'job', jobId }` source and wrote that `jobId` into `job_tag` (an FK to `jobs(id)`) with **no** validation that the Job exists and belongs to the caller's org:

- **Non-existent jobId** → Twilio places the call / sends the text, **then** the FK insert fails → 500, leaving an orphan: the call actually rang and bridged, but no row records it.
- **Existing but cross-org jobId** → the insert succeeds, tagging the row to another organization's Job. RLS masks it on read, but it's wrong stored data and a cross-org coupling.

The happy path never hits this (the Job-page button always sends a valid in-org id); this is defense-in-depth against crafted requests.

## Change

Add a **job-ownership guard** to both routes, **after** the opt-out gate and **before** the conversation upsert + Twilio dispatch. A single query filtered by `id` **and** `organization_id = ctx.orgId` refuses both failure modes with **422** — a non-existent id and a cross-org id both return no row. Mirrors the existing pattern in `messages/[id]/tag/route.ts`. A valid in-org Job is unchanged: it still auto-tags and dispatches.

Placing the guard before the conversation upsert means a refused request writes **no** DB row at all (not even a `phone_conversations` row) and never rings/sends.

## Acceptance criteria

- [x] cross-org Job → 422, before any Twilio dispatch, no DB row written
- [x] non-existent Job → 422, before any Twilio dispatch (no orphan call)
- [x] valid in-org Job → unchanged (auto-tags, places the call / sends the text)
- [x] enforced in both `POST /api/phone/calls` and `POST /api/phone/messages`
- [x] tests for both routes cover the 422-before-dispatch path and the valid path

## Testing

Built test-first (red→green per behavior). New per route: cross-org → 422 and non-existent → 422, each asserting **no** Twilio call, **no** primary-row insert, and **no** `phone_conversations` upsert (full "no DB row written" coverage). Existing happy-path job tests updated to seed a valid in-org Job (the behavior now requires it).

- `npm test -- src/app/api/phone/calls/route.test.ts src/app/api/phone/messages/route.test.ts` → **44/44 pass**
- `tsc --noEmit` clean for the changed files

Reviewed via a 3-lens adversarial pass; the one confirmed finding (guard-failure tests didn't pin the absence of the conversation upsert) is addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)