### PR TITLE
feat(estimate-builder): $-prefixed MoneyInput for unit cost & fixed markup/discount (#542)

### DIFF
--- a/src/components/estimate-builder/line-item-row.test.tsx
+++ b/src/components/estimate-builder/line-item-row.test.tsx
@@ -43,6 +43,10 @@ function noteInput(): HTMLInputElement {
   return screen.getByPlaceholderText("Note (optional)") as HTMLInputElement;
 }
 
+function unitPriceInput(): HTMLInputElement {
+  return screen.getByPlaceholderText("0.00") as HTMLInputElement;
+}
+
 describe("LineItemRow — note field (#382)", () => {
   it("seeds the note input from item.note", () => {
     renderRow({ ...baseItem, note: "Use low-VOC primer" }, vi.fn());
@@ -76,5 +80,46 @@ describe("LineItemRow — note field (#382)", () => {
     fireEvent.blur(noteInput());
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("LineItemRow — unit cost MoneyInput (#542)", () => {
+  it("shows a $ adornment on the unit-cost field", () => {
+    renderRow(baseItem, vi.fn());
+    expect(screen.getByText("$")).toBeDefined();
+  });
+
+  it("seeds the unit-cost field from item.unit_price", () => {
+    renderRow({ ...baseItem, unit_price: 42.5 }, vi.fn());
+    expect(unitPriceInput().value).toBe("42.5");
+  });
+
+  it("commits a new unit price on blur via onChange", () => {
+    const onChange = vi.fn();
+    renderRow(baseItem, onChange);
+
+    fireEvent.change(unitPriceInput(), { target: { value: "25" } });
+    fireEvent.blur(unitPriceInput());
+
+    expect(onChange).toHaveBeenCalledWith({ unit_price: 25 });
+  });
+
+  it("does not fire onChange when the unit price is unchanged", () => {
+    const onChange = vi.fn();
+    renderRow(baseItem, onChange);
+
+    fireEvent.blur(unitPriceInput());
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ticks the line total live as the unit price is typed (before blur)", () => {
+    // qty 2 × $10 = $20.00 initially; typing 20 → 2 × $20 = $40.00 immediately.
+    renderRow({ ...baseItem, quantity: 2, unit_price: 10 }, vi.fn());
+    expect(screen.getByText("$20.00")).toBeDefined();
+
+    fireEvent.change(unitPriceInput(), { target: { value: "20" } });
+
+    expect(screen.getByText("$40.00")).toBeDefined();
   });
 });

--- a/src/components/estimate-builder/line-item-row.tsx
+++ b/src/components/estimate-builder/line-item-row.tsx
@@ -15,6 +15,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/format";
+import { MoneyInput } from "./money-input";
 import type { BuilderMode, EstimateLineItem, InvoiceLineItem } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -83,7 +84,10 @@ export function LineItemRow({
   const [code, setCode] = useState(item.code ?? "");
   const [quantity, setQuantity] = useState(String(item.quantity));
   const [unit, setUnit] = useState(item.unit ?? "");
-  const [unitPrice, setUnitPrice] = useState(String(item.unit_price));
+  // Unit price now lives inside MoneyInput, which owns its own draft string.
+  // The row keeps only a numeric mirror so the line total can tick live as the
+  // user types (fed via MoneyInput's onValueChange).
+  const [unitPriceDraft, setUnitPriceDraft] = useState(item.unit_price);
 
   // Sync from props when item changes from outside (e.g. server reconcile)
   useEffect(() => {
@@ -93,12 +97,12 @@ export function LineItemRow({
     setCode(item.code ?? "");
     setQuantity(String(item.quantity));
     setUnit(item.unit ?? "");
-    setUnitPrice(String(item.unit_price));
+    setUnitPriceDraft(item.unit_price);
   }, [item.name, item.description, item.note, item.code, item.quantity, item.unit, item.unit_price]);
 
   // ── Live total (uses local editing values) ────────────────────────────────
   const localQty = Number(quantity);
-  const localUnitPrice = Number(unitPrice);
+  const localUnitPrice = unitPriceDraft;
   const liveTotal =
     Number.isFinite(localQty) && Number.isFinite(localUnitPrice)
       ? localQty * localUnitPrice
@@ -160,18 +164,6 @@ export function LineItemRow({
     const val = unit.trim() || null;
     if (val !== item.unit) {
       onChange({ unit: val });
-    }
-  }
-
-  function commitUnitPrice() {
-    const parsed = Number(unitPrice);
-    if (!unitPrice.trim() || !Number.isFinite(parsed)) {
-      // Revert on empty or NaN
-      setUnitPrice(String(item.unit_price));
-      return;
-    }
-    if (parsed !== item.unit_price) {
-      onChange({ unit_price: parsed });
     }
   }
 
@@ -314,22 +306,20 @@ export function LineItemRow({
         )}
       />
 
-      {/* Unit price */}
-      <input
-        type="number"
-        value={unitPrice}
-        disabled={readOnly}
-        onChange={(e) => setUnitPrice(e.target.value)}
-        onBlur={commitUnitPrice}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
+      {/* Unit price — $-prefixed MoneyInput (#542). Commits on blur; feeds the
+          live total via onValueChange so it ticks while typing. */}
+      <MoneyInput
+        value={item.unit_price}
+        onValueChange={(raw) => setUnitPriceDraft(Number(raw))}
+        onCommit={(n) => {
+          if (n !== item.unit_price) onChange({ unit_price: n });
         }}
+        readOnly={readOnly}
         placeholder="0.00"
         className={cn(
-          "w-24 shrink-0 mt-0.5 bg-transparent border-0 outline-none ring-0 text-sm text-foreground tabular-nums text-right placeholder:text-muted-foreground/50",
-          "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-          "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
-          "disabled:cursor-default disabled:opacity-60"
+          "w-24 shrink-0 mt-0.5 px-1 py-0.5 text-sm text-foreground transition-colors",
+          "focus-within:bg-muted/40 focus-within:rounded",
+          readOnly && "opacity-60"
         )}
       />
 

--- a/src/components/estimate-builder/money-input.test.tsx
+++ b/src/components/estimate-builder/money-input.test.tsx
@@ -1,0 +1,93 @@
+// Behavior coverage for MoneyInput (#542) — the $-prefixed numeric box used for
+// the line-item unit cost and the fixed-dollar Markup/Discount fields. Tests
+// exercise the public contract only: value seeding, commit-on-blur parsing,
+// rejection of non-numeric input, no comma reformatting mid-type, and the
+// optional live callback that keeps a consumer's running total ticking.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { MoneyInput } from "./money-input";
+
+function box(): HTMLInputElement {
+  return screen.getByRole("textbox") as HTMLInputElement;
+}
+
+describe("MoneyInput", () => {
+  it("renders a fixed $ adornment", () => {
+    render(<MoneyInput value={10} onCommit={vi.fn()} />);
+    expect(screen.getByText("$")).toBeDefined();
+  });
+
+  it("seeds the box with the numeric value", () => {
+    render(<MoneyInput value={12.5} onCommit={vi.fn()} />);
+    expect(box().value).toBe("12.5");
+  });
+
+  it("commits the typed amount as a number on blur", () => {
+    const onCommit = vi.fn();
+    render(<MoneyInput value={10} onCommit={onCommit} />);
+
+    fireEvent.change(box(), { target: { value: "12.5" } });
+    fireEvent.blur(box());
+
+    expect(onCommit).toHaveBeenCalledWith(12.5);
+  });
+
+  it("rejects non-numeric input: never commits NaN and snaps back to the last value", () => {
+    const onCommit = vi.fn();
+    render(<MoneyInput value={10} onCommit={onCommit} />);
+
+    fireEvent.change(box(), { target: { value: "abc" } });
+    fireEvent.blur(box());
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(box().value).toBe("10");
+  });
+
+  it("does not reformat with commas while typing (caret never jumps)", () => {
+    render(<MoneyInput value={0} onCommit={vi.fn()} />);
+
+    fireEvent.change(box(), { target: { value: "1234.5" } });
+
+    expect(box().value).toBe("1234.5");
+  });
+
+  it("reflects an external change to the value (server reconcile)", () => {
+    const { rerender } = render(<MoneyInput value={10} onCommit={vi.fn()} />);
+    rerender(<MoneyInput value={20} onCommit={vi.fn()} />);
+    expect(box().value).toBe("20");
+  });
+
+  it("treats a cleared box as no change: reverts instead of committing 0", () => {
+    const onCommit = vi.fn();
+    render(<MoneyInput value={10} onCommit={onCommit} />);
+
+    fireEvent.change(box(), { target: { value: "" } });
+    fireEvent.blur(box());
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(box().value).toBe("10");
+  });
+
+  it("fires the optional onValueChange with raw text on each keystroke", () => {
+    const onValueChange = vi.fn();
+    render(
+      <MoneyInput value={0} onCommit={vi.fn()} onValueChange={onValueChange} />,
+    );
+
+    fireEvent.change(box(), { target: { value: "20" } });
+
+    expect(onValueChange).toHaveBeenCalledWith("20");
+  });
+
+  it("renders a non-editable field when readOnly", () => {
+    render(<MoneyInput value={10} onCommit={vi.fn()} readOnly />);
+    expect(box().readOnly).toBe(true);
+  });
+
+  it("forwards the placeholder to the input", () => {
+    render(<MoneyInput value={0} onCommit={vi.fn()} placeholder="0.00" />);
+    expect(box().placeholder).toBe("0.00");
+  });
+});

--- a/src/components/estimate-builder/money-input.tsx
+++ b/src/components/estimate-builder/money-input.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+// MoneyInput (#542) — a $-prefixed numeric box for entering dollar amounts in
+// the Estimate Builder (line-item unit cost, fixed-dollar Markup/Discount).
+//
+// The `$` is a static visual prefix. The box holds the raw typed string while
+// editing and parses to a number only at the edges (on commit). It never
+// reformats mid-type — no comma insertion that would fight the caret. The
+// already-formatted total (e.g. $1,375.00) is shown by the consumer beside it.
+//
+// The two consumers style their box very differently (borderless inline cell in
+// the line-item row vs. a small bordered box in the totals panel), so the visual
+// treatment is passed in via `className` on the wrapper. MoneyInput owns only the
+// `$` adornment and the draft/commit behavior.
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+export interface MoneyInputProps {
+  value: number;
+  onCommit: (n: number) => void;
+  /** Fired with the raw typed string on each keystroke — lets a consumer keep a
+   *  running total ticking live without waiting for commit. */
+  onValueChange?: (raw: string) => void;
+  readOnly?: boolean;
+  placeholder?: string;
+  /** Visual treatment for the wrapper (border, width, padding, alignment). */
+  className?: string;
+}
+
+export function MoneyInput({
+  value,
+  onCommit,
+  onValueChange,
+  readOnly,
+  placeholder,
+  className,
+}: MoneyInputProps) {
+  const [draft, setDraft] = useState(String(value));
+
+  // Resync from the prop when the value changes from outside (server reconcile,
+  // or normalization of the committed number). Does not fire mid-type because
+  // the parent's value only changes on commit, not on each keystroke.
+  useEffect(() => {
+    setDraft(String(value));
+  }, [value]);
+
+  function commit() {
+    const parsed = Number(draft);
+    if (draft.trim() && Number.isFinite(parsed)) {
+      onCommit(parsed);
+    } else {
+      // Empty or non-numeric — reject and snap the box back to the last value.
+      setDraft(String(value));
+    }
+  }
+
+  return (
+    <span className={cn("inline-flex items-center gap-0.5", className)}>
+      <span className="shrink-0 select-none text-muted-foreground">$</span>
+      <input
+        type="text"
+        inputMode="decimal"
+        value={draft}
+        placeholder={placeholder}
+        readOnly={readOnly}
+        onChange={(e) => {
+          setDraft(e.target.value);
+          onValueChange?.(e.target.value);
+        }}
+        onBlur={readOnly ? undefined : commit}
+        className="min-w-0 flex-1 border-0 bg-transparent text-right tabular-nums outline-none ring-0 placeholder:text-muted-foreground/50"
+      />
+    </span>
+  );
+}

--- a/src/components/estimate-builder/totals-panel.test.tsx
+++ b/src/components/estimate-builder/totals-panel.test.tsx
@@ -1,0 +1,151 @@
+// Coverage for the TotalsPanel money fields (#542). The fixed-amount Markup and
+// Discount boxes use the $-prefixed MoneyInput; the percent variants and the Tax
+// field keep their plain number boxes (Tax stays a `%`, never a `$`).
+//
+// Query strategy: MoneyInput is a text box (role "textbox"); the plain number
+// Input is a number box (role "spinbutton"). The %/$/— toggle renders literal
+// "$"/"%" button glyphs, so we never assert on loose getByText for those — we use
+// roles and scope `$`/`%` checks to a specific field's wrapper.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { TotalsPanel } from "./totals-panel";
+import type {
+  AdjustmentType,
+  BuilderEntity,
+  EstimateWithContents,
+} from "@/lib/types";
+
+interface Overrides {
+  markup_type?: AdjustmentType;
+  markup_value?: number;
+  discount_type?: AdjustmentType;
+  discount_value?: number;
+  tax_rate?: number;
+}
+
+function makeEntity(o: Overrides = {}): BuilderEntity {
+  const data: EstimateWithContents = {
+    id: "est-1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    estimate_number: "EST-1",
+    sequence_number: 1,
+    title: "Totals test estimate",
+    status: "draft",
+    opening_statement: null,
+    closing_statement: null,
+    subtotal: 100,
+    markup_type: o.markup_type ?? "none",
+    markup_value: o.markup_value ?? 0,
+    markup_amount: 0,
+    discount_type: o.discount_type ?? "none",
+    discount_value: o.discount_value ?? 0,
+    discount_amount: 0,
+    adjusted_subtotal: 100,
+    tax_rate: o.tax_rate ?? 0,
+    tax_amount: 0,
+    total: 100,
+    issued_date: null,
+    valid_until: null,
+    converted_to_invoice_id: null,
+    converted_at: null,
+    sent_at: null,
+    approved_at: null,
+    rejected_at: null,
+    voided_at: null,
+    void_reason: null,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_sent_at: null,
+    last_sent_to_email: null,
+    deleted_at: null,
+    delete_reason: null,
+    pdf_layout: null,
+    sections: [],
+  };
+  return { kind: "estimate", data };
+}
+
+function renderPanel(
+  entity: BuilderEntity,
+  handlers: Partial<{
+    onMarkupChange: (t: AdjustmentType, n: number) => void;
+    onDiscountChange: (t: AdjustmentType, n: number) => void;
+    onTaxRateChange: (n: number) => void;
+  }> = {},
+) {
+  return render(
+    <TotalsPanel
+      entity={entity}
+      onMarkupChange={handlers.onMarkupChange ?? vi.fn()}
+      onDiscountChange={handlers.onDiscountChange ?? vi.fn()}
+      onTaxRateChange={handlers.onTaxRateChange ?? vi.fn()}
+    />,
+  );
+}
+
+describe("TotalsPanel — money fields (#542)", () => {
+  it("uses a $ MoneyInput for a fixed-amount markup", () => {
+    renderPanel(makeEntity({ markup_type: "amount", markup_value: 50 }));
+
+    const box = screen.getByRole("textbox") as HTMLInputElement;
+    expect(box.value).toBe("50");
+    expect(box.parentElement?.textContent).toContain("$");
+  });
+
+  it("commits a fixed-amount markup on blur via onMarkupChange", () => {
+    const onMarkupChange = vi.fn();
+    renderPanel(makeEntity({ markup_type: "amount", markup_value: 50 }), {
+      onMarkupChange,
+    });
+
+    const box = screen.getByRole("textbox");
+    fireEvent.change(box, { target: { value: "75" } });
+    fireEvent.blur(box);
+
+    expect(onMarkupChange).toHaveBeenCalledWith("amount", 75);
+  });
+
+  it("uses a $ MoneyInput for a fixed-amount discount", () => {
+    const onDiscountChange = vi.fn();
+    renderPanel(makeEntity({ discount_type: "amount", discount_value: 25 }), {
+      onDiscountChange,
+    });
+
+    const box = screen.getByRole("textbox") as HTMLInputElement;
+    expect(box.value).toBe("25");
+    expect(box.parentElement?.textContent).toContain("$");
+
+    fireEvent.change(box, { target: { value: "30" } });
+    fireEvent.blur(box);
+
+    expect(onDiscountChange).toHaveBeenCalledWith("amount", 30);
+  });
+
+  it("keeps a plain number box (no MoneyInput) for a percent markup", () => {
+    renderPanel(makeEntity({ markup_type: "percent", markup_value: 10 }));
+
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect((screen.getByDisplayValue("10") as HTMLInputElement).type).toBe(
+      "number",
+    );
+  });
+
+  it("keeps the Tax field as a % box, never a $ MoneyInput", () => {
+    const onTaxRateChange = vi.fn();
+    renderPanel(makeEntity({ tax_rate: 8.25 }), { onTaxRateChange });
+
+    // No money box anywhere when markup/discount are off.
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    const tax = screen.getByDisplayValue("8.25") as HTMLInputElement;
+    expect(tax.parentElement?.textContent).toContain("%");
+    expect(tax.parentElement?.textContent).not.toContain("$");
+
+    fireEvent.change(tax, { target: { value: "10" } });
+    expect(onTaxRateChange).toHaveBeenCalledWith(10);
+  });
+});

--- a/src/components/estimate-builder/totals-panel.tsx
+++ b/src/components/estimate-builder/totals-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
 import { formatCurrency } from "@/lib/format";
 import { Input } from "@/components/ui/input";
+import { MoneyInput } from "./money-input";
 import type { AdjustmentType, BuilderEntity, BuilderMode } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -114,19 +115,32 @@ function AdjustmentRow({
           onChange={onChange}
           disabled={readOnly}
         />
-        <Input
-          type="number"
-          min={0}
-          step={0.01}
-          value={isNone ? "" : value}
-          disabled={readOnly || isNone}
-          onChange={(e) => {
-            const n = parseFloat(e.target.value);
-            if (!isNaN(n) && n >= 0) onChange(type, n);
-          }}
-          className="h-6 text-xs px-1.5 flex-1 min-w-0"
-          placeholder={isNone ? "—" : type === "percent" ? "0" : "0.00"}
-        />
+        {type === "amount" ? (
+          // Fixed-dollar adjustment — $-prefixed MoneyInput (#542). Commits on
+          // blur; parses at the edge so it never reformats mid-type.
+          <MoneyInput
+            value={value}
+            onCommit={(n) => onChange("amount", n)}
+            readOnly={readOnly}
+            placeholder="0.00"
+            className="h-6 flex-1 min-w-0 rounded-lg border border-input px-1.5 text-xs focus-within:border-primary"
+          />
+        ) : (
+          // Percent (or disabled "none") — plain number box; Tax keeps its own % box.
+          <Input
+            type="number"
+            min={0}
+            step={0.01}
+            value={isNone ? "" : value}
+            disabled={readOnly || isNone}
+            onChange={(e) => {
+              const n = parseFloat(e.target.value);
+              if (!isNaN(n) && n >= 0) onChange(type, n);
+            }}
+            className="h-6 text-xs px-1.5 flex-1 min-w-0"
+            placeholder={isNone ? "—" : type === "percent" ? "0" : "0.00"}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #542.

## What to build

A reusable `MoneyInput` — a `$`-prefixed numeric box for entering dollar amounts in the Estimate Builder — wired into the two money fields that previously showed a bare number: the line-item **unit cost** and the fixed-amount **Markup / Discount** boxes in the totals panel.

The `$` is a static visual prefix. The box holds the raw typed string while editing and parses to a number only on commit (blur). It never reformats mid-type (no comma insertion that fights the caret) and rejects non-numeric input (never NaN — snaps back to the last good value). A cleared box reverts rather than committing `0`. An optional `onValueChange` feeds a consumer's running total live as the user types.

## Acceptance criteria

- [x] Renders a fixed `$` while editing
- [x] Typing `12.5` commits the number `12.5`; non-numeric rejected (never NaN)
- [x] Not reformatted with commas while typing
- [x] Line-item unit cost uses MoneyInput (live line total ticks while typing)
- [x] Fixed-amount Markup / Discount use MoneyInput
- [x] Tax still shows `%`, never `$`; percent-mode markup/discount keep plain number boxes
- [x] `readOnly` renders a non-editable field
- [x] Unit tests cover the contract: renders `$`, parses `"12.5"`→`12.5`, rejects non-numeric, emits numeric on commit, no mid-edit reformat

## Testing

Built with strict TDD — **24 tests, all green**:
- `money-input.test.tsx` — 10 (renders `$`, value seeding, commit-on-blur parse, reject non-numeric, no comma reformat, external resync, cleared-box revert, live `onValueChange`, `readOnly`, `placeholder`)
- `line-item-row.test.tsx` — 5 new (unit-cost `$` wiring + live line total)
- `totals-panel.test.tsx` — 5 (fixed-amount markup/discount use MoneyInput; percent + Tax keep their plain `%`/number boxes)

No new tsc / lint / test regressions vs the known-red baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
