### PR TITLE
feat(estimate-builder): positional numbering module + visible numbers (#568)

### DIFF
--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -44,6 +44,7 @@ import { MetadataBar } from "./metadata-bar";
 import { CustomerBlock } from "./customer-block";
 import { StatementEditor } from "./statement-editor";
 import { SectionCard } from "./section-card";
+import { buildNumberIndex } from "./number-section-tree";
 import { AddItemDialog } from "./add-item-dialog";
 import { BuilderLayout } from "./builder-layout";
 import { LineItemEditorPanel } from "./line-item-editor-panel";
@@ -1698,6 +1699,10 @@ export function EstimateBuilder({
     const invSections = invoice.sections;
     const invMode = invoiceEntity.kind;
 
+    // #568: derived positional numbers (read-model, never persisted). Recomputed
+    // each render so add / remove / drag-reorder renumber for free.
+    const invNumbering = buildNumberIndex(invSections);
+
     // #544: the line currently open in the editor panel (null when none).
     const selectedInvoiceItem = lineSelection.selectedId
       ? findLineItem(invSections, lineSelection.selectedId)
@@ -1825,6 +1830,7 @@ export function EstimateBuilder({
                       sectionIdx={sIdx}
                       selectedLineItemId={lineSelection.selectedId}
                       onSelectLineItem={lineSelection.select}
+                      numbering={invNumbering}
                     />
                   ))}
                 </ul>
@@ -1921,6 +1927,11 @@ export function EstimateBuilder({
     const template = templateEntity.data;
     const tmplSections = template.sections;
     const tmplMode = templateEntity.kind;
+
+    // #568: derived positional numbers (read-model, never persisted). Template
+    // sections are structurally compatible with the numbering generic (they carry
+    // id / sort_order / items / subsections) — the same shape SectionCard reads.
+    const tmplNumbering = buildNumberIndex(tmplSections);
 
     // #544: the line currently open in the editor panel (null when none).
     // Template line items carry the fields the panel reads (name/code/quantity/
@@ -2024,6 +2035,7 @@ export function EstimateBuilder({
                       sectionIdx={sIdx}
                       selectedLineItemId={lineSelection.selectedId}
                       onSelectLineItem={lineSelection.select}
+                      numbering={tmplNumbering}
                     />
                   ))}
                 </ul>
@@ -2114,6 +2126,10 @@ export function EstimateBuilder({
   const estimate = estimateEntity.data;
   const sections = estimate.sections;
   const mode = estimateEntity.kind;
+
+  // #568: derived positional numbers (read-model, never persisted). Recomputed
+  // each render so add / remove / drag-reorder renumber for free.
+  const numbering = buildNumberIndex(sections);
 
   // #544: the line currently open in the editor panel (null when none selected).
   const selectedItem = lineSelection.selectedId
@@ -2268,6 +2284,7 @@ export function EstimateBuilder({
                     sectionIdx={sIdx}
                     selectedLineItemId={lineSelection.selectedId}
                     onSelectLineItem={lineSelection.select}
+                    numbering={numbering}
                   />
                 ))}
               </ul>

--- a/src/components/estimate-builder/line-item-row.tsx
+++ b/src/components/estimate-builder/line-item-row.tsx
@@ -52,6 +52,12 @@ export interface LineItemRowProps {
   selected?: boolean;
   /** #544: select this row (opens the editor panel on it). */
   onSelect?: () => void;
+  /**
+   * #568: derived positional number for this row (e.g. "2.3.1" for a subsection
+   * item, "2.3" for a Section's direct item). A read-model projection computed
+   * by numberSectionTree — never persisted. Omitted → no number is shown.
+   */
+  number?: string;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -66,6 +72,7 @@ export function LineItemRow({
   domId,
   selected = false,
   onSelect,
+  number,
 }: LineItemRowProps) {
   // ── dnd-kit sortable ──────────────────────────────────────────────────────
   const {
@@ -129,6 +136,13 @@ export function LineItemRow({
       )}
       {/* Spacer when readOnly to keep alignment consistent */}
       {readOnly && <span className="w-5 shrink-0" />}
+
+      {/* Derived positional number (#568) — read-model, never persisted. */}
+      {number && (
+        <span className="w-12 shrink-0 mt-0.5 px-1 py-0.5 text-xs font-mono tabular-nums text-muted-foreground">
+          {number}
+        </span>
+      )}
 
       {/* Stacked name + description column */}
       <div className="flex-1 min-w-0 flex flex-col gap-0.5">

--- a/src/components/estimate-builder/number-section-tree.test.ts
+++ b/src/components/estimate-builder/number-section-tree.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from "vitest";
+import { numberSectionTree, buildNumberIndex } from "./number-section-tree";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Test helpers — terse builders for Section / Subsection / Line item trees.
+// Mirrors move-line-item.test.ts so the two pure-module tests read alike.
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface TestItem {
+  id: string;
+  sort_order: number;
+  section_id?: string;
+}
+
+interface TestSub {
+  id: string;
+  sort_order: number;
+  items: TestItem[];
+}
+
+interface TestSec {
+  id: string;
+  sort_order: number;
+  items: TestItem[];
+  subsections: TestSub[];
+}
+
+function item(id: string, sectionId: string, sort_order: number): TestItem {
+  return { id, section_id: sectionId, sort_order };
+}
+
+function sub(id: string, sort_order: number, items: TestItem[]): TestSub {
+  return { id, sort_order, items };
+}
+
+function sec(
+  id: string,
+  sort_order: number,
+  items: TestItem[],
+  subsections: TestSub[] = [],
+): TestSec {
+  return { id, sort_order, items, subsections };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// numberSectionTree
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("numberSectionTree", () => {
+  // Tracer — proves the path: one Section + one direct Line item → 1, 1.1.
+  it("numbers a single Section and its single direct Line item (1, 1.1)", () => {
+    const tree: TestSec[] = [sec("S1", 0, [item("A", "S1", 0)])];
+
+    expect(numberSectionTree(tree)).toEqual([
+      { id: "S1", kind: "section", number: "1" },
+      { id: "A", kind: "item", number: "1.1" },
+    ]);
+  });
+
+  // A Subsection is numbered n.k; its items are numbered n.k.m.
+  it("numbers a Subsection (n.k) and its items (n.k.m)", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [], [sub("Sub1", 0, [item("X", "Sub1", 0), item("Y", "Sub1", 1)])]),
+    ];
+
+    expect(numberSectionTree(tree)).toEqual([
+      { id: "S1", kind: "section", number: "1" },
+      { id: "Sub1", kind: "subsection", number: "1.1" },
+      { id: "X", kind: "item", number: "1.1.1" },
+      { id: "Y", kind: "item", number: "1.1.2" },
+    ]);
+  });
+
+  // Interleave decision (#568): within a Section that has BOTH subsections and
+  // loose direct items, the shared second-level counter runs subsections first
+  // (2.1, 2.2) then loose items (2.3, 2.4) — matching the on-screen render order.
+  it("shares the second-level counter: subsections first (2.1, 2.2), then loose items (2.3, 2.4)", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("Intro", "S1", 0)]),
+      sec(
+        "S2",
+        1,
+        [item("Permit", "S2", 0), item("Dumpster", "S2", 1)],
+        [
+          sub("Master", 0, [item("Tile", "Master", 0), item("Vanity", "Master", 1)]),
+          sub("Guest", 1, [item("GuestTile", "Guest", 0)]),
+        ],
+      ),
+    ];
+
+    expect(numberSectionTree(tree)).toEqual([
+      { id: "S1", kind: "section", number: "1" },
+      { id: "Intro", kind: "item", number: "1.1" },
+      { id: "S2", kind: "section", number: "2" },
+      { id: "Master", kind: "subsection", number: "2.1" },
+      { id: "Tile", kind: "item", number: "2.1.1" },
+      { id: "Vanity", kind: "item", number: "2.1.2" },
+      { id: "Guest", kind: "subsection", number: "2.2" },
+      { id: "GuestTile", kind: "item", number: "2.2.1" },
+      { id: "Permit", kind: "item", number: "2.3" },
+      { id: "Dumpster", kind: "item", number: "2.4" },
+    ]);
+  });
+
+  // Numbers come from POSITION after sorting by sort_order — not the raw
+  // sort_order values — so gaps and out-of-order input still yield contiguous
+  // 1-based numbering at every level.
+  it("derives contiguous numbers from sorted position despite gappy / out-of-order sort_order", () => {
+    const tree: TestSec[] = [
+      sec("S2", 30, [item("B", "S2", 5), item("A", "S2", 2)]),
+      sec("S1", 10, [item("C", "S1", 99)]),
+    ];
+
+    expect(numberSectionTree(tree)).toEqual([
+      { id: "S1", kind: "section", number: "1" },
+      { id: "C", kind: "item", number: "1.1" },
+      { id: "S2", kind: "section", number: "2" },
+      { id: "A", kind: "item", number: "2.1" },
+      { id: "B", kind: "item", number: "2.2" },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildNumberIndex — id → derived number, the read-model the builder renders.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("buildNumberIndex", () => {
+  it("maps each Section / Subsection / Line item id to its derived number", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0)], [sub("Sub1", 0, [item("X", "Sub1", 0)])]),
+    ];
+
+    const index = buildNumberIndex(tree);
+
+    expect(index.get("S1")).toBe("1");
+    expect(index.get("Sub1")).toBe("1.1");
+    expect(index.get("X")).toBe("1.1.1");
+    expect(index.get("A")).toBe("1.2"); // loose item numbered after the subsection
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recompute — the projection re-derives from scratch over the mutated tree, so
+// add / remove / drag-reorder shift numbers with no stored state to update.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("recompute over the mutated tree", () => {
+  it("renumbers after a Line item is added", () => {
+    const before: TestSec[] = [sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1)])];
+    expect(buildNumberIndex(before).get("B")).toBe("1.2");
+
+    const after: TestSec[] = [
+      sec("S1", 0, [item("A", "S1", 0), item("B", "S1", 1), item("C", "S1", 2)]),
+    ];
+    const idx = buildNumberIndex(after);
+    expect(idx.get("A")).toBe("1.1");
+    expect(idx.get("B")).toBe("1.2");
+    expect(idx.get("C")).toBe("1.3");
+  });
+
+  it("renumbers the trailing items after one is removed", () => {
+    // B removed from [A@0, B@1, C@2]; remaining sort_order is gappy (0, 2).
+    const after: TestSec[] = [sec("S1", 0, [item("A", "S1", 0), item("C", "S1", 2)])];
+    const idx = buildNumberIndex(after);
+    expect(idx.get("A")).toBe("1.1");
+    expect(idx.get("C")).toBe("1.2"); // was 1.3 before the removal
+    expect(idx.has("B")).toBe(false);
+  });
+
+  it("renumbers after a drag-reorder swaps sort_order", () => {
+    // Drag put B ahead of A: B@0, A@1.
+    const after: TestSec[] = [sec("S1", 0, [item("A", "S1", 1), item("B", "S1", 0)])];
+    const idx = buildNumberIndex(after);
+    expect(idx.get("B")).toBe("1.1");
+    expect(idx.get("A")).toBe("1.2");
+  });
+
+  it("renumbers a Line item dragged from a Section's loose items into a Subsection", () => {
+    // Before: A is a loose item (1.2, after subsection Sub1). After: A moved into
+    // Sub1 → it becomes a subsection item (1.1.1) and the loose slot disappears.
+    const after: TestSec[] = [
+      sec("S1", 0, [], [sub("Sub1", 0, [item("X", "Sub1", 0), item("A", "Sub1", 1)])]),
+    ];
+    const idx = buildNumberIndex(after);
+    expect(idx.get("Sub1")).toBe("1.1");
+    expect(idx.get("X")).toBe("1.1.1");
+    expect(idx.get("A")).toBe("1.1.2");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("numberSectionTree — edges", () => {
+  it("emits only the container row for empty Sections and Subsections", () => {
+    const tree: TestSec[] = [
+      sec("S1", 0, [], [sub("Sub1", 0, [])]),
+      sec("S2", 1, []),
+    ];
+
+    expect(numberSectionTree(tree)).toEqual([
+      { id: "S1", kind: "section", number: "1" },
+      { id: "Sub1", kind: "subsection", number: "1.1" },
+      { id: "S2", kind: "section", number: "2" },
+    ]);
+  });
+
+  it("returns an empty list for an empty tree", () => {
+    expect(numberSectionTree([])).toEqual([]);
+    expect(buildNumberIndex([]).size).toBe(0);
+  });
+});

--- a/src/components/estimate-builder/number-section-tree.ts
+++ b/src/components/estimate-builder/number-section-tree.ts
@@ -1,0 +1,77 @@
+// Pure positional numbering for the Estimate / Invoice / Template section tree.
+//
+// Isolated from React so it can be unit tested in plain Node and reused across
+// builder modes. It is a *read-model projection*: numbers are derived purely
+// from each row's position (after sorting by `sort_order`) and its parent
+// linkage. Nothing here is persisted.
+//
+// Domain language (CONTEXT.md):
+//   - Section: a top-level container. Numbered `n` (1, 2, 3, …).
+//   - Subsection: a one-level-deep container under a Section. Numbered `n.k`.
+//   - Line item: a row in a Section's direct items OR a Subsection's items.
+//     Direct item → `n.k`; subsection item → `n.k.m`.
+//
+// Within a Section the second-level counter is *shared* between subsections and
+// direct items, and runs in render order: subsections first (1.1, 1.2, …), then
+// the Section's loose direct items (continuing 1.3, 1.4, …).
+
+import type { LineItemLike, SubsectionLike, SectionLike } from "./move-line-item";
+
+export type NumberedRowKind = "section" | "subsection" | "item";
+
+export interface NumberedRow {
+  /** Entity id — a Section, Subsection, or Line item id. */
+  id: string;
+  kind: NumberedRowKind;
+  /** Derived display number, e.g. "1", "2.3", "2.3.1". Never persisted. */
+  number: string;
+}
+
+function bySortOrder<T extends { sort_order: number }>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => a.sort_order - b.sort_order);
+}
+
+export function numberSectionTree<
+  I extends LineItemLike,
+  Sub extends SubsectionLike<I>,
+  Sec extends SectionLike<I, Sub>,
+>(sections: Sec[]): NumberedRow[] {
+  const rows: NumberedRow[] = [];
+
+  bySortOrder(sections).forEach((section, si) => {
+    const n = si + 1;
+    rows.push({ id: section.id, kind: "section", number: `${n}` });
+
+    // Second-level counter `k`, shared between subsections and direct items and
+    // advanced in render order: subsections first, then the Section's loose items.
+    let k = 0;
+
+    bySortOrder(section.subsections).forEach((subsection) => {
+      k += 1;
+      rows.push({ id: subsection.id, kind: "subsection", number: `${n}.${k}` });
+      bySortOrder(subsection.items).forEach((it, mi) => {
+        rows.push({ id: it.id, kind: "item", number: `${n}.${k}.${mi + 1}` });
+      });
+    });
+
+    bySortOrder(section.items).forEach((it) => {
+      k += 1;
+      rows.push({ id: it.id, kind: "item", number: `${n}.${k}` });
+    });
+  });
+
+  return rows;
+}
+
+/**
+ * Read-model convenience: `id → derived number` for O(1) lookup while rendering.
+ * Re-run it over the current tree whenever rows are added, removed, or reordered;
+ * the numbering recomputes from scratch (it stores nothing).
+ */
+export function buildNumberIndex<
+  I extends LineItemLike,
+  Sub extends SubsectionLike<I>,
+  Sec extends SectionLike<I, Sub>,
+>(sections: Sec[]): Map<string, string> {
+  return new Map(numberSectionTree(sections).map((row) => [row.id, row.number]));
+}

--- a/src/components/estimate-builder/section-card.tsx
+++ b/src/components/estimate-builder/section-card.tsx
@@ -92,6 +92,13 @@ export interface SectionCardProps {
   selectedLineItemId?: string | null;
   /** #544: select a line (opens the editor panel on it). */
   onSelectLineItem?: (id: string) => void;
+  /**
+   * #568: derived `id → positional number` read-model spanning this section, its
+   * subsections, and all items (e.g. "2", "2.1", "2.1.3"). Computed by
+   * buildNumberIndex over the whole tree — never persisted. Threaded down to
+   * SubsectionCard / LineItemRow. Omitted → no numbers are shown.
+   */
+  numbering?: Map<string, string>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -239,6 +246,7 @@ export function SectionCard({
   sectionIdx,
   selectedLineItemId,
   onSelectLineItem,
+  numbering,
 }: SectionCardProps) {
   const {
     attributes,
@@ -304,6 +312,9 @@ export function SectionCard({
     (a, b) => a.sort_order - b.sort_order
   );
 
+  // ── Derived positional number (#568) — read-model, never persisted. ───────
+  const sectionNumber = numbering?.get(section.id);
+
   // ── Item counts for delete dialog ────────────────────────────────────────
 
   const subsectionItemCount = section.subsections.reduce(
@@ -331,6 +342,13 @@ export function SectionCard({
           >
             <GripVertical size={16} />
           </button>
+        )}
+
+        {/* Derived positional number (#568) — read-model, never persisted. */}
+        {sectionNumber && (
+          <span className="shrink-0 text-sm font-mono font-semibold tabular-nums text-muted-foreground">
+            {sectionNumber}
+          </span>
         )}
 
         {!readOnly && editingTitle ? (
@@ -447,6 +465,7 @@ export function SectionCard({
                     subsectionIdx={subIdx}
                     selectedLineItemId={selectedLineItemId}
                     onSelectLineItem={onSelectLineItem}
+                    numbering={numbering}
                   />
                 ))}
               </ul>
@@ -479,6 +498,7 @@ export function SectionCard({
                 }
                 selected={selectedLineItemId === item.id}
                 onSelect={() => onSelectLineItem?.(item.id)}
+                number={numbering?.get(item.id)}
               />
             ))}
           </div>

--- a/src/components/estimate-builder/subsection-card.tsx
+++ b/src/components/estimate-builder/subsection-card.tsx
@@ -70,6 +70,12 @@ export interface SubsectionCardProps {
   selectedLineItemId?: string | null;
   /** #544: select a line (opens the editor panel on it). */
   onSelectLineItem?: (id: string) => void;
+  /**
+   * #568: derived `id → positional number` read-model for this subsection and
+   * its items (e.g. "2.1" for the subsection, "2.1.3" for an item). Computed by
+   * buildNumberIndex over the whole tree — never persisted. Omitted → no numbers.
+   */
+  numbering?: Map<string, string>;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -137,6 +143,7 @@ export function SubsectionCard({
   subsectionIdx,
   selectedLineItemId,
   onSelectLineItem,
+  numbering,
 }: SubsectionCardProps) {
   const {
     attributes,
@@ -202,6 +209,9 @@ export function SubsectionCard({
 
   const sortedItems = [...subsection.items].sort((a, b) => a.sort_order - b.sort_order);
 
+  // ── Derived positional number (#568) — read-model, never persisted. ───────
+  const subsectionNumber = numbering?.get(subsection.id);
+
   return (
     <li
       ref={setNodeRef}
@@ -222,6 +232,13 @@ export function SubsectionCard({
           >
             <GripVertical size={14} />
           </button>
+        )}
+
+        {/* Derived positional number (#568) — read-model, never persisted. */}
+        {subsectionNumber && (
+          <span className="shrink-0 text-xs font-mono tabular-nums text-muted-foreground">
+            {subsectionNumber}
+          </span>
         )}
 
         {!readOnly && editingTitle ? (
@@ -326,6 +343,7 @@ export function SubsectionCard({
               }
               selected={selectedLineItemId === item.id}
               onSelect={() => onSelectLineItem?.(item.id)}
+              number={numbering?.get(item.id)}
             />
           ))}
         </SortableContext>


### PR DESCRIPTION
## What & why

Implements #568 — the estimate builder now shows positional numbers on every
section, subsection, and line item.

Numbering is a **read-model projection**: a pure function maps the two-level
Section tree to a flat, ordered, numbered row list. Numbers derive purely from
each row's `sort_order` position (after sorting) and its parent linkage — nothing
is persisted. Because the projection stores nothing, add / remove / drag-reorder
renumber for free on the next render.

### Scheme

| Level | Number | Example |
|---|---|---|
| Section | `n` | `1`, `2` |
| Subsection | `n.k` | `2.1` |
| Section direct item | `n.k` | `2.3` |
| Subsection item | `n.k.m` | `2.1.1` |

One level of nesting only. Within a section the second-level counter `k` is
**shared** between subsections and loose direct items and runs in render order:
subsections first (`2.1`, `2.2`), then the section's loose items (`2.3`, `2.4`) —
matching how `SectionCard` paints subsections before direct items.

## Changes

- **`number-section-tree.ts`** (new) — `numberSectionTree` + `buildNumberIndex`,
  generic over the `move-line-item` `LineItemLike` / `SubsectionLike` /
  `SectionLike` shapes so call sites are cast-free across estimate / invoice /
  template modes.
- **`SectionCard` / `SubsectionCard` / `LineItemRow`** — render the derived
  number; thread an optional `numbering` map / `number` string down the tree.
- **`estimate-builder.tsx`** — compute `buildNumberIndex(...)` at the three
  builder render sites (estimate / invoice / template) and pass it in.

## Tests

`number-section-tree.test.ts` — 11 unit tests (modeled on `move-line-item.test.ts`):
section/subsection/item numbering, the interleave rule, contiguity from gappy /
out-of-order `sort_order`, the `id → number` index, recompute after
add/remove/reorder/cross-container moves, and empty-container edges. All green.

`tsc --noEmit` and `eslint` are clean on the touched files (no new failures vs.
the known-red baseline).

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)
