### PR TITLE
chore(estimate-builder): editor-panel polish — animations, global Escape, $ on add-item price

### DIFF
--- a/src/components/estimate-builder/add-item-dialog.tsx
+++ b/src/components/estimate-builder/add-item-dialog.tsx
@@ -519,15 +519,20 @@ function CustomTab({
         <Label htmlFor="custom-unit-price" className="text-sm font-medium">
           Unit Price <span className="text-destructive">*</span>
         </Label>
-        <Input
-          id="custom-unit-price"
-          type="number"
-          value={unitPrice}
-          onChange={(e) => setUnitPrice(e.target.value)}
-          placeholder="0.00"
-          step="0.01"
-          className="text-sm"
-        />
+        <div className="relative">
+          <span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+            $
+          </span>
+          <Input
+            id="custom-unit-price"
+            type="number"
+            value={unitPrice}
+            onChange={(e) => setUnitPrice(e.target.value)}
+            placeholder="0.00"
+            step="0.01"
+            className="pl-6 text-sm"
+          />
+        </div>
       </div>
 
       {/* Submit button */}

--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -1735,7 +1735,6 @@ export function EstimateBuilder({
           editorSlot={
             selectedInvoiceItem && (
               <LineItemEditorPanel
-                key={selectedInvoiceItem.id}
                 item={selectedInvoiceItem}
                 onChange={(partial) =>
                   onLineItemChange(selectedInvoiceItem.id, partial)
@@ -1941,7 +1940,6 @@ export function EstimateBuilder({
           editorSlot={
             selectedTemplateItem && (
               <LineItemEditorPanel
-                key={selectedTemplateItem.id}
                 item={selectedTemplateItem as BuilderLineItem}
                 onChange={(partial) =>
                   onLineItemChange(selectedTemplateItem.id, partial)
@@ -2168,7 +2166,6 @@ export function EstimateBuilder({
         editorSlot={
           selectedItem && (
             <LineItemEditorPanel
-              key={selectedItem.id}
               item={selectedItem}
               onChange={(partial) => onLineItemChange(selectedItem.id, partial)}
               onClose={lineSelection.clear}

--- a/src/components/estimate-builder/line-item-editor-panel.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.test.tsx
@@ -239,6 +239,40 @@ describe("LineItemEditorPanel", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("closes on Escape even when focus has left the panel subtree (global)", () => {
+    const onClose = vi.fn();
+    render(
+      <LineItemEditorPanel item={makeItem()} onChange={vi.fn()} onClose={onClose} />,
+    );
+
+    // Escape fired from the document body (focus is no longer in the panel) —
+    // the local onKeyDown wouldn't see this; a window-level listener does.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not steal Escape from a modal dialog layered above it", () => {
+    const onClose = vi.fn();
+    render(
+      <>
+        <LineItemEditorPanel
+          item={makeItem()}
+          onChange={vi.fn()}
+          onClose={onClose}
+        />
+        <div role="dialog">
+          <button data-testid="dialog-button">Cancel</button>
+        </div>
+      </>,
+    );
+
+    // Escape originating inside an open dialog must close the dialog, not the
+    // editor panel — the global listener bows out when the event comes from a
+    // [role="dialog"] subtree.
+    fireEvent.keyDown(screen.getByTestId("dialog-button"), { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("disables every field when readOnly (voided entity)", () => {
     render(
       <LineItemEditorPanel

--- a/src/components/estimate-builder/line-item-editor-panel.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.tsx
@@ -3,8 +3,10 @@
 // LineItemEditorPanel (#544) — the editor surface for the currently selected
 // line. Holds its own draft state for all seven fields and commits on blur
 // through the shared change pathway (`onChange`), so auto-save behaves exactly
-// as the inline row does. Renders docked on desktop and as a slide-up sheet on
-// phone. (Built up test-first — fields/behaviors arrive per cycle.)
+// as the inline row does. Renders docked on desktop (slides in from the right)
+// and as a slide-up sheet on phone, both via tw-animate-css entrance classes.
+// Escape closes it from anywhere (window-level), and on phone a tap-dismiss
+// scrim sits behind the sheet. (Built up test-first — fields/behaviors per cycle.)
 
 import { useEffect, useRef, useState } from "react";
 import { X } from "lucide-react";
@@ -111,6 +113,28 @@ export function LineItemEditorPanel({
     nameRef.current?.focus();
   }, [item.id]);
 
+  // Escape closes the editor from anywhere — not only while focus is still
+  // inside the panel. A single window-level listener (registered once) covers
+  // the case where focus has moved to the document or the totals bar. It bows
+  // out when the Escape originates inside a modal dialog layered above the panel
+  // (e.g. the Add-item dialog) so it never steals that dialog's own Escape.
+  // onClose is read through a ref so the listener is bound once, not re-bound on
+  // every keystroke re-render.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key !== "Escape" || e.defaultPrevented) return;
+      const target = e.target as HTMLElement | null;
+      if (target?.closest?.('[role="dialog"]')) return;
+      onCloseRef.current();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   // ── Live line total — computed from the local editing values. ──────────────
   const localQty = Number(quantity);
   const liveTotal =
@@ -181,20 +205,17 @@ export function LineItemEditorPanel({
         <div
           data-testid="editor-scrim"
           onClick={onClose}
-          className="fixed inset-0 z-40 bg-black/40"
+          className="fixed inset-0 z-40 bg-black/40 animate-in fade-in-0 duration-200"
         />
       )}
       <div
         data-testid="line-item-editor-panel"
         data-variant={isDesktop ? "desktop" : "phone"}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") onClose();
-        }}
         className={cn(
-          "flex flex-col bg-card border-border",
+          "flex flex-col bg-card border-border animate-in fade-in-0 duration-200",
           isDesktop
-            ? "sticky top-6 w-full shrink-0 lg:w-[22rem] max-h-[calc(100vh-3rem)] rounded-xl border shadow-sm"
-            : "fixed inset-x-0 bottom-0 z-50 max-h-[85vh] rounded-t-2xl border-t shadow-2xl",
+            ? "sticky top-6 w-full shrink-0 lg:w-[22rem] max-h-[calc(100vh-3rem)] rounded-xl border shadow-sm slide-in-from-right-4"
+            : "fixed inset-x-0 bottom-0 z-50 max-h-[85vh] rounded-t-2xl border-t shadow-2xl slide-in-from-bottom-8",
         )}
       >
         {/* ── Header ──────────────────────────────────────────────────────── */}


### PR DESCRIPTION
## Summary

Polish follow-ups surfaced by the **#541** PRD review (all five slices — #542–#546 — already merged to `main`). Scoped to the Estimate Builder editor surface; no behavior-breaking changes.

## Changes

- **Remove redundant `key={item.id}` remount** at the three editor call sites (estimate / invoice / template). The panel's reseed-on-swap path is already test-covered, so this just activates it: no full remount per row-click, and the entrance animation now plays on *open* instead of replaying on every swap.
- **Global Escape close** — replace the panel-local `onKeyDown` with a single guarded `window` keydown listener, so Escape closes the editor even when focus has left the panel subtree. It bows out when the Escape originates inside a `[role="dialog"]` so it never steals a modal's own Escape.
- **Entrance animations** — `tw-animate-css` classes (desktop slide-in-from-right, phone slide-up, scrim fade), making the "slide-up sheet" comment true.
- **`$` on Add-item Unit Price** — adornment for parity with `MoneyInput`. Kept the plain number input to preserve the empty/required validation that `MoneyInput`'s numeric `value` can't express.

## Intentionally unchanged
- **Focus-on-swap** — asserted by an existing test (`line-item-editor-panel.test.tsx`); it's spec, not a defect.
- **"Line total beside the box"** — kept as the labeled row; clearer than cramming it beside the input.

## Testing
- `estimate-builder/` suite: **142/142 green** (incl. 2 new Escape tests + the swap/reseed paths now running without the `key`).
- `tsc --noEmit` and `eslint` clean on all touched files.

Wraps up the last polish items from #541.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
