### PR TITLE
feat(estimate-builder): simplify Estimate status → draft→sent→converted/voided (#567)

### DIFF
--- a/src/app/api/estimates/[id]/convert/route.ts
+++ b/src/app/api/estimates/[id]/convert/route.ts
@@ -38,12 +38,6 @@ export const POST = withRequestContext(
       if (result.code === "estimate_not_found") {
         return NextResponse.json({ error: "not_found" }, { status: 404 });
       }
-      if (result.code === "estimate_not_approved") {
-        return NextResponse.json(
-          { error: "estimate_not_approved", message: "Estimate must be approved before converting." },
-          { status: 400 },
-        );
-      }
       return apiDbError(result.message ?? "internal", "POST /api/estimates/[id]/convert");
     } catch (e: unknown) {
       return apiDbError(e instanceof Error ? e.message : String(e), "POST /api/estimates/[id]/convert");

--- a/src/app/api/estimates/[id]/send/preview/route.ts
+++ b/src/app/api/estimates/[id]/send/preview/route.ts
@@ -1,7 +1,7 @@
 // Build 67c2 — GET /api/estimates/[id]/send/preview
 // Returns the resolved-template subject + body (HTML→text) for the send modal.
 //
-// Status-based blocks (voided / converted / rejected) do NOT block this route.
+// Status-based blocks (voided / converted) do NOT block this route.
 // The Send button in the read-only view is the UI gate; this route just
 // answers "what would this email look like."
 

--- a/src/app/api/estimates/[id]/status/route.test.ts
+++ b/src/app/api/estimates/[id]/status/route.test.ts
@@ -20,9 +20,9 @@ beforeEach(() => {
 });
 
 function useUser(opts: Parameters<typeof fakeUserClient>[0]) {
-  vi.mocked(createServerSupabaseClient).mockResolvedValue(
-    fakeUserClient(opts) as never,
-  );
+  const client = fakeUserClient(opts);
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+  return client;
 }
 
 // A dynamic route: the `[id]` param must pass through the wrapper untouched.
@@ -59,5 +59,50 @@ describe("PUT /api/estimates/[id]/status (converted to withRequestContext)", () 
     const res = await PUT(putRequest(null), routeCtx);
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: "status required" });
+  });
+
+  // The transition gate wired in at route.ts — canTransitionEstimate(cur.status,
+  // body.status) plus the cannot-void-a-converted-estimate rule. The pure 4x4
+  // matrix is unit-tested in estimate-status.test.ts; these pin the route→helper
+  // wiring at the HTTP boundary so a future rewiring can't silently drop the
+  // rejection (or invert the gate).
+  function withEstimate(row: Record<string, unknown>) {
+    return useUser({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "member",
+        grants: ["edit_estimates"],
+        extraTables: {
+          estimates: [
+            { id: "est-1", updated_at: "2026-01-01T00:00:00.000Z", deleted_at: null, ...row },
+          ],
+        },
+      }),
+    });
+  }
+
+  it("rejects an illegal status transition with 400 invalid_transition", async () => {
+    withEstimate({ status: "draft", converted_to_invoice_id: null });
+    const res = await PUT(putRequest({ status: "converted" }), routeCtx);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "invalid_transition", from: "draft", to: "converted" });
+  });
+
+  it("refuses to void a converted estimate with 400 cannot_void_converted", async () => {
+    withEstimate({ status: "converted", converted_to_invoice_id: "inv-1" });
+    const res = await PUT(putRequest({ status: "voided" }), routeCtx);
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "cannot_void_converted", linked_invoice_id: "inv-1" });
+  });
+
+  it("allows a legal transition (draft → sent) and writes the patch", async () => {
+    const client = withEstimate({ status: "draft", converted_to_invoice_id: null });
+    const res = await PUT(putRequest({ status: "sent" }), routeCtx);
+    expect(res.status).toBe(200);
+    const update = client.__mutations.find((m) => m.table === "estimates" && m.op === "update");
+    const payload = update?.payload as { status?: string; sent_at?: string } | undefined;
+    expect(payload?.status).toBe("sent");
+    expect(typeof payload?.sent_at).toBe("string");
   });
 });

--- a/src/app/api/estimates/[id]/status/route.ts
+++ b/src/app/api/estimates/[id]/status/route.ts
@@ -3,17 +3,8 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 import { apiDbError } from "@/lib/api-errors";
 import { assertNotTrashed } from "@/lib/api/assert-not-trashed";
 import { checkSnapshot } from "@/lib/builder-shared";
-
-type EstimateStatus = "draft" | "sent" | "approved" | "rejected" | "converted" | "voided";
-
-const VALID_TRANSITIONS: Record<EstimateStatus, EstimateStatus[]> = {
-  draft:     ["sent", "voided"],
-  sent:      ["approved", "rejected", "voided"],
-  approved:  ["voided"], // Convert path goes through /convert RPC, not /status
-  rejected:  [], // terminal
-  converted: [], // terminal — CHECK constraint also blocks → voided
-  voided:    [],
-};
+import { canTransitionEstimate } from "@/lib/estimate-status";
+import type { EstimateStatus } from "@/lib/types";
 
 interface PutBody {
   status: EstimateStatus;
@@ -53,7 +44,7 @@ export const PUT = withRequestContext(
         );
       }
 
-      if (!VALID_TRANSITIONS[cur.status].includes(body.status)) {
+      if (!canTransitionEstimate(cur.status, body.status)) {
         return NextResponse.json(
           { error: "invalid_transition", from: cur.status, to: body.status },
           { status: 400 },
@@ -62,8 +53,6 @@ export const PUT = withRequestContext(
 
       const patch: Record<string, unknown> = { status: body.status, updated_at: new Date().toISOString() };
       if (body.status === "sent") patch.sent_at = new Date().toISOString();
-      if (body.status === "approved") patch.approved_at = new Date().toISOString();
-      if (body.status === "rejected") patch.rejected_at = new Date().toISOString();
       if (body.status === "voided") {
         patch.voided_at = new Date().toISOString();
         patch.void_reason = body.reason ?? null;

--- a/src/app/estimates/[id]/page.tsx
+++ b/src/app/estimates/[id]/page.tsx
@@ -4,7 +4,7 @@ import { AlertCircle, ArrowLeft, FileText, Pencil } from "lucide-react";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { requirePagePermission } from "@/lib/request-context/require-page-permission";
 import { getEstimateWithContents } from "@/lib/estimates";
-import { STATUS_BADGE_CLASSES, formatStatusLabel } from "@/lib/estimate-status";
+import { getStatusBadgeClasses, formatStatusLabel } from "@/lib/estimate-status";
 import { ExportPdfButton } from "@/components/documents/export-pdf-button";
 import { SendButton } from "@/components/send-modal/button";
 import { TrashedBanner } from "@/components/trash/trashed-banner";
@@ -151,7 +151,7 @@ export default async function EstimateViewPage({
               {estimate.estimate_number}
             </span>
             <span
-              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_BADGE_CLASSES[estimate.status]}`}
+              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${getStatusBadgeClasses("estimate", estimate.status)}`}
             >
               {statusLabel}
             </span>

--- a/src/components/estimate-builder/header-bar.tsx
+++ b/src/components/estimate-builder/header-bar.tsx
@@ -227,26 +227,6 @@ export function HeaderBar({
             Mark as Sent
           </Button>
         )}
-        {est.status === "sent" && (
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => transitionStatus("approved")}
-            >
-              <CheckCircle size={14} />
-              Mark Approved
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => transitionStatus("rejected")}
-            >
-              <XCircle size={14} />
-              Mark Rejected
-            </Button>
-          </>
-        )}
         {est.status !== "voided" && est.status !== "converted" && (
           <Button
             variant="outline"

--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -4,7 +4,6 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 
 export type ConversionErrorCode =
   | "estimate_not_found"
-  | "estimate_not_approved"
   | "estimate_already_converted"
   | "internal";
 
@@ -41,9 +40,6 @@ export async function convertEstimateToInvoice(
   const msg = error.message ?? "";
   if (msg.includes("estimate_not_found")) {
     return { ok: false, code: "estimate_not_found" };
-  }
-  if (msg.includes("estimate_not_approved")) {
-    return { ok: false, code: "estimate_not_approved" };
   }
   if (msg.includes("estimate_already_converted:")) {
     // Format: estimate_already_converted:<uuid>

--- a/src/lib/estimate-status.test.ts
+++ b/src/lib/estimate-status.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { rowTint, type RowTint, type EntityKind } from "./estimate-status";
+import {
+  rowTint,
+  canTransitionEstimate,
+  ESTIMATE_STATUS_TRANSITIONS,
+  type RowTint,
+  type EntityKind,
+} from "./estimate-status";
+import type { EstimateStatus } from "@/lib/types";
 
 // #384 — Status presentation: the Overview row tint draws attention only where
 // it's needed. A converted invoice still in draft is yellow ("ready for
@@ -17,13 +24,67 @@ describe("rowTint", () => {
     // Estimate rows — colour is reserved for invoices, so always untinted.
     ["estimate", "draft", "none"],
     ["estimate", "sent", "none"],
-    ["estimate", "approved", "none"],
-    ["estimate", "rejected", "none"],
     ["estimate", "converted", "none"],
     ["estimate", "voided", "none"],
   ];
 
   it.each(cases)("tints (%s, %s) as %s", (kind, status, expected) => {
     expect(rowTint(kind, status)).toBe(expected);
+  });
+});
+
+// #567 — the Estimate workflow is exactly draft → sent → converted / voided,
+// realigning with ADR 0007 (the approved/rejected step is dropped). These are
+// the pure transition rules extracted out of the status API route. Convert is
+// its own action (POST /convert) that flips the row to `converted`, never a
+// status transition — so neither `converted` nor any path *to* it appears here.
+describe("ESTIMATE_STATUS_TRANSITIONS", () => {
+  it("pins the allowed set: draft→{sent,voided}, sent→{voided}, converted/voided terminal", () => {
+    expect(ESTIMATE_STATUS_TRANSITIONS).toEqual({
+      draft: ["sent", "voided"],
+      sent: ["voided"],
+      converted: [],
+      voided: [],
+    });
+  });
+
+  it("has dropped the old approved / rejected states entirely", () => {
+    expect(ESTIMATE_STATUS_TRANSITIONS).not.toHaveProperty("approved");
+    expect(ESTIMATE_STATUS_TRANSITIONS).not.toHaveProperty("rejected");
+    for (const targets of Object.values(ESTIMATE_STATUS_TRANSITIONS)) {
+      expect(targets).not.toContain("approved");
+      expect(targets).not.toContain("rejected");
+    }
+  });
+});
+
+describe("canTransitionEstimate", () => {
+  const statuses: EstimateStatus[] = ["draft", "sent", "converted", "voided"];
+  const allowed = new Set(["draft→sent", "draft→voided", "sent→voided"]);
+  const cases: Array<[EstimateStatus, EstimateStatus, boolean]> = statuses.flatMap(
+    (from) =>
+      statuses.map(
+        (to) =>
+          [from, to, allowed.has(`${from}→${to}`)] as [
+            EstimateStatus,
+            EstimateStatus,
+            boolean,
+          ],
+      ),
+  );
+
+  it.each(cases)("%s → %s allowed=%s", (from, to, expected) => {
+    expect(canTransitionEstimate(from, to)).toBe(expected);
+  });
+
+  it("rejects the retired approved / rejected transitions", () => {
+    // Old workflow allowed sent→approved, sent→rejected, approved→voided.
+    // None survive: approved/rejected are no longer valid statuses, and an
+    // unknown `from` must be treated as terminal rather than throwing.
+    const approved = "approved" as string as EstimateStatus;
+    const rejected = "rejected" as string as EstimateStatus;
+    expect(canTransitionEstimate("sent", approved)).toBe(false);
+    expect(canTransitionEstimate("sent", rejected)).toBe(false);
+    expect(canTransitionEstimate(approved, "voided")).toBe(false);
   });
 });

--- a/src/lib/estimate-status.ts
+++ b/src/lib/estimate-status.ts
@@ -11,8 +11,6 @@ export type EntityKind = "estimate" | "invoice";
 export const ESTIMATE_STATUS_BADGE_CLASSES: Record<EstimateStatus, string> = {
   draft:     "bg-zinc-100 text-zinc-700",
   sent:      "bg-blue-100 text-blue-700",
-  approved:  "bg-emerald-100 text-emerald-700",
-  rejected:  "bg-rose-100 text-rose-700",
   converted: "bg-indigo-100 text-indigo-700",
   voided:    "bg-zinc-200 text-zinc-500 line-through",
 };
@@ -25,14 +23,36 @@ export const INVOICE_STATUS_BADGE_CLASSES: Record<InvoiceStatus, string> = {
   voided:  "bg-zinc-200 text-zinc-500 line-through",
 };
 
-// Back-compat alias — 67a callers import this directly.
-export const STATUS_BADGE_CLASSES = ESTIMATE_STATUS_BADGE_CLASSES;
-
 export function getStatusBadgeClasses(kind: EntityKind, status: string): string {
   if (kind === "invoice") {
     return INVOICE_STATUS_BADGE_CLASSES[status as InvoiceStatus] ?? "bg-zinc-100 text-zinc-700";
   }
   return ESTIMATE_STATUS_BADGE_CLASSES[status as EstimateStatus] ?? "bg-zinc-100 text-zinc-700";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Estimate status transitions (#567) — the pure state-machine, extracted out of
+// the PUT /api/estimates/[id]/status route so it can be unit-tested in isolation
+// and shared. The workflow is exactly draft → sent → converted / voided, per
+// ADR 0007; the old approved/rejected step is gone. Convert is its own action
+// (POST /convert) that flips the row to `converted`, so it is NOT a status
+// transition here and nothing leads *to* `converted`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const ESTIMATE_STATUS_TRANSITIONS: Partial<
+  Record<EstimateStatus, readonly EstimateStatus[]>
+> = {
+  draft: ["sent", "voided"],
+  sent: ["voided"],
+  converted: [], // terminal
+  voided: [], // terminal
+};
+
+// True iff `to` is a legal next status from `from`. An unknown `from` (e.g. a
+// legacy `approved`/`rejected` row that predates the #567 migration) is treated
+// as terminal rather than throwing.
+export function canTransitionEstimate(from: EstimateStatus, to: EstimateStatus): boolean {
+  return (ESTIMATE_STATUS_TRANSITIONS[from] ?? []).includes(to);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/lib/pdf-layout.test.ts
+++ b/src/lib/pdf-layout.test.ts
@@ -63,8 +63,6 @@ describe("isLayoutLocked — estimate freeze boundary (#482)", () => {
   const ALL_ESTIMATE_STATUSES: EstimateStatus[] = [
     "draft",
     "sent",
-    "approved",
-    "rejected",
     "converted",
     "voided",
   ];

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -646,7 +646,10 @@ export const EMAIL_PROVIDERS: Record<string, { label: string; imap_host: string;
 // Build 67a — Estimates & Invoices
 // ─────────────────────────────────────────────────────────────────────────────
 
-export type EstimateStatus = 'draft' | 'sent' | 'approved' | 'rejected' | 'converted' | 'voided';
+// #567 — the Estimate workflow is exactly draft → sent → converted / voided
+// (ADR 0007). The retired `approved`/`rejected` states are gone; the
+// `approved_at`/`rejected_at` columns below are kept nullable but never written.
+export type EstimateStatus = 'draft' | 'sent' | 'converted' | 'voided';
 export type AdjustmentType = 'percent' | 'amount' | 'none';
 export type ItemCategory = 'labor' | 'equipment' | 'materials' | 'services' | 'other';
 

--- a/supabase/migration-build80-estimate-status-simplify.sql
+++ b/supabase/migration-build80-estimate-status-simplify.sql
@@ -1,0 +1,54 @@
+-- ============================================
+-- Build 80 Migration: #567 — Simplify Estimate status
+--
+-- Realigns the estimates table with ADR 0007: the Estimate workflow is exactly
+--   draft → sent → converted / voided
+-- The retired `approved` / `rejected` states are dropped end-to-end. Build 67f
+-- already removed the `estimate_not_approved` gate from
+-- convert_estimate_to_invoice, so no live code produces those states anymore;
+-- this migration remaps any rows that still carry them and then tightens the
+-- status CHECK constraint so they can never reappear.
+--
+-- Remap rules (NEVER → converted — that must mean an Invoice was actually
+-- created via convert_estimate_to_invoice):
+--   approved → sent    (the estimate was sent; "approved" was just an ack)
+--   rejected → voided  (a dead estimate; voided is its terminal state)
+--
+-- The `approved_at` / `rejected_at` columns are intentionally KEPT (nullable)
+-- rather than dropped: they are simply no longer written. Dropping them would
+-- churn live data and several PDF/test fixtures for no functional gain.
+--
+-- Deploy ordering: run this SQL BEFORE (or together with) the deploy that
+-- narrows the EstimateStatus TypeScript union, so no remapped row is read by
+-- code that no longer knows the old states. All statements are idempotent.
+--
+-- Run in Supabase SQL Editor.
+-- ============================================
+
+-- 1. Remap live rows while the OLD constraint still permits both endpoints.
+--    Backfill the timestamp/reason a normal transition would have set so the
+--    remapped rows are internally consistent with naturally-reached states.
+--    (`updated_at` is bumped by the BEFORE UPDATE trigger.)
+
+-- approved → sent: keep the existing sent_at; fall back to approved_at.
+UPDATE estimates
+   SET status  = 'sent',
+       sent_at = COALESCE(sent_at, approved_at)
+ WHERE status = 'approved';
+
+-- rejected → voided: a voided estimate carries voided_at + void_reason.
+UPDATE estimates
+   SET status      = 'voided',
+       voided_at   = COALESCE(voided_at, rejected_at, now()),
+       void_reason = COALESCE(void_reason, 'Migrated from rejected (build80 / #567)')
+ WHERE status = 'rejected';
+
+-- 2. Tighten the status CHECK to the four surviving states. The original
+--    constraint was the inline (auto-named) one from build67a.
+ALTER TABLE estimates DROP CONSTRAINT IF EXISTS estimates_status_check;
+ALTER TABLE estimates ADD CONSTRAINT estimates_status_check
+  CHECK (status IN ('draft', 'sent', 'converted', 'voided'));
+
+-- ============================================
+-- End of build80 migration.
+-- ============================================

--- a/tests/integration/apply-template-schema.sql
+++ b/tests/integration/apply-template-schema.sql
@@ -55,7 +55,7 @@ CREATE TABLE estimates (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   organization_id uuid,
   status text NOT NULL DEFAULT 'draft'
-    CHECK (status IN ('draft', 'sent', 'approved', 'rejected', 'converted', 'voided')),
+    CHECK (status IN ('draft', 'sent', 'converted', 'voided')),
   opening_statement text,
   closing_statement text,
   subtotal numeric(10,2) NOT NULL DEFAULT 0,

--- a/tests/integration/convert-estimate-schema.sql
+++ b/tests/integration/convert-estimate-schema.sql
@@ -25,7 +25,7 @@ CREATE TABLE estimates (
   job_id uuid,
   title text,
   status text NOT NULL DEFAULT 'draft'
-    CHECK (status IN ('draft', 'sent', 'approved', 'rejected', 'converted', 'voided')),
+    CHECK (status IN ('draft', 'sent', 'converted', 'voided')),
   opening_statement text,
   closing_statement text,
   subtotal numeric(10,2) NOT NULL DEFAULT 0,


### PR DESCRIPTION
## What

Realign Estimate status with [ADR 0007](docs/adr/0007). The Estimate workflow is now exactly:

```
draft → sent → converted / voided
```

The retired `approved` / `rejected` states are dropped **end-to-end**. **Convert** stays its own action (`POST /convert`), not a status transition.

Closes #567.

## Acceptance criteria

1. ✅ **Pure, unit-tested transitions function** — `ESTIMATE_STATUS_TRANSITIONS` + `canTransitionEstimate(from, to)` in `src/lib/estimate-status.ts` (draft→{sent,voided}, sent→{voided}, converted/voided terminal).
2. ✅ **Status route collapses its duplicate union** onto the canonical helper — `status/route.ts` drops its local `EstimateStatus` union and inline `VALID_TRANSITIONS`.
3. ✅ **Narrowed `EstimateStatus` union + badge map** — `types.ts` now has the four surviving states; approved/rejected removed from `ESTIMATE_STATUS_BADGE_CLASSES` (and the back-compat alias).
4. ✅ **Fallback-safe badge lookup** on the standalone Estimate page — `estimates/[id]/page.tsx` via `getStatusBadgeClasses`.
5. ✅ **Removed Mark Approved / Mark Rejected buttons** + the dead "must be approved" error path — `header-bar.tsx`, `conversion.ts` (`estimate_not_approved` code), `convert/route.ts`.
6. ✅ **Data migration** — `migration-build80` remaps `approved → sent` (keeps/falls back to `sent_at`) and `rejected → voided` (stamps `voided_at` + `void_reason`), then tightens the `estimates_status_check` CHECK to `{draft, sent, converted, voided}`. Integration schemas tightened to match.
7. ✅ **`approved_at` / `rejected_at` columns kept nullable & unwritten** (implementer's call, documented in the migration header) — avoids churning live data + builder-test fixtures for no functional gain.
8. ✅ **Pruned the pinned status tables** — `ALL_ESTIMATE_STATUSES` in `pdf-layout.test.ts` and the approved/rejected rows in the status-tint table in `estimate-status.test.ts`.

## How it was built

TDD, red→green vertical slices — one new behavior, one failing test, minimal code, repeat. The transitions helper mirrors the existing `isOfficialInvoiceStatus` / pinned-table prior art.

## Verification

- `tsc --noEmit`: no new errors (1 pre-existing, unrelated photo-reports test).
- `vitest run` (unit): **2737 / 2737 pass**.
- `test:pg` (embedded-postgres convert + apply-template harnesses that load the edited schemas): **40 / 40 pass**.
- `test:integration` requires the `supabase` CLI (not installed in this env); it fails at global-setup before any test — unrelated to this change.

## Deploy note

Run `migration-build80` **before (or with)** the deploy that ships the narrowed `EstimateStatus` union, so no remapped row is read by code that no longer knows the old states. All statements are idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
