### PR TITLE
feat(report-builder): per-report Cover Page editor (#551)

### DIFF
--- a/src/app/jobs/[id]/reports/[reportId]/page.tsx
+++ b/src/app/jobs/[id]/reports/[reportId]/page.tsx
@@ -65,6 +65,15 @@ export default async function PhotoReportBuilderPage({
     .returns<Photo[]>();
   const photos: Photo[] = photoData ?? [];
 
+  // The Job's own cover photo seeds the report's Cover Page when the report has
+  // not chosen its own (ADR 0014, #551). Read it here so the builder can resolve
+  // the fallback without a second round-trip.
+  const { data: job } = await supabase
+    .from("jobs")
+    .select("cover_photo_id")
+    .eq("id", jobId)
+    .maybeSingle<{ cover_photo_id: string | null }>();
+
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 
   return (
@@ -73,6 +82,7 @@ export default async function PhotoReportBuilderPage({
       report={report}
       photos={photos}
       supabaseUrl={supabaseUrl}
+      jobCoverPhotoId={job?.cover_photo_id ?? null}
     />
   );
 }

--- a/src/components/photo-report-builder-desktop.test.tsx
+++ b/src/components/photo-report-builder-desktop.test.tsx
@@ -127,6 +127,9 @@ function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
     created_at: "2026-06-04T00:00:00Z",
     updated_at: "2026-06-04T00:00:00Z",
     deleted_at: null,
+    report_settings: null,
+    cover_config: null,
+    cover_photo_id: null,
     ...overrides,
   };
 }

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -49,6 +49,10 @@ import {
   type ReportSection,
   type StoredReportSection,
 } from "@/lib/build-initial-sections";
+import {
+  resolveReportSettings,
+  type CoverBlockVisibility,
+} from "@/lib/photo-report-settings";
 import type { Photo, PhotoReport } from "@/lib/types";
 
 // How long to wait after the last edit before persisting (mirrors the
@@ -56,6 +60,18 @@ import type { Photo, PhotoReport } from "@/lib/types";
 const DEBOUNCE_MS = 2000;
 
 type SaveStatus = "idle" | "saving" | "saved" | "error" | "blocked";
+
+// The five identifying blocks the Cover Page editor can show or hide, in print
+// order, paired with their user-facing label (#551). The canonical set and
+// order come from ADR 0014 / CONTEXT.md ("logo, customer, property address,
+// point of contact, insurance").
+const COVER_BLOCKS: { field: keyof CoverBlockVisibility; label: string }[] = [
+  { field: "logo", label: "Logo" },
+  { field: "customer", label: "Customer" },
+  { field: "propertyAddress", label: "Property address" },
+  { field: "pointOfContact", label: "Point of contact" },
+  { field: "insurance", label: "Insurance" },
+];
 
 // A report can't be persisted while any Section's write-up overflows its
 // one-page intro (issue #404). Every save path gates on this one rule — the
@@ -73,8 +89,19 @@ function snapshotOf(state: PhotoReportBuilderState) {
     title: state.title,
     reportDate: state.reportDate,
     sections: state.sections,
+    cover: state.cover,
     revision: state.revision,
   };
+}
+
+// Split the in-memory resolved cover back into the two persisted columns: the
+// five identifying-block flags go to `cover_config`, the chosen photo to
+// `cover_photo_id`. Writing both on every save materializes the report's own
+// cover snapshot — including the Job-cover fallback the builder seeded — on the
+// first edit (ADR 0014 "freeze on first edit", #551).
+function coverColumns(cover: PhotoReportBuilderState["cover"]) {
+  const { coverPhotoId, ...blocks } = cover;
+  return { cover_config: blocks, cover_photo_id: coverPhotoId };
 }
 
 interface PhotoReportBuilderProps {
@@ -83,6 +110,13 @@ interface PhotoReportBuilderProps {
   /** All of the Job's photos, so any can be added to the report (#401). */
   photos: Photo[];
   supabaseUrl: string;
+  /**
+   * The Job's own cover photo, used as the fallback when the report has not
+   * chosen its own (ADR 0014, #551). Optional and defaults to null so existing
+   * call sites and tests that don't supply it still seed an all-on, no-photo
+   * cover.
+   */
+  jobCoverPhotoId?: string | null;
 }
 
 export default function PhotoReportBuilder({
@@ -90,6 +124,7 @@ export default function PhotoReportBuilder({
   report,
   photos,
   supabaseUrl,
+  jobCoverPhotoId = null,
 }: PhotoReportBuilderProps) {
   const [state, dispatch] = useReducer(
     photoReportBuilderReducer,
@@ -97,6 +132,19 @@ export default function PhotoReportBuilder({
       title: report.title,
       report_date: report.report_date,
       sections: report.sections as StoredReportSection[],
+      // Seed the Cover Page editor with the report's fully-resolved cover: its
+      // own snapshot if any, else the Job's cover photo, else all-on/no-photo.
+      // The builder then persists whatever is in state, so the first edit
+      // freezes this resolved cover into the report's own copy (#551).
+      cover: resolveReportSettings(
+        {
+          report_settings: report.report_settings,
+          cover_config: report.cover_config,
+          cover_photo_id: report.cover_photo_id,
+        },
+        null,
+        jobCoverPhotoId,
+      ).cover,
     },
     initBuilderState,
   );
@@ -145,6 +193,7 @@ export default function PhotoReportBuilder({
           title: snapshot.title,
           report_date: snapshot.reportDate,
           sections: snapshot.sections,
+          ...coverColumns(snapshot.cover),
         })
         .eq("id", report.id);
       if (error) {
@@ -212,6 +261,7 @@ export default function PhotoReportBuilder({
         title: state.title,
         report_date: state.reportDate,
         sections: state.sections,
+        ...coverColumns(state.cover),
       }),
       keepalive: true,
     });
@@ -477,6 +527,82 @@ export default function PhotoReportBuilder({
                   className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
                 />
               </label>
+
+              {/* Cover photo — pick one of the Job's photos to print on the
+                  cover. Seeded with the report's resolved cover (Job-cover
+                  fallback included); the chosen photo persists on the report's
+                  own snapshot (#551). */}
+              <div>
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Cover photo
+                </span>
+                {photos.length === 0 ? (
+                  <p className="text-xs text-muted-foreground">
+                    This job has no photos to use as a cover.
+                  </p>
+                ) : (
+                  <div className="grid grid-cols-[repeat(auto-fill,minmax(72px,1fr))] gap-2">
+                    {photos.map((photo) => {
+                      const selected = state.cover.coverPhotoId === photo.id;
+                      return (
+                        <button
+                          key={photo.id}
+                          type="button"
+                          aria-pressed={selected}
+                          aria-label={`Use ${
+                            photo.caption || "this photo"
+                          } as cover photo`}
+                          onClick={() =>
+                            dispatch({
+                              type: "setCoverPhoto",
+                              photoId: photo.id,
+                            })
+                          }
+                          className={cn(
+                            "aspect-square overflow-hidden rounded-lg ring-2 transition-shadow",
+                            selected
+                              ? "ring-primary"
+                              : "ring-transparent hover:ring-border",
+                          )}
+                        >
+                          <img
+                            src={photoUrl(photo, supabaseUrl, "grid")}
+                            alt={photo.caption || "Photo"}
+                            className="h-full w-full object-cover"
+                          />
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              {/* Identifying blocks — show/hide each on the cover (#551). All
+                  default on; the canonical set is logo, customer, property
+                  address, point of contact, insurance (ADR 0014). */}
+              <div>
+                <span className="mb-1 block text-xs font-medium text-muted-foreground">
+                  Show on cover
+                </span>
+                <div className="space-y-1.5">
+                  {COVER_BLOCKS.map(({ field, label }) => (
+                    <label
+                      key={field}
+                      className="flex items-center gap-2 text-sm text-foreground"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={state.cover[field]}
+                        onChange={() =>
+                          dispatch({ type: "toggleCoverField", field })
+                        }
+                        className="h-4 w-4 rounded border-border text-primary focus:ring-2 focus:ring-primary/20"
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+              </div>
             </div>
 
             {/*

--- a/src/components/photo-report-cover-editor.test.tsx
+++ b/src/components/photo-report-cover-editor.test.tsx
@@ -1,0 +1,329 @@
+// Issue #551 — per-report Cover Page editor.
+//
+// Behavior of the Cover Page editor surfaced in the builder's center pane when
+// the pinned Cover Page rail row is selected. Driven through the DOM: the cover
+// photo picker (choose one of the Job's photos), the five identifying-block
+// toggles (logo, customer, property address, point of contact, insurance), and
+// the "freeze on first edit" persistence — the report materializes its own copy
+// of the resolved cover (Job-cover fallback included) on the first autosave.
+// Mirrors the harness in photo-report-builder.test.tsx but adds the
+// `jobCoverPhotoId` prop the cover seed resolves through.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, act, cleanup } from "@testing-library/react";
+
+import type { Photo, PhotoReport } from "@/lib/types";
+
+// Capture the Supabase write payload so a test can assert what autosave persists.
+const h = vi.hoisted(() => ({
+  updateMock: vi.fn<(payload: Record<string, unknown>) => void>(),
+}));
+
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({
+    from: () => ({
+      update: (payload: Record<string, unknown>) => {
+        h.updateMock(payload);
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }),
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/lib/generate-report-pdf", () => ({
+  generateReportPDF: vi.fn(async () => "job-1/report-1.pdf"),
+}));
+
+vi.mock("@/components/tiptap-editor", () => ({
+  default: ({
+    content,
+    onChange,
+  }: {
+    content: string;
+    onChange: (html: string) => void;
+  }) => (
+    <textarea
+      data-testid="tiptap-stub"
+      aria-label="Section write-up"
+      defaultValue={content}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+// A passthrough DndContext — the cover editor never drags, and the sortable
+// hooks tolerate the absent provider and render fine.
+vi.mock("@dnd-kit/core", async () => {
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+import React from "react";
+import PhotoReportBuilder from "./photo-report-builder";
+
+function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
+  return {
+    id: "report-1",
+    organization_id: "org-1",
+    job_id: "job-1",
+    template_id: null,
+    title: "Photo Report #1",
+    report_number: 1,
+    report_date: "2026-06-04",
+    sections: [{ title: "Photos", description: "", photo_ids: ["p1"] }],
+    pdf_path: null,
+    status: "draft",
+    created_by: "Eric Daniels",
+    created_at: "2026-06-04T00:00:00Z",
+    updated_at: "2026-06-04T00:00:00Z",
+    deleted_at: null,
+    report_settings: null,
+    cover_config: null,
+    cover_photo_id: null,
+    ...overrides,
+  };
+}
+
+function makePhoto(id: string, caption: string | null = null): Photo {
+  return {
+    id,
+    storage_path: `job-1/${id}.jpg`,
+    annotated_path: null,
+    caption,
+  } as Photo;
+}
+
+function renderBuilder(
+  report = makeReport(),
+  photos: Photo[] = [],
+  jobCoverPhotoId: string | null = null,
+) {
+  return render(
+    <PhotoReportBuilder
+      jobId="job-1"
+      report={report}
+      photos={photos}
+      supabaseUrl="https://example.supabase.co"
+      jobCoverPhotoId={jobCoverPhotoId}
+    />,
+  );
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn(() =>
+    Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  h.updateMock.mockClear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Cover Page editor — freeze on first edit (#551)", () => {
+  it("autosaves the resolved cover (Job-cover fallback + all blocks on) on the first edit", async () => {
+    // The report owns no cover yet, but the Job has a cover photo. Editing the
+    // title materializes the report's own cover snapshot: the Job's cover photo
+    // and every identifying block on (ADR 0014 "freeze on first edit").
+    renderBuilder(makeReport(), [makePhoto("job-cover-9")], "job-cover-9");
+
+    const titleInput = screen.getByLabelText("Report title");
+    act(() => {
+      fireEvent.change(titleInput, { target: { value: "Roof inspection" } });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    const payload = h.updateMock.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      title: "Roof inspection",
+      cover_photo_id: "job-cover-9",
+      cover_config: {
+        logo: true,
+        customer: true,
+        propertyAddress: true,
+        pointOfContact: true,
+        insurance: true,
+      },
+    });
+  });
+
+  it("flushes the cover columns on unmount before the debounce fires", async () => {
+    // Leaving the builder (in-app unmount) within the 2s debounce window must
+    // not drop the cover snapshot: the keepalive PUT carries it too, identical
+    // to the debounced write.
+    const { unmount } = renderBuilder(
+      makeReport(),
+      [makePhoto("job-cover-9")],
+      "job-cover-9",
+    );
+
+    const titleInput = screen.getByLabelText("Report title");
+    act(() => {
+      fireEvent.change(titleInput, { target: { value: "Roof inspection" } });
+    });
+
+    // Unmount before the debounce elapses — the Supabase write never fires.
+    act(() => {
+      unmount();
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [, init] = fetchMock.mock.calls[0];
+    expect((init as RequestInit).keepalive).toBe(true);
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toMatchObject({
+      title: "Roof inspection",
+      cover_photo_id: "job-cover-9",
+      cover_config: {
+        logo: true,
+        customer: true,
+        propertyAddress: true,
+        pointOfContact: true,
+        insurance: true,
+      },
+    });
+  });
+});
+
+describe("Cover Page editor — choosing a cover photo (#551)", () => {
+  it("persists the photo the author picks, overriding the Job-cover fallback", async () => {
+    renderBuilder(
+      makeReport(),
+      [makePhoto("job-cover-9", "Front"), makePhoto("p2", "Back")],
+      "job-cover-9",
+    );
+
+    // Pick the second photo as the cover, away from the Job's default.
+    const option = screen.getByRole("button", {
+      name: /Back.*cover/i,
+    });
+    act(() => {
+      fireEvent.click(option);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    expect(h.updateMock.mock.calls[0][0]).toMatchObject({
+      cover_photo_id: "p2",
+    });
+  });
+});
+
+describe("Cover Page editor — block toggles (#551)", () => {
+  it("offers every identifying block, all on by default", () => {
+    renderBuilder();
+
+    for (const label of [
+      "Logo",
+      "Customer",
+      "Property address",
+      "Point of contact",
+      "Insurance",
+    ]) {
+      const toggle = screen.getByRole("checkbox", { name: label });
+      expect((toggle as HTMLInputElement).checked).toBe(true);
+    }
+  });
+
+  it("persists a block switched off, leaving the others on", async () => {
+    renderBuilder();
+
+    const insurance = screen.getByRole("checkbox", { name: "Insurance" });
+    act(() => {
+      fireEvent.click(insurance);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(h.updateMock).toHaveBeenCalledTimes(1);
+    expect(h.updateMock.mock.calls[0][0]).toMatchObject({
+      cover_config: {
+        logo: true,
+        customer: true,
+        propertyAddress: true,
+        pointOfContact: true,
+        insurance: false,
+      },
+    });
+  });
+});
+
+describe("Cover Page editor — seeded cover selection (#551)", () => {
+  it("defaults the cover to the Job's cover photo when the report has none", () => {
+    renderBuilder(
+      makeReport({ cover_photo_id: null }),
+      [makePhoto("job-cover-9", "Front"), makePhoto("p2", "Back")],
+      "job-cover-9",
+    );
+
+    // The Job's cover photo shows pre-selected, with no edit needed.
+    expect(
+      screen
+        .getByRole("button", { name: /Front.*cover/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: /Back.*cover/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("prefers the report's own cover photo over the Job's", () => {
+    renderBuilder(
+      makeReport({ cover_photo_id: "p2" }),
+      [makePhoto("job-cover-9", "Front"), makePhoto("p2", "Back")],
+      "job-cover-9",
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: /Back.*cover/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      screen
+        .getByRole("button", { name: /Front.*cover/i })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
+  it("seeds the block toggles from the report's own cover_config snapshot", () => {
+    renderBuilder(makeReport({ cover_config: { insurance: false } }));
+
+    expect(
+      (screen.getByRole("checkbox", { name: "Insurance" }) as HTMLInputElement)
+        .checked,
+    ).toBe(false);
+    expect(
+      (screen.getByRole("checkbox", { name: "Customer" }) as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+  });
+});

--- a/src/lib/photo-report-builder.test.ts
+++ b/src/lib/photo-report-builder.test.ts
@@ -21,6 +21,15 @@ function loaded() {
   });
 }
 
+/** The five Cover Page block flags, all on — the #551 cover-block default. */
+const DEFAULT_COVER_BLOCKS = {
+  logo: true,
+  customer: true,
+  propertyAddress: true,
+  pointOfContact: true,
+  insurance: true,
+} as const;
+
 describe("buildDefaultReportSections", () => {
   it("puts every selected photo into a single default section, in order", () => {
     expect(buildDefaultReportSections(["p1", "p2", "p3"])).toEqual([
@@ -347,6 +356,108 @@ describe("photoReportBuilderReducer", () => {
       heading: "Nowhere",
     });
     expect(next).toBe(before);
+  });
+});
+
+describe("cover page editor (#551)", () => {
+  it("seeds the cover with all five blocks on and no photo by default", () => {
+    // A loaded report carries a resolved cover (the resolver supplies the
+    // job-photo fallback and the all-on block defaults); the builder brain just
+    // seeds whatever it is handed. With nothing provided it is all-on, no photo.
+    expect(loaded().cover).toEqual({
+      logo: true,
+      customer: true,
+      propertyAddress: true,
+      pointOfContact: true,
+      insurance: true,
+      coverPhotoId: null,
+    });
+  });
+
+  it("seeds the cover from the report's resolved cover, without marking dirty", () => {
+    // The component resolves the cover (report snapshot → Job cover photo →
+    // defaults) and hands it in; the builder seeds it verbatim. Loading is not
+    // an edit, so the report is not dirty.
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [{ title: "Photos", description: "", photo_ids: [] }],
+      cover: {
+        logo: false,
+        customer: true,
+        propertyAddress: true,
+        pointOfContact: false,
+        insurance: true,
+        coverPhotoId: "job-photo-1",
+      },
+    });
+    expect(state.cover).toEqual({
+      logo: false,
+      customer: true,
+      propertyAddress: true,
+      pointOfContact: false,
+      insurance: true,
+      coverPhotoId: "job-photo-1",
+    });
+    expect(state.dirty).toBe(false);
+  });
+
+  it("setCoverPhoto chooses the cover photo, marking dirty and bumping the revision", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "setCoverPhoto",
+      photoId: "p2",
+    });
+    expect(next.cover.coverPhotoId).toBe("p2");
+    // The block toggles are untouched.
+    expect(next.cover.logo).toBe(true);
+    expect(next.dirty).toBe(true);
+    expect(next.revision).toBeGreaterThan(before.revision);
+  });
+
+  it("treats re-choosing the cover photo it already has as a no-op", () => {
+    // Seed a report whose cover photo is already p2; re-picking p2 must change
+    // nothing — same state object back, not dirty (mirrors the assign no-op).
+    const before = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [{ title: "Photos", description: "", photo_ids: [] }],
+      cover: { ...DEFAULT_COVER_BLOCKS, coverPhotoId: "p2" },
+    });
+    const next = photoReportBuilderReducer(before, {
+      type: "setCoverPhoto",
+      photoId: "p2",
+    });
+    expect(next).toBe(before);
+  });
+
+  it("toggleCoverField turns a block off, marking dirty and bumping the revision", () => {
+    const before = loaded(); // all blocks on
+    const next = photoReportBuilderReducer(before, {
+      type: "toggleCoverField",
+      field: "insurance",
+    });
+    expect(next.cover.insurance).toBe(false);
+    // The other blocks and the cover photo are untouched.
+    expect(next.cover.logo).toBe(true);
+    expect(next.cover.customer).toBe(true);
+    expect(next.cover.coverPhotoId).toBe(null);
+    expect(next.dirty).toBe(true);
+    expect(next.revision).toBeGreaterThan(before.revision);
+  });
+
+  it("toggleCoverField flips a block back on when applied twice", () => {
+    const off = photoReportBuilderReducer(loaded(), {
+      type: "toggleCoverField",
+      field: "logo",
+    });
+    expect(off.cover.logo).toBe(false);
+    const onAgain = photoReportBuilderReducer(off, {
+      type: "toggleCoverField",
+      field: "logo",
+    });
+    expect(onAgain.cover.logo).toBe(true);
+    expect(onAgain.dirty).toBe(true);
   });
 });
 

--- a/src/lib/photo-report-builder.ts
+++ b/src/lib/photo-report-builder.ts
@@ -21,6 +21,26 @@ import {
   type ReportSection,
   type StoredReportSection,
 } from "./build-initial-sections";
+import type {
+  CoverBlockVisibility,
+  ResolvedCoverConfig,
+} from "./photo-report-settings";
+
+/**
+ * The cover config a freshly loaded report falls back to when none is supplied:
+ * every identifying block on, no cover photo (ADR 0014). The component normally
+ * hands `initBuilderState` a fully-resolved cover (which already applies the
+ * Job-cover-photo fallback); this is the read-tolerant default for callers — and
+ * tests — that pass none.
+ */
+const DEFAULT_COVER: ResolvedCoverConfig = {
+  logo: true,
+  customer: true,
+  propertyAddress: true,
+  pointOfContact: true,
+  insurance: true,
+  coverPhotoId: null,
+};
 
 /** Heading the lone starter Section gets until the user renames it. */
 const DEFAULT_SECTION_TITLE = "Photos";
@@ -53,6 +73,14 @@ export interface PhotoReportBuilderState {
   /** Editable report date, a `YYYY-MM-DD` calendar date. */
   reportDate: string;
   sections: ReportSection[];
+  /**
+   * The per-report Cover Page config: which identifying blocks show and the
+   * chosen cover photo (#551). Seeded from the report's resolved cover (already
+   * carrying the Job-cover-photo fallback) and edited via `setCoverPhoto` /
+   * `toggleCoverField`. Persisted by splitting back into `cover_photo_id` and
+   * the five `cover_config` block flags.
+   */
+  cover: ResolvedCoverConfig;
   /** True once an edit has happened that has not yet been persisted. */
   dirty: boolean;
   /**
@@ -77,6 +105,13 @@ export interface LoadedPhotoReport {
    * always fully identified.
    */
   sections: StoredReportSection[];
+  /**
+   * The report's fully-resolved Cover Page config — the component resolves this
+   * (report snapshot → Job cover photo → defaults) before seeding the builder.
+   * Optional and read-tolerant: a caller that passes none gets the all-on,
+   * no-photo {@link DEFAULT_COVER}.
+   */
+  cover?: ResolvedCoverConfig;
 }
 
 export type PhotoReportBuilderAction =
@@ -89,6 +124,8 @@ export type PhotoReportBuilderAction =
   | { type: "reorderSection"; from: number; to: number }
   | { type: "assignPhotoToSection"; photoId: string; sectionIndex: number }
   | { type: "removePhotoFromReport"; photoId: string }
+  | { type: "setCoverPhoto"; photoId: string | null }
+  | { type: "toggleCoverField"; field: keyof CoverBlockVisibility }
   | { type: "markSaved"; revision: number };
 
 /**
@@ -102,6 +139,7 @@ export function initBuilderState(
     title: report.title,
     reportDate: report.report_date,
     sections: ensureSectionIds(report.sections),
+    cover: report.cover ?? DEFAULT_COVER,
     dirty: false,
     revision: 0,
   };
@@ -254,6 +292,29 @@ export function photoReportBuilderReducer(
         revision: state.revision + 1,
       };
     }
+    case "setCoverPhoto":
+      // Choose (or clear) the report's own cover photo. A no-op when it already
+      // matches — leave state untouched so an idle re-pick does not dirty the
+      // report (mirrors the photo-assignment no-op guards).
+      if (action.photoId === state.cover.coverPhotoId) return state;
+      return {
+        ...state,
+        cover: { ...state.cover, coverPhotoId: action.photoId },
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    case "toggleCoverField":
+      // Flip one identifying block on/off. Toggling always changes the value, so
+      // there is no no-op case — every dispatch dirties the report.
+      return {
+        ...state,
+        cover: {
+          ...state.cover,
+          [action.field]: !state.cover[action.field],
+        },
+        dirty: true,
+        revision: state.revision + 1,
+      };
     case "markSaved":
       // Only clear dirty if the write that just landed was for the *current*
       // revision. If an edit happened while the save was in flight, the state


### PR DESCRIPTION
Closes #551.

Builds the per-report **Cover Page editor** for the Photo Report builder. It surfaces in the center pane when the pinned **Cover Page** rail row is selected (desktop) / the always-visible report-meta block (phone). The author can:

- edit the report **title** (already wired via `setTitle`)
- pick the **cover photo** from the Job's photos (`setCoverPhoto`)
- toggle each of the **five identifying blocks** on/off — logo, customer, property address, point of contact, insurance — all default **on** (`toggleCoverField`)

### Freeze on first edit (ADR 0014)
Cover state is seeded with the report's fully-resolved cover via `resolveReportSettings` (own snapshot → Job cover photo → all-on/no-photo). The builder persists whatever is in state, so the **first edit** — even a title-only one — freezes that resolved cover (Job-cover fallback included) into the report's own copy. Later Job-cover changes no longer reach back in.

Both save paths carry the cover columns: the debounced Supabase `.update()` and the keepalive unmount-flush `PUT`, split into `cover_config` (the five block flags) + `cover_photo_id`.

The route reads the Job's `cover_photo_id` and passes it as `jobCoverPhotoId` so the fallback resolves without a second round-trip.

### Scope
Editing surface + reducer + persistence only. **PDF rendering of the cover is a separate slice** — not in this PR.

### Changes
- `src/lib/photo-report-builder.ts` — `cover` state + `setCoverPhoto`/`toggleCoverField` actions (commit 1)
- `src/components/photo-report-builder.tsx` — cover photo picker + block toggles UI, resolver seed, cover columns on both save paths
- `src/app/jobs/[id]/reports/[reportId]/page.tsx` — read Job `cover_photo_id`, pass `jobCoverPhotoId`
- `src/components/photo-report-cover-editor.test.tsx` — new DOM tests (freeze-on-first-edit, picker, toggles, seeded selection)
- `src/components/photo-report-builder-desktop.test.tsx` — backfill the three now-required `PhotoReport` fields (`report_settings`, `cover_config`, `cover_photo_id`) that #549 left type-incompatible in this older test's `makeReport`

### Verification
- **tsc**: zero new errors in any touched file (baseline is pre-existing/environmental — mobile-camera plugin + integration `.pg.test.ts` missing-module/implicit-any)
- **vitest**: full suite green — 345 files / 2723 tests; 38 reducer tests + 8 cover-editor DOM tests cover `setCoverPhoto`/`toggleCoverField`

🤖 Generated with [Claude Code](https://claude.com/claude-code)