### PR TITLE
feat(photo-report): restore app nav + desktop multi-pane shell (#548)

### DIFF
--- a/src/app/jobs/[id]/reports/[reportId]/page.tsx
+++ b/src/app/jobs/[id]/reports/[reportId]/page.tsx
@@ -7,10 +7,11 @@ import { requirePagePermission } from "@/lib/request-context/require-page-permis
 import PhotoReportBuilder from "@/components/photo-report-builder";
 import type { Photo, PhotoReport } from "@/lib/types";
 
-// The full-screen, Job-scoped Photo Report builder route (#400). Rendered
-// full-screen via the AppShell `INTERNAL_FULLSCREEN_PATTERNS` regex. The page
-// fetches the draft + its photos server-side (RLS scopes to the active org) and
-// hands them to the client builder, which auto-saves edits.
+// The Job-scoped Photo Report builder route (#400). A builder route in the
+// AppShell `BUILDER_ROUTE_PATTERNS` sense (#548): the app nav renders as the
+// slim collapsed rail beside the builder. The page fetches the draft + its
+// photos server-side (RLS scopes to the active org) and hands them to the
+// client builder, which auto-saves edits.
 export default async function PhotoReportBuilderPage({
   params,
 }: {

--- a/src/components/app-shell.test.tsx
+++ b/src/components/app-shell.test.tsx
@@ -140,6 +140,36 @@ describe("AppShell — persisted navbar unchanged off builder routes (#543)", ()
   });
 });
 
+describe("AppShell — Photo Report builder is a builder route (#548)", () => {
+  it("renders the app navigation in rail mode on the report builder route", () => {
+    // The in-Job Photo Report builder used to be in INTERNAL_FULLSCREEN_PATTERNS
+    // (nav stripped — a dead-end). #548 restores the nav: the route is now a
+    // builder route, so the Sidebar renders as the slim rail, collapsed by
+    // default, with the ephemeral toggle.
+    pathnameRef.current = "/jobs/job-1/reports/report-1";
+    renderShell();
+
+    expect(sidebarProps.last?.forceCollapsed).toBe(true);
+    expect(typeof sidebarProps.last?.onToggleRail).toBe("function");
+  });
+
+  it("toggles the rail on the report route without writing the persisted pref", () => {
+    // Same crux as #543, pinned against this route: expanding the rail while
+    // authoring a report must never write "sidebar-collapsed" — leaving the
+    // builder restores whatever navbar state the user had.
+    pathnameRef.current = "/jobs/job-1/reports/report-1";
+    renderShell();
+
+    fireEvent.click(screen.getByText("rail-toggle"));
+    expect(sidebarProps.last?.forceCollapsed).toBe(false);
+
+    const wrotePref = setItemSpy.mock.calls.some(
+      ([key]) => key === "sidebar-collapsed",
+    );
+    expect(wrotePref).toBe(false);
+  });
+});
+
 describe("AppShell — content margin tracks the rail (#543)", () => {
   it("reserves the slim-rail margin on a builder route and widens when expanded", () => {
     // The document must sit beside the slim rail (narrow left margin) even

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -16,16 +16,17 @@ const PUBLIC_ROUTES = ["/sign", "/pay"];
 const INTERNAL_FULLSCREEN_PATTERNS: RegExp[] = [
   /^\/contracts\/[^/]+\/sign-in-person(\/|$)/,
   /^\/jobs\/[^/]+\/capture(\/|$)/,
-  // The in-Job Photo Report builder (#400) is full-screen, like capture.
-  /^\/jobs\/[^/]+\/reports\/[^/]+(\/|$)/,
 ];
-// Estimate Builder routes (#543) render the side navbar as a slim icon rail so
-// the document gets full content width. Covers the estimate, invoice, and
-// template editing modes — all served by EstimateBuilder.
+// Builder routes render the side navbar as a slim icon rail so the document
+// gets full content width (#543). Covers the estimate, invoice, and template
+// editing modes — all served by EstimateBuilder — plus the in-Job Photo Report
+// builder (#548), which used to be full-screen and now keeps the nav so the
+// author is never trapped.
 const BUILDER_ROUTE_PATTERNS: RegExp[] = [
   /^\/estimates\/[^/]+\/edit(\/|$)/,
   /^\/invoices\/[^/]+\/edit(\/|$)/,
   /^\/settings\/estimate-templates\/[^/]+\/edit(\/|$)/,
+  /^\/jobs\/[^/]+\/reports\/[^/]+(\/|$)/,
 ];
 
 export default function AppShell({ children }: { children: React.ReactNode }) {

--- a/src/components/photo-report-builder-desktop.test.tsx
+++ b/src/components/photo-report-builder-desktop.test.tsx
@@ -1,0 +1,427 @@
+// Issue #548 — Photo Report builder: desktop multi-pane shell.
+//
+// On desktop (lg+) the builder renders a left rail (Cover Page pinned, then the
+// report's Sections, drag-to-reorder, "+ New Section") beside a center editor
+// showing the ONE selected Section; below lg the existing phone builder is
+// unchanged. Both surfaces are present in the DOM and gated purely by Tailwind
+// breakpoint classes (no JS viewport hook), so jsdom — which has no layout
+// engine — asserts the gating via class strings, the same approach as
+// builder-layout.test.tsx. Section selection is component-local UI state and
+// only pre-existing reducer actions are used.
+//
+// Mock scaffolding mirrors photo-report-builder.test.tsx: the Supabase client
+// captures the auto-save write, TipTap is stubbed, DndContext is a passthrough
+// that captures onDragEnd, and fetch is stubbed inert so the teardown flush
+// (#443) is harmless.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  cleanup,
+  within,
+} from "@testing-library/react";
+
+import type { Photo, PhotoReport } from "@/lib/types";
+
+const h = vi.hoisted(() => ({
+  updateMock: vi.fn<(payload: Record<string, unknown>) => void>(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    from: () => ({
+      update: (payload: Record<string, unknown>) => {
+        h.updateMock(payload);
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }),
+  }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/lib/generate-report-pdf", () => ({
+  generateReportPDF: vi.fn(async () => "job-1/report-1.pdf"),
+}));
+
+vi.mock("@/components/tiptap-editor", () => ({
+  default: ({
+    content,
+    onChange,
+    placeholder,
+  }: {
+    content: string;
+    onChange: (html: string) => void;
+    placeholder?: string;
+  }) => (
+    <textarea
+      data-testid="tiptap-stub"
+      aria-label="Section write-up"
+      placeholder={placeholder}
+      defaultValue={content}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+// Passthrough DndContext capturing onDragEnd, so a test can fire a synthetic
+// drag without a pointer (same pattern as photo-report-builder.test.tsx).
+let capturedOnDragEnd: ((e: unknown) => void) | null = null;
+vi.mock("@dnd-kit/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({
+      children,
+      onDragEnd,
+    }: {
+      children: React.ReactNode;
+      onDragEnd?: (e: unknown) => void;
+    }) => {
+      capturedOnDragEnd = onDragEnd ?? null;
+      return <>{children}</>;
+    },
+  };
+});
+
+// Record every id registered with useSortable, so a test can prove the rail's
+// Section items are sortable under stable, rail-scoped ids.
+let capturedSortableIds: string[] = [];
+vi.mock("@dnd-kit/sortable", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/sortable")>(
+      "@dnd-kit/sortable",
+    );
+  return {
+    ...actual,
+    useSortable: (args: { id: string }) => {
+      capturedSortableIds.push(args.id);
+      return actual.useSortable(args);
+    },
+  };
+});
+
+import React from "react";
+import PhotoReportBuilder from "./photo-report-builder";
+
+function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
+  return {
+    id: "report-1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    template_id: null,
+    title: "Photo Report #1",
+    report_number: 1,
+    report_date: "2026-06-04",
+    sections: [
+      { id: "sec-a", title: "Roof", description: "", photo_ids: [] },
+      { id: "sec-b", title: "Gutters", description: "", photo_ids: [] },
+    ],
+    pdf_path: null,
+    status: "draft",
+    created_by: "Eric Daniels",
+    created_at: "2026-06-04T00:00:00Z",
+    updated_at: "2026-06-04T00:00:00Z",
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+function renderBuilder(report = makeReport(), photos: Photo[] = []) {
+  return render(
+    <PhotoReportBuilder
+      jobId="job-1"
+      report={report}
+      photos={photos}
+      supabaseUrl="https://example.supabase.co"
+    />,
+  );
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  h.updateMock.mockClear();
+  capturedOnDragEnd = null;
+  capturedSortableIds = [];
+  fetchMock = vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  // Unmount while fetch is still stubbed so a dirty builder's teardown flush
+  // (#443) hits the inert mock (see photo-report-builder.test.tsx).
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function getRail() {
+  return screen.getByTestId("report-rail");
+}
+
+// The rail's navigable entries by visible label. Each Section row also holds
+// an icon-only grip handle (empty textContent) — drag must live on a control
+// separate from the select button (see the keyboard-selection describe), so
+// enumerations of the rail's entries skip the grips.
+function railEntryNames() {
+  return within(getRail())
+    .getAllByRole("button")
+    .map((el) => el.textContent?.trim())
+    .filter(Boolean);
+}
+
+describe("PhotoReportBuilder — desktop left rail (#548)", () => {
+  it("renders a desktop-only rail listing the Cover Page pinned first, then the Sections in order, with + New Section", () => {
+    renderBuilder();
+
+    // Desktop-only: present in the DOM, hidden below lg purely by CSS classes.
+    const rail = getRail();
+    expect(rail.className).toContain("hidden");
+    expect(rail.className).toContain("lg:block");
+
+    // Cover Page pinned at the top, then the report's Sections in their order.
+    const names = railEntryNames();
+    expect(names[0]).toBe("Cover Page");
+    expect(names.slice(1, 3)).toEqual(["Roof", "Gutters"]);
+
+    // The rail offers the add affordance.
+    expect(
+      within(rail).getByRole("button", { name: /new section/i }),
+    ).toBeTruthy();
+  });
+
+  it("highlights the Cover Page by default and moves the highlight to a clicked Section", () => {
+    renderBuilder();
+    const rail = getRail();
+
+    // Fresh open: nothing is being edited yet — the pinned Cover Page holds
+    // the highlight.
+    const cover = within(rail).getByRole("button", { name: "Cover Page" });
+    const roof = within(rail).getByRole("button", { name: "Roof" });
+    expect(cover.getAttribute("aria-current")).toBe("true");
+    expect(roof.getAttribute("aria-current")).toBeNull();
+
+    // Selecting a Section moves the highlight off the Cover Page onto it.
+    fireEvent.click(roof);
+    expect(roof.getAttribute("aria-current")).toBe("true");
+    expect(cover.getAttribute("aria-current")).toBeNull();
+  });
+});
+
+describe("PhotoReportBuilder — rail + New Section (#548)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds a Section from the rail, selects it as the center pane, and autosaves", async () => {
+    renderBuilder();
+    const rail = getRail();
+
+    // Grab the affordance before clicking: afterwards the rail also holds the
+    // new item "New section" (reducer default title), which a /new section/i
+    // name match would catch too.
+    const addButton = within(rail).getByRole("button", {
+      name: /new section/i,
+    });
+    fireEvent.click(addButton);
+
+    // The new Section appears in the rail after the existing Sections, and the
+    // highlight (the pane being edited) moves straight onto it. (getByRole
+    // string names are exact-match, so "New section" — the reducer's default
+    // title — does not collide with the "New Section" add affordance.)
+    expect(railEntryNames().slice(0, 4)).toEqual([
+      "Cover Page",
+      "Roof",
+      "Gutters",
+      "New section",
+    ]);
+    const newItem = within(rail).getByRole("button", { name: "New section" });
+    expect(newItem.getAttribute("aria-current")).toBe("true");
+
+    // The new Section is the one visible desktop pane; the others stay
+    // desktop-hidden (phone surface untouched).
+    const cards = screen
+      .getAllByLabelText("Section heading")
+      .map((el) => el.closest("section") as HTMLElement);
+    expect(cards).toHaveLength(3);
+    expect(cards[2].className.split(/\s+/)).not.toContain("lg:hidden");
+    expect(cards[0].className.split(/\s+/)).toContain("lg:hidden");
+    expect(cards[1].className.split(/\s+/)).toContain("lg:hidden");
+
+    // The addition autosaves like any other edit: the debounced write persists
+    // all three Sections.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: Array<{ title: string }>;
+    };
+    expect(payload.sections).toHaveLength(3);
+    expect(payload.sections[2].title).toBe("New section");
+  });
+});
+
+describe("PhotoReportBuilder — rail drag-to-reorder (#548)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("registers the rail's Sections as sortable under stable rail-scoped ids", () => {
+    renderBuilder();
+
+    // Rail ids are namespaced (`rail-` prefix) so they can coexist with the
+    // center cards' bare section ids inside the one shared DndContext —
+    // dnd-kit forbids duplicate ids. The rail renders before the center
+    // editor, so its registrations come first.
+    expect(capturedSortableIds.slice(0, 2)).toEqual([
+      "rail-sec-a",
+      "rail-sec-b",
+    ]);
+    expect(capturedSortableIds).toContain("sec-a");
+    expect(capturedSortableIds).toContain("sec-b");
+  });
+
+  it("reorders Sections dragged in the rail and autosaves the new order", async () => {
+    // Pins the full path a real rail drag takes once the items are sortable:
+    // resolvePhotoReportDragEnd reads only data.current (photo-report-drag
+    // pins that ids are immaterial), so the rail-scoped ids resolve to the
+    // same reorderSection a center-card drag produces.
+    renderBuilder();
+    expect(capturedOnDragEnd).toBeTruthy();
+
+    act(() => {
+      capturedOnDragEnd?.({
+        active: {
+          id: "rail-sec-a",
+          data: { current: { type: "section", index: 0 } },
+        },
+        over: {
+          id: "rail-sec-b",
+          data: { current: { type: "section", index: 1 } },
+        },
+      });
+    });
+
+    // The rail reflects the new order…
+    expect(railEntryNames().slice(1, 3)).toEqual(["Gutters", "Roof"]);
+
+    // …and the reorder autosaves like any other edit.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: Array<{ title: string }>;
+    };
+    expect(payload.sections.map((s) => s.title)).toEqual(["Gutters", "Roof"]);
+  });
+});
+
+describe("PhotoReportBuilder — rail selection stays keyboard-reachable (#548)", () => {
+  it("keeps each Section's select control free of the sortable's listeners — drag lives on a dedicated grip handle", () => {
+    // dnd-kit's KeyboardSensor activates on Enter/Space through the sortable
+    // listeners and preventDefault()s the keydown, which swallows a button's
+    // native keyboard activation. Fusing select + drag onto one button would
+    // therefore leave keyboard users unable to ever select a Section (the
+    // keypress picks the row up for a drag instead). So the select button
+    // must carry NO sortable wiring; the sortable attributes/listeners live
+    // on a dedicated grip handle beside it, the same split the center
+    // editor's cards use.
+    renderBuilder();
+    const rail = getRail();
+
+    // The select control is a plain button: no sortable role description.
+    const roof = within(rail).getByRole("button", { name: "Roof" });
+    expect(roof.getAttribute("aria-roledescription")).toBeNull();
+
+    // Each Section row has its own grip, and the sortable attributes landed
+    // there instead.
+    const grips = within(rail).getAllByRole("button", {
+      name: "Drag to reorder section",
+    });
+    expect(grips).toHaveLength(2);
+    for (const grip of grips) {
+      expect(grip.getAttribute("aria-roledescription")).toBe("sortable");
+    }
+
+    // And the select control still selects.
+    fireEvent.click(roof);
+    expect(roof.getAttribute("aria-current")).toBe("true");
+  });
+});
+
+describe("PhotoReportBuilder — desktop top-bar placeholders (#548)", () => {
+  it("offers desktop-only gear and Preview placeholders while Generate stays the one real action", () => {
+    renderBuilder();
+
+    // Gear (Report Settings, per the glossary) and Preview ship as disabled
+    // desktop-only placeholders this slice; later slices wire them up.
+    const gear = screen.getByRole("button", { name: "Report settings" });
+    const preview = screen.getByRole("button", { name: "Preview" });
+    for (const el of [gear, preview]) {
+      const t = el.className.split(/\s+/);
+      expect(t).toContain("hidden");
+      expect(t).toContain("lg:inline-flex");
+      expect((el as HTMLButtonElement).disabled).toBe(true);
+    }
+
+    // Generate keeps today's behavior — one button, both surfaces share it.
+    expect(
+      screen.getAllByRole("button", { name: /generate pdf/i }),
+    ).toHaveLength(1);
+  });
+});
+
+describe("PhotoReportBuilder — desktop center editor shows one pane (#548)", () => {
+  // jsdom has no layout engine, so desktop visibility is asserted the way it is
+  // implemented: exact Tailwind class tokens (`lg:hidden` hides on desktop
+  // only; a bare `hidden` would break the phone surface).
+  const tokens = (el: Element) => (el as HTMLElement).className.split(/\s+/);
+
+  it("shows the report meta for the Cover Page by default, with every Section card desktop-hidden but intact for the phone surface", () => {
+    renderBuilder();
+
+    const cards = screen
+      .getAllByLabelText("Section heading")
+      .map((el) => el.closest("section") as HTMLElement);
+    expect(cards).toHaveLength(2);
+    const meta = screen.getByTestId("report-meta");
+
+    expect(tokens(meta)).not.toContain("lg:hidden");
+    for (const card of cards) {
+      expect(tokens(card)).toContain("lg:hidden");
+      // The phone surface still renders every Section below lg.
+      expect(tokens(card)).not.toContain("hidden");
+    }
+  });
+
+  it("shows just the selected Section in the center editor", () => {
+    renderBuilder();
+
+    fireEvent.click(within(getRail()).getByRole("button", { name: "Roof" }));
+
+    const cards = screen
+      .getAllByLabelText("Section heading")
+      .map((el) => el.closest("section") as HTMLElement);
+    const meta = screen.getByTestId("report-meta");
+
+    // Roof (sec-a) is the one visible desktop pane; Gutters and the cover's
+    // meta editor are desktop-hidden.
+    expect(tokens(cards[0])).not.toContain("lg:hidden");
+    expect(tokens(cards[1])).toContain("lg:hidden");
+    expect(tokens(meta)).toContain("lg:hidden");
+  });
+});

--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -594,7 +594,11 @@ describe("PhotoReportBuilder section reorder focus (#467)", () => {
     // The DndContext is stubbed in these tests, so a revert of `useSortable({ id })`
     // back to a positional `section-${index}` would not surface through the focus
     // test above — this asserts it directly. Sections loaded with explicit ids keep
-    // them (ensureSectionIds), making the expected ids deterministic.
+    // them (ensureSectionIds), making the expected ids deterministic. Since #548
+    // the desktop rail registers its own `rail-`-prefixed sortable per section
+    // (ids must be unique within the one DndContext) alongside the center
+    // editor's — membership is asserted, not order, because rail-vs-center
+    // registration order is incidental JSX layout, not part of this contract.
     capturedSortableIds = [];
     renderBuilder(
       makeReport({
@@ -605,7 +609,10 @@ describe("PhotoReportBuilder section reorder focus (#467)", () => {
       }),
     );
 
-    expect(capturedSortableIds).toEqual(["sec-a", "sec-b"]);
+    expect(capturedSortableIds).toHaveLength(4);
+    expect(capturedSortableIds).toEqual(
+      expect.arrayContaining(["rail-sec-a", "rail-sec-b", "sec-a", "sec-b"]),
+    );
   });
 });
 

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -21,16 +21,19 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 import {
   ArrowLeft,
+  Eye,
   FileDown,
   GripVertical,
   Loader2,
   Plus,
+  Settings,
   Trash2,
   X,
 } from "lucide-react";
 import { toast } from "sonner";
 
 import { createClient } from "@/lib/supabase";
+import { cn } from "@/lib/utils";
 import { photoUrl } from "@/lib/jobs/photo-url";
 import { generateReportPDF } from "@/lib/generate-report-pdf";
 import TiptapEditor from "@/components/tiptap-editor";
@@ -104,6 +107,16 @@ export default function PhotoReportBuilder({
   // PDF generated in an earlier session is retrievable on load without
   // regenerating.
   const [pdfPath, setPdfPath] = useState<string | null>(report.pdf_path);
+  // Which pane the desktop rail has selected for the center editor (#548).
+  // `null` means the pinned Cover Page. Purely ephemeral UI state — never in
+  // the reducer, never persisted. Resolved against the live sections below so
+  // a selection left dangling by a removed Section falls back to the cover.
+  const [selectedSectionId, setSelectedSectionId] = useState<string | null>(
+    null,
+  );
+  const selectedId = state.sections.some((s) => s.id === selectedSectionId)
+    ? selectedSectionId
+    : null;
 
   // The latest edit revision, mirrored into a ref so the async save tail can
   // tell whether a newer edit landed while it was in flight (its own captured
@@ -281,7 +294,10 @@ export default function PhotoReportBuilder({
   };
 
   return (
-    <div className="flex h-dvh flex-col bg-background">
+    // The builder sits inside the normal AppShell chrome (#548 restored the
+    // nav — the route is a BUILDER_ROUTE_PATTERNS entry now), so it flows with
+    // the page instead of owning the viewport (the old full-screen h-dvh).
+    <div className="bg-background">
       {/* Header bar */}
       <header className="flex items-center gap-3 border-b border-border bg-card px-4 py-3">
         <Link
@@ -305,6 +321,25 @@ export default function PhotoReportBuilder({
           {saveStatus === "error" && "Save failed"}
           {saveStatus === "blocked" && "Can't save — write-up too long"}
         </span>
+        {/* Desktop-only placeholders (#548): the gear opens Report Settings and
+            Preview shows the rendered PDF in later slices (#549+). Shipped
+            disabled so the top bar's final shape is in place from the start. */}
+        <button
+          type="button"
+          aria-label="Report settings"
+          disabled
+          className="hidden lg:inline-flex items-center rounded-lg border border-border p-2 text-muted-foreground opacity-60"
+        >
+          <Settings size={16} />
+        </button>
+        <button
+          type="button"
+          disabled
+          className="hidden lg:inline-flex items-center gap-1.5 rounded-lg border border-border px-4 py-1.5 text-sm font-semibold text-muted-foreground opacity-60"
+        >
+          <Eye size={14} />
+          Preview
+        </button>
         <button
           type="button"
           onClick={handleGenerate}
@@ -331,64 +366,129 @@ export default function PhotoReportBuilder({
         )}
       </header>
 
-      {/* Body */}
-      <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-3xl px-4 py-6 space-y-6">
-          {/* Report meta */}
-          <div className="space-y-3">
-            <label className="block">
-              <span className="mb-1 block text-xs font-medium text-muted-foreground">
-                Report title
-              </span>
-              <input
-                type="text"
-                aria-label="Report title"
-                value={state.title}
-                onChange={(e) =>
-                  dispatch({ type: "setTitle", title: e.target.value })
-                }
-                className="w-full rounded-lg border border-border bg-card px-3 py-2 text-lg font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
-              />
-            </label>
-            <label className="block w-48">
-              <span className="mb-1 block text-xs font-medium text-muted-foreground">
-                Report date
-              </span>
-              <input
-                type="date"
-                aria-label="Report date"
-                value={state.reportDate}
-                onChange={(e) => {
-                  // Native date inputs can be cleared to "". report_date is a
-                  // NOT NULL column, so never persist an empty date — ignore the
-                  // change and keep the last valid one.
-                  if (e.target.value) {
-                    dispatch({
-                      type: "setReportDate",
-                      reportDate: e.target.value,
-                    });
-                  }
-                }}
-                className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
-              />
-            </label>
-          </div>
-
-          {/*
-            Slice-2b drag wiring. Sections are keyed (React key + dnd-kit
-            sortable id) off their stable `id` (#467), so editing a Section then
-            reordering it keeps input focus/caret pinned to that Section and the
-            reorder animates smoothly. One known low-severity follow-up remains,
-            left for a later slice: closestCenter targets the nearest section
-            *center*, so on very tall section cards a photo dropped near an edge
-            can land in the neighbouring section; a pointer-based strategy would
-            be more precise.
-          */}
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
+      {/* Body — on desktop (lg+) a multi-pane shell: the left rail beside the
+          center editor. Below lg the rail is display-hidden and the original
+          single-column phone builder flows unchanged. Both surfaces share one
+          DndContext so rail drags and photo drags resolve through the same
+          onDragEnd. */}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <div className="lg:flex lg:items-start lg:gap-6 lg:px-4 lg:py-6">
+          {/* Left rail (#548): Cover Page pinned, then the Sections. */}
+          <aside
+            data-testid="report-rail"
+            className="hidden lg:block w-56 shrink-0 space-y-1"
           >
+            <button
+              type="button"
+              aria-current={selectedId === null ? "true" : undefined}
+              onClick={() => setSelectedSectionId(null)}
+              className={cn(
+                "w-full rounded-lg px-3 py-2 text-left text-sm font-medium transition-colors",
+                // Primary-tinted like the Section rows, so selected stays
+                // distinguishable from a merely-hovered entry.
+                selectedId === null
+                  ? "bg-primary/10 text-primary"
+                  : "text-foreground hover:bg-muted",
+              )}
+            >
+              Cover Page
+            </button>
+            {/* Rail items are sortable under `rail-`-prefixed ids: they share
+                the one DndContext with the center cards (dnd-kit forbids
+                duplicate ids), and resolvePhotoReportDragEnd reads only
+                data.current, so a rail drag resolves to the same
+                reorderSection a center-card drag does. */}
+            <SortableContext
+              items={state.sections.map((s) => `rail-${s.id}`)}
+              strategy={verticalListSortingStrategy}
+            >
+              {state.sections.map((section, index) => (
+                <RailSectionItem
+                  key={section.id}
+                  section={section}
+                  index={index}
+                  selected={selectedId === section.id}
+                  onSelect={() => setSelectedSectionId(section.id)}
+                />
+              ))}
+            </SortableContext>
+            <button
+              type="button"
+              onClick={() => {
+                // Add and jump straight into the new Section: the rail
+                // highlight and the center editor both move onto it, so the
+                // author can start typing immediately.
+                const id = newSectionId();
+                dispatch({ type: "addSection", id });
+                setSelectedSectionId(id);
+              }}
+              className="inline-flex w-full items-center gap-1.5 rounded-lg border border-dashed border-border px-3 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+            >
+              <Plus size={15} />
+              New Section
+            </button>
+          </aside>
+
+          <div className="mx-auto max-w-3xl px-4 py-6 space-y-6 lg:mx-0 lg:flex-1 lg:min-w-0 lg:p-0">
+            {/* Report meta — the Cover Page's center pane (#548). On desktop it
+                shows only while the pinned Cover Page is selected; below lg the
+                class is inert, so the phone builder always renders it. */}
+            <div
+              data-testid="report-meta"
+              className={cn("space-y-3", selectedId !== null && "lg:hidden")}
+            >
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Report title
+                </span>
+                <input
+                  type="text"
+                  aria-label="Report title"
+                  value={state.title}
+                  onChange={(e) =>
+                    dispatch({ type: "setTitle", title: e.target.value })
+                  }
+                  className="w-full rounded-lg border border-border bg-card px-3 py-2 text-lg font-semibold text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                />
+              </label>
+              <label className="block w-48">
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Report date
+                </span>
+                <input
+                  type="date"
+                  aria-label="Report date"
+                  value={state.reportDate}
+                  onChange={(e) => {
+                    // Native date inputs can be cleared to "". report_date is a
+                    // NOT NULL column, so never persist an empty date — ignore the
+                    // change and keep the last valid one.
+                    if (e.target.value) {
+                      dispatch({
+                        type: "setReportDate",
+                        reportDate: e.target.value,
+                      });
+                    }
+                  }}
+                  className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
+                />
+              </label>
+            </div>
+
+            {/*
+              Slice-2b drag wiring. Sections are keyed (React key + dnd-kit
+              sortable id) off their stable `id` (#467), so editing a Section then
+              reordering it keeps input focus/caret pinned to that Section and the
+              reorder animates smoothly. One known low-severity follow-up remains,
+              left for a later slice: closestCenter targets the nearest section
+              *center*, so on very tall section cards a photo dropped near an edge
+              can land in the neighbouring section; a pointer-based strategy would
+              be more precise.
+            */}
             {/* Sections */}
             <SortableContext
               items={state.sections.map((s) => s.id)}
@@ -403,6 +503,7 @@ export default function PhotoReportBuilder({
                     photosById={photosById}
                     supabaseUrl={supabaseUrl}
                     dispatch={dispatch}
+                    desktopSelected={selectedId === section.id}
                   />
                 ))}
               </div>
@@ -411,7 +512,9 @@ export default function PhotoReportBuilder({
             <button
               type="button"
               onClick={() => dispatch({ type: "addSection", id: newSectionId() })}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-dashed border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+              // The phone surface's add affordance; on desktop the rail's
+              // "+ New Section" covers it (#548), so it hides at lg+.
+              className="lg:hidden inline-flex items-center gap-1.5 rounded-lg border border-dashed border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
             >
               <Plus size={15} />
               Add section
@@ -419,9 +522,88 @@ export default function PhotoReportBuilder({
 
             {/* Photos not yet in the report — drag into a Section to add. */}
             <PhotoTray photos={availablePhotos} supabaseUrl={supabaseUrl} />
-          </DndContext>
+          </div>
         </div>
-      </div>
+      </DndContext>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RailSectionItem — a Section's entry in the desktop rail (#548): click the
+// label to select it as the center pane, drag the grip to reorder. Select and
+// drag are SEPARATE controls (the same split as the center cards'): dnd-kit's
+// KeyboardSensor activates on Enter/Space through the sortable listeners and
+// preventDefault()s the keydown, so fusing both onto one button would leave
+// keyboard users unable to ever select a Section.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function RailSectionItem({
+  section,
+  index,
+  selected,
+  onSelect,
+}: {
+  section: ReportSection;
+  index: number;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({
+    // Namespaced so the id can't collide with this Section's center card,
+    // which registers under the bare `section.id` in the same DndContext.
+    id: `rail-${section.id}`,
+    data: { type: "section", index },
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group flex w-full items-center rounded-lg transition-colors",
+        // Selected is primary-tinted so it stays distinguishable from a
+        // merely-hovered row (hover uses the muted background).
+        selected ? "bg-primary/10" : "hover:bg-muted",
+      )}
+    >
+      <button
+        type="button"
+        aria-current={selected ? "true" : undefined}
+        onClick={onSelect}
+        className={cn(
+          "min-w-0 flex-1 truncate py-2 pl-3 text-left text-sm",
+          selected
+            ? "font-medium text-primary"
+            : "text-muted-foreground group-hover:text-foreground",
+        )}
+      >
+        {section.title || "Untitled section"}
+      </button>
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        aria-label="Drag to reorder section"
+        className="cursor-grab touch-none px-2 py-2 text-muted-foreground/60 hover:text-foreground"
+        {...attributes}
+        {...listeners}
+      >
+        <GripVertical size={14} />
+      </button>
     </div>
   );
 }
@@ -437,6 +619,7 @@ function SortableSection({
   photosById,
   supabaseUrl,
   dispatch,
+  desktopSelected,
 }: {
   index: number;
   section: ReportSection;
@@ -445,6 +628,12 @@ function SortableSection({
   dispatch: React.Dispatch<
     Parameters<typeof photoReportBuilderReducer>[1]
   >;
+  /**
+   * Whether the desktop rail has this Section selected (#548). The center
+   * editor shows one pane at a time, so an unselected card is `lg:hidden` —
+   * inert below lg, where the phone builder still renders every Section.
+   */
+  desktopSelected: boolean;
 }) {
   const {
     attributes,
@@ -488,7 +677,10 @@ function SortableSection({
     <section
       ref={setNodeRef}
       style={style}
-      className="rounded-xl border border-border bg-card p-4 space-y-3"
+      className={cn(
+        "rounded-xl border border-border bg-card p-4 space-y-3",
+        !desktopSelected && "lg:hidden",
+      )}
     >
       <div className="flex items-center gap-2">
         <button


### PR DESCRIPTION
Closes #548 — first slice of the #547 Photo Report Builder desktop build.

## What changed

- **App nav restored on the builder** — the builder route moved from `INTERNAL_FULLSCREEN_PATTERNS` to `BUILDER_ROUTE_PATTERNS` in `app-shell.tsx`: the nav renders as the slim collapsed rail beside the builder, so the author is never trapped (AC a, b).
- **Desktop multi-pane shell, CSS breakpoints only** — on `lg+` the builder renders a left rail + center editor; below `lg` the phone builder is unchanged. Both surfaces live in one DOM, gated purely by `hidden lg:block` / `lg:hidden` (no JS viewport hook) (AC c).
- **Left rail** — Cover Page pinned first, then the Sections (highlighting the one being edited via `aria-current` + a primary-tinted background), then "+ New Section" which adds and selects in one motion (AC d).
- **Rail drag-to-reorder** — rail items are sortable under `rail-`-prefixed ids inside the one shared DndContext (dnd-kit forbids duplicate ids); `resolvePhotoReportDragEnd` reads only `data.current`, so a rail drag resolves to the same `reorderSection` a center-card drag does, and autosaves (AC e).
- **One pane at a time** — selecting a Section shows just it in the center editor; the Cover Page pane is the report meta (AC f).
- **Top bar** — gear (Report Settings) and Preview ship as disabled desktop-only placeholders; Generate keeps today's behavior (AC g).
- Selection is component-local UI state; **no new reducer actions, no schema change** (AC h).

## Adversarial review (ultracode)

A 19-agent multi-lens review (responsive-DOM, dnd-kit, a11y, test quality, AC compliance) produced 14 findings; 10 were refuted on verification, 4 confirmed and fixed before commit:

- **Keyboard selection** (critical): rail rows originally fused select + drag on one button — dnd-kit's KeyboardSensor `preventDefault()`s Enter/Space, locking keyboard users out of selecting a Section. Now select and drag are separate controls (dedicated grip handle wired through `setActivatorNodeRef`), pinned by a new test.
- **Selected vs hovered** (minor): selected rail entries were near-identical to hovered ones (`bg-muted` both ways); selected is now primary-tinted.
- **Over-specified test** (minor): the #467 AC2 assertion now checks sortable-id membership, not incidental rail-vs-center registration order.

## Test plan

- [x] 54/54 across the three touched suites (`photo-report-builder-desktop` ×9 new, `photo-report-builder` ×39, `app-shell` ×6)
- [x] Full suite: 2688/2688 (343 files)
- [x] `tsc --noEmit`: 19 errors = pre-existing baseline only (camera plugin + pg-integration)
- [x] `eslint` on touched files: 0 errors (2 pre-existing `<img>` warnings in untouched code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)