### PR TITLE
feat(estimate-builder): floating totals card replaces pinned bottom bar (#569)

### DIFF
--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -39,7 +39,7 @@ import {
   resolveLineItemDropTarget,
 } from "./move-line-item";
 import { HeaderBar } from "./header-bar";
-import { TotalsBar } from "./totals-bar";
+import { TotalsCard } from "./totals-card";
 import { MetadataBar } from "./metadata-bar";
 import { CustomerBlock } from "./customer-block";
 import { StatementEditor } from "./statement-editor";
@@ -1723,7 +1723,7 @@ export function EstimateBuilder({
             lives in the totals slot (#545). */}
         <BuilderLayout
           totalsSlot={
-            <TotalsBar
+            <TotalsCard
               entity={invoiceEntity}
               onMarkupChange={onMarkupChange}
               onDiscountChange={onDiscountChange}
@@ -2154,7 +2154,7 @@ export function EstimateBuilder({
           lives in the totals slot (#545). */}
       <BuilderLayout
         totalsSlot={
-          <TotalsBar
+          <TotalsCard
             entity={estimateEntity}
             onMarkupChange={onMarkupChange}
             onDiscountChange={onDiscountChange}

--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -1719,8 +1719,9 @@ export function EstimateBuilder({
         )}
 
         {/* Builder document — full-width shell. The editor panel docks in
-            BuilderLayout's editor slot (#544); the pinned bottom totals bar
-            lives in the totals slot (#545). */}
+            BuilderLayout's editor slot (#544); the floating totals card lives
+            in the totals slot (#545, #569) and auto-collapses to a pill while
+            the editor is open. */}
         <BuilderLayout
           totalsSlot={
             <TotalsCard
@@ -1730,6 +1731,7 @@ export function EstimateBuilder({
               onTaxRateChange={onTaxRateChange}
               readOnly={isVoided}
               mode={invMode}
+              editorOpen={selectedInvoiceItem != null}
             />
           }
           editorSlot={
@@ -2150,8 +2152,9 @@ export function EstimateBuilder({
       )}
 
       {/* Builder document — full-width shell. The editor panel docks in
-          BuilderLayout's editor slot (#544); the pinned bottom totals bar
-          lives in the totals slot (#545). */}
+          BuilderLayout's editor slot (#544); the floating totals card lives in
+          the totals slot (#545, #569) and auto-collapses to a pill while the
+          editor is open. */}
       <BuilderLayout
         totalsSlot={
           <TotalsCard
@@ -2161,6 +2164,7 @@ export function EstimateBuilder({
             onTaxRateChange={onTaxRateChange}
             readOnly={isVoided}
             mode={mode}
+            editorOpen={selectedItem != null}
           />
         }
         editorSlot={

--- a/src/components/estimate-builder/totals-card.test.tsx
+++ b/src/components/estimate-builder/totals-card.test.tsx
@@ -134,6 +134,7 @@ function renderBar(
     onTaxRateChange: (n: number) => void;
     readOnly: boolean;
     mode: BuilderEntity["kind"] | "template";
+    editorOpen: boolean;
   }> = {},
 ) {
   return render(
@@ -144,6 +145,7 @@ function renderBar(
       onTaxRateChange={handlers.onTaxRateChange ?? vi.fn()}
       readOnly={handlers.readOnly}
       mode={handlers.mode as BuilderMode | undefined}
+      editorOpen={handlers.editorOpen}
     />,
   );
 }
@@ -274,19 +276,133 @@ describe("TotalsCard (#545)", () => {
     );
   });
 
-  it("is a compact tap-to-expand bar: collapsed by default, toggles on tap", () => {
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #569 — floating totals card. The pinned bottom bar becomes a floating card
+// that tracks the viewport on scroll, defaults to the full breakdown, and
+// collapses to a total-only PILL (breakdown removed from the DOM, not merely
+// CSS-hidden). It also auto-collapses to a pill while the side line-item editor
+// is open (driven by the `editorOpen` signal) and restores the prior state when
+// the editor closes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("TotalsCard floating card (#569)", () => {
+  it("renders as a floating card pinned to the viewport (fixed), not an inline bar", () => {
     renderBar(makeEstimate({ total: 125 }));
 
-    const toggle = screen.getByRole("button", { name: /totals/i });
-    expect(toggle.getAttribute("aria-expanded")).toBe("false");
-
-    // The grand total always stays visible in the compact summary.
+    const card = screen.getByTestId("totals-card");
+    expect(card.className).toContain("fixed");
+    // It must keep the grand Total in view.
     expect(screen.getByText("$125.00")).toBeTruthy();
+  });
 
-    fireEvent.click(toggle);
+  it("defaults to the full breakdown expanded (not the pill)", () => {
+    renderBar(makeEstimate({ subtotal: 100, total: 125 }));
+
+    const toggle = screen.getByRole("button", { name: /totals/i });
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Subtotal")).toBeTruthy();
+  });
 
+  it("collapses to a total-only pill: breakdown removed from the DOM, Total stays", () => {
+    renderBar(makeEstimate({ subtotal: 100, total: 125 }));
+
+    const toggle = screen.getByRole("button", { name: /totals/i });
     fireEvent.click(toggle);
+
+    // Pill: the whole breakdown is gone from the DOM (not merely CSS-hidden).
+    expect(screen.queryByText("Subtotal")).toBeNull();
+    expect(screen.queryByText("Markup")).toBeNull();
+    expect(screen.queryByText("Tax")).toBeNull();
+
+    // ...but the grand Total — the reason the pill exists — stays in view.
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.getByText("$125.00")).toBeTruthy();
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("auto-collapses to a pill while the line-item editor is open", () => {
+    // Even though the card defaults to expanded, an open editor forces the pill
+    // so the floating card never overlaps the side editor panel.
+    renderBar(makeEstimate({ subtotal: 100, total: 125 }), { editorOpen: true });
+
+    expect(screen.queryByText("Subtotal")).toBeNull();
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.getByText("$125.00")).toBeTruthy();
+  });
+
+  it("hides the expand toggle while the editor is open (can't re-expand over it)", () => {
+    renderBar(makeEstimate({ total: 125 }), { editorOpen: true });
+
+    expect(screen.queryByRole("button", { name: /totals/i })).toBeNull();
+  });
+
+  // The editor toggling open/closed must not clobber the user's expand/collapse
+  // choice — `editorOpen` only suppresses the breakdown, never rewrites it.
+  const card = (entity: BuilderEntity, editorOpen: boolean) => (
+    <TotalsCard
+      entity={entity}
+      onMarkupChange={vi.fn()}
+      onDiscountChange={vi.fn()}
+      onTaxRateChange={vi.fn()}
+      editorOpen={editorOpen}
+    />
+  );
+
+  it("restores the expanded breakdown after the editor closes", () => {
+    const entity = makeEstimate({ subtotal: 100, total: 125 });
+    const { rerender } = render(card(entity, false));
+
+    expect(screen.getByText("Subtotal")).toBeTruthy(); // expanded by default
+
+    rerender(card(entity, true));
+    expect(screen.queryByText("Subtotal")).toBeNull(); // pill while editor open
+
+    rerender(card(entity, false));
+    expect(screen.getByText("Subtotal")).toBeTruthy(); // restored to expanded
+  });
+
+  it("keeps the card a pill after the editor closes if the user had collapsed it", () => {
+    const entity = makeEstimate({ subtotal: 100, total: 125 });
+    const { rerender } = render(card(entity, false));
+
+    // User collapses to a pill before the editor ever opens.
+    fireEvent.click(screen.getByRole("button", { name: /totals/i }));
+    expect(screen.queryByText("Subtotal")).toBeNull();
+
+    // Editor opens, then closes.
+    rerender(card(entity, true));
+    rerender(card(entity, false));
+
+    // Still a pill — the editor must not silently re-expand the card.
+    expect(screen.queryByText("Subtotal")).toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: /totals/i })
+        .getAttribute("aria-expanded"),
+    ).toBe("false");
+  });
+
+  it("keeps a negative Total visibly flagged even when collapsed to a pill", () => {
+    renderBar(
+      makeEstimate({
+        subtotal: 100,
+        discount_type: "amount",
+        discount_value: 150,
+        discount_amount: 150,
+        adjusted_subtotal: -50,
+        total: -50,
+      }),
+      { editorOpen: true },
+    );
+
+    // Pill: the breakdown is gone...
+    expect(screen.queryByText("Subtotal")).toBeNull();
+
+    // ...but the negative warning and the destructive-styled Total persist.
+    expect(screen.getByText("Negative total")).toBeTruthy();
+    const total = screen.getByText("-$50.00");
+    expect(total.className).toContain("text-destructive");
   });
 });

--- a/src/components/estimate-builder/totals-card.test.tsx
+++ b/src/components/estimate-builder/totals-card.test.tsx
@@ -1,8 +1,8 @@
-// TotalsBar (#545) — the pinned bottom totals bar that replaces the floating
-// TotalsPanel card. Same computed values and inline Markup / Discount / Tax
-// controls as before (this is a presentation/placement refactor, not a
-// totals-math change): a full-width bar that is compact + tap-to-expand on
-// phones and hidden in Template mode.
+// TotalsCard (#545, #569) — the totals component carrying the computed values
+// and inline Markup / Discount / Tax controls. Same totals math as the retired
+// TotalsPanel/TotalsBar (this lineage has been a series of presentation/
+// placement refactors): compact + tap-to-expand on phones and hidden in
+// Template mode.
 //
 // Query strategy mirrors the retired totals-panel.test.tsx: MoneyInput is a
 // text box (role "textbox"); the plain number Input is a number box; the %/$/—
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-import { TotalsBar } from "./totals-bar";
+import { TotalsCard } from "./totals-card";
 import type {
   AdjustmentType,
   BuilderEntity,
@@ -137,7 +137,7 @@ function renderBar(
   }> = {},
 ) {
   return render(
-    <TotalsBar
+    <TotalsCard
       entity={entity}
       onMarkupChange={handlers.onMarkupChange ?? vi.fn()}
       onDiscountChange={handlers.onDiscountChange ?? vi.fn()}
@@ -148,7 +148,7 @@ function renderBar(
   );
 }
 
-describe("TotalsBar (#545)", () => {
+describe("TotalsCard (#545)", () => {
   it("renders the Subtotal and the grand Total", () => {
     renderBar(makeEstimate({ subtotal: 100, total: 125 }));
 

--- a/src/components/estimate-builder/totals-card.tsx
+++ b/src/components/estimate-builder/totals-card.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { MoneyInput } from "./money-input";
 import type { AdjustmentType, BuilderEntity, BuilderMode } from "@/lib/types";
 
-interface TotalsBarProps {
+interface TotalsCardProps {
   entity: BuilderEntity;
   onMarkupChange: (type: AdjustmentType, value: number) => void;
   onDiscountChange: (type: AdjustmentType, value: number) => void;
@@ -157,14 +157,14 @@ function AdjustmentRow({
   );
 }
 
-export function TotalsBar({
+export function TotalsCard({
   entity,
   onMarkupChange,
   onDiscountChange,
   onTaxRateChange,
   readOnly = false,
   mode = "estimate",
-}: TotalsBarProps) {
+}: TotalsCardProps) {
   // Phone: the bar is compact (grand Total only) and taps open to reveal the
   // breakdown so it never covers the document lines. Desktop always shows the
   // full row (the `lg:` classes below force it regardless of this state).

--- a/src/components/estimate-builder/totals-card.tsx
+++ b/src/components/estimate-builder/totals-card.tsx
@@ -15,6 +15,12 @@ interface TotalsCardProps {
   onTaxRateChange: (rate: number) => void;
   readOnly?: boolean;
   mode?: BuilderMode;
+  /**
+   * True while the side line-item editor panel is open. The card auto-collapses
+   * to its total-only pill so it never overlaps the editor, and restores the
+   * user's prior expand/collapse choice once the editor closes.
+   */
+  editorOpen?: boolean;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -164,11 +170,12 @@ export function TotalsCard({
   onTaxRateChange,
   readOnly = false,
   mode = "estimate",
+  editorOpen = false,
 }: TotalsCardProps) {
-  // Phone: the bar is compact (grand Total only) and taps open to reveal the
-  // breakdown so it never covers the document lines. Desktop always shows the
-  // full row (the `lg:` classes below force it regardless of this state).
-  const [expanded, setExpanded] = useState(false);
+  // The floating card defaults to the full breakdown and can be collapsed to a
+  // total-only pill (the pill removes the breakdown from the DOM rather than
+  // CSS-hiding it, so it never covers the document lines).
+  const [expanded, setExpanded] = useState(true);
 
   if (mode === "template" || entity.kind === "template") return null;
 
@@ -205,73 +212,89 @@ export function TotalsCard({
 
   const isNegative = totals.total < 0;
 
+  // Derived at render: the card shows its full breakdown only when the user
+  // has it expanded AND the side line-item editor is closed. This makes the
+  // editor-open auto-collapse (and the restore-on-close) fall out for free —
+  // `expanded` is never mutated by the editor, so closing it returns the card
+  // to whatever the user last chose.
+  const showExpanded = expanded && !editorOpen;
+
   return (
-    <div className="sticky bottom-0 z-20 w-full border-t border-border bg-card shadow-[0_-1px_3px_rgba(0,0,0,0.06)]">
-      <div className="flex flex-col gap-2 px-4 py-2 lg:flex-row lg:items-end lg:justify-between lg:gap-6">
-        {/* Breakdown — collapsible on phone, always inline on desktop. */}
-        <div
-          className={`${
-            expanded ? "grid" : "hidden"
-          } grid-cols-2 gap-x-4 gap-y-2 lg:flex lg:flex-1 lg:flex-wrap lg:items-end lg:gap-x-6 lg:gap-y-2`}
-        >
-          <SummaryLine label="Subtotal" amount={totals.subtotal} />
-          <AdjustmentRow
-            label="Markup"
-            type={totals.markup_type}
-            value={totals.markup_value}
-            amount={totals.markup_amount}
-            onChange={onMarkupChange}
-            readOnly={readOnly}
-          />
-          <AdjustmentRow
-            label="Discount"
-            type={totals.discount_type}
-            value={totals.discount_value}
-            amount={totals.discount_amount}
-            onChange={onDiscountChange}
-            readOnly={readOnly}
-            isDiscount
-          />
-          <SummaryLine label="Adjusted subtotal" amount={totals.adjusted_subtotal} />
-          <div className="space-y-1">
-            <div className="flex items-center justify-between gap-1">
-              <span className="text-xs text-muted-foreground">Tax</span>
-              <span className="text-xs font-mono text-foreground">
-                {formatCurrency(totals.tax_amount)}
-              </span>
-            </div>
-            <div className="flex items-center gap-1">
-              <Input
-                type="number"
-                min={0}
-                max={100}
-                step={0.01}
-                value={totals.tax_rate}
-                disabled={readOnly}
-                onChange={(e) => {
-                  const n = parseFloat(e.target.value);
-                  if (!isNaN(n)) onTaxRateChange(n);
-                }}
-                className="h-6 text-xs px-1.5 w-16 flex-none"
-                placeholder="0"
-              />
-              <span className="text-xs text-muted-foreground">%</span>
+    <div
+      data-testid="totals-card"
+      className="fixed bottom-4 right-4 z-30 w-[calc(100%-2rem)] max-w-sm rounded-xl border border-border bg-card shadow-lg"
+    >
+      <div className="flex flex-col gap-2 px-4 py-3">
+        {/* Breakdown — present only when expanded (pill removes it from DOM). */}
+        {showExpanded && (
+          <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+            <SummaryLine label="Subtotal" amount={totals.subtotal} />
+            <AdjustmentRow
+              label="Markup"
+              type={totals.markup_type}
+              value={totals.markup_value}
+              amount={totals.markup_amount}
+              onChange={onMarkupChange}
+              readOnly={readOnly}
+            />
+            <AdjustmentRow
+              label="Discount"
+              type={totals.discount_type}
+              value={totals.discount_value}
+              amount={totals.discount_amount}
+              onChange={onDiscountChange}
+              readOnly={readOnly}
+              isDiscount
+            />
+            <SummaryLine
+              label="Adjusted subtotal"
+              amount={totals.adjusted_subtotal}
+            />
+            <div className="space-y-1">
+              <div className="flex items-center justify-between gap-1">
+                <span className="text-xs text-muted-foreground">Tax</span>
+                <span className="text-xs font-mono text-foreground">
+                  {formatCurrency(totals.tax_amount)}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step={0.01}
+                  value={totals.tax_rate}
+                  disabled={readOnly}
+                  onChange={(e) => {
+                    const n = parseFloat(e.target.value);
+                    if (!isNaN(n)) onTaxRateChange(n);
+                  }}
+                  className="h-6 text-xs px-1.5 w-16 flex-none"
+                  placeholder="0"
+                />
+                <span className="text-xs text-muted-foreground">%</span>
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
-        {/* Compact summary — always visible: phone expand toggle + grand Total. */}
-        <div className="flex items-center justify-between gap-3 lg:justify-end">
-          <button
-            type="button"
-            aria-expanded={expanded}
-            aria-label="Totals breakdown"
-            onClick={() => setExpanded((v) => !v)}
-            className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground lg:hidden"
-          >
-            {expanded ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
-            <span>Details</span>
-          </button>
+        {/* Compact summary — always shows the grand Total. The expand toggle is
+            withheld while the editor is open, so the card stays a pill. */}
+        <div className="flex items-center justify-between gap-3">
+          {editorOpen ? (
+            <span />
+          ) : (
+            <button
+              type="button"
+              aria-expanded={showExpanded}
+              aria-label="Totals breakdown"
+              onClick={() => setExpanded((v) => !v)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            >
+              {showExpanded ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+              <span>{showExpanded ? "Hide" : "Details"}</span>
+            </button>
+          )}
           <div className="flex items-center gap-2">
             <span className="text-sm font-semibold text-foreground">Total</span>
             <span


### PR DESCRIPTION
## What & why

Closes #569. Replaces the pinned bottom `TotalsBar` (a full-width `sticky bottom-0` bar) with a **floating totals card** that tracks the page on scroll and always keeps the grand **Total** in view.

## Behavior

- **Floating card.** `fixed` bottom-right card (theme tokens only — the arbitrary box-shadow gives way to `shadow-lg`); it follows the viewport on scroll instead of pinning to the document bottom.
- **Expand ↔ pill.** Defaults to the full breakdown (Subtotal, Markup, Discount, adjusted Subtotal, Tax, Total). Collapsing produces a **total-only pill** that *removes the breakdown from the DOM* (not CSS-hidden), so it never covers the document lines. (Overhead/Profit rows slot into the same breakdown when that future slice lands.)
- **Editor-aware.** A new `editorOpen` signal — threaded from line-item selection in both estimate and invoice modes — auto-collapses the card to a pill while the side line-item editor is open and withholds the expand toggle. Closing the editor **restores the user's prior expand/collapse choice**.
- **Negative Total** stays visibly flagged (destructive amount + "Negative total" warning) **even in the pill**.
- **Template mode** still renders nothing. Autosave/save behavior is untouched.

## Design note

`showExpanded = expanded && !editorOpen` is derived at render — `expanded` is never mutated by the editor, so the auto-collapse *and* the restore-on-close fall out for free with no `useEffect` (in line with the repo's no-`set-state-in-effect` convention).

## Tests

- The totals component was renamed `TotalsBar → TotalsCard` in a separate history-preserving `git mv` commit (kept distinct from the behavior change for a clean diff).
- The totals suite is extended to **19 tests**: floating-position contract, expanded-by-default, collapse-to-pill-removes-breakdown, editor-open auto-collapse + toggle withholding, restore-on-close (expanded and collapsed cases), and negative-flagged-in-pill.
- All **15 estimate-builder suites green (149 tests)**, including the builder shell-contract and line-item-editor-panel integration suites. No new `tsc`/eslint findings on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
