### PR TITLE
docs(reports): ADR 0014 + glossary for per-report cover & layout (#540)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -139,12 +139,58 @@ reopened from the Job's Overview tab. There is no standalone reports area.
 _Avoid_: report (ambiguous — there is also the accounting/profitability report), photo log, gallery
 
 **Section** (of a Photo Report):
-One unit of a Photo Report: a heading, a one-page rich-text write-up
-(paragraphs and bullet/numbered lists), and the Photos that illustrate it.
-Renders as an intro page (heading + write-up, capped to one page) followed
-by the photo pages. Distinct from an **Estimate** Section, which is a group
-of priced line items — the two share only the word and no code.
+One unit of a Photo Report: a heading, a rich-text write-up (paragraphs and
+bullet/numbered lists), and the Photos that illustrate it. Renders as an
+optional **Section Title Page** (heading + write-up) followed by its **Photo
+Pages**; the write-up is capped to a length set by the report's
+photos-per-page choice. Distinct from an **Estimate** Section, which is a
+group of priced line items — the two share only the word and no code.
 _Avoid_: chapter, page, group
+
+**Cover Page** (of a Photo Report):
+The first page of a Photo Report — its title, an optional lead Photo (the
+cover photo), and identifying blocks drawn from the Job and Organization
+(logo, customer, property address, point of contact, insurance). Each report
+owns its Cover Page: the title is editable, the cover photo is chosen per
+report, and any block can be hidden. Previously every report's cover was
+fixed and derived wholesale from the Job; it is now a per-report surface (see
+[ADR 0014](docs/adr/0014-photo-reports-carry-per-report-cover-and-layout.md)).
+_Avoid_: title page, front page, splash
+
+**Section Title Page** (of a Photo Report):
+The full page that carries one Section's heading and its write-up, printed
+ahead of that Section's Photo Pages. Optional per report: when a report's
+Report Settings switch Section Title Pages off, the write-up is left out of
+the PDF and the Section is named only by the footer running along its Photo
+Pages. The code calls this `section-divider-page`.
+_Avoid_: section divider, intro page, summary page
+
+**Photo Page** (of a Photo Report):
+A page that lays out a Section's Photos — 2, 3, or 4 to a page per the
+report's Report Settings — each Photo shown with the per-photo details the
+report leaves switched on: its number, who captured it, where ("location
+captured" — the Job's property address, as Photos carry no GPS), when it was
+captured, and its tags. Carries a slim footer (Section name + page number)
+and no running top header.
+_Avoid_: gallery page, grid page, photo grid
+
+**Report Settings** (of a Photo Report):
+The per-report set of look choices a Photo Report renders with — how many
+Photos sit on a Photo Page (2/3/4, which also fixes the Section write-up's
+character cap) and the show/hide switches for Section Title Pages and each
+per-photo detail. A new report copies these from its Organization's **Report
+layout default**; from then on the report keeps its own copy, so changing the
+Organization default never rewrites a report that already exists. Parallel in
+shape to a billing document's **PDF layout** (the per-document copy) versus
+its **PDF preset** (the Organization default it was seeded from) — see
+[ADR 0014](docs/adr/0014-photo-reports-carry-per-report-cover-and-layout.md).
+_Avoid_: report layout (unqualified), report preset, report look
+
+**Report layout default** (of an Organization):
+The Organization-wide default **Report Settings** that every new Photo Report
+is seeded from, set once in Settings. Distinct from a **Photo Report
+template**, which seeds a report's Sections, not its look.
+_Avoid_: company report settings, default report layout, report preset
 
 **Photo Report template**:
 A saved, reusable set of Sections (headings plus optional boilerplate
@@ -235,8 +281,9 @@ _Avoid_: stage, pipeline status, partner status
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 - A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).
 - An **Estimate** or **Invoice** has zero or one **PDF layout** of its own; with none it renders using its Organization's **default preset**. A document's own layout always wins over the default, resolved by a pure precedence rule, and is locked once the document is frozen (Estimate converted, Invoice paid or voided). A **PDF preset** belongs to one **Organization** and seeds a document's layout; applying one copies its preferences in, it is not a binding link.
-- A **Job** has zero or more **Photo Reports**; each Photo Report belongs to exactly one Job, gathers that Job's **Photos** into ordered **Sections**, and is created and edited only from within the Job. Reports are numbered per Job (Report #1, #2, …).
+- A **Job** has zero or more **Photo Reports**; each Photo Report belongs to exactly one Job, gathers that Job's **Photos** into ordered **Sections**, and is created and edited only from within the Job. Reports are numbered per Job (Report #1, #2, …). Each Photo Report also owns a per-report **Cover Page** and per-report **Report Settings**, seeded from the Organization at creation (the settings from the **Report layout default**, the cover photo from the Job) and editable per report thereafter — a later change to the Organization default does not rewrite an existing report.
 - A **Photo Report template** belongs to one **Organization** and seeds a new Photo Report's **Sections**; applying one is a starting point, not a binding link.
+- An **Organization** has one **Report layout default**; it seeds every new Photo Report's **Report Settings** at creation and is not a binding link (the report keeps its own copy). Distinct from a **Photo Report template**, which seeds Sections rather than look.
 
 ## Example dialogue
 

--- a/docs/adr/0003-single-photo-report-layout.md
+++ b/docs/adr/0003-single-photo-report-layout.md
@@ -1,6 +1,6 @@
 # Single hardcoded photo report layout
 
-**Status:** Superseded in part by [ADR 0009](0009-photo-reports-are-an-in-job-narrative-document.md) (issue #390) — the "one minimal layout / every report serves the same audience" rationale is reversed for section content (Sections regain a one-page rich-text narrative). The global photos-per-page knob from the amendment below is retained.
+**Status:** Superseded in part by [ADR 0009](0009-photo-reports-are-an-in-job-narrative-document.md) (issue #390) — the "one minimal layout / every report serves the same audience" rationale is reversed for section content (Sections regain a one-page rich-text narrative). Further superseded in part by [ADR 0014](0014-photo-reports-carry-per-report-cover-and-layout.md) (issue #540) — the cover becomes per-report and photos-per-page becomes a per-report setting seeded by an Organization default, ending the global knob the amendment below introduced.
 
 Photo reports previously supported per-template cover pages and configurable
 layouts via the `photo_report_templates` table. With the May 2026 rework

--- a/docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md
+++ b/docs/adr/0009-photo-reports-are-an-in-job-narrative-document.md
@@ -1,6 +1,6 @@
 # Photo Reports are an in-job, section-narrative document
 
-**Status:** Accepted — supersedes [ADR 0003](0003-single-photo-report-layout.md) in part
+**Status:** Accepted — supersedes [ADR 0003](0003-single-photo-report-layout.md) in part. Partly superseded by [ADR 0014](0014-photo-reports-carry-per-report-cover-and-layout.md) (issue #540) — the fixed cover and company-wide photos-per-page it kept become per-report, and the full-screen builder regains the (collapsed) app navigation.
 **Date:** 2026-06-04
 
 ## Context

--- a/docs/adr/0014-photo-reports-carry-per-report-cover-and-layout.md
+++ b/docs/adr/0014-photo-reports-carry-per-report-cover-and-layout.md
@@ -1,0 +1,114 @@
+# Photo Reports carry a per-report cover and per-report layout settings
+
+**Status:** Accepted — supersedes [ADR 0003](0003-single-photo-report-layout.md) and [ADR 0009](0009-photo-reports-are-an-in-job-narrative-document.md) in part (issue #540)
+**Date:** 2026-06-08
+
+## Context
+
+[ADR 0003](0003-single-photo-report-layout.md) collapsed Photo Reports to **one
+hardcoded layout** — fixed cover page, fixed header/footer, fixed section divider
+— on the reasoning that "every photo report this business produces serves the
+same audience and benefits from looking the same every time," leaving
+photos-per-page as the only knob. Its #361 amendment made that knob **global**
+(Organization-wide, `company_settings.report_photos_per_page`).
+
+[ADR 0009](0009-photo-reports-are-an-in-job-narrative-document.md) reversed 0003
+for *section content* — Sections regained a one-page rich-text write-up — but
+explicitly **kept the cover fixed**, **kept photos-per-page company-wide**, and
+opened the builder **full-screen** with the app navigation stripped.
+
+Issue #540 reworks the desktop builder against a provided mockup, and the owner
+asked for control the "one look for everyone" rationale does not allow: a cover
+that differs per report (different title, a chosen lead photo, some blocks
+hidden), and per-report layout choices (how many photos per page, which
+per-photo details show). In practice reports do **not** all serve the same
+audience — an adjuster packet and an owner walk-through want different covers and
+different photo density — so 0003's consistency rationale no longer holds for the
+cover or the layout knobs. The owner also wants the app navigation reachable from
+inside the builder.
+
+## Decision
+
+1. **The Cover Page becomes per-report customizable.** Each report owns its
+   cover: an editable title, a cover photo chosen per report (seeded from the
+   Job's cover photo, overridable), and a show/hide switch for each identifying
+   block (logo, customer, property address, point of contact, insurance; all
+   default on). This reverses the "fixed cover" that both 0003 and 0009 kept.
+
+2. **Layout choices become per-report Report Settings, seeded from an
+   Organization default.** A report carries its own copy of photos-per-page and
+   the show/hide switches for Section Title Pages and each per-photo detail
+   (photo number, captured-by, location, date, tags; all default on). A new
+   report copies these from the Organization's **Report layout default**;
+   thereafter the report keeps its own copy, so editing the Organization default
+   never rewrites a report that already exists. This is the same per-document
+   **snapshot** model as billing PDFs
+   ([ADR 0012](0012-pdf-layout-is-a-per-document-snapshot.md)), and it reverses
+   the "photos-per-page is global" of 0003's amendment and 0009.
+
+3. **Photos-per-page changes from 1/2/4 to 2/3/4.** A new 3-per-page Photo Page
+   layout is added; the 1-per-page (single large photo) layout is dropped.
+   Reports and Organizations previously on 1-per-page fall back to the default
+   (2).
+
+4. **The Section write-up cap becomes per-layout.** The single 1500-character
+   budget is replaced by a per-photos-per-page cap (2 → 750, 3 → 400, 4 → 260),
+   still a conservatively-tuned character count with a live counter (per 0009).
+
+5. **The builder is no longer full-screen.** The app navigation stays reachable
+   inside the builder, collapsed by default. This reverses 0009's "full-screen,
+   job-scoped builder."
+
+6. **"Location captured" is the Job's property address.** Photos carry no GPS;
+   the per-photo "location captured" detail prints the Job's property address
+   (identical on every photo in a report). Photo Pages drop their running top
+   header (customer + date) and keep only a slim footer (Section name + page
+   number).
+
+7. **Scope: desktop only.** The new layout (restored nav, left-rail section
+   navigation, one-section-at-a-time editing, the Add-Photos picker, the Cover
+   Page editor, the Report Settings panel, the Preview pane) is a **computer**
+   (`lg`, ≥1024px) experience rendered with CSS breakpoints. The phone builder is
+   unchanged and still renders below `lg`.
+
+## Consequences
+
+- Reverses the "single look / same audience" rationale of 0003 (already partly
+  reversed by 0009) for the **cover** and the **layout knobs**, re-growing the
+  surface area those ADRs shrank. Accepted because the business genuinely
+  produces reports for different audiences.
+- **Data-shape change** requiring a migration: `photo_reports` gains a per-report
+  cover photo reference, the cover-block visibility flags, and the Report
+  Settings (photos-per-page + detail toggles); the Organization gains a **Report
+  layout default** (the seed). Old rows must be read-tolerant — a report with no
+  stored settings reads as the Organization default, no stored cover config reads
+  as "all blocks on," and no per-report cover photo falls back to the Job's.
+- The PDF engine gains a **3-per-page Photo Page layout** and loses 1-per-page;
+  the cover renderer becomes driven by per-report config rather than wholesale
+  Job data; `resolvePhotosPerPage` widens to 2/3/4 and reads the report's
+  snapshot (Organization default as fallback).
+- Snapshot-on-create means a report's look is **stable** once created; an
+  Organization changing its default is not a way to restyle existing reports
+  (consistent with 0012). Restyling an existing report is a per-report edit.
+- The builder's auto-save whitelist and reducer grow to carry the cover config,
+  cover photo, and Report Settings alongside title/date/sections.
+- Existing generated PDFs in the `reports` bucket are not regenerated; they keep
+  their old layout as a historical record (consistent with 0003/0009).
+
+## Considered options
+
+- **Keep the cover and photos-per-page global; only restyle the builder UI.**
+  Rejected: it ignores the actual driver — the owner wants per-report covers and
+  density, which a global look cannot express.
+- **Live (non-snapshot) settings: a report always reads the current Organization
+  default.** Rejected in favor of the snapshot model (0012) so editing the
+  default cannot silently change the look of reports already sent to an adjuster.
+- **Keep 1-per-page alongside 2/3/4.** Rejected to match the mockup; the
+  single-photo layout is dropped and its users fall back to the default.
+- **Build text-alignment in the write-up to match the mockup toolbar.** Rejected:
+  the rich-text → PDF mapping does not carry alignment and the canonical write-up
+  is paragraphs + lists only, so the alignment buttons are dropped rather than
+  shown-but-ignored.
+- **Always-live Preview that re-renders on every keystroke.** Rejected for an
+  on-demand Preview pane (refresh on click) that reuses the real PDF engine, so
+  what you see is the actual output without paying a re-render on every edit.


### PR DESCRIPTION
Design docs for the Photo Report Builder desktop upgrade (issue #540), synthesized into PRD #547.

## What's here

- **ADR 0014** (new) — Photo Reports carry a per-report Cover Page and per-report Report Settings (snapshot-seeded from an Organization default), photos-per-page `1/2/4 → 2/3/4`, per-layout write-up caps, the builder regains the (collapsed) app navigation, photo pages drop the running top header, and "location captured" = the Job's property address.
- **ADR 0003 / 0009** — status lines cross-linked to 0014 (it supersedes parts of both).
- **CONTEXT.md** — new glossary terms (Cover Page, Section Title Page, Photo Page, Report Settings, Report layout default) and an updated Section definition.

## Scope

Docs only — no code. Implementation is tracked in PRD #547, decomposed into slices #548–#554.

Refs #540, #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
