### PR TITLE
feat(photo-reports): per-report Report Settings + Cover Page data layer (#549)

### DIFF
--- a/src/app/api/jobs/[id]/reports/[reportId]/route.test.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/route.test.ts
@@ -112,6 +112,47 @@ describe("PUT /api/jobs/[id]/reports/[reportId]", () => {
     );
   });
 
+  it("persists per-report Report Settings / Cover config / cover photo (ADR 0014, #549)", async () => {
+    // The builder's autosave also flushes the per-report layout snapshot: the
+    // Report Settings JSONB (photos-per-page + detail toggles), the Cover Page
+    // block-visibility config, and the chosen cover photo. These ride the same
+    // keepalive PUT and must be whitelisted through to the update payload.
+    const client = fakeUserClient({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_jobs"],
+        extraTables: {
+          photo_reports: [{ id: "r-1", job_id: "job-1", deleted_at: null }],
+        },
+      }),
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await PUT(
+      putRequest({
+        report_settings: { photosPerPage: 3, photoNumbers: false },
+        cover_config: { logo: false, insurance: true },
+        cover_photo_id: "photo-9",
+      }),
+      paramsFor("job-1", "r-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(client.__mutations).toContainEqual(
+      expect.objectContaining({
+        table: "photo_reports",
+        op: "update",
+        payload: {
+          report_settings: { photosPerPage: 3, photoNumbers: false },
+          cover_config: { logo: false, insurance: true },
+          cover_photo_id: "photo-9",
+        },
+      }),
+    );
+  });
+
   it("rejects a cross-tenant write (report reached through the wrong Job) with 404", async () => {
     // The report exists, but it belongs to a different Job — a caller must not be
     // able to write to it by guessing its id through their own Job. The

--- a/src/app/api/jobs/[id]/reports/[reportId]/route.ts
+++ b/src/app/api/jobs/[id]/reports/[reportId]/route.ts
@@ -21,6 +21,14 @@ interface UpdatePayload {
   title?: string;
   report_date?: string;
   sections?: unknown[];
+  // Per-report layout snapshot (ADR 0014, #549): the Report Settings JSONB
+  // (photos-per-page + detail toggles), the Cover Page block-visibility config,
+  // and the chosen cover photo. The shapes are validated by the resolver in
+  // src/lib/photo-report-settings.ts on read (read-tolerant), so the write path
+  // only needs to whitelist them through.
+  report_settings?: unknown;
+  cover_config?: unknown;
+  cover_photo_id?: string | null;
 }
 
 export const PUT = withRequestContext(
@@ -33,11 +41,20 @@ export const PUT = withRequestContext(
     const { id: jobId, reportId } = await params;
     const body = (await request.json()) as UpdatePayload;
 
-    // Whitelist the three editable content columns; only keys actually present
-    // in the body are written, so a partial flush never clobbers a field the
-    // client didn't send.
+    // Whitelist the editable content columns; only keys actually present in the
+    // body are written, so a partial flush never clobbers a field the client
+    // didn't send. Beyond the original title/report_date/sections, ADR 0014
+    // (#549) adds the per-report layout snapshot: report_settings, cover_config,
+    // and cover_photo_id.
     const update: Record<string, unknown> = {};
-    for (const k of ["title", "report_date", "sections"] as const) {
+    for (const k of [
+      "title",
+      "report_date",
+      "sections",
+      "report_settings",
+      "cover_config",
+      "cover_photo_id",
+    ] as const) {
       if (k in body && body[k] !== undefined) update[k] = body[k];
     }
 

--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -125,7 +125,13 @@ vi.mock("@dnd-kit/sortable", async () => {
 
 import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
-import { WRITEUP_CHARACTER_LIMIT } from "@/lib/section-writeup-fit";
+import { writeupLimitFor } from "@/lib/section-writeup-fit";
+
+// The builder caps the write-up at one PDF intro page. Until the builder is
+// wired to the report's resolved photos-per-page (a later #540 slice), it
+// measures against the default 2-per-page cap, so that is the limit these tests
+// assert against (the single 1500-char budget was retired in ADR 0014 / #549).
+const WRITEUP_CHARACTER_LIMIT = writeupLimitFor(2);
 import { generateReportPDF } from "@/lib/generate-report-pdf";
 import { toast } from "sonner";
 
@@ -145,6 +151,9 @@ function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
     created_at: "2026-06-04T00:00:00Z",
     updated_at: "2026-06-04T00:00:00Z",
     deleted_at: null,
+    report_settings: null,
+    cover_config: null,
+    cover_photo_id: null,
     ...overrides,
   };
 }

--- a/src/lib/photo-report-settings.test.ts
+++ b/src/lib/photo-report-settings.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REPORT_DEFAULT_SETTING_KEYS,
+  companySettingsToReportDefault,
+  resolveReportSettings,
+} from "./photo-report-settings";
+
+describe("resolveReportSettings", () => {
+  it("falls back to the hardcoded defaults when nothing is stored (2-up, all toggles on, all cover blocks on)", () => {
+    // A pre-0014 report has no stored settings and the Organization has no
+    // Report layout default: the resolver must still return a complete look.
+    // The last-resort defaults are 2 photos per page, every detail toggle on,
+    // every cover block on, and no cover photo.
+    const resolved = resolveReportSettings(null, null);
+
+    expect(resolved.photosPerPage).toBe(2);
+    expect(resolved.details).toEqual({
+      sectionTitlePages: true,
+      photoNumbers: true,
+      capturedBy: true,
+      location: true,
+      dateCaptured: true,
+      photoTags: true,
+    });
+    expect(resolved.cover).toEqual({
+      logo: true,
+      customer: true,
+      propertyAddress: true,
+      pointOfContact: true,
+      insurance: true,
+      coverPhotoId: null,
+    });
+  });
+
+  it("uses the Organization default when the report has no stored settings of its own", () => {
+    // A freshly-created report whose snapshot is absent reads as the
+    // Organization's Report layout default (the seed it would have copied).
+    const resolved = resolveReportSettings(null, {
+      photosPerPage: 4,
+      details: {
+        sectionTitlePages: false,
+        photoNumbers: true,
+        capturedBy: false,
+        location: true,
+        dateCaptured: false,
+        photoTags: true,
+      },
+    });
+
+    expect(resolved.photosPerPage).toBe(4);
+    expect(resolved.details).toEqual({
+      sectionTitlePages: false,
+      photoNumbers: true,
+      capturedBy: false,
+      location: true,
+      dateCaptured: false,
+      photoTags: true,
+    });
+  });
+
+  it("falls through a partial Organization default field-by-field to the hardcoded defaults", () => {
+    // The Organization default need not be complete: a field it omits falls
+    // through to the hardcoded default (on / 2-up), never to "off".
+    const resolved = resolveReportSettings(null, {
+      details: { photoNumbers: false },
+    });
+
+    expect(resolved.photosPerPage).toBe(2); // omitted → hardcoded default
+    expect(resolved.details).toEqual({
+      sectionTitlePages: true,
+      photoNumbers: false, // the one field the Org default set
+      capturedBy: true,
+      location: true,
+      dateCaptured: true,
+      photoTags: true,
+    });
+  });
+
+  it("lets the report's own snapshot win over the Organization default, field-by-field", () => {
+    // Once a report has its own snapshot, that is its look — editing the
+    // Organization default never reaches back into it (snapshot model, ADR 0014).
+    // A field the snapshot omits still falls through to the Org default.
+    const resolved = resolveReportSettings(
+      {
+        report_settings: {
+          photosPerPage: 3,
+          capturedBy: false,
+        },
+      },
+      {
+        photosPerPage: 4,
+        details: {
+          sectionTitlePages: false,
+          capturedBy: true,
+          photoTags: false,
+        },
+      },
+    );
+
+    expect(resolved.photosPerPage).toBe(3); // snapshot wins over Org's 4
+    expect(resolved.details).toEqual({
+      sectionTitlePages: false, // snapshot silent → Org default
+      photoNumbers: true, // silent in both → hardcoded default
+      capturedBy: false, // snapshot wins over Org's true
+      location: true,
+      dateCaptured: true,
+      photoTags: false, // snapshot silent → Org default
+    });
+  });
+
+  it("normalizes a legacy 1-per-page value to 2, the retired layout's fallback (ADR 0014)", () => {
+    // 1-per-page is dropped. A report or Organization still carrying 1 reads as
+    // 2 — the hardcoded default — rather than falling through or rendering an
+    // unsupported layout. This holds whether the value is a number or a string.
+    expect(
+      resolveReportSettings({ report_settings: { photosPerPage: 1 } }, { photosPerPage: 4 })
+        .photosPerPage,
+    ).toBe(2); // snapshot's retired 1 → 2, not the Org's 4
+    expect(
+      resolveReportSettings({ report_settings: { photosPerPage: "1" } }, null).photosPerPage,
+    ).toBe(2);
+    // (A legacy Organization default of 1 is normalized when the key-value rows
+    // are parsed — see the companySettingsToReportDefault "legacy 1" test.)
+  });
+
+  it("accepts a string photos-per-page (JSONB / key-value rows arrive as strings)", () => {
+    // The snapshot JSONB and the Organization key-value rows can carry "3" as a
+    // string; the resolver coerces it to the numeric layout it names.
+    expect(
+      resolveReportSettings({ report_settings: { photosPerPage: "3" } }, null).photosPerPage,
+    ).toBe(3);
+  });
+
+  it("ignores an out-of-range photos-per-page and falls through the precedence chain", () => {
+    // A garbage or unsupported value (0, 5, "abc") is treated as absent, so the
+    // next tier decides — never an unsupported layout reaching the renderer.
+    expect(
+      resolveReportSettings({ report_settings: { photosPerPage: 5 } }, { photosPerPage: 3 })
+        .photosPerPage,
+    ).toBe(3); // snapshot garbage → Org default
+    expect(
+      resolveReportSettings({ report_settings: { photosPerPage: "abc" } }, null).photosPerPage,
+    ).toBe(2); // garbage with no Org default → hardcoded default
+  });
+
+  it("reads a report's own cover-block visibility, defaulting any omitted block to on", () => {
+    // Cover config is per-report (no Organization tier): a block the report
+    // hides stays hidden, and any block it leaves unset defaults on.
+    const resolved = resolveReportSettings(
+      { cover_config: { logo: false, insurance: false } },
+      null,
+    );
+
+    expect(resolved.cover).toEqual({
+      logo: false, // hidden by the report
+      customer: true, // unset → default on
+      propertyAddress: true,
+      pointOfContact: true,
+      insurance: false, // hidden by the report
+      coverPhotoId: null,
+    });
+  });
+
+  it("falls back to the Job's cover photo when the report has none of its own", () => {
+    // A new report seeds its cover photo from the Job's (ADR 0014). Until the
+    // report picks its own, the resolver fills in the Job's cover photo.
+    expect(resolveReportSettings(null, null, "job-photo-1").cover.coverPhotoId).toBe(
+      "job-photo-1",
+    );
+    expect(
+      resolveReportSettings({ cover_photo_id: null }, null, "job-photo-1").cover.coverPhotoId,
+    ).toBe("job-photo-1");
+  });
+
+  it("lets the report's own cover photo win over the Job's", () => {
+    // Once the report picks a cover photo, that overrides the Job's seed.
+    expect(
+      resolveReportSettings({ cover_photo_id: "report-photo-9" }, null, "job-photo-1").cover
+        .coverPhotoId,
+    ).toBe("report-photo-9");
+  });
+
+  it("resolves the cover photo to null when neither the report nor the Job has one", () => {
+    expect(resolveReportSettings(null, null).cover.coverPhotoId).toBe(null);
+    expect(resolveReportSettings({ cover_photo_id: null }, null, null).cover.coverPhotoId).toBe(
+      null,
+    );
+  });
+});
+
+describe("companySettingsToReportDefault", () => {
+  it("parses the Organization key-value rows into a Report layout default", () => {
+    // company_settings rows are strings; the photos-per-page key parses to a
+    // number and the detail keys parse "true"/"false" to booleans.
+    const def = companySettingsToReportDefault({
+      [REPORT_DEFAULT_SETTING_KEYS.photosPerPage]: "3",
+      [REPORT_DEFAULT_SETTING_KEYS.sectionTitlePages]: "false",
+      [REPORT_DEFAULT_SETTING_KEYS.photoNumbers]: "true",
+      [REPORT_DEFAULT_SETTING_KEYS.capturedBy]: "false",
+      [REPORT_DEFAULT_SETTING_KEYS.location]: "true",
+      [REPORT_DEFAULT_SETTING_KEYS.dateCaptured]: "false",
+      [REPORT_DEFAULT_SETTING_KEYS.photoTags]: "true",
+    });
+
+    expect(def).toEqual({
+      photosPerPage: 3,
+      details: {
+        sectionTitlePages: false,
+        photoNumbers: true,
+        capturedBy: false,
+        location: true,
+        dateCaptured: false,
+        photoTags: true,
+      },
+    });
+  });
+
+  it("omits keys the Organization has not set, leaving them to fall through (read-tolerant)", () => {
+    // An Organization that never configured a Report layout default produces an
+    // empty default, which resolves to the hardcoded defaults.
+    expect(companySettingsToReportDefault(null)).toEqual({});
+    expect(companySettingsToReportDefault({})).toEqual({});
+
+    const resolved = resolveReportSettings(null, companySettingsToReportDefault({}));
+    expect(resolved.photosPerPage).toBe(2);
+    expect(resolved.details.photoNumbers).toBe(true);
+
+    // A partially-configured Organization carries only what it set.
+    expect(
+      companySettingsToReportDefault({
+        [REPORT_DEFAULT_SETTING_KEYS.photosPerPage]: "4",
+        [REPORT_DEFAULT_SETTING_KEYS.capturedBy]: "false",
+      }),
+    ).toEqual({ photosPerPage: 4, details: { capturedBy: false } });
+  });
+
+  it("normalizes a legacy 1-per-page Organization default to 2", () => {
+    expect(
+      companySettingsToReportDefault({
+        [REPORT_DEFAULT_SETTING_KEYS.photosPerPage]: "1",
+      }),
+    ).toEqual({ photosPerPage: 2 });
+  });
+});

--- a/src/lib/photo-report-settings.ts
+++ b/src/lib/photo-report-settings.ts
@@ -1,0 +1,209 @@
+// src/lib/photo-report-settings.ts — the per-report Report Settings + Cover
+// Page config core (ADR 0014, #549).
+//
+// A report carries its own snapshot of how it looks: photos-per-page, the six
+// detail toggles, and the Cover Page config (which identifying blocks show, plus
+// the chosen cover photo). A new report seeds these from the Organization's
+// Report layout default; thereafter the report keeps its own copy, so editing
+// the Organization default never rewrites a report that already exists (the same
+// snapshot model as billing PDFs, ADR 0012). This module holds the pure pieces
+// the feature resolves through — no I/O. Every function here is unit-tested.
+
+import type { ReportPhotosPerPage } from "./types";
+
+/** The six per-report detail toggles (ADR 0014). All default on. */
+export interface ReportDetailToggles {
+  sectionTitlePages: boolean;
+  photoNumbers: boolean;
+  capturedBy: boolean;
+  location: boolean;
+  dateCaptured: boolean;
+  photoTags: boolean;
+}
+
+/** The five Cover Page block-visibility flags (ADR 0014). All default on. */
+export interface CoverBlockVisibility {
+  logo: boolean;
+  customer: boolean;
+  propertyAddress: boolean;
+  pointOfContact: boolean;
+  insurance: boolean;
+}
+
+/** A report's fully-resolved Cover Page config: block visibility + cover photo. */
+export interface ResolvedCoverConfig extends CoverBlockVisibility {
+  /** The photo printed on the cover, or null when none is chosen anywhere. */
+  coverPhotoId: string | null;
+}
+
+/** A report's fully-resolved look: photos-per-page, details, and cover config. */
+export interface ResolvedReportSettings {
+  photosPerPage: ReportPhotosPerPage;
+  details: ReportDetailToggles;
+  cover: ResolvedCoverConfig;
+}
+
+/**
+ * The Organization's Report layout default — the seed a new report copies (ADR
+ * 0014). Every field is optional: an Organization that has set nothing, or only
+ * some knobs, leaves the rest to fall through to the hardcoded defaults. It
+ * carries no cover config; the cover is per-report only.
+ */
+export interface ReportLayoutDefault {
+  photosPerPage?: ReportPhotosPerPage;
+  details?: Partial<ReportDetailToggles>;
+}
+
+/**
+ * The `report_settings` JSONB a report stores — photos-per-page plus the six
+ * detail toggles. Every field is optional and read-tolerant: a pre-0014 row, or
+ * a partial write, leaves fields absent and they fall through the precedence
+ * chain. `photosPerPage` is typed loosely because JSONB and the legacy
+ * 1-per-page value can arrive as a string or a number.
+ */
+export interface StoredReportSettingsJson extends Partial<ReportDetailToggles> {
+  photosPerPage?: ReportPhotosPerPage | number | string | null;
+}
+
+/**
+ * The slice of a `photo_reports` row this resolver reads: its own settings
+ * snapshot, cover config, and cover photo. All read-tolerant — a pre-0014 row
+ * has them all absent and reads as the Organization default / all-on cover.
+ */
+export interface StoredReportSettings {
+  report_settings?: StoredReportSettingsJson | null;
+  cover_config?: Partial<CoverBlockVisibility> | null;
+  cover_photo_id?: string | null;
+}
+
+// The last-resort defaults: 2 photos per page, every detail toggle on, every
+// cover block on, no cover photo. Used when a report has neither its own
+// snapshot nor an Organization default (ADR 0014).
+const DEFAULT_PHOTOS_PER_PAGE: ReportPhotosPerPage = 2;
+
+const ALL_DETAILS_ON: ReportDetailToggles = {
+  sectionTitlePages: true,
+  photoNumbers: true,
+  capturedBy: true,
+  location: true,
+  dateCaptured: true,
+  photoTags: true,
+};
+
+const ALL_COVER_BLOCKS_ON: CoverBlockVisibility = {
+  logo: true,
+  customer: true,
+  propertyAddress: true,
+  pointOfContact: true,
+  insurance: true,
+};
+
+const DETAIL_KEYS = Object.keys(ALL_DETAILS_ON) as (keyof ReportDetailToggles)[];
+const COVER_BLOCK_KEYS = Object.keys(
+  ALL_COVER_BLOCKS_ON,
+) as (keyof CoverBlockVisibility)[];
+
+/**
+ * Coerce a stored photos-per-page value (number or string, from JSONB or a
+ * key-value row) to a supported {@link ReportPhotosPerPage}. The retired
+ * 1-per-page layout maps to 2 (ADR 0014); an out-of-range or unparseable value
+ * returns undefined so the caller falls through the precedence chain.
+ */
+export function normalizePhotosPerPage(
+  value: ReportPhotosPerPage | number | string | null | undefined,
+): ReportPhotosPerPage | undefined {
+  const n = Number(value);
+  if (n === 1) return 2; // retired single-photo layout → the default
+  if (n === 2 || n === 3 || n === 4) return n;
+  return undefined;
+}
+
+/**
+ * The `company_settings` key-value keys that hold the Organization's Report
+ * layout default (ADR 0014, #549). `photosPerPage` reuses the pre-existing
+ * `report_photos_per_page` key; the six detail toggles are new.
+ */
+export const REPORT_DEFAULT_SETTING_KEYS = {
+  photosPerPage: "report_photos_per_page",
+  sectionTitlePages: "report_detail_section_title_pages",
+  photoNumbers: "report_detail_photo_numbers",
+  capturedBy: "report_detail_captured_by",
+  location: "report_detail_location",
+  dateCaptured: "report_detail_date_captured",
+  photoTags: "report_detail_photo_tags",
+} as const;
+
+// Parse a key-value string into a boolean, or undefined when unset/unparseable
+// so the field falls through the precedence chain rather than reading as "off".
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+/**
+ * Build the Organization's {@link ReportLayoutDefault} from its `company_settings`
+ * key-value rows (a flat string record). Unset or unparseable keys are omitted,
+ * so a never-configured Organization yields an empty default that resolves to
+ * the hardcoded defaults. A legacy 1-per-page value normalizes to 2.
+ */
+export function companySettingsToReportDefault(
+  settings: Record<string, string | undefined> | null | undefined,
+): ReportLayoutDefault {
+  const result: ReportLayoutDefault = {};
+
+  const photosPerPage = normalizePhotosPerPage(
+    settings?.[REPORT_DEFAULT_SETTING_KEYS.photosPerPage],
+  );
+  if (photosPerPage !== undefined) result.photosPerPage = photosPerPage;
+
+  const details: Partial<ReportDetailToggles> = {};
+  for (const key of DETAIL_KEYS) {
+    const parsed = parseBool(settings?.[REPORT_DEFAULT_SETTING_KEYS[key]]);
+    if (parsed !== undefined) details[key] = parsed;
+  }
+  if (Object.keys(details).length > 0) result.details = details;
+
+  return result;
+}
+
+/**
+ * Resolve a report's effective look. Precedence, per field: the report's own
+ * snapshot wins; else the Organization's Report layout default; else the
+ * hardcoded defaults. Always returns a complete {@link ResolvedReportSettings} —
+ * the builder and PDF engine must never face a report with "no look."
+ *
+ * The cover photo resolves the report's own choice first, then the Job's cover
+ * photo (`jobCoverPhotoId` — the seed a new report copies, ADR 0014), then null.
+ */
+export function resolveReportSettings(
+  reportStored: StoredReportSettings | null,
+  organizationDefault: ReportLayoutDefault | null,
+  jobCoverPhotoId: string | null = null,
+): ResolvedReportSettings {
+  const stored = reportStored?.report_settings;
+  const orgDetails = organizationDefault?.details;
+
+  const photosPerPage =
+    normalizePhotosPerPage(stored?.photosPerPage) ??
+    normalizePhotosPerPage(organizationDefault?.photosPerPage) ??
+    DEFAULT_PHOTOS_PER_PAGE;
+
+  // Per-field precedence: report snapshot > Organization default > hardcoded
+  // default. A field absent (`undefined`) at one tier falls through, never "off".
+  const details = {} as ReportDetailToggles;
+  for (const key of DETAIL_KEYS) {
+    details[key] = stored?.[key] ?? orgDetails?.[key] ?? ALL_DETAILS_ON[key];
+  }
+
+  // Cover config is per-report only (no Organization tier): each block the
+  // report leaves unset defaults on.
+  const storedCover = reportStored?.cover_config;
+  const coverPhotoId = reportStored?.cover_photo_id ?? jobCoverPhotoId ?? null;
+  const cover = { coverPhotoId } as ResolvedCoverConfig;
+  for (const key of COVER_BLOCK_KEYS) {
+    cover[key] = storedCover?.[key] ?? ALL_COVER_BLOCKS_ON[key];
+  }
+
+  return { photosPerPage, details, cover };
+}

--- a/src/lib/photo-reports.test.ts
+++ b/src/lib/photo-reports.test.ts
@@ -21,6 +21,12 @@ import { createPhotoReportDraft } from "./photo-reports";
 //   - photo_report_templates: the select chain ends in `.maybeSingle()`, which
 //     resolves to `opts.template` (or null when the id resolves to nothing —
 //     e.g. a deleted template or another Organization's id dropped by RLS).
+//   - company_settings: the select chain (key/value rows for the org) is awaited
+//     and resolves to `opts.companySettings` (the Organization's Report layout
+//     default, in key/value form); defaults to none set.
+//   - jobs: the select chain ends in `.maybeSingle()` and resolves the Job's
+//     `cover_photo_id` (`opts.jobCoverPhotoId`, default null) — the per-report
+//     cover photo's seed.
 // `inserted` exposes the captured insert payload so a test can assert exactly
 // what was written.
 function fakeSupabase(
@@ -28,6 +34,8 @@ function fakeSupabase(
   opts: {
     ownedPhotoIds?: string[];
     template?: Record<string, unknown> | null;
+    companySettings?: Array<{ key: string; value: string }>;
+    jobCoverPhotoId?: string | null;
   } = {},
 ) {
   let inserted: Record<string, unknown> | null = null;
@@ -50,17 +58,27 @@ function fakeSupabase(
         data: { id: "report-1", ...inserted },
         error: null,
       });
-      builder.maybeSingle = async () => ({
-        data:
-          table === "photo_report_templates" ? (opts.template ?? null) : null,
-        error: null,
-      });
+      builder.maybeSingle = async () => {
+        if (table === "photo_report_templates") {
+          return { data: opts.template ?? null, error: null };
+        }
+        if (table === "jobs") {
+          return {
+            data: { cover_photo_id: opts.jobCoverPhotoId ?? null },
+            error: null,
+          };
+        }
+        return { data: null, error: null };
+      };
       builder.then = (resolve: (r: unknown) => void) => {
         if (table === "photos") {
           const owned = opts.ownedPhotoIds
             ? inIds.filter((id) => opts.ownedPhotoIds!.includes(id))
             : inIds;
           return resolve({ data: owned.map((id) => ({ id })), error: null });
+        }
+        if (table === "company_settings") {
+          return resolve({ data: opts.companySettings ?? [], error: null });
         }
         return resolve({ data: existing, error: null });
       };
@@ -386,5 +404,86 @@ describe("createPhotoReportDraft", () => {
 
     const sections = supabase.inserted?.sections as Array<{ id: string }>;
     expect(sections.map((s) => s.id)).toEqual(["sec-1", "sec-2", "sec-3"]);
+  });
+
+  it("snapshots the Organization's Report layout default into the new report's settings (#549)", async () => {
+    // ADR 0014: a new report COPIES the Organization's Report layout default at
+    // creation, then keeps its own copy. The snapshot is complete — fields the
+    // Organization left unset are filled with the hardcoded defaults — so a later
+    // edit to the Organization default can never reach back into this report.
+    const supabase = fakeSupabase([], {
+      companySettings: [
+        { key: "report_photos_per_page", value: "3" },
+        { key: "report_detail_captured_by", value: "false" },
+      ],
+    });
+
+    await createPhotoReportDraft(supabase, {
+      organizationId: "org-1",
+      jobId: "job-1",
+      preparerName: "Eric Daniels",
+      photoIds: ["p1"],
+    });
+
+    expect(supabase.inserted?.report_settings).toEqual({
+      photosPerPage: 3, // from the Org default
+      sectionTitlePages: true, // unset in the Org default → hardcoded on
+      photoNumbers: true,
+      capturedBy: false, // from the Org default
+      location: true,
+      dateCaptured: true,
+      photoTags: true,
+    });
+  });
+
+  it("snapshots the hardcoded defaults when the Organization has no Report layout default", async () => {
+    // With nothing configured, the report still freezes a complete snapshot
+    // (2-up, every toggle on) rather than a null that would re-read the Org
+    // default live — keeping the report's look stable from creation.
+    const supabase = fakeSupabase([]);
+
+    await createPhotoReportDraft(supabase, {
+      organizationId: "org-1",
+      jobId: "job-1",
+      preparerName: "Eric Daniels",
+      photoIds: ["p1"],
+    });
+
+    expect(supabase.inserted?.report_settings).toEqual({
+      photosPerPage: 2,
+      sectionTitlePages: true,
+      photoNumbers: true,
+      capturedBy: true,
+      location: true,
+      dateCaptured: true,
+      photoTags: true,
+    });
+  });
+
+  it("seeds the report's cover photo from the Job's cover photo (#549)", async () => {
+    // ADR 0014: the per-report cover photo is seeded from the Job's at creation.
+    const supabase = fakeSupabase([], { jobCoverPhotoId: "job-cover-7" });
+
+    await createPhotoReportDraft(supabase, {
+      organizationId: "org-1",
+      jobId: "job-1",
+      preparerName: "Eric Daniels",
+      photoIds: ["p1"],
+    });
+
+    expect(supabase.inserted?.cover_photo_id).toBe("job-cover-7");
+  });
+
+  it("seeds a null cover photo when the Job has none", async () => {
+    const supabase = fakeSupabase([]);
+
+    await createPhotoReportDraft(supabase, {
+      organizationId: "org-1",
+      jobId: "job-1",
+      preparerName: "Eric Daniels",
+      photoIds: ["p1"],
+    });
+
+    expect(supabase.inserted?.cover_photo_id).toBeNull();
   });
 });

--- a/src/lib/photo-reports.ts
+++ b/src/lib/photo-reports.ts
@@ -17,6 +17,11 @@ import type { PhotoReport, PhotoReportTemplate } from "@/lib/types";
 import { nextReportNumber } from "./next-report-number";
 import { buildDefaultReportSections } from "./photo-report-builder";
 import { buildInitialSections, newSectionId } from "./build-initial-sections";
+import {
+  companySettingsToReportDefault,
+  resolveReportSettings,
+  type StoredReportSettingsJson,
+} from "./photo-report-settings";
 
 export interface CreatePhotoReportDraftInput {
   organizationId: string;
@@ -66,6 +71,18 @@ export async function createPhotoReportDraft(
   // blank, single-Photos-section start. `template_id` is provenance only.
   const template = await fetchTemplate(supabase, input.templateId);
 
+  // Snapshot the Organization's Report layout default into this report at
+  // creation (ADR 0014, #549): the report copies photos-per-page + the detail
+  // toggles, then keeps its own copy, so later edits to the Organization default
+  // never restyle a report that already exists (the per-document snapshot model
+  // of ADR 0012). The snapshot is complete — `resolveReportSettings` fills any
+  // field the Organization left unset with the hardcoded defaults — so it never
+  // re-reads the live Organization default. The per-report cover photo is seeded
+  // from the Job's cover photo (overridable later); cover-block visibility is
+  // left unset (NULL reads as "all blocks on") since it has no Organization seed.
+  const reportSettings = await seedReportSettings(supabase, input.organizationId);
+  const coverPhotoId = await fetchJobCoverPhotoId(supabase, input.jobId);
+
   const sections = template
     ? // Start from the template's boilerplate Sections (heading + write-up, no
       // photos), then append the user's selection as a separate Photos section
@@ -103,6 +120,8 @@ export async function createPhotoReportDraft(
         created_by: input.preparerName,
         sections,
         status: "draft",
+        report_settings: reportSettings,
+        cover_photo_id: coverPhotoId,
       })
       .select("*")
       .single<PhotoReport>();
@@ -141,6 +160,54 @@ async function nextReportNumberForJob(
     .map((row) => (row as { report_number: number | null }).report_number)
     .filter((n): n is number => typeof n === "number");
   return nextReportNumber(existingNumbers);
+}
+
+/**
+ * Build the complete Report Settings snapshot for a new report from the
+ * Organization's Report layout default (ADR 0014). Reads the Organization's
+ * `company_settings` key/value rows under the caller's RLS, resolves them
+ * through the shared precedence resolver (so every field is concrete, never
+ * "no look"), and flattens to the stored `report_settings` JSONB shape.
+ */
+async function seedReportSettings(
+  supabase: SupabaseClient,
+  organizationId: string,
+): Promise<StoredReportSettingsJson> {
+  const { data, error } = await supabase
+    .from("company_settings")
+    .select("key, value")
+    .eq("organization_id", organizationId);
+  if (error) throw new Error(error.message);
+
+  const settings: Record<string, string> = {};
+  for (const row of (data ?? []) as Array<{ key: string; value: string | null }>) {
+    settings[row.key] = row.value ?? "";
+  }
+
+  const resolved = resolveReportSettings(
+    null,
+    companySettingsToReportDefault(settings),
+  );
+  return { photosPerPage: resolved.photosPerPage, ...resolved.details };
+}
+
+/**
+ * Read a Job's cover photo id (the per-report cover photo's seed, ADR 0014), or
+ * null. Runs under the caller's RLS. A Job with no cover, or that resolves to
+ * nothing, yields null — the report starts with no per-report cover and falls
+ * back to the Job's at render time.
+ */
+async function fetchJobCoverPhotoId(
+  supabase: SupabaseClient,
+  jobId: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("jobs")
+    .select("cover_photo_id")
+    .eq("id", jobId)
+    .maybeSingle<{ cover_photo_id: string | null }>();
+  if (error) throw new Error(error.message);
+  return data?.cover_photo_id ?? null;
 }
 
 /**

--- a/src/lib/section-writeup-fit.test.ts
+++ b/src/lib/section-writeup-fit.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  measureWriteupFit,
-  WRITEUP_CHARACTER_LIMIT,
-} from "./section-writeup-fit";
+import { measureWriteupFit, writeupLimitFor } from "./section-writeup-fit";
 
 describe("measureWriteupFit", () => {
   it("counts the visible characters of a simple write-up", () => {
@@ -134,8 +131,29 @@ describe("measureWriteupFit", () => {
     expect(over.remaining).toBe(-1);
   });
 
-  it("exposes a positive default one-page character limit in the result", () => {
-    expect(WRITEUP_CHARACTER_LIMIT).toBeGreaterThan(0);
-    expect(measureWriteupFit("<p>x</p>").limit).toBe(WRITEUP_CHARACTER_LIMIT);
+  it("defaults the limit to the 2-per-page write-up cap (ADR 0014)", () => {
+    // The single 1500-char budget is gone; measureWriteupFit with no explicit
+    // limit now uses the 2-per-page cap, the densest write-up a 2-up page allows.
+    expect(measureWriteupFit("<p>x</p>").limit).toBe(writeupLimitFor(2));
+  });
+});
+
+describe("writeupLimitFor", () => {
+  it("returns the per-layout write-up cap for each photos-per-page layout", () => {
+    // Per ADR 0014: a 2-up page leaves the most room for prose, a 4-up the least.
+    expect(writeupLimitFor(2)).toBe(750);
+    expect(writeupLimitFor(3)).toBe(400);
+    expect(writeupLimitFor(4)).toBe(260);
+  });
+
+  it("is exercised through measureWriteupFit as the limit it measures against", () => {
+    // The cap a layout imposes is the same number measureWriteupFit checks the
+    // visible-character count against — the builder passes writeupLimitFor(N) in.
+    const body = `<p>${"a".repeat(401)}</p>`;
+    const at3 = measureWriteupFit(body, writeupLimitFor(3));
+    expect(at3.limit).toBe(400);
+    expect(at3.fits).toBe(false); // 401 visible chars over the 3-up cap of 400
+    const at2 = measureWriteupFit(body, writeupLimitFor(2));
+    expect(at2.fits).toBe(true); // same body fits under the looser 2-up cap of 750
   });
 });

--- a/src/lib/section-writeup-fit.ts
+++ b/src/lib/section-writeup-fit.ts
@@ -28,9 +28,28 @@
  */
 
 import { normalizeSectionWriteup } from "./section-writeup";
+import type { ReportPhotosPerPage } from "./types";
 
-/** Visible characters that comfortably fit on one Section intro page. */
-export const WRITEUP_CHARACTER_LIMIT = 1500;
+/**
+ * The one-page write-up character budget, per photos-per-page layout (ADR 0014,
+ * #549). A denser Photo Page leaves less room for the Section's intro prose, so
+ * the cap shrinks as the layout packs more photos per page. This replaces the
+ * single 1500-char {@link WRITEUP_CHARACTER_LIMIT} of the one-layout era.
+ */
+const WRITEUP_LIMITS: Record<ReportPhotosPerPage, number> = {
+  2: 750,
+  3: 400,
+  4: 260,
+};
+
+/**
+ * The one-page Section write-up character cap for a photos-per-page layout. The
+ * single source of truth the builder's live counter and save-time guard read,
+ * now keyed by the report's resolved layout rather than a global constant.
+ */
+export function writeupLimitFor(photosPerPage: ReportPhotosPerPage): number {
+  return WRITEUP_LIMITS[photosPerPage];
+}
 
 // Match real tags the same way `html-to-pdf`'s tokenizer does: "<" (optionally
 // "/") immediately followed by a letter. A stray "<" in prose ("gap was < 2in")
@@ -66,14 +85,14 @@ function visibleLength(html: string): number {
 
 /**
  * Measure how full a Section write-up is against the one-page character budget.
- * `limit` defaults to {@link WRITEUP_CHARACTER_LIMIT} but is overridable so the
- * counter, the guard, and tests all share one calculation. The write-up is run
+ * `limit` defaults to the 2-per-page cap ({@link writeupLimitFor}) but is
+ * overridable so the counter, the guard, and tests all share one calculation. The write-up is run
  * through {@link normalizeSectionWriteup} first, so it is measured as exactly the
  * string the PDF renderer receives.
  */
 export function measureWriteupFit(
   writeup: string | null | undefined,
-  limit: number = WRITEUP_CHARACTER_LIMIT,
+  limit: number = writeupLimitFor(2),
 ): WriteupFit {
   const used = visibleLength(normalizeSectionWriteup(writeup));
   return { used, limit, fits: used <= limit, remaining: limit - used };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,8 @@
+import type {
+  CoverBlockVisibility,
+  StoredReportSettingsJson,
+} from "./photo-report-settings";
+
 export interface Contact {
   id: string;
   /** Owning Organization. NOT NULL in the DB and enforced by RLS. */
@@ -230,6 +235,13 @@ export interface PhotoReportTemplate {
   updated_at: string;
 }
 
+/**
+ * Photos per Photo Page for a report's Report Settings (ADR 0014, #549). The
+ * legacy 1-per-page layout is dropped; reports/orgs previously on 1 fall back to
+ * 2. Widened from the old 1|2|4 to 2|3|4 (a new 3-up Photo Page is added).
+ */
+export type ReportPhotosPerPage = 2 | 3 | 4;
+
 export interface PhotoReport {
   id: string;
   /** Owning Organization. NOT NULL in the DB and enforced by RLS (#400). */
@@ -248,6 +260,22 @@ export interface PhotoReport {
   updated_at: string;
   /** Soft-delete timestamp for the recoverable trash (#402). Null = not deleted. */
   deleted_at: string | null;
+  /**
+   * Per-report snapshot of the Report Settings (photos-per-page + the six detail
+   * toggles), seeded from the Organization default at creation (ADR 0014, #549).
+   * Null on pre-0014 rows — read-tolerant, resolves to the Organization default.
+   */
+  report_settings: StoredReportSettingsJson | null;
+  /**
+   * Per-report Cover Page block visibility (logo/customer/property/contact/
+   * insurance). Null on pre-0014 rows — read-tolerant, resolves to all-on.
+   */
+  cover_config: Partial<CoverBlockVisibility> | null;
+  /**
+   * The report's own cover photo (ADR 0014). Null falls back to the Job's cover
+   * photo at resolve time. FK to `photos`, ON DELETE SET NULL.
+   */
+  cover_photo_id: string | null;
 }
 
 export interface EmailAddress {

--- a/supabase/migration-549-photo-report-settings.sql
+++ b/supabase/migration-549-photo-report-settings.sql
@@ -1,0 +1,43 @@
+-- migration-549 (issue #549, ADR 0014): per-report Report Settings + Cover Page.
+--
+-- A Photo Report becomes a per-document SNAPSHOT of how it looks, the same model
+-- as billing PDFs (ADR 0012): it carries its own copy of the Report Settings
+-- (photos-per-page + the six detail toggles) and the Cover Page config (which
+-- identifying blocks show + a chosen cover photo). A new report seeds these from
+-- the Organization's Report layout default at creation; thereafter editing the
+-- Organization default never rewrites a report that already exists.
+--
+-- All three columns are READ-TOLERANT for pre-0014 rows (the resolver in
+-- src/lib/photo-report-settings.ts decides the fallbacks):
+--   - report_settings NULL  -> the report reads as the Organization default
+--   - cover_config    NULL  -> every cover block reads as shown ("all on")
+--   - cover_photo_id  NULL  -> the cover photo falls back to the Job's cover photo
+-- so no backfill is needed and the columns are added nullable with no default.
+--
+-- report_settings JSONB shape (every field optional, read-tolerant):
+--   { photosPerPage: 2|3|4,
+--     sectionTitlePages, photoNumbers, capturedBy, location, dateCaptured,
+--     photoTags: boolean }
+-- cover_config JSONB shape (every field optional, defaults to shown when absent):
+--   { logo, customer, propertyAddress, pointOfContact, insurance: boolean }
+--
+-- cover_photo_id references photos(id) ON DELETE SET NULL, mirroring the Job's
+-- cover photo (migration-build77): deleting the referenced photo silently
+-- reverts the report to no per-report cover (falling back to the Job's) rather
+-- than blocking the delete or leaving a dangling id.
+--
+-- The Organization's Report layout default lives in the existing key/value
+-- company_settings table (keys in REPORT_DEFAULT_SETTING_KEYS), so it needs no
+-- schema change — its rows are written on demand by the settings UI.
+
+ALTER TABLE public.photo_reports
+  ADD COLUMN IF NOT EXISTS report_settings jsonb,
+  ADD COLUMN IF NOT EXISTS cover_config jsonb,
+  ADD COLUMN IF NOT EXISTS cover_photo_id uuid
+    REFERENCES public.photos(id) ON DELETE SET NULL;
+
+-- ROLLBACK ---
+-- ALTER TABLE public.photo_reports
+--   DROP COLUMN IF EXISTS report_settings,
+--   DROP COLUMN IF EXISTS cover_config,
+--   DROP COLUMN IF EXISTS cover_photo_id;

--- a/supabase/schema-photos.sql
+++ b/supabase/schema-photos.sql
@@ -119,6 +119,13 @@ CREATE TABLE photo_reports (
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
   deleted_at timestamptz,                      -- soft-delete for the recoverable trash (#402); NULL = not deleted
+  -- Per-report SNAPSHOT of how the report looks (ADR 0014, #549). All three are
+  -- read-tolerant: NULL report_settings reads as the Organization default, NULL
+  -- cover_config reads as "all cover blocks on", NULL cover_photo_id falls back
+  -- to the Job's cover photo. Resolved in src/lib/photo-report-settings.ts.
+  report_settings jsonb,                       -- { photosPerPage, sectionTitlePages, photoNumbers, capturedBy, location, dateCaptured, photoTags }
+  cover_config jsonb,                          -- { logo, customer, propertyAddress, pointOfContact, insurance }
+  cover_photo_id uuid REFERENCES photos(id) ON DELETE SET NULL,  -- per-report cover photo; seeded from the Job's, overridable (#549)
   organization_id uuid NOT NULL REFERENCES organizations(id)
 );
 


### PR DESCRIPTION
Closes #549.

Builds the **data layer** for per-report Report Settings + Cover Page config with snapshot-on-create semantics (ADR 0014, mirroring ADR 0012). **No builder UI** in this slice — that's a later slice.

## What's in it

**Migration / schema**
- `supabase/migration-549-photo-report-settings.sql` — adds `report_settings jsonb`, `cover_config jsonb`, `cover_photo_id uuid → photos(id) ON DELETE SET NULL` to `photo_reports`, all nullable + read-tolerant (no backfill). `company_settings` keeps its key/value shape (no schema change).
- `supabase/schema-photos.sql` — mirrors the three columns in the CREATE TABLE.

**Pure resolver** (`src/lib/photo-report-settings.ts`)
- `resolveReportSettings(reportStored, organizationDefault, jobCoverPhotoId?)` — precedence report snapshot → Org default → hardcoded (2-per-page, all toggles on, all cover blocks on). Legacy `1` → `2`; missing cover config ⇒ all blocks on; no per-report cover ⇒ Job's cover photo.
- `companySettingsToReportDefault`, `normalizePhotosPerPage`, key constants.

**Write-up limits** (`src/lib/section-writeup-fit.ts`)
- `writeupLimitFor(photosPerPage)` → `{2:750, 3:400, 4:260}`, replacing the single `WRITEUP_CHARACTER_LIMIT`.

**Seeding** (`src/lib/photo-reports.ts`)
- `createPhotoReportDraft` snapshots a complete `report_settings` from the Org default and seeds `cover_photo_id` from the Job's cover photo at creation.

**Autosave whitelist** (`src/app/api/jobs/[id]/reports/[reportId]/route.ts`)
- PUT now flushes `report_settings`, `cover_config`, `cover_photo_id` through the same `edit_jobs`-gated, tenancy-scoped path.

## Testing

Built test-first via vertical TDD slices.
- Full suite: 2698/2698 pass.
- `tsc --noEmit`: clean against the pre-existing 19-error environmental baseline (pg-integration missing modules + Capacitor camera plugin typing) — no new errors.

## Migration note

`migration-549-photo-report-settings.sql` is **not yet applied to prod** (`rzzprgidqbnqcdupmpfe`). The columns are read-tolerant so existing rows resolve fine, but the migration must be applied before the seeding/autosave write paths can persist the new columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)