### PR TITLE
feat(estimate-builder): full-width desktop BuilderLayout + slim nav rail (#543)

### DIFF
--- a/src/app/settings/layout.test.tsx
+++ b/src/app/settings/layout.test.tsx
@@ -1,0 +1,57 @@
+// Issue #543 — Estimate Builder full-width layout: settings chrome escape.
+//
+// The template editor lives under /settings/estimate-templates/[id]/edit, so it
+// is wrapped by SettingsLayout — which normally constrains its children to a
+// `max-w-6xl` column beside the "Settings" header and the settings sub-nav. For
+// the template editing mode to render full-width in the new BuilderLayout shell
+// (the same way estimate/invoice modes do), the layout must step out of the way
+// on that one route and render the builder bare, while leaving every other
+// settings page wrapped exactly as before.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { pathnameRef } = vi.hoisted(() => ({
+  pathnameRef: { current: "/settings/company" as string },
+}));
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameRef.current,
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+import SettingsLayout from "./layout";
+
+beforeEach(() => {
+  pathnameRef.current = "/settings/company";
+});
+
+describe("SettingsLayout — full-width escape on the template editor (#543)", () => {
+  it("renders the template editor bare, without the settings chrome", () => {
+    pathnameRef.current = "/settings/estimate-templates/tmpl-1/edit";
+    render(
+      <SettingsLayout>
+        <div>builder-marker</div>
+      </SettingsLayout>,
+    );
+
+    // The builder content is present …
+    expect(screen.getByText("builder-marker")).toBeDefined();
+    // … but the settings chrome (header + narrow column + sub-nav) is gone.
+    expect(screen.queryByText("Settings")).toBeNull();
+    expect(document.querySelector(".max-w-6xl")).toBeNull();
+  });
+
+  it("keeps the settings chrome on every other settings page", () => {
+    pathnameRef.current = "/settings/company";
+    render(
+      <SettingsLayout>
+        <div>page-marker</div>
+      </SettingsLayout>,
+    );
+
+    expect(screen.getByText("page-marker")).toBeDefined();
+    // Ordinary settings pages still get the header + narrow column wrapper.
+    expect(screen.getByText("Settings")).toBeDefined();
+    expect(document.querySelector(".max-w-6xl")).not.toBeNull();
+  });
+});

--- a/src/app/settings/layout.tsx
+++ b/src/app/settings/layout.tsx
@@ -6,6 +6,11 @@ import { settingsNavItems } from "@/lib/settings-nav";
 import { cn } from "@/lib/utils";
 import { Settings, ChevronDown } from "lucide-react";
 
+// The template editor (#543) renders in the full-width BuilderLayout shell, so
+// it must escape the settings chrome (header + max-w-6xl column + sub-nav) and
+// render bare — exactly as the estimate/invoice builders do outside /settings.
+const BUILDER_ROUTE = /^\/settings\/estimate-templates\/[^/]+\/edit(\/|$)/;
+
 export default function SettingsLayout({
   children,
 }: {
@@ -13,6 +18,10 @@ export default function SettingsLayout({
 }) {
   const pathname = usePathname();
   const router = useRouter();
+
+  if (BUILDER_ROUTE.test(pathname)) {
+    return <>{children}</>;
+  }
 
   const currentItem = settingsNavItems.find(
     (item) => pathname === item.href || pathname.startsWith(item.href + "/")

--- a/src/components/app-shell.test.tsx
+++ b/src/components/app-shell.test.tsx
@@ -1,0 +1,158 @@
+// Issue #543 — Estimate Builder full-width layout: AppShell route wiring.
+//
+// AppShell is the chokepoint that decides, per route, whether the side navbar
+// renders as the builder's slim rail or follows the persisted global pref.
+// Its responsibilities, pinned here:
+//
+//   1. On a builder route it renders the Sidebar in rail mode (forceCollapsed)
+//      with an ephemeral onToggleRail handler.
+//   2. Toggling that rail flips the display but NEVER writes the persisted
+//      "sidebar-collapsed" key (the crux acceptance criterion).
+//   3. On a non-builder route it passes no rail props, so the persisted
+//      preference drives the navbar exactly as before.
+//
+// The heavy Sidebar is replaced by a stand-in that records the props it
+// receives and exposes the rail toggle. The persistence context is the REAL
+// SidebarCollapseProvider, so the no-write guarantee is checked against the
+// actual localStorage code, not a mock.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+const { pathnameRef } = vi.hoisted(() => ({
+  pathnameRef: { current: "/" as string },
+}));
+vi.mock("next/navigation", () => ({
+  usePathname: () => pathnameRef.current,
+}));
+
+const { sidebarProps } = vi.hoisted(() => ({
+  sidebarProps: {
+    last: null as null | {
+      forceCollapsed?: boolean;
+      onToggleRail?: () => void;
+    },
+  },
+}));
+vi.mock("@/components/nav", () => ({
+  __esModule: true,
+  default: (props: { forceCollapsed?: boolean; onToggleRail?: () => void }) => {
+    sidebarProps.last = props;
+    return (
+      <div data-testid="sidebar-stub">
+        <button type="button" onClick={() => props.onToggleRail?.()}>
+          rail-toggle
+        </button>
+      </div>
+    );
+  },
+}));
+
+import AppShell from "./app-shell";
+import { SidebarCollapseProvider } from "@/lib/sidebar-collapse-context";
+
+// The real SidebarCollapseProvider reads/writes window.localStorage on mount.
+// Under Node's experimental localStorage the global is a bare object missing
+// getItem/setItem, so we install a functional in-memory fake the provider can
+// drive. Later tracers upgrade setItem to a spy to prove the rail never writes.
+const store = new Map<string, string>();
+let setItemSpy: ReturnType<typeof vi.fn>;
+function installLocalStorage() {
+  store.clear();
+  setItemSpy = vi.fn((k: string, v: string) => {
+    store.set(k, String(v));
+  });
+  const fake = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: setItemSpy,
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    value: fake,
+    configurable: true,
+    writable: true,
+  });
+}
+
+beforeEach(() => {
+  installLocalStorage();
+  sidebarProps.last = null;
+  pathnameRef.current = "/";
+});
+
+function renderShell() {
+  return render(
+    <SidebarCollapseProvider>
+      <AppShell>
+        <div>page content</div>
+      </AppShell>
+    </SidebarCollapseProvider>,
+  );
+}
+
+describe("AppShell — slim rail on builder routes (#543)", () => {
+  it("renders the sidebar in rail mode on a builder route", () => {
+    pathnameRef.current = "/estimates/est-1/edit";
+    renderShell();
+
+    expect(sidebarProps.last?.forceCollapsed).toBe(true);
+    expect(typeof sidebarProps.last?.onToggleRail).toBe("function");
+  });
+
+  it("expands and collapses the rail on click without writing the persisted pref", () => {
+    // Acceptance crux: one click expands the rail (forceCollapsed flips to
+    // false) and a second collapses it — but the global "sidebar-collapsed"
+    // preference must NEVER be written while in the builder.
+    pathnameRef.current = "/estimates/est-1/edit";
+    renderShell();
+
+    expect(sidebarProps.last?.forceCollapsed).toBe(true);
+
+    fireEvent.click(screen.getByText("rail-toggle"));
+    expect(sidebarProps.last?.forceCollapsed).toBe(false);
+
+    fireEvent.click(screen.getByText("rail-toggle"));
+    expect(sidebarProps.last?.forceCollapsed).toBe(true);
+
+    const wrotePref = setItemSpy.mock.calls.some(
+      ([key]) => key === "sidebar-collapsed",
+    );
+    expect(wrotePref).toBe(false);
+  });
+});
+
+describe("AppShell — persisted navbar unchanged off builder routes (#543)", () => {
+  it("passes no rail props on a non-builder route", () => {
+    // Off the builder, the navbar must behave exactly as before: the persisted
+    // global pref drives it, so AppShell forwards neither rail override.
+    pathnameRef.current = "/estimates";
+    renderShell();
+
+    expect(sidebarProps.last?.forceCollapsed).toBeUndefined();
+    expect(sidebarProps.last?.onToggleRail).toBeUndefined();
+  });
+});
+
+describe("AppShell — content margin tracks the rail (#543)", () => {
+  it("reserves the slim-rail margin on a builder route and widens when expanded", () => {
+    // The document must sit beside the slim rail (narrow left margin) even
+    // though the persisted pref is expanded — then follow the rail as it opens.
+    pathnameRef.current = "/estimates/est-1/edit";
+    renderShell();
+
+    const main = screen.getByRole("main");
+    expect(main.className).toContain("lg:ml-16");
+    expect(main.className).not.toContain("lg:ml-52");
+
+    fireEvent.click(screen.getByText("rail-toggle"));
+    expect(main.className).toContain("lg:ml-52");
+    expect(main.className).not.toContain("lg:ml-16");
+  });
+});

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Sidebar from "@/components/nav";
 import { useSidebarCollapse } from "@/lib/sidebar-collapse-context";
@@ -18,13 +19,26 @@ const INTERNAL_FULLSCREEN_PATTERNS: RegExp[] = [
   // The in-Job Photo Report builder (#400) is full-screen, like capture.
   /^\/jobs\/[^/]+\/reports\/[^/]+(\/|$)/,
 ];
+// Estimate Builder routes (#543) render the side navbar as a slim icon rail so
+// the document gets full content width. Covers the estimate, invoice, and
+// template editing modes — all served by EstimateBuilder.
+const BUILDER_ROUTE_PATTERNS: RegExp[] = [
+  /^\/estimates\/[^/]+\/edit(\/|$)/,
+  /^\/invoices\/[^/]+\/edit(\/|$)/,
+  /^\/settings\/estimate-templates\/[^/]+\/edit(\/|$)/,
+];
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { collapsed } = useSidebarCollapse();
+  // Ephemeral rail state, scoped to this mount. Entering/leaving the builder
+  // must NOT touch the persisted global "sidebar-collapsed" pref, so the rail
+  // is driven by local state — never the persisting context toggle.
+  const [railExpanded, setRailExpanded] = useState(false);
   const isAuthPage = AUTH_ROUTES.some((r) => pathname.startsWith(r));
   const isPublicPage = PUBLIC_ROUTES.some((r) => pathname.startsWith(r));
   const isInternalFullscreen = INTERNAL_FULLSCREEN_PATTERNS.some((re) => re.test(pathname));
+  const isBuilderRoute = BUILDER_ROUTE_PATTERNS.some((re) => re.test(pathname));
   const isFullBleed = FULL_BLEED_ROUTES.some(
     (r) => pathname === r || pathname.startsWith(`${r}/`),
   );
@@ -33,13 +47,22 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     return <>{children}</>;
   }
 
+  // On a builder route the content sits beside the slim rail (or the expanded
+  // navbar when the rail is open); elsewhere it follows the persisted pref.
+  const effectiveCollapsed = isBuilderRoute ? !railExpanded : collapsed;
+
   return (
     <>
-      <Sidebar />
+      <Sidebar
+        forceCollapsed={isBuilderRoute ? !railExpanded : undefined}
+        onToggleRail={
+          isBuilderRoute ? () => setRailExpanded((v) => !v) : undefined
+        }
+      />
       <main
         className={cn(
           "pt-[calc(env(safe-area-inset-top)+3.5rem)] lg:pt-0 min-h-screen transition-[margin] duration-200 ease-out",
-          collapsed ? "lg:ml-16" : "lg:ml-52",
+          effectiveCollapsed ? "lg:ml-16" : "lg:ml-52",
         )}
       >
         {isFullBleed ? children : <div className="p-6 lg:p-8">{children}</div>}

--- a/src/components/estimate-builder/builder-fullwidth.test.tsx
+++ b/src/components/estimate-builder/builder-fullwidth.test.tsx
@@ -1,0 +1,346 @@
+// Issue #543 — Estimate Builder full-width layout: integration.
+//
+// These tests mount the REAL EstimateBuilder in each of its three modes
+// (estimate, invoice, template) and assert the document renders inside the new
+// full-width BuilderLayout shell — not the old narrow, centered `max-w-4xl
+// mx-auto` column — while the letterhead title and Section structure stay
+// intact. They are the end-to-end proof that the shell swap reached every mode.
+//
+// Harness mirrors the established EstimateBuilder RTL pattern from
+// estimate-drag-end.test.tsx (stub use-auto-save / next-navigation / sonner;
+// real @dnd-kit so the section cards render).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import type {
+  BuilderEntity,
+  EstimateWithContents,
+  InvoiceWithContents,
+  TemplateWithContents,
+} from "@/lib/types";
+
+vi.mock("./use-auto-save", () => ({
+  useAutoSave: () => ({
+    saveStatus: "idle",
+    lastSavedAt: null,
+    saveSectionsReorder: vi.fn(async () => true),
+    saveLineItemsReorder: vi.fn(async () => true),
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import { EstimateBuilder } from "./estimate-builder";
+
+// EstimateBuilder reads localStorage (the per-estimate template-applied flag).
+// Under Node's experimental localStorage the global is a bare object missing
+// getItem/setItem, so we install a functional in-memory fake on both the bare
+// global and window before each mount. (This is the same Node-25 artifact that
+// leaves the sibling *-drag-end suites red without a shim.)
+const store = new Map<string, string>();
+beforeEach(() => {
+  store.clear();
+  const fake = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: fake,
+    configurable: true,
+    writable: true,
+  });
+  Object.defineProperty(window, "localStorage", {
+    value: fake,
+    configurable: true,
+    writable: true,
+  });
+});
+
+// ── Minimal seeded entities (one Section with a Subsection line item, plus an
+// empty Section) — enough to prove the letterhead + nested Section structure
+// survive inside the new shell. ──────────────────────────────────────────────
+
+function makeEstimateEntity(): BuilderEntity {
+  const estimate: EstimateWithContents = {
+    id: "est-1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    estimate_number: "EST-1",
+    sequence_number: 1,
+    title: "Full-width test estimate",
+    status: "draft",
+    opening_statement: null,
+    closing_statement: null,
+    subtotal: 150,
+    markup_type: "none",
+    markup_value: 0,
+    markup_amount: 0,
+    discount_type: "none",
+    discount_value: 0,
+    discount_amount: 0,
+    adjusted_subtotal: 150,
+    tax_rate: 0,
+    tax_amount: 0,
+    total: 150,
+    issued_date: null,
+    valid_until: null,
+    converted_to_invoice_id: null,
+    converted_at: null,
+    sent_at: null,
+    approved_at: null,
+    rejected_at: null,
+    voided_at: null,
+    void_reason: null,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_sent_at: null,
+    last_sent_to_email: null,
+    deleted_at: null,
+    delete_reason: null,
+    pdf_layout: null,
+    sections: [
+      {
+        id: "S1",
+        organization_id: "org-1",
+        estimate_id: "est-1",
+        parent_section_id: null,
+        title: "Roof",
+        sort_order: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        items: [],
+        subsections: [
+          {
+            id: "Sub1",
+            organization_id: "org-1",
+            estimate_id: "est-1",
+            parent_section_id: "S1",
+            title: "Flashing",
+            sort_order: 0,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            items: [
+              {
+                id: "X",
+                organization_id: "org-1",
+                estimate_id: "est-1",
+                section_id: "Sub1",
+                library_item_id: null,
+                name: "Step flashing",
+                description: "Install step flashing",
+                note: null,
+                code: null,
+                quantity: 10,
+                unit: null,
+                unit_price: 5,
+                total: 50,
+                sort_order: 0,
+                created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  return { kind: "estimate", data: estimate };
+}
+
+function makeInvoiceEntity(): BuilderEntity {
+  const invoice: InvoiceWithContents = {
+    id: "inv-1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    invoice_number: "INV-1",
+    sequence_number: 1,
+    title: "Full-width test invoice",
+    status: "draft",
+    issued_date: "2026-01-01T00:00:00Z",
+    due_date: null,
+    opening_statement: null,
+    closing_statement: null,
+    subtotal: 150,
+    markup_type: "none",
+    markup_value: 0,
+    markup_amount: 0,
+    discount_type: "none",
+    discount_value: 0,
+    discount_amount: 0,
+    adjusted_subtotal: 150,
+    tax_rate: 0,
+    tax_amount: 0,
+    total_amount: 150,
+    po_number: null,
+    memo: null,
+    notes: null,
+    converted_from_estimate_id: null,
+    voided_at: null,
+    voided_by: null,
+    void_reason: null,
+    qb_invoice_id: null,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    last_sent_at: null,
+    last_sent_to_email: null,
+    deleted_at: null,
+    delete_reason: null,
+    pdf_layout: null,
+    sections: [
+      {
+        id: "IS1",
+        organization_id: "org-1",
+        invoice_id: "inv-1",
+        parent_section_id: null,
+        title: "Roof",
+        sort_order: 0,
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+        items: [],
+        subsections: [
+          {
+            id: "ISub1",
+            organization_id: "org-1",
+            invoice_id: "inv-1",
+            parent_section_id: "IS1",
+            title: "Flashing",
+            sort_order: 0,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+            items: [
+              {
+                id: "IX",
+                organization_id: "org-1",
+                invoice_id: "inv-1",
+                section_id: "ISub1",
+                library_item_id: null,
+                name: "Invoice step flashing",
+                description: "Install step flashing",
+                note: null,
+                code: null,
+                quantity: 10,
+                unit: null,
+                unit_price: 5,
+                amount: 50,
+                sort_order: 0,
+                created_at: "2026-01-01T00:00:00Z",
+                updated_at: "2026-01-01T00:00:00Z",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  return { kind: "invoice", data: invoice };
+}
+
+function makeTemplateEntity(): BuilderEntity {
+  const template: TemplateWithContents = {
+    id: "tmpl-1",
+    organization_id: "org-1",
+    name: "Full-width test template",
+    description: null,
+    damage_type_tags: [],
+    opening_statement: null,
+    closing_statement: null,
+    structure: { sections: [] },
+    is_active: true,
+    created_by: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    sections: [
+      {
+        id: "TS1",
+        title: "Roof",
+        sort_order: 0,
+        parent_section_id: null,
+        items: [],
+        subsections: [
+          {
+            id: "TSub1",
+            title: "Flashing",
+            sort_order: 0,
+            items: [
+              {
+                id: "TX",
+                library_item_id: null,
+                name: "Template step flashing",
+                description: "Install step flashing",
+                note: null,
+                code: null,
+                quantity: 10,
+                unit: null,
+                unit_price: 5,
+                sort_order: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  return { kind: "template", data: template };
+}
+
+describe("EstimateBuilder — full-width shell across modes (#543)", () => {
+  it("renders the estimate inside the full-width BuilderLayout, not a narrow centered column", () => {
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    // Letterhead title + nested Section structure remain visible/intact.
+    expect(screen.getByText("Full-width test estimate")).toBeDefined();
+    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+
+    // The document lives in the full-width shell …
+    expect(screen.getByTestId("builder-document")).toBeDefined();
+    // … and the old narrow centered column is gone.
+    expect(document.querySelector(".max-w-4xl")).toBeNull();
+  });
+
+  it("renders the invoice inside the full-width BuilderLayout, not a narrow centered column", () => {
+    render(<EstimateBuilder entity={makeInvoiceEntity()} />);
+
+    // Letterhead title + nested Section structure remain visible/intact.
+    expect(screen.getByText("Full-width test invoice")).toBeDefined();
+    expect(screen.getByDisplayValue("Invoice step flashing")).toBeDefined();
+
+    // The document lives in the full-width shell …
+    expect(screen.getByTestId("builder-document")).toBeDefined();
+    // … and the old narrow centered column is gone.
+    expect(document.querySelector(".max-w-4xl")).toBeNull();
+  });
+
+  it("renders the template inside the full-width BuilderLayout, not a narrow centered column", () => {
+    render(<EstimateBuilder entity={makeTemplateEntity()} />);
+
+    // Letterhead title (template name) + nested Section structure stay intact.
+    // The name surfaces in both the HeaderBar and the TemplateMetaBar, so just
+    // assert it is present (at least once) — the letterhead survived the shell.
+    expect(screen.getAllByText("Full-width test template").length).toBeGreaterThan(0);
+    expect(screen.getByDisplayValue("Template step flashing")).toBeDefined();
+
+    // The document lives in the full-width shell …
+    expect(screen.getByTestId("builder-document")).toBeDefined();
+    // … and the old narrow centered column is gone.
+    expect(document.querySelector(".max-w-4xl")).toBeNull();
+  });
+});

--- a/src/components/estimate-builder/builder-layout.test.tsx
+++ b/src/components/estimate-builder/builder-layout.test.tsx
@@ -1,0 +1,91 @@
+// Issue #543 — Estimate Builder: full-width desktop layout (BuilderLayout).
+//
+// BuilderLayout is the responsive shell that replaces the old narrow,
+// centered document column (`max-w-4xl mx-auto`) shared by all three builder
+// modes. This slice delivers ONLY the full-width frame plus an (empty)
+// right-side editor-panel slot and an (empty) bottom totals-bar slot — the
+// slot *content* arrives in later slices of PRD #541.
+//
+// These tests pin the layout contract through BuilderLayout's public props
+// (children / editorSlot / totalsSlot) so the internal markup can be
+// refactored freely.
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BuilderLayout } from "./builder-layout";
+
+describe("BuilderLayout — document body", () => {
+  it("renders the document passed as children", () => {
+    render(
+      <BuilderLayout>
+        <p>Letterhead and sections live here</p>
+      </BuilderLayout>,
+    );
+
+    expect(
+      screen.getByText("Letterhead and sections live here"),
+    ).not.toBeNull();
+  });
+
+  it("does not constrain the document to a narrow centered column", () => {
+    // Acceptance: the builder document fills full content width — the old
+    // narrow centered column (`max-w-4xl mx-auto`) must be gone.
+    render(
+      <BuilderLayout>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    const doc = screen.getByTestId("builder-document");
+    expect(doc.className).not.toMatch(/max-w-/);
+    expect(doc.className).not.toContain("mx-auto");
+  });
+});
+
+describe("BuilderLayout — editor panel slot", () => {
+  it("renders the editor panel content when an editorSlot is provided", () => {
+    render(
+      <BuilderLayout editorSlot={<p>Editor panel content</p>}>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    expect(screen.getByText("Editor panel content")).not.toBeNull();
+  });
+
+  it("renders no editor panel when the editorSlot is empty (this slice)", () => {
+    // The editor-panel slot is reserved but stays EMPTY in this slice, so the
+    // document keeps the full content row.
+    render(
+      <BuilderLayout>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
+  });
+});
+
+describe("BuilderLayout — totals bar slot", () => {
+  it("renders the totals bar content when a totalsSlot is provided", () => {
+    render(
+      <BuilderLayout totalsSlot={<p>Totals bar content</p>}>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    expect(screen.getByText("Totals bar content")).not.toBeNull();
+  });
+
+  it("renders no totals bar when the totalsSlot is empty (this slice)", () => {
+    // The totals-bar slot is reserved but stays EMPTY in this slice; the
+    // existing floating TotalsPanel is left untouched.
+    render(
+      <BuilderLayout>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    expect(screen.queryByTestId("builder-totals-bar")).toBeNull();
+  });
+});

--- a/src/components/estimate-builder/builder-layout.tsx
+++ b/src/components/estimate-builder/builder-layout.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+interface BuilderLayoutProps {
+  children: ReactNode;
+  /** Right-side editor panel. Reserved this slice — content arrives later. */
+  editorSlot?: ReactNode;
+  /** Bottom totals bar. Reserved this slice — content arrives later. */
+  totalsSlot?: ReactNode;
+}
+
+export function BuilderLayout({
+  children,
+  editorSlot,
+  totalsSlot,
+}: BuilderLayoutProps) {
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col lg:flex-row lg:items-start gap-4">
+        <main
+          data-testid="builder-document"
+          className="flex-1 min-w-0 px-4 py-6 pb-24 space-y-4"
+        >
+          {children}
+        </main>
+        {editorSlot != null && (
+          <aside data-testid="builder-editor-panel">{editorSlot}</aside>
+        )}
+      </div>
+      {totalsSlot != null && (
+        <div data-testid="builder-totals-bar">{totalsSlot}</div>
+      )}
+    </div>
+  );
+}

--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -45,6 +45,7 @@ import { CustomerBlock } from "./customer-block";
 import { StatementEditor } from "./statement-editor";
 import { SectionCard } from "./section-card";
 import { AddItemDialog } from "./add-item-dialog";
+import { BuilderLayout } from "./builder-layout";
 import TemplateMetaBar from "./template-meta-bar";
 import ConvertConfirmModal from "@/components/conversion/convert-confirm-modal";
 import { Button } from "@/components/ui/button";
@@ -1659,7 +1660,10 @@ export function EstimateBuilder({
           </div>
         )}
 
-        <main className="max-w-4xl mx-auto px-4 py-6 pb-24 space-y-4">
+        {/* Builder document — full-width shell (#543). The floating TotalsPanel
+            stays a sibling below; BuilderLayout's totals slot is reserved/empty
+            this slice. */}
+        <BuilderLayout>
           {/* ── HeaderBar — Mark as Sent / Mark as Paid / Send Payment / Void ── */}
           <HeaderBar
             entity={invoiceEntity}
@@ -1807,7 +1811,7 @@ export function EstimateBuilder({
             readOnly={isVoided}
             mode={invMode}
           />
-        </main>
+        </BuilderLayout>
 
         {/* ── TotalsPanel (sticky bottom-right) ─────────────────────────── */}
         <TotalsPanel
@@ -1845,7 +1849,10 @@ export function EstimateBuilder({
 
     return (
       <div className="relative min-h-screen bg-background">
-        <main className="max-w-4xl mx-auto px-4 py-6 pb-24 space-y-4">
+        {/* Builder document — full-width shell (#543). Templates have no
+            TotalsPanel; BuilderLayout's editor/totals slots stay reserved/empty
+            this slice. */}
+        <BuilderLayout>
           {/* ── HeaderBar — Save Template / Cancel-edit per spec §4.1 ── */}
           <HeaderBar
             entity={templateEntity}
@@ -1986,7 +1993,7 @@ export function EstimateBuilder({
             defaultText=""
             mode={tmplMode}
           />
-        </main>
+        </BuilderLayout>
 
         {/* ── AddItemDialog — template-aware per Task 32 ── */}
         <AddItemDialog
@@ -2037,9 +2044,10 @@ export function EstimateBuilder({
         </div>
       )}
 
-      {/* Main content column. TotalsPanel — fixed bottom-right at desktop widths.
-          Post-67a: responsive layout for mobile (overlap is expected on narrow viewports). */}
-      <main className="max-w-4xl mx-auto px-4 py-6 pb-24 space-y-4">
+      {/* Builder document — full-width shell (#543). The floating TotalsPanel
+          stays a sibling below; BuilderLayout's totals slot is reserved/empty
+          this slice. */}
+      <BuilderLayout>
 
         {/* ── SLOT 1: HeaderBar ────────────────────────────────────────────── */}
         <HeaderBar
@@ -2200,7 +2208,7 @@ export function EstimateBuilder({
           readOnly={isVoided}
           mode={mode}
         />
-      </main>
+      </BuilderLayout>
 
       {/* ── SLOT 7: TotalsPanel (sticky bottom-right) ─────────────────────── */}
       <TotalsPanel

--- a/src/components/nav-rail.test.tsx
+++ b/src/components/nav-rail.test.tsx
@@ -1,0 +1,110 @@
+// Issue #543 — Estimate Builder full-width layout: slim nav rail.
+//
+// On a builder route the side navbar must render as a slim icon rail, and a
+// single click expands/collapses it — WITHOUT mutating the persisted global
+// collapse preference (localStorage "sidebar-collapsed"). The rail is driven
+// by two new, optional Sidebar props:
+//
+//   forceCollapsed?: boolean   — overrides the persisted collapsed state for
+//                                display while in the builder (ephemeral)
+//   onToggleRail?: () => void  — the click handler used instead of the
+//                                persisted context toggle, so no write happens
+//
+// These tests pin the rail behavior at the Sidebar render level, mirroring the
+// context-mocking approach in nav.test.tsx.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/estimates/est-1/edit",
+  useRouter: () => ({ push: () => {}, refresh: () => {} }),
+}));
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const useAuthMock = vi.fn();
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock("@/lib/nav-order-context", () => ({
+  useNavOrder: () => ({ order: new Map<string, number>() }),
+}));
+
+// The persisted-pref context toggle is a spy so a test can prove the rail
+// toggle never reaches it.
+const { toggleSpy } = vi.hoisted(() => ({ toggleSpy: vi.fn() }));
+vi.mock("@/lib/sidebar-collapse-context", () => ({
+  useSidebarCollapse: () => ({
+    collapsed: false,
+    toggle: toggleSpy,
+    setCollapsed: () => {},
+  }),
+}));
+
+vi.mock("@/components/notification-bell", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+vi.mock("@/components/workspace-switcher", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import Sidebar from "./nav";
+
+beforeEach(() => {
+  toggleSpy.mockReset();
+  useAuthMock.mockReset();
+  useAuthMock.mockReturnValue({
+    user: { id: "u-1" },
+    profile: { id: "u-1", full_name: "Test User", role: "admin" },
+    permissions: {},
+    loading: false,
+    hasPermission: () => true,
+    signOut: () => Promise.resolve(),
+    refreshProfile: () => Promise.resolve(),
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() => Promise.resolve({ ok: false } as Response)),
+  );
+});
+
+describe("Sidebar — slim rail in the builder (#543)", () => {
+  it("renders the slim rail when forceCollapsed, even though the persisted pref is expanded", () => {
+    // Persisted pref is collapsed:false (expanded). forceCollapsed must win
+    // for display, putting the rail in its collapsed/icon state — surfaced by
+    // the "Expand sidebar" affordance that only exists when collapsed.
+    render(<Sidebar forceCollapsed onToggleRail={() => {}} />);
+
+    expect(screen.getByLabelText("Expand sidebar")).not.toBeNull();
+  });
+
+  it("routes the rail toggle click to onToggleRail, never the persisted context toggle", () => {
+    const onToggleRail = vi.fn();
+    render(<Sidebar forceCollapsed onToggleRail={onToggleRail} />);
+
+    fireEvent.click(screen.getByLabelText("Expand sidebar"));
+
+    expect(onToggleRail).toHaveBeenCalledTimes(1);
+    expect(toggleSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Sidebar — persisted toggle unchanged outside the builder (#543)", () => {
+  it("still toggles via the persisting context when no rail props are given", () => {
+    // No forceCollapsed / onToggleRail → ordinary navbar. The persisted
+    // context toggle must still fire (and persist) exactly as before.
+    render(<Sidebar />);
+
+    fireEvent.click(screen.getByLabelText("Collapse sidebar"));
+
+    expect(toggleSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -14,12 +14,30 @@ import { useNavOrder } from "@/lib/nav-order-context";
 import { useSidebarCollapse } from "@/lib/sidebar-collapse-context";
 import { Tooltip } from "@base-ui/react/tooltip";
 
-export default function Sidebar() {
+export default function Sidebar({
+  forceCollapsed,
+  onToggleRail,
+}: {
+  /** When set, overrides the persisted collapsed state for display — used by
+   *  the builder's slim rail without touching the global preference. */
+  forceCollapsed?: boolean;
+  /** Click handler for the rail toggle while in the builder; when provided it
+   *  replaces the persisted context toggle so no localStorage write happens. */
+  onToggleRail?: () => void;
+} = {}) {
   const pathname = usePathname();
   const router = useRouter();
   const { profile, signOut, hasPermission } = useAuth();
   const { order } = useNavOrder();
-  const { collapsed, toggle } = useSidebarCollapse();
+  const { collapsed: persistedCollapsed, toggle } = useSidebarCollapse();
+  // The builder passes forceCollapsed to render the slim rail without mutating
+  // the persisted global preference. Outside the builder it is undefined and
+  // the persisted value drives the display exactly as before.
+  const collapsed = forceCollapsed ?? persistedCollapsed;
+  // In the builder the toggle is ephemeral (onToggleRail) so it never writes
+  // the persisted "sidebar-collapsed" key. Everywhere else it falls back to the
+  // persisting context toggle.
+  const handleToggle = onToggleRail ?? toggle;
 
   // Filter by membership role + required permission, then sort by DB
   // sort_order. Items missing from the DB fall to the bottom in code-
@@ -211,7 +229,7 @@ export default function Sidebar() {
               <NotificationBell />
               <button
                 type="button"
-                onClick={toggle}
+                onClick={handleToggle}
                 aria-label="Expand sidebar"
                 aria-expanded={false}
                 className="p-1.5 rounded-lg text-white/60 hover:text-white hover:bg-white/10 transition-colors"
@@ -240,7 +258,7 @@ export default function Sidebar() {
               <NotificationBell />
               <button
                 type="button"
-                onClick={toggle}
+                onClick={handleToggle}
                 aria-label="Collapse sidebar"
                 aria-expanded={true}
                 className="p-1.5 rounded-lg text-white/60 hover:text-white hover:bg-white/10 transition-colors"


### PR DESCRIPTION
## What & why

First slice of the Estimate Builder desktop-layout PRD (#541). Makes the builder full-width on desktop and turns the side navbar into a slim icon rail on builder routes. This slice delivers the **frame + rail only** — editor-panel and totals-bar content arrive in later slices (their slots are reserved but empty here).

## Changes

- **BuilderLayout** (`builder-layout.tsx`): full-width flex shell; the document fills the width (`flex-1 min-w-0`) with reserved-but-empty right editor-panel and bottom totals-bar slots.
- **EstimateBuilder**: all three modes (estimate / invoice / template) now render inside `BuilderLayout` instead of the old `max-w-4xl mx-auto` centered column.
- **Slim rail**: `Sidebar` gains optional `forceCollapsed` / `onToggleRail` props; `AppShell` drives them from ephemeral, mount-scoped state on builder routes. One click expands the rail, another collapses it.
- **No-persist crux**: the global `sidebar-collapsed` preference is never written while in the builder, so entering/leaving it doesn't change the navbar on other pages.
- **Settings escape**: the template editor lives under `/settings/...`, so `SettingsLayout` now steps out of the way (header + `max-w-6xl` column + sub-nav) on that route, letting template mode go full-width too.

The floating `TotalsPanel` is untouched; the totals-bar slot stays empty this slice.

## Acceptance criteria

- [x] Builder document fills full content width on desktop (no narrow centered column).
- [x] Side navbar is a slim icon rail on builder routes.
- [x] One click expands the rail; another collapses it.
- [x] The persisted global navbar preference is unchanged by entering/leaving the builder.
- [x] Letterhead + Section structure remain intact.
- [x] Right editor-panel slot and bottom totals-bar slot are reserved (empty this slice); document gets full width when the editor slot is empty.
- [x] Estimate, invoice, and template modes all render in the new shell.

## Testing

Built with TDD, red→green per behavior. New/touched suites (18 tests) green:

- `builder-layout.test.tsx`
- `nav-rail.test.tsx`
- `app-shell.test.tsx` — the no-persist crux is checked via a `setItem` spy against the **real** `SidebarCollapseProvider`
- `settings/layout.test.tsx` — chrome escape + guard
- `builder-fullwidth.test.tsx` — all three modes mount in the new shell with letterhead + Section structure intact

`tsc --noEmit` clean. Remaining repo-baseline reds are unchanged and unrelated (Node-25 `localStorage` artifact in `estimate-drag-end`; the repo-wide `react-hooks/set-state-in-effect` lint in untouched code).

jsdom has no layout engine, so width/rail behavior is verified through the CSS classes that produce it (presence/absence of `max-w-*`, `lg:ml-16` vs `lg:ml-52`) rather than measured pixels.

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
