### PR TITLE
feat(estimate-builder): retire inline row editing → select-only rows (#546)

### DIFF
--- a/src/components/estimate-builder/builder-fullwidth.test.tsx
+++ b/src/components/estimate-builder/builder-fullwidth.test.tsx
@@ -308,7 +308,7 @@ describe("EstimateBuilder — full-width shell across modes (#543)", () => {
 
     // Letterhead title + nested Section structure remain visible/intact.
     expect(screen.getByText("Full-width test estimate")).toBeDefined();
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
 
     // The document lives in the full-width shell …
     expect(screen.getByTestId("builder-document")).toBeDefined();
@@ -321,7 +321,7 @@ describe("EstimateBuilder — full-width shell across modes (#543)", () => {
 
     // Letterhead title + nested Section structure remain visible/intact.
     expect(screen.getByText("Full-width test invoice")).toBeDefined();
-    expect(screen.getByDisplayValue("Invoice step flashing")).toBeDefined();
+    expect(screen.getByText("Invoice step flashing")).toBeDefined();
 
     // The document lives in the full-width shell …
     expect(screen.getByTestId("builder-document")).toBeDefined();
@@ -336,7 +336,7 @@ describe("EstimateBuilder — full-width shell across modes (#543)", () => {
     // The name surfaces in both the HeaderBar and the TemplateMetaBar, so just
     // assert it is present (at least once) — the letterhead survived the shell.
     expect(screen.getAllByText("Full-width test template").length).toBeGreaterThan(0);
-    expect(screen.getByDisplayValue("Template step flashing")).toBeDefined();
+    expect(screen.getByText("Template step flashing")).toBeDefined();
 
     // The document lives in the full-width shell …
     expect(screen.getByTestId("builder-document")).toBeDefined();

--- a/src/components/estimate-builder/estimate-drag-end.test.tsx
+++ b/src/components/estimate-builder/estimate-drag-end.test.tsx
@@ -243,9 +243,44 @@ function makeEstimateEntity(): BuilderEntity {
   return { kind: "estimate", data: estimate };
 }
 
+// Node 25's experimental global `localStorage` shadows jsdom's with a
+// non-functional stub in this runner (the documented known-red artifact). The
+// estimate branch reads localStorage on mount (the template-applied flag), so
+// install a working in-memory store on both `window` and `globalThis` to let
+// the builder mount. Mirrors line-item-editor-panel.integration.test.tsx.
+function installLocalStorage() {
+  const store = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      store.delete(k);
+    },
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+  for (const target of [globalThis, window]) {
+    try {
+      Object.defineProperty(target, "localStorage", {
+        configurable: true,
+        writable: true,
+        value: stub,
+      });
+    } catch {
+      // Non-configurable in some runtimes — best-effort.
+    }
+  }
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
+  installLocalStorage();
   capturedRootOnDragEnd = null;
   listeners = [];
   saveLineItemsReorderMock.mockClear();
@@ -258,7 +293,7 @@ describe("EstimateBuilder estimate drag-end", () => {
     render(<EstimateBuilder entity={makeEstimateEntity()} />);
 
     // Sanity: X is rendered initially.
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
 
     dispatchDragEnd(
       makeDragEndEvent({
@@ -270,7 +305,7 @@ describe("EstimateBuilder estimate drag-end", () => {
     );
 
     // After the drop, X still exists on screen — the same row moved containers.
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
     // Source Subsection is now empty.
     expect(screen.getByText("No items yet.")).toBeDefined();
 
@@ -330,7 +365,7 @@ describe("EstimateBuilder estimate drag-end", () => {
     const sub1Card = sub1Heading.closest("li");
     expect(sub1Card).not.toBeNull();
     expect(
-      within(sub1Card as HTMLElement).getByDisplayValue("Step flashing"),
+      within(sub1Card as HTMLElement).getByText("Step flashing"),
     ).toBeDefined();
 
     // Drag X out of Sub1 into S1.
@@ -349,7 +384,7 @@ describe("EstimateBuilder estimate drag-end", () => {
 
     // Tree is back to the pre-drag state — X is back inside Sub1.
     expect(
-      within(sub1Card as HTMLElement).getByDisplayValue("Step flashing"),
+      within(sub1Card as HTMLElement).getByText("Step flashing"),
     ).toBeDefined();
     // Error toast was rendered.
     expect(toastErrorMock).toHaveBeenCalledWith("Failed to save line item order");
@@ -394,8 +429,8 @@ describe("EstimateBuilder estimate drag-end", () => {
     );
 
     // Both items still rendered.
-    expect(screen.getByDisplayValue("Tear-off")).toBeDefined();
-    expect(screen.getByDisplayValue("Underlayment")).toBeDefined();
+    expect(screen.getByText("Tear-off")).toBeDefined();
+    expect(screen.getByText("Underlayment")).toBeDefined();
 
     // Persisted payload covers the single affected container, contiguous 0..N.
     expect(saveLineItemsReorderMock).toHaveBeenCalledTimes(1);

--- a/src/components/estimate-builder/invoice-drag-end.test.tsx
+++ b/src/components/estimate-builder/invoice-drag-end.test.tsx
@@ -258,7 +258,7 @@ describe("EstimateBuilder invoice drag-end", () => {
   it("moves a Line item from a Subsection into its parent Section's direct items and persists every item in both containers", async () => {
     render(<EstimateBuilder entity={makeInvoiceEntity()} />);
 
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
 
     dispatchDragEnd(
       makeDragEndEvent({
@@ -269,7 +269,7 @@ describe("EstimateBuilder invoice drag-end", () => {
       }),
     );
 
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
     expect(screen.getByText("No items yet.")).toBeDefined();
 
     expect(saveLineItemsReorderMock).toHaveBeenCalledTimes(1);
@@ -320,7 +320,7 @@ describe("EstimateBuilder invoice drag-end", () => {
     const sub1Card = sub1Heading.closest("li");
     expect(sub1Card).not.toBeNull();
     expect(
-      within(sub1Card as HTMLElement).getByDisplayValue("Step flashing"),
+      within(sub1Card as HTMLElement).getByText("Step flashing"),
     ).toBeDefined();
 
     await act(async () => {
@@ -336,7 +336,7 @@ describe("EstimateBuilder invoice drag-end", () => {
     });
 
     expect(
-      within(sub1Card as HTMLElement).getByDisplayValue("Step flashing"),
+      within(sub1Card as HTMLElement).getByText("Step flashing"),
     ).toBeDefined();
     expect(toastErrorMock).toHaveBeenCalledWith("Failed to save line item order");
   });
@@ -377,8 +377,8 @@ describe("EstimateBuilder invoice drag-end", () => {
       }),
     );
 
-    expect(screen.getByDisplayValue("Tear-off")).toBeDefined();
-    expect(screen.getByDisplayValue("Underlayment")).toBeDefined();
+    expect(screen.getByText("Tear-off")).toBeDefined();
+    expect(screen.getByText("Underlayment")).toBeDefined();
 
     expect(saveLineItemsReorderMock).toHaveBeenCalledTimes(1);
     const payload = saveLineItemsReorderMock.mock.calls[0][0];

--- a/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
@@ -360,19 +360,21 @@ function makeVoidedEstimateEntity(): BuilderEntity {
   return e;
 }
 
-// Click the inline row whose name field shows `name`. Scoped to the document
-// surface so it never accidentally matches the editor panel's own name field.
+// Click the inline row whose static name text reads `name`. Scoped to the
+// document surface so it never accidentally matches the editor panel's own
+// name field (the panel is a sibling of builder-document, not inside it).
 function selectRowByName(name: string) {
   const doc = screen.getByTestId("builder-document");
-  fireEvent.click(within(doc).getByDisplayValue(name));
+  fireEvent.click(within(doc).getByText(name));
 }
 
-// Click the row CONTAINER (not an input). Needed when fields are disabled —
-// disabled inputs don't dispatch clicks, but the row div still does.
+// Click the row CONTAINER explicitly (vs. its text). Rows are display-only
+// since #546, so a text click already bubbles to select — but read-only modes
+// keep this for clarity about what is being clicked.
 function clickRowContainer(name: string) {
   const doc = screen.getByTestId("builder-document");
   const row = within(doc)
-    .getByDisplayValue(name)
+    .getByText(name)
     .closest('[data-testid="line-item-row"]') as HTMLElement;
   fireEvent.click(row);
 }
@@ -436,14 +438,14 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
     render(<EstimateBuilder entity={makeEstimateEntity()} />);
 
     const doc = screen.getByTestId("builder-document");
-    const rowInput = within(doc).getByDisplayValue("Tear-off");
-    const row = rowInput.closest('[data-testid="line-item-row"]');
+    const rowName = within(doc).getByText("Tear-off");
+    const row = rowName.closest('[data-testid="line-item-row"]');
     expect(row).not.toBeNull();
 
     // Not highlighted until selected.
     expect((row as HTMLElement).getAttribute("data-selected")).toBeNull();
 
-    fireEvent.click(rowInput);
+    fireEvent.click(rowName);
 
     expect((row as HTMLElement).getAttribute("data-selected")).toBe("true");
   });
@@ -488,10 +490,12 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
     fireEvent.blur(panelCost);
 
     // The INLINE row (inside the document, not the panel) now shows the new
-    // unit cost and recomputed total — both surfaces share one model.
+    // unit cost and recomputed total as static currency — both surfaces share
+    // one model. With qty 1, the unit-price cell and the total cell both read
+    // $250.00, and the old $100.00 is gone from the row.
     const doc = screen.getByTestId("builder-document");
-    expect(within(doc).getByDisplayValue("250")).toBeDefined();
-    expect(within(doc).getByText("$250.00")).toBeDefined();
+    expect(within(doc).getAllByText("$250.00").length).toBe(2);
+    expect(within(doc).queryByText("$100.00")).toBeNull();
   });
 
   it("renders the editor docked on desktop (no scrim)", () => {
@@ -593,7 +597,7 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
 
     const doc = screen.getByTestId("builder-document");
     const rowA = within(doc)
-      .getByDisplayValue("Tear-off")
+      .getByText("Tear-off")
       .closest('[data-testid="line-item-row"]') as HTMLElement;
     fireEvent.click(
       within(rowA).getByRole("button", { name: /delete line item/i }),
@@ -621,7 +625,7 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
     // Delete the OTHER line (X, in the subsection) via its delete button.
     const doc = screen.getByTestId("builder-document");
     const rowX = within(doc)
-      .getByDisplayValue("Step flashing")
+      .getByText("Step flashing")
       .closest('[data-testid="line-item-row"]') as HTMLElement;
     fireEvent.click(
       within(rowX).getByRole("button", { name: /delete line item/i }),
@@ -636,17 +640,21 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps the inline row editable (the panel is additive)", () => {
+  it("makes the row display-only — selecting it is the sole path to edit (#546)", () => {
     render(<EstimateBuilder entity={makeEstimateEntity()} />);
     const doc = screen.getByTestId("builder-document");
 
-    // Edit and commit directly on the inline row — no panel needed.
-    const inlineName = within(doc).getByDisplayValue("Tear-off");
-    fireEvent.change(inlineName, { target: { value: "Tear-off & haul" } });
-    fireEvent.blur(inlineName);
+    // The row carries no inline inputs anymore — every field is static text.
+    const rowA = within(doc)
+      .getByText("Tear-off")
+      .closest('[data-testid="line-item-row"]') as HTMLElement;
+    expect(within(rowA).queryByRole("textbox")).toBeNull();
+    expect(within(rowA).queryByRole("spinbutton")).toBeNull();
 
-    // The committed value persists on the inline row.
-    expect(within(doc).getByDisplayValue("Tear-off & haul")).toBeDefined();
+    // Editing is reached only by selecting the row, which opens the panel.
+    expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
+    fireEvent.click(within(doc).getByText("Tear-off"));
+    expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
   });
 
   it("opens the panel with disabled fields on a voided (read-only) estimate", () => {

--- a/src/components/estimate-builder/line-item-row.test.tsx
+++ b/src/components/estimate-builder/line-item-row.test.tsx
@@ -7,7 +7,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { DndContext } from "@dnd-kit/core";
 import { SortableContext } from "@dnd-kit/sortable";
 
-import { LineItemRow, type BuilderLineItem } from "./line-item-row";
+import { LineItemRow, type BuilderLineItem, type LineItemRowProps } from "./line-item-row";
 import type { EstimateLineItem } from "@/lib/types";
 
 const baseItem: EstimateLineItem = {
@@ -29,97 +29,145 @@ const baseItem: EstimateLineItem = {
   updated_at: "",
 };
 
-function renderRow(item: EstimateLineItem, onChange: (n: Partial<BuilderLineItem>) => void) {
+function renderRow(
+  item: EstimateLineItem,
+  onChange: (n: Partial<BuilderLineItem>) => void,
+  extra: Partial<LineItemRowProps> = {},
+) {
   return render(
     <DndContext>
       <SortableContext items={[item.id]}>
-        <LineItemRow item={item} parentSectionId="sec-1" onChange={onChange} onDelete={() => {}} />
+        <LineItemRow
+          item={item}
+          parentSectionId="sec-1"
+          onChange={onChange}
+          onDelete={() => {}}
+          {...extra}
+        />
       </SortableContext>
     </DndContext>,
   );
 }
 
-function noteInput(): HTMLInputElement {
-  return screen.getByPlaceholderText("Note (optional)") as HTMLInputElement;
-}
-
-function unitPriceInput(): HTMLInputElement {
-  return screen.getByPlaceholderText("0.00") as HTMLInputElement;
-}
-
-describe("LineItemRow — note field (#382)", () => {
-  it("seeds the note input from item.note", () => {
+describe("LineItemRow — note display (#546, supersedes #382)", () => {
+  it("renders the note as static text when the item has one", () => {
     renderRow({ ...baseItem, note: "Use low-VOC primer" }, vi.fn());
-    expect(noteInput().value).toBe("Use low-VOC primer");
+    expect(screen.getByText("Use low-VOC primer")).toBeDefined();
   });
 
-  it("commits the typed note on blur via onChange", () => {
-    const onChange = vi.fn();
-    renderRow(baseItem, onChange);
-
-    fireEvent.change(noteInput(), { target: { value: "Match existing color" } });
-    fireEvent.blur(noteInput());
-
-    expect(onChange).toHaveBeenCalledWith({ note: "Match existing color" });
+  it("no longer renders an editable note input", () => {
+    renderRow({ ...baseItem, note: "Use low-VOC primer" }, vi.fn());
+    expect(screen.queryByPlaceholderText("Note (optional)")).toBeNull();
   });
 
-  it("commits null when the note is cleared", () => {
-    const onChange = vi.fn();
-    renderRow({ ...baseItem, note: "stale" }, onChange);
-
-    fireEvent.change(noteInput(), { target: { value: "   " } });
-    fireEvent.blur(noteInput());
-
-    expect(onChange).toHaveBeenCalledWith({ note: null });
+  it("omits the note line entirely when the item has no note", () => {
+    renderRow({ ...baseItem, note: null }, vi.fn());
+    // No placeholder, and no stray empty note text node to mistake for a field.
+    expect(screen.queryByPlaceholderText("Note (optional)")).toBeNull();
   });
 
-  it("does not fire onChange when the note is unchanged", () => {
+  it("never commits a note edit — the row no longer calls onChange", () => {
     const onChange = vi.fn();
     renderRow({ ...baseItem, note: "Keep me" }, onChange);
-
-    fireEvent.blur(noteInput());
-
+    // The note is display-only now: there is nothing to type into or blur.
     expect(onChange).not.toHaveBeenCalled();
   });
 });
 
-describe("LineItemRow — unit cost MoneyInput (#542)", () => {
-  it("shows a $ adornment on the unit-cost field", () => {
-    renderRow(baseItem, vi.fn());
-    expect(screen.getByText("$")).toBeDefined();
+describe("LineItemRow — read-only display (#546)", () => {
+  it("renders the item name as static text, not an inline input", () => {
+    renderRow({ ...baseItem, name: "Antimicrobial" }, vi.fn());
+    // The editable name input is gone …
+    expect(screen.queryByPlaceholderText("Item name")).toBeNull();
+    // … the name now renders as plain text.
+    expect(screen.getByText("Antimicrobial")).toBeDefined();
   });
 
-  it("seeds the unit-cost field from item.unit_price", () => {
-    renderRow({ ...baseItem, unit_price: 42.5 }, vi.fn());
-    expect(unitPriceInput().value).toBe("42.5");
+  it("renders description, code, quantity, and unit as static text, not inputs", () => {
+    renderRow(
+      { ...baseItem, description: "Apply to affected framing", code: "AM-1", quantity: 3, unit: "ea" },
+      vi.fn(),
+    );
+    // The editable inputs are gone …
+    expect(screen.queryByPlaceholderText("Description")).toBeNull();
+    expect(screen.queryByPlaceholderText("Code")).toBeNull();
+    expect(screen.queryByPlaceholderText("Qty")).toBeNull();
+    expect(screen.queryByPlaceholderText("Unit")).toBeNull();
+    // … each value now renders as plain text.
+    expect(screen.getByText("Apply to affected framing")).toBeDefined();
+    expect(screen.getByText("AM-1")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+    expect(screen.getByText("ea")).toBeDefined();
+  });
+});
+
+describe("LineItemRow — static price & total (#546, supersedes #542)", () => {
+  it("renders the unit price as static currency, not an editable MoneyInput", () => {
+    // qty 2 keeps the unit-price value ($42.50) distinct from the total ($85.00).
+    renderRow({ ...baseItem, quantity: 2, unit_price: 42.5 }, vi.fn());
+    expect(screen.queryByPlaceholderText("0.00")).toBeNull();
+    expect(screen.getByText("$42.50")).toBeDefined();
   });
 
-  it("commits a new unit price on blur via onChange", () => {
-    const onChange = vi.fn();
-    renderRow(baseItem, onChange);
-
-    fireEvent.change(unitPriceInput(), { target: { value: "25" } });
-    fireEvent.blur(unitPriceInput());
-
-    expect(onChange).toHaveBeenCalledWith({ unit_price: 25 });
-  });
-
-  it("does not fire onChange when the unit price is unchanged", () => {
-    const onChange = vi.fn();
-    renderRow(baseItem, onChange);
-
-    fireEvent.blur(unitPriceInput());
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it("ticks the line total live as the unit price is typed (before blur)", () => {
-    // qty 2 × $10 = $20.00 initially; typing 20 → 2 × $20 = $40.00 immediately.
+  it("renders the line total as static currency derived from quantity × unit price", () => {
     renderRow({ ...baseItem, quantity: 2, unit_price: 10 }, vi.fn());
     expect(screen.getByText("$20.00")).toBeDefined();
+  });
 
-    fireEvent.change(unitPriceInput(), { target: { value: "20" } });
+  it("updates the displayed total when the item prop changes (no local draft state)", () => {
+    const { rerender } = renderRow({ ...baseItem, quantity: 3, unit_price: 10 }, vi.fn());
+    expect(screen.getByText("$30.00")).toBeDefined();
 
-    expect(screen.getByText("$40.00")).toBeDefined();
+    rerender(
+      <DndContext>
+        <SortableContext items={[baseItem.id]}>
+          <LineItemRow
+            item={{ ...baseItem, quantity: 3, unit_price: 20 }}
+            parentSectionId="sec-1"
+            onChange={vi.fn()}
+            onDelete={() => {}}
+          />
+        </SortableContext>
+      </DndContext>,
+    );
+
+    expect(screen.getByText("$60.00")).toBeDefined();
+    expect(screen.queryByText("$30.00")).toBeNull();
+  });
+});
+
+// Locks in criteria 1–4: the conversion removed every input, and the drag /
+// select / delete affordances #544 introduced survive the rewrite unchanged.
+describe("LineItemRow — select-only interactions (#546)", () => {
+  it("renders no inline inputs at all — the row is display-only", () => {
+    renderRow({ ...baseItem, code: "AM-1", unit: "ea", note: "Match existing color" }, vi.fn());
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(screen.queryByRole("spinbutton")).toBeNull();
+  });
+
+  it("selects the row when clicked (the only path to edit)", () => {
+    const onSelect = vi.fn();
+    renderRow(baseItem, vi.fn(), { onSelect });
+    fireEvent.click(screen.getByTestId("line-item-row"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it("highlights the row via data-selected when selected", () => {
+    renderRow(baseItem, vi.fn(), { selected: true });
+    expect(screen.getByTestId("line-item-row").getAttribute("data-selected")).toBe("true");
+  });
+
+  it("deletes directly from the row without first selecting it", () => {
+    const onDelete = vi.fn();
+    const onSelect = vi.fn();
+    renderRow(baseItem, vi.fn(), { onDelete, onSelect });
+    fireEvent.click(screen.getByLabelText("Delete line item"));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the drag handle for reordering", () => {
+    renderRow(baseItem, vi.fn());
+    expect(screen.getByLabelText("Drag to reorder")).toBeDefined();
   });
 });

--- a/src/components/estimate-builder/line-item-row.tsx
+++ b/src/components/estimate-builder/line-item-row.tsx
@@ -1,21 +1,21 @@
 "use client";
 
-// LineItemRow — inline-editable line item with drag handle and live total.
+// LineItemRow — read-only display of a line item with a drag handle (#546).
+//
+// As of #546 rows are select-only: clicking a row opens the editor panel
+// (see line-item-editor-panel.tsx) where every field is edited. The row no
+// longer renders inline inputs — name, description, note, code, quantity,
+// unit, unit price and total all render as static text.
 //
 // Plan deviation: `parentSectionId: string` added to props (the plan's literal
 // interface omitted it, but it is required for dnd-kit sortable registration so
 // that handleDragEnd in estimate-builder.tsx can enforce cross-context snap-back).
-//
-// Inputs commit on blur (spreadsheet pattern — NOT click-to-edit). Total cell
-// updates live from local state during editing.
 
-import { useState, useEffect } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/format";
-import { MoneyInput } from "./money-input";
 import type { BuilderMode, EstimateLineItem, InvoiceLineItem } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -32,9 +32,15 @@ export interface LineItemRowProps {
   item: BuilderLineItem;
   /** Required for dnd-kit — the immediate container's id (section.id or subsection.id). */
   parentSectionId: string;
+  /**
+   * Retained for caller compatibility but no longer consumed: as of #546 the
+   * row is display-only and all edits flow through the editor panel. Callers
+   * (section-card / subsection-card) still pass it harmlessly.
+   */
   onChange: (next: Partial<BuilderLineItem>) => void;
   onDelete: () => void;
   readOnly?: boolean;
+  /** Retained for caller compatibility; no longer consumed by the row (#546). */
   mode?: BuilderMode;
   /**
    * Optional DOM id for scroll-to-item helpers.
@@ -55,10 +61,8 @@ export interface LineItemRowProps {
 export function LineItemRow({
   item,
   parentSectionId,
-  onChange,
   onDelete,
   readOnly = false,
-  mode = "estimate",
   domId,
   selected = false,
   onSelect,
@@ -82,96 +86,8 @@ export function LineItemRow({
     opacity: isDragging ? 0.4 : 1,
   };
 
-  // ── Local editing state ───────────────────────────────────────────────────
-  // Strings for controlled inputs; numbers parsed on blur.
-  const [name, setName] = useState(item.name ?? "");
-  const [description, setDescription] = useState(item.description);
-  const [note, setNote] = useState(item.note ?? "");
-  const [code, setCode] = useState(item.code ?? "");
-  const [quantity, setQuantity] = useState(String(item.quantity));
-  const [unit, setUnit] = useState(item.unit ?? "");
-  // Unit price now lives inside MoneyInput, which owns its own draft string.
-  // The row keeps only a numeric mirror so the line total can tick live as the
-  // user types (fed via MoneyInput's onValueChange).
-  const [unitPriceDraft, setUnitPriceDraft] = useState(item.unit_price);
-
-  // Sync from props when item changes from outside (e.g. server reconcile)
-  useEffect(() => {
-    setName(item.name ?? "");
-    setDescription(item.description);
-    setNote(item.note ?? "");
-    setCode(item.code ?? "");
-    setQuantity(String(item.quantity));
-    setUnit(item.unit ?? "");
-    setUnitPriceDraft(item.unit_price);
-  }, [item.name, item.description, item.note, item.code, item.quantity, item.unit, item.unit_price]);
-
-  // ── Live total (uses local editing values) ────────────────────────────────
-  const localQty = Number(quantity);
-  const localUnitPrice = unitPriceDraft;
-  const liveTotal =
-    Number.isFinite(localQty) && Number.isFinite(localUnitPrice)
-      ? localQty * localUnitPrice
-      : item.quantity * item.unit_price;
-
-  // ── Blur commit helpers ───────────────────────────────────────────────────
-
-  function commitName() {
-    const trimmed = name.trim();
-    const next: string | null = trimmed.length > 0 ? trimmed : null;
-    if (next !== (item.name ?? null)) {
-      onChange({ name: next });
-    }
-  }
-
-  function commitDescription() {
-    const trimmed = description.trim();
-    if (!trimmed) {
-      // Revert — description is required
-      setDescription(item.description);
-      return;
-    }
-    if (trimmed !== item.description) {
-      onChange({ description: trimmed });
-    }
-  }
-
-  function commitNote() {
-    // Empty / whitespace-only → null (nullable, optional sub-line).
-    const trimmed = note.trim();
-    const next: string | null = trimmed.length > 0 ? trimmed : null;
-    if (next !== (item.note ?? null)) {
-      onChange({ note: next });
-    }
-  }
-
-  function commitCode() {
-    // Empty string → null (nullable in schema)
-    const val = code.trim() || null;
-    if (val !== item.code) {
-      onChange({ code: val });
-    }
-  }
-
-  function commitQuantity() {
-    const parsed = Number(quantity);
-    if (!quantity.trim() || !Number.isFinite(parsed)) {
-      // Revert on empty or NaN
-      setQuantity(String(item.quantity));
-      return;
-    }
-    if (parsed !== item.quantity) {
-      onChange({ quantity: parsed });
-    }
-  }
-
-  function commitUnit() {
-    // Empty string → null (nullable in schema)
-    const val = unit.trim() || null;
-    if (val !== item.unit) {
-      onChange({ unit: val });
-    }
-  }
+  // ── Line total — read-only, derived straight from props (#546). ────────────
+  const lineTotal = item.quantity * item.unit_price;
 
   // ── Render ────────────────────────────────────────────────────────────────
 
@@ -216,135 +132,44 @@ export function LineItemRow({
 
       {/* Stacked name + description column */}
       <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-        <input
-          type="text"
-          value={name}
-          maxLength={200}
-          disabled={readOnly}
-          onChange={(e) => setName(e.target.value)}
-          onBlur={commitName}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-          }}
-          placeholder="Item name"
-          className={cn(
-            "w-full bg-transparent border-0 outline-none ring-0 font-semibold text-sm text-foreground placeholder:text-muted-foreground/60",
-            "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-            "disabled:cursor-default disabled:opacity-60"
-          )}
-        />
-        <input
-          type="text"
-          value={description}
-          maxLength={2000}
-          disabled={readOnly}
-          onChange={(e) => setDescription(e.target.value)}
-          onBlur={commitDescription}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-          }}
-          placeholder="Description"
-          className={cn(
-            "w-full bg-transparent border-0 outline-none ring-0 text-sm text-muted-foreground placeholder:text-muted-foreground/50",
-            "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-            "disabled:cursor-default disabled:opacity-60"
-          )}
-        />
-        {/* Optional note — italic sub-line tucked under the item (#382). */}
-        <input
-          type="text"
-          value={note}
-          maxLength={2000}
-          disabled={readOnly}
-          onChange={(e) => setNote(e.target.value)}
-          onBlur={commitNote}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") e.currentTarget.blur();
-          }}
-          placeholder="Note (optional)"
-          className={cn(
-            "w-full bg-transparent border-0 outline-none ring-0 text-xs italic text-muted-foreground placeholder:text-muted-foreground/50",
-            "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-            "disabled:cursor-default disabled:opacity-60"
-          )}
-        />
+        <span className="px-1 py-0.5 font-semibold text-sm text-foreground">
+          {item.name}
+        </span>
+        <span className="px-1 py-0.5 text-sm text-muted-foreground">
+          {item.description}
+        </span>
+        {/* Optional note — italic sub-line tucked under the item (#382).
+            Display-only since #546; editing happens in the editor panel. */}
+        {item.note && (
+          <span className="px-1 py-0.5 text-xs italic text-muted-foreground">
+            {item.note}
+          </span>
+        )}
       </div>
 
       {/* Code */}
-      <input
-        type="text"
-        value={code}
-        disabled={readOnly}
-        onChange={(e) => setCode(e.target.value)}
-        onBlur={commitCode}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-        }}
-        placeholder="Code"
-        className={cn(
-          "w-20 shrink-0 mt-0.5 bg-transparent border-0 outline-none ring-0 text-sm text-muted-foreground placeholder:text-muted-foreground/50",
-          "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-          "disabled:cursor-default disabled:opacity-60"
-        )}
-      />
+      <span className="w-20 shrink-0 mt-0.5 px-1 py-0.5 text-sm text-muted-foreground">
+        {item.code}
+      </span>
 
       {/* Quantity */}
-      <input
-        type="number"
-        value={quantity}
-        disabled={readOnly}
-        onChange={(e) => setQuantity(e.target.value)}
-        onBlur={commitQuantity}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-        }}
-        placeholder="Qty"
-        className={cn(
-          "w-16 shrink-0 mt-0.5 bg-transparent border-0 outline-none ring-0 text-sm text-foreground tabular-nums text-right placeholder:text-muted-foreground/50",
-          "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-          "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
-          "disabled:cursor-default disabled:opacity-60"
-        )}
-      />
+      <span className="w-16 shrink-0 mt-0.5 px-1 py-0.5 text-sm text-foreground tabular-nums text-right">
+        {item.quantity}
+      </span>
 
       {/* Unit */}
-      <input
-        type="text"
-        value={unit}
-        disabled={readOnly}
-        onChange={(e) => setUnit(e.target.value)}
-        onBlur={commitUnit}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-        }}
-        placeholder="Unit"
-        className={cn(
-          "w-14 shrink-0 mt-0.5 bg-transparent border-0 outline-none ring-0 text-sm text-muted-foreground placeholder:text-muted-foreground/50",
-          "focus:bg-muted/40 focus:rounded px-1 py-0.5 transition-colors",
-          "disabled:cursor-default disabled:opacity-60"
-        )}
-      />
+      <span className="w-14 shrink-0 mt-0.5 px-1 py-0.5 text-sm text-muted-foreground">
+        {item.unit}
+      </span>
 
-      {/* Unit price — $-prefixed MoneyInput (#542). Commits on blur; feeds the
-          live total via onValueChange so it ticks while typing. */}
-      <MoneyInput
-        value={item.unit_price}
-        onValueChange={(raw) => setUnitPriceDraft(Number(raw))}
-        onCommit={(n) => {
-          if (n !== item.unit_price) onChange({ unit_price: n });
-        }}
-        readOnly={readOnly}
-        placeholder="0.00"
-        className={cn(
-          "w-24 shrink-0 mt-0.5 px-1 py-0.5 text-sm text-foreground transition-colors",
-          "focus-within:bg-muted/40 focus-within:rounded",
-          readOnly && "opacity-60"
-        )}
-      />
+      {/* Unit price — static currency since #546 (editing lives in the panel). */}
+      <span className="w-24 shrink-0 mt-0.5 px-1 py-0.5 text-right font-mono tabular-nums text-sm text-foreground">
+        {formatCurrency(item.unit_price)}
+      </span>
 
-      {/* Live total — read-only, computed from local editing values */}
+      {/* Line total — read-only, derived from quantity × unit price. */}
       <span className="w-24 shrink-0 mt-0.5 text-right font-mono tabular-nums text-sm text-foreground">
-        {formatCurrency(liveTotal)}
+        {formatCurrency(lineTotal)}
       </span>
 
       {/* Delete button */}

--- a/src/components/estimate-builder/template-drag-end.test.tsx
+++ b/src/components/estimate-builder/template-drag-end.test.tsx
@@ -193,7 +193,7 @@ describe("EstimateBuilder template drag-end", () => {
     render(<EstimateBuilder entity={makeTemplateEntity()} />);
 
     // Sanity: X is rendered initially (Subsection is expanded by default).
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
 
     dispatchDragEnd(
       makeDragEndEvent({
@@ -206,7 +206,7 @@ describe("EstimateBuilder template drag-end", () => {
 
     // After the drop, X still exists on screen — semantics are that the same
     // row moved containers. Source Subsection should now be empty.
-    expect(screen.getByDisplayValue("Step flashing")).toBeDefined();
+    expect(screen.getByText("Step flashing")).toBeDefined();
     // Empty subsection placeholder appears.
     expect(screen.getByText("No items yet.")).toBeDefined();
   });
@@ -284,7 +284,7 @@ describe("EstimateBuilder template drag-end", () => {
     );
 
     // Both items still rendered.
-    expect(screen.getByDisplayValue("Tear-off")).toBeDefined();
-    expect(screen.getByDisplayValue("Underlayment")).toBeDefined();
+    expect(screen.getByText("Tear-off")).toBeDefined();
+    expect(screen.getByText("Underlayment")).toBeDefined();
   });
 });


### PR DESCRIPTION
## What

Retires inline row editing in the desktop Estimate Builder. Each `LineItemRow` is now a **read-only display** — name, description, note, code, quantity, unit, unit price and total all render as static text. Clicking anywhere on a row selects it and opens the editor panel from #544, which becomes the single surface for editing every field.

Closes #546. Builds on #544 (already on `main` via #558) in the #541 desktop Estimate Builder epic; based on `main`.

## Changes

- **`line-item-row.tsx`** — strip all draft state, the value-sync effect, and the six per-field commit handlers (~260 lines removed). Render each field as static text; derive the line total locally from `quantity × unit_price`. `onChange`/`mode` stay on the props interface (commented) for caller compatibility — `section-card` / `subsection-card` still pass them harmlessly — but are no longer consumed.
- **Test migration (fallout of removing the inputs)** — row-side `getByDisplayValue` → `getByText` across the suites that assert on rendered rows: `estimate` / `invoice` / `template-drag-end`, `builder-fullwidth`, and the editor-panel integration test. **Panel-side** `getByDisplayValue` assertions are preserved — the editor panel still edits via inputs.
- **`line-item-editor-panel.integration.test.tsx`** — the old "keeps the inline row editable (the panel is additive)" test is replaced with one asserting the row is display-only (no `textbox` / `spinbutton`) and that selecting it is the *sole* path into the editor.
- **`estimate-drag-end.test.tsx`** — install the in-memory `localStorage` shim (the Node-25 artifact) the estimate kind reads on mount, so the migrated assertions run green.

## Acceptance criteria (#546)

All criteria from the issue covered: rows render every field statically, no inline inputs remain, clicking selects + opens the panel, delete and drag-to-reorder still work, the note sub-line (#382) and static price/total (#542) still display, and the selection highlight (#544) is preserved.

## Testing

- `npx vitest run src/components/estimate-builder` → **140 / 140 green** (full directory).
- `line-item-row.test.tsx` reworked to spec the read-only display + select-only interactions (14 tests).
- ESLint clean on all 7 touched files; `tsc --noEmit` adds no new errors on touched files.

## Built with TDD

Implemented as vertical red→green tracer-bullet slices (one test → one impl), then a GREEN-permitted refactor to strip the dead inline-edit code, then a guard suite preserving the #382 / #542 / #544 behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
