### PR TITLE
feat(estimate-builder): pricing waterfall — one shared computeWaterfall + unit test (#566)

### DIFF
--- a/src/lib/builder-shared.ts
+++ b/src/lib/builder-shared.ts
@@ -10,44 +10,8 @@ export function roundMoney(n: number): number {
   return Math.round(n * 100) / 100;
 }
 
-export interface MonetaryInput {
-  lineItemTotals: number[]; // already-computed per-line totals
-  markup_type: "percent" | "amount" | "none";
-  markup_value: number;
-  discount_type: "percent" | "amount" | "none";
-  discount_value: number;
-  tax_rate: number;
-}
-
-export interface MonetaryResult {
-  subtotal: number;
-  markup_amount: number;
-  discount_amount: number;
-  adjusted_subtotal: number;
-  tax_amount: number;
-  total: number;
-}
-
-/** Pure calc — no DB. Used by both estimate and invoice recalc paths. */
-export function recalculateMonetary(input: MonetaryInput): MonetaryResult {
-  const subtotal = roundMoney(input.lineItemTotals.reduce((a, b) => a + b, 0));
-  const markup_amount =
-    input.markup_type === "percent"
-      ? roundMoney((subtotal * input.markup_value) / 100)
-      : input.markup_type === "amount"
-        ? roundMoney(input.markup_value)
-        : 0;
-  const discount_amount =
-    input.discount_type === "percent"
-      ? roundMoney((subtotal * input.discount_value) / 100)
-      : input.discount_type === "amount"
-        ? roundMoney(input.discount_value)
-        : 0;
-  const adjusted_subtotal = roundMoney(subtotal + markup_amount - discount_amount);
-  const tax_amount = roundMoney((adjusted_subtotal * input.tax_rate) / 100);
-  const total = roundMoney(adjusted_subtotal + tax_amount);
-  return { subtotal, markup_amount, discount_amount, adjusted_subtotal, tax_amount, total };
-}
+// The pricing-waterfall calc that used to live here (recalculateMonetary) is
+// now computeWaterfall in @/lib/waterfall — shared with the client builder.
 
 /** Bumps `updated_at` on a parent estimate or invoice. Used after child-table writes
  *  so the next snapshot read sees the change (lesson from 67a I2 closure). */

--- a/src/lib/estimates-calc.ts
+++ b/src/lib/estimates-calc.ts
@@ -1,14 +1,16 @@
-// Pure client-side calculation helpers — mirrors the server's recalculateTotals
-// math from src/lib/estimates.ts (lines 148–166). No Supabase imports.
+// Pure client-side calculation helpers. No Supabase imports.
 //
 // These are used by the EstimateBuilder to update the totals bar live as the user
 // edits markup / discount / tax fields, and when line-item qty/price changes.
 
 import type { AdjustmentType } from "@/lib/types";
 import { round2 } from "@/lib/format";
+import { computeWaterfall } from "@/lib/waterfall";
 
 // ─────────────────────────────────────────────────────────────────────────────
-// computeEstimateTotals
+// computeEstimateTotals — maps an estimate/invoice row's flat adjustment
+// fields onto the shared pricing waterfall, so the builder's live totals are
+// computed by the exact same function as the server-persisted ones.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export function computeEstimateTotals(input: {
@@ -25,28 +27,20 @@ export function computeEstimateTotals(input: {
   tax_amount: number;
   total: number;
 } {
-  const { subtotal, markup_type, markup_value, discount_type, discount_value, tax_rate } = input;
-
-  // Markup
-  let markup_amount = 0;
-  if (markup_type === "amount") markup_amount = round2(Number(markup_value));
-  else if (markup_type === "percent") markup_amount = round2(subtotal * Number(markup_value) / 100);
-
-  // Discount
-  let discount_amount = 0;
-  if (discount_type === "amount") discount_amount = round2(Number(discount_value));
-  else if (discount_type === "percent") discount_amount = round2(subtotal * Number(discount_value) / 100);
-
-  // Adjusted subtotal
-  const adjusted_subtotal = round2(subtotal + markup_amount - discount_amount);
-
-  // Tax
-  const tax_amount = round2(adjusted_subtotal * Number(tax_rate) / 100);
-
-  // Total
-  const total = round2(adjusted_subtotal + tax_amount);
-
-  return { markup_amount, discount_amount, adjusted_subtotal, tax_amount, total };
+  const t = computeWaterfall({
+    subtotal: input.subtotal,
+    markup: { type: input.markup_type, value: Number(input.markup_value) },
+    discount: { type: input.discount_type, value: Number(input.discount_value) },
+    taxRatePercent: Number(input.tax_rate),
+  });
+  // Callers spread this into row state — keep the historical shape (no subtotal).
+  return {
+    markup_amount: t.markup_amount,
+    discount_amount: t.discount_amount,
+    adjusted_subtotal: t.adjusted_subtotal,
+    tax_amount: t.tax_amount,
+    total: t.total,
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/estimates.ts
+++ b/src/lib/estimates.ts
@@ -7,7 +7,8 @@ import type {
   EstimateWithContents,
 } from "@/lib/types";
 import { round2 } from "@/lib/format";
-import { recalculateMonetary, touchEntity, checkSnapshot as checkSnapshotGeneric } from "@/lib/builder-shared";
+import { touchEntity, checkSnapshot as checkSnapshotGeneric } from "@/lib/builder-shared";
+import { computeWaterfall } from "@/lib/waterfall";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Numbering — atomic per-job sequence via RPC (uses SELECT FOR UPDATE in SQL)
@@ -145,15 +146,13 @@ export async function recalculateTotals(
   const lineItemTotals = ((items ?? []) as Array<{ quantity: number; unit_price: number }>)
     .map((li) => round2(Number(li.quantity) * Number(li.unit_price)));
 
-  // 5. Delegate pure monetary calc to shared helper
+  // 5. Delegate pure monetary calc to the shared waterfall
   const { subtotal, markup_amount, discount_amount, adjusted_subtotal, tax_amount, total } =
-    recalculateMonetary({
-      lineItemTotals,
-      markup_type: est.markup_type,
-      markup_value: Number(est.markup_value),
-      discount_type: est.discount_type,
-      discount_value: Number(est.discount_value),
-      tax_rate: Number(est.tax_rate),
+    computeWaterfall({
+      lineItemCharges: lineItemTotals,
+      markup: { type: est.markup_type, value: Number(est.markup_value) },
+      discount: { type: est.discount_type, value: Number(est.discount_value) },
+      taxRatePercent: Number(est.tax_rate),
     });
 
   // 6. Write back

--- a/src/lib/invoices.ts
+++ b/src/lib/invoices.ts
@@ -3,12 +3,12 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
-  recalculateMonetary,
   roundMoney,
   touchEntity,
   checkSnapshot,
   type SnapshotCheck,
 } from "@/lib/builder-shared";
+import { computeWaterfall } from "@/lib/waterfall";
 import type {
   Invoice,
   InvoiceWithContents,
@@ -165,13 +165,11 @@ export async function recalculateInvoiceTotals(
 
   const { data: items } = await supabase
     .from("invoice_line_items").select("amount").eq("invoice_id", invoiceId);
-  const totals = recalculateMonetary({
-    lineItemTotals: (items ?? []).map((li) => Number(li.amount) || 0),
-    markup_type: inv.markup_type as "percent" | "amount" | "none",
-    markup_value: Number(inv.markup_value) || 0,
-    discount_type: inv.discount_type as "percent" | "amount" | "none",
-    discount_value: Number(inv.discount_value) || 0,
-    tax_rate: Number(inv.tax_rate) || 0,
+  const totals = computeWaterfall({
+    lineItemCharges: (items ?? []).map((li) => Number(li.amount) || 0),
+    markup: { type: inv.markup_type as "percent" | "amount" | "none", value: Number(inv.markup_value) || 0 },
+    discount: { type: inv.discount_type as "percent" | "amount" | "none", value: Number(inv.discount_value) || 0 },
+    taxRatePercent: Number(inv.tax_rate) || 0,
   });
 
   const { error } = await supabase.from("invoices").update({
@@ -219,7 +217,7 @@ export async function touchInvoice(
 // Compat helpers — kept routes (mark-sent, pdf, send, void) still call these
 // =============================================================================
 
-/** computeTotals retained for kept-route compatibility. New routes use recalculateMonetary. */
+/** computeTotals retained for kept-route compatibility. New routes use computeWaterfall. */
 export function computeTotals(
   items: InvoiceLineItemInput[],
   taxRate: number,

--- a/src/lib/invoices.ts
+++ b/src/lib/invoices.ts
@@ -214,10 +214,16 @@ export async function touchInvoice(
 }
 
 // =============================================================================
-// Compat helpers — kept routes (mark-sent, pdf, send, void) still call these
+// Legacy helpers
 // =============================================================================
 
-/** computeTotals retained for kept-route compatibility. New routes use computeWaterfall. */
+/**
+ * Dead code — no caller anywhere as of #577 (the kept routes this section once
+ * served now read persisted totals or use computeWaterfall). Kept only to
+ * avoid churn; delete in a follow-up rather than reuse. WARNING: unlike the
+ * waterfall, taxRate here is a FRACTION (0.0825), not a whole-number percent —
+ * feeding it a DB tax_rate produces 100× tax.
+ */
 export function computeTotals(
   items: InvoiceLineItemInput[],
   taxRate: number,

--- a/src/lib/waterfall.test.ts
+++ b/src/lib/waterfall.test.ts
@@ -1,12 +1,17 @@
 import { describe, it, expect } from "vitest";
-import { computeWaterfall } from "./waterfall";
+import { computeWaterfall, type Adjustment, type WaterfallInput } from "./waterfall";
 
 // #566 — the pricing waterfall (subtotal → +markup → −discount → adjusted
 // subtotal → +tax → total) is a single pure function shared by the server
 // recalc paths and the builder's live totals. These tests pin the money
 // contracts: discount comes off the RAW subtotal, tax is
 // adjusted_subtotal × taxRatePercent / 100 (whole-number percent, matching
-// the tax_rate numeric(6,4) column), and every leg rounds to cents on its own.
+// the tax_rate columns — numeric(5,2) on estimates, numeric(6,4) on
+// invoices), and every leg rounds to cents on its own.
+//
+// NB: keep `$` and `%%` out of the it.each title templates — vitest treats
+// `$1` as positional-arg injection, so a literal like "$1,000" renders as
+// garbage in test output.
 
 describe("computeWaterfall", () => {
   it.each([
@@ -14,7 +19,7 @@ describe("computeWaterfall", () => {
     ["amount", 250, 250], // flat $250
     ["none", 10, 0], // value is ignored when type is none
   ] as const)(
-    "markup %s %s on a $1,000 subtotal adds $%s",
+    "markup %s %s on a 1000 subtotal adds %s",
     (type, value, expected) => {
       const result = computeWaterfall({
         lineItemCharges: [600, 400],
@@ -35,7 +40,7 @@ describe("computeWaterfall", () => {
     ["amount", 75, 75],
     ["none", 10, 0],
   ] as const)(
-    "discount %s %s comes off the raw subtotal, after a 20%% markup",
+    "discount %s %s takes %s off the raw 1000 subtotal, not the 1200 marked-up one",
     (type, value, expected) => {
       const result = computeWaterfall({
         lineItemCharges: [1000],
@@ -92,6 +97,50 @@ describe("computeWaterfall", () => {
 
     expect(result.subtotal).toBe(0.3);
     expect(result.total).toBe(0.3);
+  });
+
+  it("rounds a precomputed subtotal to cents before computing the legs", () => {
+    // Pins the { subtotal } branch's round2 — a mutation-test survivor in the
+    // original suite (the parity test below feeds a clean 2-decimal literal,
+    // which can't tell rounded from unrounded).
+    const result = computeWaterfall({
+      subtotal: 0.1 + 0.2, // 0.30000000000000004 in IEEE 754
+      markup: { type: "none", value: 0 },
+      discount: { type: "none", value: 0 },
+      taxRatePercent: 0,
+    });
+
+    expect(result.subtotal).toBe(0.3);
+    expect(result.total).toBe(0.3);
+  });
+
+  it("coerces string line charges — Supabase numeric columns can arrive as strings", () => {
+    const result = computeWaterfall({
+      lineItemCharges: ["600", "400"] as unknown as number[],
+      markup: { type: "none", value: 0 },
+      discount: { type: "none", value: 0 },
+      taxRatePercent: 0,
+    });
+
+    expect(result.subtotal).toBe(1000); // not string concatenation
+  });
+
+  it("rejects an input carrying both line charges and a precomputed subtotal", () => {
+    const markup: Adjustment = { type: "none", value: 0 };
+    const discount: Adjustment = { type: "none", value: 0 };
+    // @ts-expect-error — WaterfallInput forbids supplying both forms at once;
+    // if the `?: never` exclusion is ever dropped, this directive turns into
+    // an "unused @ts-expect-error" tsc failure.
+    const both: WaterfallInput = {
+      lineItemCharges: [100, 200],
+      subtotal: 999999,
+      markup,
+      discount,
+      taxRatePercent: 0,
+    };
+
+    // And if the types are bypassed with a cast anyway, subtotal wins:
+    expect(computeWaterfall(both).subtotal).toBe(999999);
   });
 
   it("accepts a precomputed subtotal (the builder's live path) and matches the line-charges path exactly", () => {

--- a/src/lib/waterfall.test.ts
+++ b/src/lib/waterfall.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { computeWaterfall } from "./waterfall";
+
+// #566 — the pricing waterfall (subtotal → +markup → −discount → adjusted
+// subtotal → +tax → total) is a single pure function shared by the server
+// recalc paths and the builder's live totals. These tests pin the money
+// contracts: discount comes off the RAW subtotal, tax is
+// adjusted_subtotal × taxRatePercent / 100 (whole-number percent, matching
+// the tax_rate numeric(6,4) column), and every leg rounds to cents on its own.
+
+describe("computeWaterfall", () => {
+  it.each([
+    ["percent", 10, 100], // 10% of $1,000
+    ["amount", 250, 250], // flat $250
+    ["none", 10, 0], // value is ignored when type is none
+  ] as const)(
+    "markup %s %s on a $1,000 subtotal adds $%s",
+    (type, value, expected) => {
+      const result = computeWaterfall({
+        lineItemCharges: [600, 400],
+        markup: { type, value },
+        discount: { type: "none", value: 0 },
+        taxRatePercent: 0,
+      });
+
+      expect(result.subtotal).toBe(1000);
+      expect(result.markup_amount).toBe(expected);
+      expect(result.adjusted_subtotal).toBe(1000 + expected);
+      expect(result.total).toBe(1000 + expected);
+    },
+  );
+
+  it.each([
+    ["percent", 10, 100], // 10% of the RAW $1,000 subtotal — NOT of $1,200
+    ["amount", 75, 75],
+    ["none", 10, 0],
+  ] as const)(
+    "discount %s %s comes off the raw subtotal, after a 20%% markup",
+    (type, value, expected) => {
+      const result = computeWaterfall({
+        lineItemCharges: [1000],
+        markup: { type: "percent", value: 20 },
+        discount: { type, value },
+        taxRatePercent: 0,
+      });
+
+      expect(result.discount_amount).toBe(expected);
+      expect(result.adjusted_subtotal).toBe(1200 - expected);
+      expect(result.total).toBe(1200 - expected);
+    },
+  );
+
+  it("taxes the adjusted subtotal at taxRatePercent/100 — 8.25 means 8.25%, not a fraction", () => {
+    const result = computeWaterfall({
+      lineItemCharges: [1000],
+      markup: { type: "amount", value: 200 },
+      discount: { type: "amount", value: 100 },
+      taxRatePercent: 8.25,
+    });
+
+    // adjusted = 1000 + 200 − 100 = 1100; tax = 1100 × 8.25 / 100
+    expect(result.adjusted_subtotal).toBe(1100);
+    expect(result.tax_amount).toBe(90.75);
+    expect(result.total).toBe(1190.75);
+  });
+
+  it("rounds each leg to cents independently, not just the total", () => {
+    const result = computeWaterfall({
+      lineItemCharges: [33.33, 33.33, 33.33],
+      markup: { type: "percent", value: 7.5 }, // 7.49925 → 7.50
+      discount: { type: "percent", value: 5 }, // 4.9995 → 5.00
+      taxRatePercent: 8.25, // 102.49 × 8.25% = 8.4554… → 8.46
+    });
+
+    expect(result).toEqual({
+      subtotal: 99.99,
+      markup_amount: 7.5,
+      discount_amount: 5,
+      adjusted_subtotal: 102.49,
+      tax_amount: 8.46,
+      total: 110.95,
+    });
+  });
+
+  it("rounds a floating-point line-charge sum to cents", () => {
+    const result = computeWaterfall({
+      lineItemCharges: [0.1, 0.2], // 0.30000000000000004 in IEEE 754
+      markup: { type: "none", value: 0 },
+      discount: { type: "none", value: 0 },
+      taxRatePercent: 0,
+    });
+
+    expect(result.subtotal).toBe(0.3);
+    expect(result.total).toBe(0.3);
+  });
+
+  it("accepts a precomputed subtotal (the builder's live path) and matches the line-charges path exactly", () => {
+    const legs = {
+      markup: { type: "percent", value: 12.5 },
+      discount: { type: "amount", value: 19.99 },
+      taxRatePercent: 8.25,
+    } as const;
+
+    const fromCharges = computeWaterfall({ lineItemCharges: [149.5, 320.75, 89.99], ...legs });
+    const fromSubtotal = computeWaterfall({ subtotal: 560.24, ...legs });
+
+    expect(fromSubtotal).toEqual(fromCharges);
+  });
+
+  it("returns all-zero legs for an empty estimate", () => {
+    const result = computeWaterfall({
+      lineItemCharges: [],
+      markup: { type: "none", value: 0 },
+      discount: { type: "none", value: 0 },
+      taxRatePercent: 0,
+    });
+
+    expect(result).toEqual({
+      subtotal: 0,
+      markup_amount: 0,
+      discount_amount: 0,
+      adjusted_subtotal: 0,
+      tax_amount: 0,
+      total: 0,
+    });
+  });
+});

--- a/src/lib/waterfall.ts
+++ b/src/lib/waterfall.ts
@@ -6,12 +6,17 @@
 // Money contracts:
 // - discount is computed from the RAW subtotal, not the marked-up one
 // - tax is adjusted_subtotal × taxRatePercent / 100 — taxRatePercent is a
-//   whole-number percent (8.25 = 8.25%) matching the tax_rate numeric(6,4)
-//   column, NOT a fraction
+//   whole-number percent (8.25 = 8.25%) matching the tax_rate columns
+//   (numeric(5,2) on estimates, numeric(6,4) on invoices), NOT a fraction
 // - each leg is rounded to cents independently
 //
-// The PL/pgSQL convert-to-invoice copy still duplicates this math; it gets
-// folded in when Overhead & Profit lands (#564).
+// Two PL/pgSQL copies of this math are still live (latest bodies in
+// migration-382b): convert_estimate_to_invoice and apply_template_to_estimate.
+// Their formulas match but their rounding doesn't — Postgres round(numeric,2)
+// is exact half-away-from-zero while round2 is float Math.round, so a leg
+// landing on an exact half cent can differ by a penny (e.g. $2.90 at 5%
+// markup → 0.15 SQL vs 0.14 here). Both get reworked with Overhead & Profit
+// (#564; see #572/#575).
 
 import type { AdjustmentType } from "@/lib/types";
 import { round2 } from "@/lib/format";
@@ -27,8 +32,13 @@ export type WaterfallInput = {
   /** Whole-number percent, e.g. 8.25 = 8.25%. */
   taxRatePercent: number;
 } & (
-  | { lineItemCharges: number[] }
-  | { subtotal: number } // precomputed, e.g. the builder's summed sections
+  // The `?: never` members keep the two forms mutually exclusive — without
+  // them an object carrying BOTH keys would typecheck and `subtotal` would
+  // silently win (the implementation checks "subtotal" in input first).
+  | { lineItemCharges: number[]; subtotal?: never }
+  // Precomputed (e.g. the builder's summed sections); re-rounded to cents
+  // before the legs are computed.
+  | { subtotal: number; lineItemCharges?: never }
 );
 
 export interface WaterfallResult {

--- a/src/lib/waterfall.ts
+++ b/src/lib/waterfall.ts
@@ -1,0 +1,64 @@
+// The pricing waterfall — the single source of the estimate/invoice money
+// math (#566): subtotal → +markup → −discount → adjusted subtotal → +tax →
+// total. Pure, no Supabase imports, so both the server recalc paths
+// (estimates.ts / invoices.ts) and the client builder's live totals share it.
+//
+// Money contracts:
+// - discount is computed from the RAW subtotal, not the marked-up one
+// - tax is adjusted_subtotal × taxRatePercent / 100 — taxRatePercent is a
+//   whole-number percent (8.25 = 8.25%) matching the tax_rate numeric(6,4)
+//   column, NOT a fraction
+// - each leg is rounded to cents independently
+//
+// The PL/pgSQL convert-to-invoice copy still duplicates this math; it gets
+// folded in when Overhead & Profit lands (#564).
+
+import type { AdjustmentType } from "@/lib/types";
+import { round2 } from "@/lib/format";
+
+export interface Adjustment {
+  type: AdjustmentType;
+  value: number;
+}
+
+export type WaterfallInput = {
+  markup: Adjustment;
+  discount: Adjustment;
+  /** Whole-number percent, e.g. 8.25 = 8.25%. */
+  taxRatePercent: number;
+} & (
+  | { lineItemCharges: number[] }
+  | { subtotal: number } // precomputed, e.g. the builder's summed sections
+);
+
+export interface WaterfallResult {
+  subtotal: number;
+  markup_amount: number;
+  discount_amount: number;
+  adjusted_subtotal: number;
+  tax_amount: number;
+  total: number;
+}
+
+export function computeWaterfall(input: WaterfallInput): WaterfallResult {
+  const subtotal = round2(
+    "subtotal" in input
+      ? Number(input.subtotal)
+      : input.lineItemCharges.reduce((a, b) => a + Number(b), 0),
+  );
+
+  const markup_amount = adjustmentAmount(input.markup, subtotal);
+  const discount_amount = adjustmentAmount(input.discount, subtotal); // raw subtotal, not marked-up
+  const adjusted_subtotal = round2(subtotal + markup_amount - discount_amount);
+
+  const tax_amount = round2((adjusted_subtotal * Number(input.taxRatePercent)) / 100);
+  const total = round2(adjusted_subtotal + tax_amount);
+
+  return { subtotal, markup_amount, discount_amount, adjusted_subtotal, tax_amount, total };
+}
+
+function adjustmentAmount(adjustment: Adjustment, subtotal: number): number {
+  if (adjustment.type === "percent") return round2((subtotal * Number(adjustment.value)) / 100);
+  if (adjustment.type === "amount") return round2(Number(adjustment.value));
+  return 0;
+}


### PR DESCRIPTION
## What

Implements #566 (slice of #564): collapses the estimate/invoice pricing math into one pure `computeWaterfall` in `src/lib/waterfall.ts`, under unit test for the first time. **No behavior, schema, or UI change.**

## How

- `computeWaterfall({ lineItemCharges | subtotal, markup, discount, taxRatePercent })` returns all six legs (`subtotal`, `markup_amount`, `discount_amount`, `adjusted_subtotal`, `tax_amount`, `total`) — the shape settled in the grill.
- `builder-shared.ts`'s `recalculateMonetary` is deleted; the server recalc paths (`estimates.ts` `recalculateTotals`, `invoices.ts` `recalculateInvoiceTotals`) call `computeWaterfall` directly.
- `estimates-calc.ts`'s `computeEstimateTotals` keeps its signature (the builder is untouched) but is now a thin adapter over `computeWaterfall` — live totals and persisted totals share one implementation and can never drift.
- The PL/pgSQL convert-to-invoice copy and the legacy `computeTotals` compat helper (fractional tax rate, kept routes) are deliberately untouched in this slice.

## Tests

`src/lib/waterfall.test.ts` (11 tests, table-driven like the invoice-status / billing-rows prior art) pins the money contracts:

- markup & discount across `percent` / `amount` / `none`
- discount computed from the **raw** subtotal (not the marked-up one)
- tax = `adjusted_subtotal × taxRatePercent / 100` — whole-number percent, not a fraction
- per-leg cent rounding + floating-point line-charge sums
- zero/empty estimate
- precomputed-subtotal path (builder) matches the line-charges path (server) exactly

Verification: `vitest run src/lib src/components/estimate-builder` → 134 files / 1249 tests pass; `tsc --noEmit` and `eslint` show no new issues in touched files.

Closes #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
