### PR TITLE
feat(photo-report): + Add Photos picker + within-Section photo reorder (#552)

### DIFF
--- a/src/components/photo-report-add-photos-dialog.tsx
+++ b/src/components/photo-report-add-photos-dialog.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+// Issue #552 — Photo Report builder: the "+ Add Photos" picker.
+//
+// The desktop replacement for the always-visible drag tray: a modal listing ALL
+// of the Job's photos, from which the author multi-selects to drop into the
+// Section they are editing. A photo already in that Section is disabled (it is
+// already exactly where the picker would put it); a photo used in ANOTHER
+// Section is selectable but marked with that Section's name — adding it moves
+// it here (the one-Section invariant: a photo lives in at most one Section, so
+// `addPhotosToSection` dedupes by removing it from wherever else it lived).
+//
+// Selection is kept as an ordered array, not a Set: the reducer appends in
+// selection order, so the order the author picks in is the order the photos
+// land in (and the order the PDF numbers them).
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { photoUrl } from "@/lib/jobs/photo-url";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { ReportSection } from "@/lib/build-initial-sections";
+import type { Photo } from "@/lib/types";
+
+export interface AddPhotosDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** All of the Job's photos, in the Job's order. */
+  photos: Photo[];
+  /** The report's live Sections, for marking photos already used. */
+  sections: ReportSection[];
+  /** The Section the picker adds into. */
+  sectionIndex: number;
+  supabaseUrl: string;
+  /** Hand the selection (in pick order) back to the builder to dispatch. */
+  onAdd: (photoIds: string[]) => void;
+}
+
+export function AddPhotosDialog({
+  open,
+  onOpenChange,
+  photos,
+  sections,
+  sectionIndex,
+  supabaseUrl,
+  onAdd,
+}: AddPhotosDialogProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+
+  const target = sections[sectionIndex];
+  const targetTitle = target?.title || "Untitled section";
+  const inTarget = new Set(target?.photo_ids ?? []);
+  // photoId → the title of the OTHER Section currently holding it.
+  const usedElsewhere = new Map<string, string>();
+  sections.forEach((section, i) => {
+    if (i === sectionIndex) return;
+    for (const id of section.photo_ids) {
+      usedElsewhere.set(id, section.title || "Untitled section");
+    }
+  });
+
+  function toggle(photoId: string) {
+    setSelected((prev) =>
+      prev.includes(photoId)
+        ? prev.filter((id) => id !== photoId)
+        : [...prev, photoId],
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add photos</DialogTitle>
+          <DialogDescription>
+            Select photos to add to “{targetTitle}”. A photo used in another
+            section moves here.
+          </DialogDescription>
+        </DialogHeader>
+
+        {photos.length === 0 ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No photos on this job yet.
+          </p>
+        ) : (
+          <div className="grid max-h-[55vh] grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2 overflow-y-auto">
+            {photos.map((photo) => {
+              const isInTarget = inTarget.has(photo.id);
+              const elsewhere = usedElsewhere.get(photo.id);
+              const isSelected = selected.includes(photo.id);
+              return (
+                <button
+                  key={photo.id}
+                  type="button"
+                  data-testid={`picker-photo-${photo.id}`}
+                  disabled={isInTarget}
+                  aria-pressed={isSelected}
+                  onClick={() => toggle(photo.id)}
+                  className={cn(
+                    "group relative aspect-square overflow-hidden rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+                    isSelected && "ring-2 ring-primary",
+                    isInTarget && "cursor-default opacity-50",
+                  )}
+                >
+                  <img
+                    src={photoUrl(photo, supabaseUrl, "grid")}
+                    alt={photo.caption || "Photo"}
+                    className="h-full w-full object-cover"
+                  />
+                  {isSelected && (
+                    <span className="absolute left-1 top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground">
+                      {selected.indexOf(photo.id) + 1}
+                    </span>
+                  )}
+                  {/* Used-elsewhere marking: which Section holds it now. */}
+                  {isInTarget ? (
+                    <span className="absolute inset-x-0 bottom-0 truncate bg-black/55 px-1.5 py-0.5 text-left text-[10px] text-white">
+                      In this section
+                    </span>
+                  ) : elsewhere ? (
+                    <span className="absolute inset-x-0 bottom-0 truncate bg-black/55 px-1.5 py-0.5 text-left text-[10px] text-white">
+                      In {elsewhere}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            disabled={selected.length === 0}
+            onClick={() => onAdd(selected)}
+            className="gap-1.5"
+          >
+            <Plus size={14} />
+            Add {selected.length} photo{selected.length === 1 ? "" : "s"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/photo-report-builder-desktop.test.tsx
+++ b/src/components/photo-report-builder-desktop.test.tsx
@@ -131,6 +131,15 @@ function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
   };
 }
 
+function makePhoto(id: string): Photo {
+  return {
+    id,
+    storage_path: `job-1/${id}.jpg`,
+    annotated_path: null,
+    caption: null,
+  } as Photo;
+}
+
 function renderBuilder(report = makeReport(), photos: Photo[] = []) {
   return render(
     <PhotoReportBuilder
@@ -423,5 +432,243 @@ describe("PhotoReportBuilder — desktop center editor shows one pane (#548)", (
     expect(tokens(cards[0])).not.toContain("lg:hidden");
     expect(tokens(cards[1])).toContain("lg:hidden");
     expect(tokens(meta)).toContain("lg:hidden");
+  });
+});
+
+// ─── #552: the "+ Add Photos" picker replaces the desktop drag tray ─────────
+
+const tokens = (el: Element) => (el as HTMLElement).className.split(/\s+/);
+
+function sectionCards() {
+  return screen
+    .getAllByLabelText("Section heading")
+    .map((el) => el.closest("section") as HTMLElement);
+}
+
+describe("PhotoReportBuilder — desktop picker replaces the drag tray (#552)", () => {
+  it("offers a desktop-only + Add Photos button on each Section card", () => {
+    renderBuilder(makeReport(), [makePhoto("p1")]);
+
+    for (const card of sectionCards()) {
+      const add = within(card).getByRole("button", { name: "Add Photos" });
+      expect(tokens(add)).toContain("hidden");
+      expect(tokens(add)).toContain("lg:inline-flex");
+    }
+  });
+
+  it("hides the drag tray on desktop only, keeping it for the phone surface", () => {
+    renderBuilder(makeReport(), [makePhoto("p1")]);
+
+    // The tray is still in the DOM (the phone surface needs it) and hidden at
+    // lg+ purely by class — a bare `hidden` would break the phone builder.
+    const tray = screen
+      .getByText("Photos not in the report")
+      .closest("div") as HTMLElement;
+    expect(tokens(tray)).toContain("lg:hidden");
+    expect(tokens(tray)).not.toContain("hidden");
+
+    // The "drag photos here" hint only makes sense where the tray exists.
+    const hints = screen.getAllByText(/drag photos here to add them/, {
+      selector: "span",
+    });
+    expect(hints.length).toBeGreaterThan(0);
+    for (const hint of hints) {
+      expect(tokens(hint)).toContain("lg:hidden");
+    }
+  });
+});
+
+describe("PhotoReportBuilder — + Add Photos picker (#552)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // p1 already lives in the target (Roof), p2 in another Section (Gutters),
+  // p3/p4 are not in the report at all.
+  function pickerReport() {
+    return makeReport({
+      sections: [
+        { id: "sec-a", title: "Roof", description: "", photo_ids: ["p1"] },
+        { id: "sec-b", title: "Gutters", description: "", photo_ids: ["p2"] },
+      ],
+    });
+  }
+  const jobPhotos = () => ["p1", "p2", "p3", "p4"].map(makePhoto);
+
+  function openPickerFor(cardIndex: number) {
+    fireEvent.click(
+      within(sectionCards()[cardIndex]).getByRole("button", {
+        name: "Add Photos",
+      }),
+    );
+  }
+
+  it("lists the Job's photos, marking in-this-section (disabled) and used-elsewhere", () => {
+    renderBuilder(pickerReport(), jobPhotos());
+    openPickerFor(0); // Roof
+
+    // The dialog portal renders into document.body, so screen finds it.
+    expect(screen.getByText("Add photos")).toBeTruthy();
+
+    // Already in the target Section: disabled — it is already exactly where
+    // the picker would put it.
+    const p1 = screen.getByTestId("picker-photo-p1") as HTMLButtonElement;
+    expect(p1.disabled).toBe(true);
+    expect(within(p1).getByText("In this section")).toBeTruthy();
+
+    // Used in another Section: selectable, marked with that Section's name.
+    const p2 = screen.getByTestId("picker-photo-p2") as HTMLButtonElement;
+    expect(p2.disabled).toBe(false);
+    expect(within(p2).getByText("In Gutters")).toBeTruthy();
+
+    // Not in the report: no marking.
+    const p3 = screen.getByTestId("picker-photo-p3");
+    expect(within(p3).queryByText(/^In /)).toBeNull();
+  });
+
+  it("multi-adds the selection in pick order — moving a used-elsewhere photo, no duplicates — and autosaves once", async () => {
+    renderBuilder(pickerReport(), jobPhotos());
+    openPickerFor(0); // Roof
+
+    // The footer button counts the selection and is disabled at zero.
+    const addSelection = () =>
+      screen.getByRole("button", {
+        name: /add \d+ photos?/i,
+      }) as HTMLButtonElement;
+    expect(addSelection().disabled).toBe(true);
+
+    // Pick p3, then p2 (currently in Gutters), then p4 — order matters: it is
+    // the append order, hence the PDF numbering order.
+    fireEvent.click(screen.getByTestId("picker-photo-p3"));
+    fireEvent.click(screen.getByTestId("picker-photo-p2"));
+    fireEvent.click(screen.getByTestId("picker-photo-p4"));
+    expect(
+      screen.getByTestId("picker-photo-p2").getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(addSelection().textContent).toContain("Add 3 photos");
+
+    fireEvent.click(addSelection());
+
+    // The dialog closes (it only mounts while open)…
+    expect(screen.queryByText("Add photos")).toBeNull();
+
+    // …and the single dispatch autosaves once: Roof appends in pick order and
+    // Gutters lost p2 — the one-Section invariant, no duplicates.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: Array<{ title: string; photo_ids: string[] }>;
+    };
+    expect(payload.sections[0].photo_ids).toEqual(["p1", "p3", "p2", "p4"]);
+    expect(payload.sections[1].photo_ids).toEqual([]);
+  });
+
+  it("Cancel closes without dispatching, and a reopened picker starts with a fresh selection", async () => {
+    renderBuilder(pickerReport(), jobPhotos());
+    openPickerFor(0);
+
+    fireEvent.click(screen.getByTestId("picker-photo-p3"));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText("Add photos")).toBeNull();
+
+    // No edit was made, so nothing autosaves.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    // The dialog mounts per open, so the abandoned selection is gone.
+    openPickerFor(0);
+    expect(
+      screen.getByTestId("picker-photo-p3").getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+});
+
+describe("PhotoReportBuilder — within-Section photo reorder (#552)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function reorderReport() {
+    return makeReport({
+      sections: [
+        {
+          id: "sec-a",
+          title: "Roof",
+          description: "",
+          photo_ids: ["p1", "p2", "p3"],
+        },
+        { id: "sec-b", title: "Gutters", description: "", photo_ids: [] },
+      ],
+    });
+  }
+  const jobPhotos = () => ["p1", "p2", "p3"].map(makePhoto);
+
+  it("registers a Section's photos as sortable, so they are reorder drop targets", () => {
+    renderBuilder(reorderReport(), jobPhotos());
+
+    for (const id of ["p1", "p2", "p3"]) {
+      expect(capturedSortableIds).toContain(id);
+    }
+  });
+
+  it("reorders a photo dragged onto another in its Section and autosaves the new photo_ids order", async () => {
+    renderBuilder(reorderReport(), jobPhotos());
+    expect(capturedOnDragEnd).toBeTruthy();
+
+    // Drag p1 (position 0) onto p3 (position 2) — the descriptors the builder
+    // attaches to in-Section photos carry sectionIndex + photoIndex.
+    act(() => {
+      capturedOnDragEnd?.({
+        active: {
+          id: "p1",
+          data: {
+            current: {
+              type: "photo",
+              photoId: "p1",
+              sectionIndex: 0,
+              photoIndex: 0,
+            },
+          },
+        },
+        over: {
+          id: "p3",
+          data: {
+            current: {
+              type: "photo",
+              photoId: "p3",
+              sectionIndex: 0,
+              photoIndex: 2,
+            },
+          },
+        },
+      });
+    });
+
+    // The grid re-renders in the new order immediately…
+    const order = within(sectionCards()[0])
+      .getAllByAltText("Photo")
+      .map((img) => (img as HTMLImageElement).src.match(/p\d/)?.[0]);
+    expect(order).toEqual(["p2", "p3", "p1"]);
+
+    // …and the persisted photo_ids order — what the PDF's continuous photo
+    // numbering walks — autosaves.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0] as {
+      sections: Array<{ photo_ids: string[] }>;
+    };
+    expect(payload.sections[0].photo_ids).toEqual(["p2", "p3", "p1"]);
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -14,6 +14,7 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
+  rectSortingStrategy,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
@@ -43,6 +44,7 @@ import {
   type PhotoReportBuilderState,
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
+import { AddPhotosDialog } from "@/components/photo-report-add-photos-dialog";
 import { measureWriteupFit } from "@/lib/section-writeup-fit";
 import {
   newSectionId,
@@ -117,6 +119,12 @@ export default function PhotoReportBuilder({
   const selectedId = state.sections.some((s) => s.id === selectedSectionId)
     ? selectedSectionId
     : null;
+  // Which Section the "+ Add Photos" picker is adding into (#552), or null
+  // while closed. Like selectedSectionId, purely ephemeral UI state. The dialog
+  // mounts only while open, so every open starts with a fresh, empty selection.
+  const [pickerSectionIndex, setPickerSectionIndex] = useState<number | null>(
+    null,
+  );
 
   // The latest edit revision, mirrored into a ref so the async save tail can
   // tell whether a newer edit landed while it was in flight (its own captured
@@ -504,6 +512,7 @@ export default function PhotoReportBuilder({
                     supabaseUrl={supabaseUrl}
                     dispatch={dispatch}
                     desktopSelected={selectedId === section.id}
+                    onOpenPicker={() => setPickerSectionIndex(index)}
                   />
                 ))}
               </div>
@@ -520,11 +529,36 @@ export default function PhotoReportBuilder({
               Add section
             </button>
 
-            {/* Photos not yet in the report — drag into a Section to add. */}
+            {/* Photos not yet in the report — drag into a Section to add.
+                Phone-only (#552): on desktop the "+ Add Photos" picker replaces
+                the always-visible tray. */}
             <PhotoTray photos={availablePhotos} supabaseUrl={supabaseUrl} />
           </div>
         </div>
       </DndContext>
+
+      {/* The "+ Add Photos" picker (#552): adds a multi-selection of the Job's
+          photos into the Section whose button opened it. */}
+      {pickerSectionIndex !== null && (
+        <AddPhotosDialog
+          open
+          onOpenChange={(open) => {
+            if (!open) setPickerSectionIndex(null);
+          }}
+          photos={photos}
+          sections={state.sections}
+          sectionIndex={pickerSectionIndex}
+          supabaseUrl={supabaseUrl}
+          onAdd={(photoIds) => {
+            dispatch({
+              type: "addPhotosToSection",
+              photoIds,
+              sectionIndex: pickerSectionIndex,
+            });
+            setPickerSectionIndex(null);
+          }}
+        />
+      )}
     </div>
   );
 }
@@ -620,6 +654,7 @@ function SortableSection({
   supabaseUrl,
   dispatch,
   desktopSelected,
+  onOpenPicker,
 }: {
   index: number;
   section: ReportSection;
@@ -634,6 +669,8 @@ function SortableSection({
    * inert below lg, where the phone builder still renders every Section.
    */
   desktopSelected: boolean;
+  /** Open the "+ Add Photos" picker targeting this Section (#552). */
+  onOpenPicker: () => void;
 }) {
   const {
     attributes,
@@ -742,55 +779,81 @@ function SortableSection({
         {!fit.fits && ` · ${-fit.remaining} over the limit`}
       </p>
 
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
-        {section.photo_ids.map((photoId) => {
-          const photo = photosById.get(photoId);
-          if (!photo) return null;
-          return (
-            <DraggablePhoto
-              key={photoId}
-              photo={photo}
-              sectionIndex={index}
-              supabaseUrl={supabaseUrl}
-              dispatch={dispatch}
-            />
-          );
-        })}
+      {/* Photos are sortable within their Section (#552): the items are the
+          raw photo_ids (a dangling id still occupies its index, so photoIndex
+          stays aligned with the reducer's photo_ids positions). rect strategy:
+          this is a wrapping grid, not a vertical list. */}
+      <SortableContext items={section.photo_ids} strategy={rectSortingStrategy}>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(96px,1fr))] gap-2">
+          {section.photo_ids.map((photoId, photoIndex) => {
+            const photo = photosById.get(photoId);
+            if (!photo) return null;
+            return (
+              <DraggablePhoto
+                key={photoId}
+                photo={photo}
+                sectionIndex={index}
+                photoIndex={photoIndex}
+                supabaseUrl={supabaseUrl}
+                dispatch={dispatch}
+              />
+            );
+          })}
+        </div>
+      </SortableContext>
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          {visibleCount} photo{visibleCount === 1 ? "" : "s"}
+          {/* The drag-here hint only makes sense where the tray exists (phone);
+              on desktop the picker is the add affordance (#552). */}
+          <span className="lg:hidden"> — drag photos here to add them</span>
+        </p>
+        <button
+          type="button"
+          onClick={onOpenPicker}
+          className="hidden lg:inline-flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+        >
+          <Plus size={14} />
+          Add Photos
+        </button>
       </div>
-      <p className="text-xs text-muted-foreground">
-        {visibleCount} photo{visibleCount === 1 ? "" : "s"} — drag photos here to
-        add them
-      </p>
     </section>
   );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// DraggablePhoto — a photo inside a Section: drag it to another Section, or
-// remove it from the report.
+// DraggablePhoto — a photo inside a Section: drag it within its Section to
+// reorder (#552), drag it to another Section to move it, or remove it from the
+// report. Sortable (so it is also a drop target), unlike the tray's photos —
+// its id can't collide with a tray photo's because a photo is never in a
+// Section and the tray at once.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function DraggablePhoto({
   photo,
   sectionIndex,
+  photoIndex,
   supabaseUrl,
   dispatch,
 }: {
   photo: Photo;
   sectionIndex: number;
+  /** This photo's position in its Section's photo_ids. */
+  photoIndex: number;
   supabaseUrl: string;
   dispatch: React.Dispatch<
     Parameters<typeof photoReportBuilderReducer>[1]
   >;
 }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } =
-    useDraggable({
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({
       id: photo.id,
-      data: { type: "photo", photoId: photo.id, sectionIndex },
+      data: { type: "photo", photoId: photo.id, sectionIndex, photoIndex },
     });
 
   const style = {
-    transform: CSS.Translate.toString(transform),
+    transform: CSS.Transform.toString(transform),
+    transition,
     opacity: isDragging ? 0.4 : 1,
   };
 
@@ -823,7 +886,8 @@ function DraggablePhoto({
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PhotoTray — the Job's photos that are not yet in the report; drag one into a
-// Section to add it.
+// Section to add it. Phone-only (#552): on desktop the "+ Add Photos" picker is
+// the add affordance, so the tray hides at lg+.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function PhotoTray({
@@ -834,7 +898,7 @@ function PhotoTray({
   supabaseUrl: string;
 }) {
   return (
-    <div className="rounded-xl border border-border bg-muted/30 p-4">
+    <div className="lg:hidden rounded-xl border border-border bg-muted/30 p-4">
       <h2 className="mb-2 text-xs font-medium text-muted-foreground">
         Photos not in the report
       </h2>

--- a/src/lib/photo-report-builder.test.ts
+++ b/src/lib/photo-report-builder.test.ts
@@ -292,6 +292,149 @@ describe("photoReportBuilderReducer", () => {
     expect(next).toBe(before);
   });
 
+  it("adds several photos to a section in selection order with one revision bump (#552)", () => {
+    const before = loaded(); // [ Photos(p1,p2) ]
+    const next = photoReportBuilderReducer(before, {
+      type: "addPhotosToSection",
+      photoIds: ["p3", "p4", "p5"],
+      sectionIndex: 0,
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p1", "p2", "p3", "p4", "p5"]);
+    expect(next.dirty).toBe(true);
+    // The whole multi-add is one edit: one revision bump, one auto-save.
+    expect(next.revision).toBe(before.revision + 1);
+  });
+
+  it("dedupes a selection that names the same photo twice", () => {
+    const next = photoReportBuilderReducer(loaded(), {
+      type: "addPhotosToSection",
+      photoIds: ["p3", "p4", "p3"],
+      sectionIndex: 0,
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p1", "p2", "p3", "p4"]);
+  });
+
+  it("adding a photo that lives in another section moves it (no duplicates)", () => {
+    // [ Photos(p1,p2), New section() ]; add p1 + a new p9 into section 1.
+    const before = photoReportBuilderReducer(loaded(), {
+      type: "addSection",
+      id: "s2",
+    });
+    const next = photoReportBuilderReducer(before, {
+      type: "addPhotosToSection",
+      photoIds: ["p1", "p9"],
+      sectionIndex: 1,
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p2"]);
+    expect(next.sections[1].photo_ids).toEqual(["p1", "p9"]);
+  });
+
+  it("keeps a photo already in the target section in place while appending the rest", () => {
+    // p1 is already first in section 0 — re-adding it must not move it to the
+    // end (the picker disables in-Section photos, but the reducer guards too).
+    const next = photoReportBuilderReducer(loaded(), {
+      type: "addPhotosToSection",
+      photoIds: ["p1", "p3"],
+      sectionIndex: 0,
+    });
+    expect(next.sections[0].photo_ids).toEqual(["p1", "p2", "p3"]);
+  });
+
+  it("treats an add that changes nothing as a no-op", () => {
+    const before = loaded();
+    // Everything requested is already (only) in the target section.
+    expect(
+      photoReportBuilderReducer(before, {
+        type: "addPhotosToSection",
+        photoIds: ["p1", "p2"],
+        sectionIndex: 0,
+      }),
+    ).toBe(before);
+    // An empty selection is equally a no-op.
+    expect(
+      photoReportBuilderReducer(before, {
+        type: "addPhotosToSection",
+        photoIds: [],
+        sectionIndex: 0,
+      }),
+    ).toBe(before);
+  });
+
+  it("ignores adding photos to a section index that does not exist", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "addPhotosToSection",
+      photoIds: ["p3"],
+      sectionIndex: 9,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("reorders a photo within its section and marks dirty (#552)", () => {
+    const before = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [
+        { title: "Photos", description: "", photo_ids: ["p1", "p2", "p3"] },
+        { title: "Other", description: "", photo_ids: ["p4"] },
+      ],
+    });
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderPhotoWithinSection",
+      sectionIndex: 0,
+      from: 0,
+      to: 2,
+    });
+    // arrayMove semantics: the dragged photo lands at the target index.
+    expect(next.sections[0].photo_ids).toEqual(["p2", "p3", "p1"]);
+    // The other section is untouched (same object, not just equal).
+    expect(next.sections[1]).toBe(before.sections[1]);
+    expect(next.dirty).toBe(true);
+    expect(next.revision).toBe(before.revision + 1);
+  });
+
+  it("treats reordering a photo onto its own position as a no-op", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderPhotoWithinSection",
+      sectionIndex: 0,
+      from: 1,
+      to: 1,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("ignores a photo reorder with an out-of-range photo index", () => {
+    const before = loaded(); // section 0 has two photos
+    expect(
+      photoReportBuilderReducer(before, {
+        type: "reorderPhotoWithinSection",
+        sectionIndex: 0,
+        from: 0,
+        to: 5,
+      }),
+    ).toBe(before);
+    expect(
+      photoReportBuilderReducer(before, {
+        type: "reorderPhotoWithinSection",
+        sectionIndex: 0,
+        from: -1,
+        to: 0,
+      }),
+    ).toBe(before);
+  });
+
+  it("ignores a photo reorder in a section index that does not exist", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "reorderPhotoWithinSection",
+      sectionIndex: 9,
+      from: 0,
+      to: 1,
+    });
+    expect(next).toBe(before);
+  });
+
   it("removes a photo from the report, taking it out of its section and marking dirty", () => {
     const before = loaded(); // [ Photos(p1,p2) ]
     const next = photoReportBuilderReducer(before, {

--- a/src/lib/photo-report-builder.ts
+++ b/src/lib/photo-report-builder.ts
@@ -88,6 +88,13 @@ export type PhotoReportBuilderAction =
   | { type: "removeSection"; index: number }
   | { type: "reorderSection"; from: number; to: number }
   | { type: "assignPhotoToSection"; photoId: string; sectionIndex: number }
+  | { type: "addPhotosToSection"; photoIds: string[]; sectionIndex: number }
+  | {
+      type: "reorderPhotoWithinSection";
+      sectionIndex: number;
+      from: number;
+      to: number;
+    }
   | { type: "removePhotoFromReport"; photoId: string }
   | { type: "markSaved"; revision: number };
 
@@ -228,6 +235,61 @@ export function photoReportBuilderReducer(
       return {
         ...state,
         sections,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    }
+    case "addPhotosToSection": {
+      // Multi-photo assignPhotoToSection (#552): the "+ Add Photos" picker adds
+      // its whole selection in one action so the result is a single revision
+      // bump (one auto-save). Same one-Section invariant: every requested photo
+      // ends up in the target Section, removed from wherever else it lived.
+      // Photos already in the target keep their position (the picker marks them
+      // and a re-add must not shuffle the Section); the rest append in selection
+      // order. A selection that changes nothing leaves state untouched.
+      if (!isSectionIndex(state, action.sectionIndex)) return state;
+      const requested = new Set(action.photoIds);
+      const target = state.sections[action.sectionIndex];
+      const inTarget = new Set(target.photo_ids);
+      const appended = [...requested].filter((id) => !inTarget.has(id));
+      let changed = appended.length > 0;
+      const sections = state.sections.map((section, i) => {
+        if (i === action.sectionIndex) {
+          if (appended.length === 0) return section;
+          return { ...section, photo_ids: [...section.photo_ids, ...appended] };
+        }
+        const without = section.photo_ids.filter((id) => !requested.has(id));
+        if (without.length === section.photo_ids.length) return section;
+        changed = true;
+        return { ...section, photo_ids: without };
+      });
+      if (!changed) return state;
+      return {
+        ...state,
+        sections,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    }
+    case "reorderPhotoWithinSection": {
+      // Move a photo to a new position inside its own Section (#552), matching
+      // dnd-kit's arrayMove like reorderSection. The persisted photo_ids order
+      // is what the PDF's continuous photo numbering walks, so this is the
+      // user's lever on numbering.
+      const { sectionIndex, from, to } = action;
+      if (!isSectionIndex(state, sectionIndex)) return state;
+      const photoIds = state.sections[sectionIndex].photo_ids;
+      if (from < 0 || from >= photoIds.length) return state;
+      if (to < 0 || to >= photoIds.length) return state;
+      if (from === to) return state;
+      const reordered = [...photoIds];
+      const [moved] = reordered.splice(from, 1);
+      reordered.splice(to, 0, moved);
+      return {
+        ...state,
+        sections: state.sections.map((section, i) =>
+          i === sectionIndex ? { ...section, photo_ids: reordered } : section,
+        ),
         dirty: true,
         revision: state.revision + 1,
       };

--- a/src/lib/photo-report-drag.test.ts
+++ b/src/lib/photo-report-drag.test.ts
@@ -13,8 +13,16 @@ function section(id: string, index: number) {
   return { id, data: { current: { type: "section", index } } };
 }
 
-function photo(id: string, sectionIndex: number) {
-  return { id, data: { current: { type: "photo", photoId: id, sectionIndex } } };
+function photo(id: string, sectionIndex: number, photoIndex?: number) {
+  return {
+    id,
+    data: { current: { type: "photo", photoId: id, sectionIndex, photoIndex } },
+  };
+}
+
+// A photo in the phone-only "not in the report" tray: no Section, no position.
+function trayPhoto(id: string) {
+  return { id, data: { current: { type: "photo", photoId: id } } };
 }
 
 describe("resolvePhotoReportDragEnd", () => {
@@ -44,13 +52,77 @@ describe("resolvePhotoReportDragEnd", () => {
     });
   });
 
-  it("treats dropping a photo back onto its own section as a no-op", () => {
-    // No within-section reordering this slice — a same-section drop changes
-    // nothing rather than surprising the user by jumping the photo to the end.
-    // (Sections are the only drop targets, so `over` is always a section.)
+  it("treats dropping a photo back onto its own section's container as a no-op", () => {
+    // The container drop carries no target position, and assigning would
+    // surprise the user by jumping the photo to the end.
     expect(
       resolvePhotoReportDragEnd({ active: photo("p1", 0), over: section("s0", 0) }),
     ).toBeNull();
+  });
+
+  it("maps a photo dropped onto another photo in the same section to a within-section reorder (#552)", () => {
+    const action = resolvePhotoReportDragEnd({
+      active: photo("p1", 0, 0),
+      over: photo("p3", 0, 2),
+    });
+    expect(action).toEqual({
+      type: "reorderPhotoWithinSection",
+      sectionIndex: 0,
+      from: 0,
+      to: 2,
+    });
+  });
+
+  it("treats a photo dropped onto its own position as a no-op", () => {
+    expect(
+      resolvePhotoReportDragEnd({
+        active: photo("p1", 0, 1),
+        over: photo("p1", 0, 1),
+      }),
+    ).toBeNull();
+  });
+
+  it("maps a photo dropped onto a photo in another section to an assignment into that section", () => {
+    const action = resolvePhotoReportDragEnd({
+      active: photo("p1", 0, 0),
+      over: photo("p9", 2, 1),
+    });
+    expect(action).toEqual({
+      type: "assignPhotoToSection",
+      photoId: "p1",
+      sectionIndex: 2,
+    });
+  });
+
+  it("maps a tray photo dropped onto a photo in a section to an assignment into that section", () => {
+    const action = resolvePhotoReportDragEnd({
+      active: trayPhoto("p9"),
+      over: photo("p1", 1, 0),
+    });
+    expect(action).toEqual({
+      type: "assignPhotoToSection",
+      photoId: "p9",
+      sectionIndex: 1,
+    });
+  });
+
+  it("treats a photo dropped onto a tray photo as a no-op (the tray is not a drop target)", () => {
+    expect(
+      resolvePhotoReportDragEnd({
+        active: photo("p1", 0, 0),
+        over: trayPhoto("p9"),
+      }),
+    ).toBeNull();
+  });
+
+  it("maps a section dropped onto a photo to a reorder targeting that photo's section", () => {
+    // closestCenter can pick a photo as the nearest droppable while a section
+    // card is being dragged; landing on a photo means landing on its section.
+    const action = resolvePhotoReportDragEnd({
+      active: section("s0", 0),
+      over: photo("p9", 2, 1),
+    });
+    expect(action).toEqual({ type: "reorderSection", from: 0, to: 2 });
   });
 
   it("returns null for an unrecognized drag descriptor", () => {

--- a/src/lib/photo-report-drag.ts
+++ b/src/lib/photo-report-drag.ts
@@ -6,11 +6,12 @@
 // testable without React. Mirrors estimate-builder/move-line-item.ts.
 //
 // The builder attaches a `data.current` descriptor to each node:
-//   - a Section container (the only drop target): { type: "section", index }
-//   - a Photo (a drag source only): { type: "photo", photoId, sectionIndex? }
-//     A photo already in a Section carries its sectionIndex; a photo in the "not
-//     in the report" tray carries none. Photos are draggable but not droppable,
-//     so a drop's `over` is always a Section (or null).
+//   - a Section container: { type: "section", index }
+//   - a Photo: { type: "photo", photoId, sectionIndex?, photoIndex? }
+//     A photo already in a Section carries its sectionIndex and its position
+//     within that Section's photo_ids (#552 made in-Section photos sortable, so
+//     they are drop targets too); a photo in the phone-only "not in the report"
+//     tray carries neither, and the tray itself is not a drop target.
 
 import type { PhotoReportBuilderAction } from "./photo-report-builder";
 
@@ -35,31 +36,55 @@ export function resolvePhotoReportDragEnd(
 
   if (activeData.type === "section") {
     const from = numberOrNull(activeData.index);
-    const to = overData.type === "section" ? numberOrNull(overData.index) : null;
+    const to = dropTargetSectionIndex(overData);
     if (from === null || to === null || from === to) return null;
     return { type: "reorderSection", from, to };
   }
 
   if (activeData.type === "photo") {
     const photoId = typeof activeData.photoId === "string" ? activeData.photoId : null;
+    if (photoId === null) return null;
+    const fromSection = numberOrNull(activeData.sectionIndex);
+
+    // A photo dropped onto another photo in its own Section reorders within it
+    // (#552): the dragged photo lands at the target's position, dnd-kit's
+    // arrayMove semantics.
+    if (
+      overData.type === "photo" &&
+      fromSection !== null &&
+      numberOrNull(overData.sectionIndex) === fromSection
+    ) {
+      const from = numberOrNull(activeData.photoIndex);
+      const to = numberOrNull(overData.photoIndex);
+      if (from === null || to === null || from === to) return null;
+      return {
+        type: "reorderPhotoWithinSection",
+        sectionIndex: fromSection,
+        from,
+        to,
+      };
+    }
+
     const sectionIndex = dropTargetSectionIndex(overData);
-    if (photoId === null || sectionIndex === null) return null;
-    // A photo dropped back onto the Section it already belongs to is a no-op (no
-    // within-section reordering this slice). Tray photos carry no sectionIndex,
-    // so they always assign.
-    if (numberOrNull(activeData.sectionIndex) === sectionIndex) return null;
+    if (sectionIndex === null) return null;
+    // A photo dropped back onto its own Section's container changes nothing —
+    // assigning would surprise the user by jumping the photo to the end.
+    if (fromSection === sectionIndex) return null;
     return { type: "assignPhotoToSection", photoId, sectionIndex };
   }
 
   return null;
 }
 
-// The Section index a drop lands in. Sections are the only drop targets (photos
-// are draggable but not droppable), so a drop's `over` is always a Section.
+// The Section index a drop lands in: the Section container itself, or — since
+// in-Section photos are sortable and therefore droppable (#552) — a photo that
+// lives in a Section, which stands in for its Section. Tray photos carry no
+// sectionIndex and resolve to null (the tray is not a drop target).
 function dropTargetSectionIndex(
   overData: Record<string, unknown>,
 ): number | null {
   if (overData.type === "section") return numberOrNull(overData.index);
+  if (overData.type === "photo") return numberOrNull(overData.sectionIndex);
   return null;
 }
 


### PR DESCRIPTION
Closes #552 (parent PRD #547). Blocker #548 was merged via #565 before this branch was cut.

## What changed

**"+ Add Photos" picker replaces the desktop drag tray**
- Each Section card gets a desktop-only (`hidden lg:inline-flex`) "+ Add Photos" button opening a modal (`photo-report-add-photos-dialog.tsx`, Base UI Dialog) listing **all** of the Job's photos.
- Photos already in the target Section are disabled and marked "In this section"; photos used in **another** Section are selectable and marked "In {section}" — adding them moves them (one-Section invariant, no duplicates).
- Selection is an ordered array: pick order = append order = the PDF's continuous numbering order. The dialog mounts per open, so every open starts with a fresh selection.
- The drag tray + "drag photos here" hint are now `lg:hidden` — phone surface unchanged.

**Within-Section photo reorder**
- Section thumbnails switch from `useDraggable` to `useSortable` inside a `SortableContext` (`rectSortingStrategy`, items = raw `photo_ids` so indices stay aligned even past dangling ids).
- Dropping a photo onto another in its own Section reorders `photo_ids`; the order autosaves and is exactly what `build-report-document.ts` walks for continuous photo numbering — no PDF change needed.

**Reducer** (`photo-report-builder.ts`): new `addPhotosToSection` (multi-add in one revision bump → one auto-save; dedupes; already-in-target photos keep their position; referential-identity no-op when nothing changes) and `reorderPhotoWithinSection` (arrayMove semantics, bounds-checked no-ops).

**Drag resolver** (`photo-report-drag.ts`): photo-over-photo in the same Section → `reorderPhotoWithinSection`; a photo in a Section now stands in for its Section as a drop target (assign/move + the defensive section-over-photo → `reorderSection` case for `closestCenter`); tray photos are not drop targets.

## Acceptance criteria

- [x] Picker opens per Section; multi-add works
- [x] Used-elsewhere marking visible (+ in-this-section disabled state)
- [x] Adding a photo from another Section moves it — no duplicates
- [x] Thumbnails drag-reorder within a Section with autosave (drives PDF numbering)
- [x] Drag tray removed on desktop only; phone surface untouched
- [x] Both new reducer actions covered by unit tests

## Tests

- `npx vitest run` — **344 files / 2732 tests, all green** (10 new reducer cases, 6 new resolver cases, 7 new desktop component tests covering the picker flow incl. autosave payloads, tray gating tokens, and synthetic reorder drags)
- `npx tsc --noEmit` — 1 pre-existing error on HEAD (`makeReport` missing the #561 cover fields), unchanged by this branch; no new errors. (The old 19-error baseline is stale — main is down to 1.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)