### PR TITLE
feat(photo-report): Report Settings gear panel + Settings→Defaults admin + per-layout write-up cap (#550)

### DIFF
--- a/src/app/settings/templates/photo-report-defaults-tab.test.tsx
+++ b/src/app/settings/templates/photo-report-defaults-tab.test.tsx
@@ -1,16 +1,13 @@
-// PRD #326 — Photo Report Rework, Slice 6 (#332).
+// Issue #550 — Settings → Report Defaults admin UI (ADR 0014).
 //
-// The photo-report-defaults settings tab used to expose four knobs
-// (default template, preparer name, photos-per-page, footer text). Slice 6
-// collapses it to a single knob: photos-per-page (1 / 2 / 4, default 2).
+// The Organization's Report layout default is the seed every new report copies:
+// photos-per-page (2 / 3 / 4 — the 1-per-page layout was retired in ADR 0014)
+// plus the six detail toggles (Section Title Pages, Photo numbers, Captured by,
+// Location, Date captured, Photo tags), all default on. The tab reads and writes
+// these as `company_settings` key/value rows under REPORT_DEFAULT_SETTING_KEYS.
 //
-// AC pinned here:
-//   - "The photo-report-defaults settings tab renders only one control:
-//      photos-per-page (1, 2, or 4 — default 2)."
-//   - "Changing the photos-per-page setting persists to
-//      photo_report_defaults.report_photos_per_page and is read back on
-//      page reload." — settings live in `company_settings` (key/value),
-//      so the PUT body carries only `report_photos_per_page`.
+// Tests drive the public behavior through the DOM: which controls render, what
+// loads selected/checked, and exactly what the Save PUT carries.
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -53,28 +50,40 @@ function stubFetch(opts: {
   return spy;
 }
 
+// Pull the PUT body the Save button sent (the only PUT to the company route).
+async function putBody(
+  fetchSpy: ReturnType<typeof vi.fn>,
+): Promise<Record<string, string>> {
+  let body: Record<string, string> | undefined;
+  await waitFor(() => {
+    const putCall = fetchSpy.mock.calls.find(
+      (c) =>
+        String(c[0]) === "/api/settings/company" &&
+        (c[1] as RequestInit | undefined)?.method === "PUT",
+    );
+    expect(putCall).toBeDefined();
+    body = JSON.parse(String((putCall![1] as RequestInit).body));
+  });
+  return body!;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("PhotoReportDefaultsTab", () => {
-  it("renders only the photos-per-page knob — no template / preparer / footer fields", async () => {
+describe("PhotoReportDefaultsTab — photos per page", () => {
+  it("offers 2 / 3 / 4 per page (the 1-per-page layout was retired in ADR 0014)", async () => {
     stubFetch({ settings: {} });
 
     render(<PhotoReportDefaultsTab />);
 
-    // Photos-per-page buttons must be present.
     expect(
-      await screen.findByRole("button", { name: /1 per page/i }),
+      await screen.findByRole("button", { name: /2 per page/i }),
     ).toBeDefined();
-    expect(screen.getByRole("button", { name: /2 per page/i })).toBeDefined();
+    expect(screen.getByRole("button", { name: /3 per page/i })).toBeDefined();
     expect(screen.getByRole("button", { name: /4 per page/i })).toBeDefined();
-
-    // The three retired controls must be gone. Labels in this file aren't
-    // associated via htmlFor, so we check by visible text instead.
-    expect(screen.queryByText(/default template/i)).toBeNull();
-    expect(screen.queryByText(/preparer/i)).toBeNull();
-    expect(screen.queryByText(/footer/i)).toBeNull();
+    // The retired 1-per-page option must be gone.
+    expect(screen.queryByRole("button", { name: /1 per page/i })).toBeNull();
   });
 
   it("defaults to 2-per-page on a fresh load (no saved value)", async () => {
@@ -83,42 +92,87 @@ describe("PhotoReportDefaultsTab", () => {
     render(<PhotoReportDefaultsTab />);
 
     const twoBtn = await screen.findByRole("button", { name: /2 per page/i });
-    // The selected button gets the gradient class; the simpler check is that
-    // it carries the `text-white` class (only the selected one does in the
-    // current visual style).
+    // Selection is exposed semantically via aria-pressed, not a CSS class, so
+    // this survives a visual refactor of the gradient styling.
     await waitFor(() => {
-      expect(twoBtn.className).toMatch(/text-white/);
+      expect(twoBtn.getAttribute("aria-pressed")).toBe("true");
     });
   });
 
   it("reads back the saved photos-per-page from /api/settings/company", async () => {
-    stubFetch({ settings: { report_photos_per_page: "4" } });
+    stubFetch({ settings: { report_photos_per_page: "3" } });
 
     render(<PhotoReportDefaultsTab />);
 
-    const fourBtn = await screen.findByRole("button", { name: /4 per page/i });
+    const threeBtn = await screen.findByRole("button", { name: /3 per page/i });
     await waitFor(() => {
-      expect(fourBtn.className).toMatch(/text-white/);
+      expect(threeBtn.getAttribute("aria-pressed")).toBe("true");
     });
+    // And the previously-selected default is no longer pressed.
+    expect(
+      screen.getByRole("button", { name: /2 per page/i }).getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+});
+
+describe("PhotoReportDefaultsTab — detail toggles", () => {
+  it("renders all six detail toggles, every one on by default (no saved value)", async () => {
+    stubFetch({ settings: {} });
+
+    render(<PhotoReportDefaultsTab />);
+
+    const checkbox = (name: RegExp) =>
+      screen.getByRole("checkbox", { name }) as HTMLInputElement;
+    await screen.findByRole("checkbox", { name: /section title pages/i });
+    expect(checkbox(/section title pages/i).checked).toBe(true);
+    expect(checkbox(/photo numbers/i).checked).toBe(true);
+    expect(checkbox(/captured by/i).checked).toBe(true);
+    expect(checkbox(/location/i).checked).toBe(true);
+    expect(checkbox(/date captured/i).checked).toBe(true);
+    expect(checkbox(/photo tags/i).checked).toBe(true);
   });
 
-  it("saves only report_photos_per_page (none of the dropped keys)", async () => {
-    const fetchSpy = stubFetch({ settings: { report_photos_per_page: "2" } });
+  it("reads back a saved toggle that was turned off", async () => {
+    stubFetch({ settings: { report_detail_photo_tags: "false" } });
 
     render(<PhotoReportDefaultsTab />);
 
-    fireEvent.click(await screen.findByRole("button", { name: /1 per page/i }));
+    const photoTags = (await screen.findByRole("checkbox", {
+      name: /photo tags/i,
+    })) as HTMLInputElement;
+    await waitFor(() => {
+      expect(photoTags.checked).toBe(false);
+    });
+    // Other toggles, unset, stay on.
+    expect(
+      (screen.getByRole("checkbox", { name: /location/i }) as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+  });
+});
+
+describe("PhotoReportDefaultsTab — saving", () => {
+  it("saves all seven layout keys: photos-per-page plus the six detail toggles", async () => {
+    const fetchSpy = stubFetch({ settings: {} });
+
+    render(<PhotoReportDefaultsTab />);
+
+    // Change the density and flip one toggle off, then save.
+    fireEvent.click(await screen.findByRole("button", { name: /3 per page/i }));
+    fireEvent.click(screen.getByRole("checkbox", { name: /photo tags/i }));
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
-    await waitFor(() => {
-      const putCall = fetchSpy.mock.calls.find(
-        (c) =>
-          String(c[0]) === "/api/settings/company" &&
-          (c[1] as RequestInit | undefined)?.method === "PUT",
-      );
-      expect(putCall).toBeDefined();
-      const body = JSON.parse(String((putCall![1] as RequestInit).body));
-      expect(body).toEqual({ report_photos_per_page: "1" });
+    const body = await putBody(fetchSpy);
+    // Every key is written as a string (company_settings is key/value text), so
+    // a new report's seed is fully specified, not partially defaulted.
+    expect(body).toEqual({
+      report_photos_per_page: "3",
+      report_detail_section_title_pages: "true",
+      report_detail_photo_numbers: "true",
+      report_detail_captured_by: "true",
+      report_detail_location: "true",
+      report_detail_date_captured: "true",
+      report_detail_photo_tags: "false",
     });
   });
 });

--- a/src/app/settings/templates/photo-report-defaults-tab.tsx
+++ b/src/app/settings/templates/photo-report-defaults-tab.tsx
@@ -4,20 +4,56 @@ import { useEffect, useState, useCallback } from "react";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
-// PRD #326 — Photo Report Rework, Slice 6 (#332). The tab used to expose
-// four knobs; it now exposes only photos-per-page (1 / 2 / 4, default 2).
-// The dropped values (default template, preparer name, footer text) live
-// in `company_settings` as key/value rows and are deleted by migration.
+import {
+  REPORT_DEFAULT_SETTING_KEYS,
+  companySettingsToReportDefault,
+  type ReportDetailToggles,
+} from "@/lib/photo-report-settings";
+
+// Issue #550 — the Organization's Report layout default (ADR 0014): the seed
+// every new report copies. The tab exposes photos-per-page (2 / 3 / 4 — the
+// 1-per-page layout was retired) plus the six detail toggles (Section Title
+// Pages, Photo numbers, Captured by, Location, Date captured, Photo tags), all
+// default on. Each knob is a `company_settings` key/value row under
+// REPORT_DEFAULT_SETTING_KEYS; Save writes every key as a string so a new
+// report's seed is fully specified, never partially defaulted.
+
+const PHOTOS_PER_PAGE_OPTIONS = ["2", "3", "4"] as const;
+
+// The six detail toggles in display order, with the canonical report labels.
+const DETAIL_FIELDS: { field: keyof ReportDetailToggles; label: string }[] = [
+  { field: "sectionTitlePages", label: "Section Title Pages" },
+  { field: "photoNumbers", label: "Photo numbers" },
+  { field: "capturedBy", label: "Captured by" },
+  { field: "location", label: "Location" },
+  { field: "dateCaptured", label: "Date captured" },
+  { field: "photoTags", label: "Photo tags" },
+];
+
+const ALL_DETAILS_ON: ReportDetailToggles = {
+  sectionTitlePages: true,
+  photoNumbers: true,
+  capturedBy: true,
+  location: true,
+  dateCaptured: true,
+  photoTags: true,
+};
+
 export function PhotoReportDefaultsTab() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [photosPerPage, setPhotosPerPage] = useState("2");
+  const [details, setDetails] = useState<ReportDetailToggles>(ALL_DETAILS_ON);
 
   const fetchData = useCallback(async () => {
     const res = await fetch("/api/settings/company");
     if (res.ok) {
       const data = await res.json();
       setPhotosPerPage(data.report_photos_per_page || "2");
+      // Unset keys fall through to the all-on defaults; a saved "false" reads
+      // back as off (parsing handled by companySettingsToReportDefault).
+      const saved = companySettingsToReportDefault(data).details;
+      setDetails({ ...ALL_DETAILS_ON, ...saved });
     }
     setLoading(false);
   }, []);
@@ -28,12 +64,17 @@ export function PhotoReportDefaultsTab() {
 
   async function handleSave() {
     setSaving(true);
+    const body: Record<string, string> = {
+      [REPORT_DEFAULT_SETTING_KEYS.photosPerPage]: photosPerPage,
+    };
+    for (const { field } of DETAIL_FIELDS) {
+      body[REPORT_DEFAULT_SETTING_KEYS[field]] = String(details[field]);
+    }
+
     const res = await fetch("/api/settings/company", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        report_photos_per_page: photosPerPage,
-      }),
+      body: JSON.stringify(body),
     });
 
     if (res.ok) {
@@ -57,16 +98,17 @@ export function PhotoReportDefaultsTab() {
         </p>
       </div>
 
-      <div className="bg-card rounded-xl border border-border p-6 space-y-4">
+      <div className="bg-card rounded-xl border border-border p-6 space-y-6">
         <div>
           <label className="block text-xs font-medium text-muted-foreground mb-1">
             Photos Per Page
           </label>
           <div className="flex gap-2">
-            {["1", "2", "4"].map((n) => (
+            {PHOTOS_PER_PAGE_OPTIONS.map((n) => (
               <button
                 key={n}
                 type="button"
+                aria-pressed={photosPerPage === n}
                 onClick={() => setPhotosPerPage(n)}
                 className={`px-4 py-2 rounded-lg text-sm font-medium border transition-all ${
                   photosPerPage === n
@@ -76,6 +118,30 @@ export function PhotoReportDefaultsTab() {
               >
                 {n} per page
               </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <span className="block text-xs font-medium text-muted-foreground mb-1">
+            Show on photos
+          </span>
+          <div className="space-y-1">
+            {DETAIL_FIELDS.map(({ field, label }) => (
+              <label
+                key={field}
+                className="flex cursor-pointer items-center justify-between rounded-lg px-1 py-2 text-sm text-foreground hover:bg-muted/50"
+              >
+                <span>{label}</span>
+                <input
+                  type="checkbox"
+                  checked={details[field]}
+                  onChange={() =>
+                    setDetails((prev) => ({ ...prev, [field]: !prev[field] }))
+                  }
+                  className="h-4 w-4 accent-primary"
+                />
+              </label>
             ))}
           </div>
         </div>

--- a/src/components/photo-report-builder-desktop.test.tsx
+++ b/src/components/photo-report-builder-desktop.test.tsx
@@ -127,6 +127,9 @@ function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
     created_at: "2026-06-04T00:00:00Z",
     updated_at: "2026-06-04T00:00:00Z",
     deleted_at: null,
+    report_settings: null,
+    cover_config: null,
+    cover_photo_id: null,
     ...overrides,
   };
 }
@@ -364,19 +367,21 @@ describe("PhotoReportBuilder — rail selection stays keyboard-reachable (#548)"
 });
 
 describe("PhotoReportBuilder — desktop top-bar placeholders (#548)", () => {
-  it("offers desktop-only gear and Preview placeholders while Generate stays the one real action", () => {
+  it("offers desktop-only gear and Preview controls while Generate stays the one real action", () => {
     renderBuilder();
 
-    // Gear (Report Settings, per the glossary) and Preview ship as disabled
-    // desktop-only placeholders this slice; later slices wire them up.
+    // Both are desktop-only (hidden on phone, shown at lg). #550 wired the gear
+    // up to open Report Settings, so it is now a real action; Preview is still a
+    // disabled placeholder a later slice fills in.
     const gear = screen.getByRole("button", { name: "Report settings" });
     const preview = screen.getByRole("button", { name: "Preview" });
     for (const el of [gear, preview]) {
       const t = el.className.split(/\s+/);
       expect(t).toContain("hidden");
       expect(t).toContain("lg:inline-flex");
-      expect((el as HTMLButtonElement).disabled).toBe(true);
     }
+    expect((gear as HTMLButtonElement).disabled).toBe(false);
+    expect((preview as HTMLButtonElement).disabled).toBe(true);
 
     // Generate keeps today's behavior — one button, both surfaces share it.
     expect(

--- a/src/components/photo-report-builder.test.tsx
+++ b/src/components/photo-report-builder.test.tsx
@@ -127,10 +127,11 @@ import React from "react";
 import PhotoReportBuilder from "./photo-report-builder";
 import { writeupLimitFor } from "@/lib/section-writeup-fit";
 
-// The builder caps the write-up at one PDF intro page. Until the builder is
-// wired to the report's resolved photos-per-page (a later #540 slice), it
-// measures against the default 2-per-page cap, so that is the limit these tests
-// assert against (the single 1500-char budget was retired in ADR 0014 / #549).
+// The live counter measures the write-up against the report's resolved
+// photos-per-page (#550): the budget is layout-dependent (writeupLimitFor), and
+// a settings-less report defaults to 2-per-page, so that is the cap these
+// default-report tests assert against (the single 1500-char budget was retired
+// in ADR 0014 / #549). A report carrying its own density is exercised separately.
 const WRITEUP_CHARACTER_LIMIT = writeupLimitFor(2);
 import { generateReportPDF } from "@/lib/generate-report-pdf";
 import { toast } from "sonner";
@@ -751,7 +752,8 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
     expect(keepalivePuts(fetchMock)).toHaveLength(0);
   });
 
-  it("does not flush an over-limit write-up on unmount", () => {
+  it("flushes an over-limit write-up on unmount (#550: the cap is a soft warning, not a block)", () => {
+    const tooLong = `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`;
     const { unmount } = renderBuilder(
       makeReport({
         sections: [{ title: "Findings", description: "", photo_ids: [] }],
@@ -760,18 +762,24 @@ describe("PhotoReportBuilder unmount flush (#443)", () => {
 
     act(() => {
       fireEvent.change(screen.getByTestId("tiptap-stub"), {
-        target: { value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>` },
+        target: { value: tooLong },
       });
     });
 
-    // The write-up overflows its one-page intro, so the report is dirty but
-    // blocked. The flush must honour the same save-time guard (#404) as the
-    // debounced save and refuse to persist the over-limit content.
+    // The write-up overflows its Section Title Page, but that no longer holds
+    // back the save (#550 / ADR 0014): it renders on its own page and mild
+    // overflow is tolerable. The flush persists it like any other dirty edit.
     act(() => {
       unmount();
     });
 
-    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+    const puts = keepalivePuts(fetchMock);
+    expect(puts).toHaveLength(1);
+    expect(
+      (JSON.parse((puts[0][1] as RequestInit).body as string) as {
+        sections: { description: string }[];
+      }).sections[0].description,
+    ).toBe(tooLong);
   });
 });
 
@@ -881,15 +889,16 @@ describe("PhotoReportBuilder hard-unload flush (#479)", () => {
     });
   });
 
-  it("does not flush an over-limit write-up on pagehide or visibilitychange (#404)", () => {
+  it("flushes an over-limit write-up on pagehide / visibilitychange (#550: soft cap, no block)", () => {
     const { unmount } = renderBuilder(
       makeReport({
         sections: [{ title: "Findings", description: "", photo_ids: [] }],
       }),
     );
 
-    // Dirty, but the write-up overflows its one-page intro — the same save-time
-    // guard (#404) that holds back the debounced save must hold back the flush.
+    // Dirty and over the per-layout budget — but the cap is a soft warning
+    // since #550, so the hard-unload flush persists it like any other edit
+    // rather than holding it back.
     act(() => {
       fireEvent.change(screen.getByTestId("tiptap-stub"), {
         target: { value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>` },
@@ -898,11 +907,9 @@ describe("PhotoReportBuilder hard-unload flush (#479)", () => {
 
     act(() => {
       window.dispatchEvent(new Event("pagehide"));
-      setVisibility("hidden");
-      document.dispatchEvent(new Event("visibilitychange"));
     });
 
-    expect(keepalivePuts(fetchMock)).toHaveLength(0);
+    expect(keepalivePuts(fetchMock)).toHaveLength(1);
 
     act(() => {
       unmount();
@@ -953,7 +960,7 @@ describe("PhotoReportBuilder hard-unload flush (#479)", () => {
   });
 });
 
-describe("PhotoReportBuilder save-time guard", () => {
+describe("PhotoReportBuilder over-limit write-up (soft cap, #550)", () => {
   beforeEach(() => {
     h.updateMock.mockClear();
     h.manual = false;
@@ -961,92 +968,37 @@ describe("PhotoReportBuilder save-time guard", () => {
     vi.useFakeTimers();
   });
 
-  it("does not persist a write-up that is over the one-page limit", async () => {
+  it("persists an over-limit write-up — the cap only turns the counter red, it does not block the save", async () => {
     renderBuilder(
       makeReport({
         sections: [{ title: "Findings", description: "", photo_ids: [] }],
       }),
     );
 
+    const tooLong = `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`;
     act(() => {
       fireEvent.change(screen.getByTestId("tiptap-stub"), {
-        target: {
-          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
-        },
+        target: { value: tooLong },
       });
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
 
-    expect(h.updateMock).not.toHaveBeenCalled();
-    expect(screen.getByText(/can't save/i)).toBeTruthy();
-  });
-
-  it("resumes saving once an over-limit write-up is trimmed back under", async () => {
-    renderBuilder(
-      makeReport({
-        sections: [{ title: "Findings", description: "", photo_ids: [] }],
-      }),
-    );
-    const editor = screen.getByTestId("tiptap-stub");
-
-    // Over the limit → blocked, nothing written.
-    act(() => {
-      fireEvent.change(editor, {
-        target: {
-          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
-        },
-      });
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-    expect(h.updateMock).not.toHaveBeenCalled();
-
-    // Trimmed back under → the next debounce persists it.
-    act(() => {
-      fireEvent.change(editor, { target: { value: "<p>short</p>" } });
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
+    // The over-limit write-up saves like any other edit (#550 / ADR 0014): it
+    // renders on its own full Section Title Page, so mild overflow is tolerable.
     expect(h.updateMock).toHaveBeenCalledTimes(1);
     const payload = h.updateMock.mock.calls[0][0] as {
       sections: { description: string }[];
     };
-    expect(payload.sections[0].description).toBe("<p>short</p>");
+    expect(payload.sections[0].description).toBe(tooLong);
     expect(screen.getByText("Saved")).toBeTruthy();
-  });
-
-  it("blocks the whole save when any one section is over the limit", async () => {
-    renderBuilder(
-      makeReport({
-        sections: [
-          { title: "A", description: "<p>fine</p>", photo_ids: [] },
-          {
-            title: "B",
-            description: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
-            photo_ids: [],
-          },
-        ],
-      }),
-    );
-
-    // Edit an unrelated field (the title) to make the report dirty without
-    // touching the overflowing section: the save is still held back.
-    act(() => {
-      fireEvent.change(screen.getByLabelText("Report title"), {
-        target: { value: "Renamed report" },
-      });
-    });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-
-    expect(h.updateMock).not.toHaveBeenCalled();
-    expect(screen.getByText(/can't save/i)).toBeTruthy();
+    // The only warning is the counter going red and reporting the overflow —
+    // assert both: the magnitude AND the destructive styling that is the entire
+    // user-facing signal once the hard block was removed (#550 / ADR 0014).
+    const counter = screen.getByTestId("writeup-counter-0");
+    expect(counter.textContent).toContain("1 over");
+    expect(counter.className).toMatch(/text-destructive/);
   });
 
   it("persists a write-up that is exactly at the limit", async () => {
@@ -1072,9 +1024,17 @@ describe("PhotoReportBuilder save-time guard", () => {
     };
     expect(payload.sections[0].description).toBe(atLimit);
     expect(screen.getByText("Saved")).toBeTruthy();
+    // Exactly at the cap still fits — the counter must NOT be red, fixing the
+    // off-by-one boundary of the soft warning.
+    expect(screen.getByTestId("writeup-counter-0").className).not.toMatch(
+      /text-destructive/,
+    );
   });
 
-  it("keeps the blocked status when a stale in-flight save resolves after an over-limit edit", async () => {
+  it("does not mark the report Saved when a stale in-flight save resolves after a newer over-limit edit", async () => {
+    // The revision guard (revisionRef) must hold under the soft-cap regime: a
+    // slow save that resolves after a newer (over-limit, but valid) edit landed
+    // must not flip the badge to "Saved" while that newer edit is unpersisted.
     h.manual = true;
     renderBuilder(
       makeReport({
@@ -1082,50 +1042,51 @@ describe("PhotoReportBuilder save-time guard", () => {
       }),
     );
 
-    // A valid edit goes in flight and is held open ("Saving…").
+    const editor = screen.getByTestId("tiptap-stub");
+
+    // A fitting edit goes in flight (held open by manual mode).
     act(() => {
-      fireEvent.change(screen.getByLabelText("Report title"), {
-        target: { value: "Valid title" },
-      });
+      fireEvent.change(editor, { target: { value: "<p>fits</p>" } });
     });
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2000);
     });
     expect(h.updateMock).toHaveBeenCalledTimes(1);
     expect(h.resolvers).toHaveLength(1);
-    expect(screen.getByText(/saving/i)).toBeTruthy();
 
-    // Before it resolves, the write-up goes over the limit → next debounce blocks
-    // and writes nothing new.
+    // A newer, over-limit edit lands WHILE that save is still in flight. The cap
+    // is soft (#550), so it is a valid edit that must still be persisted.
+    const tooLong = `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`;
     act(() => {
-      fireEvent.change(screen.getByTestId("tiptap-stub"), {
-        target: {
-          value: `<p>${"a".repeat(WRITEUP_CHARACTER_LIMIT + 1)}</p>`,
-        },
-      });
+      fireEvent.change(editor, { target: { value: tooLong } });
     });
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-    expect(screen.getByText(/can't save/i)).toBeTruthy();
-    expect(h.updateMock).toHaveBeenCalledTimes(1);
 
-    // The stale valid save now resolves. It must NOT flip the badge to "Saved" —
-    // the over-limit content was never persisted.
+    // The stale save (of the fitting edit) resolves now. It must NOT claim
+    // "Saved", because the newer over-limit edit has not been persisted yet.
     await act(async () => {
       h.resolvers[0]();
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(screen.queryByText("Saved")).toBeNull();
-    expect(screen.getByText(/can't save/i)).toBeTruthy();
+
+    // The newer edit gets its own debounced save; once that resolves, settle.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(h.updateMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      h.resolvers[1]();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText("Saved")).toBeTruthy();
   });
 });
 
 // Issue #441 — Generating the PDF must reflect what is on screen, not the
 // last-saved row. The generator (`generateReportPDF`) re-reads the persisted row
 // and is mocked here, so these tests assert what the builder does *before* it
-// calls the generator: it flushes pending edits, and it refuses to generate a
-// stale PDF when the report is over the one-page limit.
+// calls the generator: it flushes pending edits first. Since #550 an over-limit
+// write-up no longer blocks generation — it flushes and renders like any other.
 describe("PhotoReportBuilder generate", () => {
   beforeEach(() => {
     h.updateMock.mockClear();
@@ -1175,7 +1136,7 @@ describe("PhotoReportBuilder generate", () => {
     expect(vi.mocked(generateReportPDF)).toHaveBeenCalledWith("report-1");
   });
 
-  it("refuses to generate when a section write-up is over the one-page limit, producing no PDF", async () => {
+  it("generates even when a section write-up is over the limit (#550: soft cap, no block)", async () => {
     renderBuilder(
       makeReport({
         sections: [
@@ -1190,13 +1151,11 @@ describe("PhotoReportBuilder generate", () => {
 
     await clickGenerate();
 
-    // No stale PDF: the generator (which would render the persisted, shorter
-    // row) is never invoked.
-    expect(vi.mocked(generateReportPDF)).not.toHaveBeenCalled();
-    // The user is told why, in plain terms.
-    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
-      expect.stringMatching(/too long|shorten/i),
-    );
+    // The over-limit write-up renders on its own Section Title Page (ADR 0014),
+    // so generation proceeds normally — no refusal, no error toast.
+    expect(vi.mocked(generateReportPDF)).toHaveBeenCalledWith("report-1");
+    expect(vi.mocked(toast.success)).toHaveBeenCalled();
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
   it("does not generate a PDF when flushing the pending edit fails", async () => {
@@ -1283,6 +1242,134 @@ describe("PhotoReportBuilder generate", () => {
       screen.getByRole("link", { name: /open pdf/i }).getAttribute("href"),
     ).toBe(
       "https://example.supabase.co/storage/v1/object/public/reports/job-1/report-1.pdf",
+    );
+  });
+});
+
+// Issue #550 — the in-builder Report Settings panel behind the top-bar gear, and
+// the per-layout write-up cap wired to the report's resolved photos-per-page.
+// These assert the builder ↔ panel wiring through the DOM: the live counter
+// reads the report's density, the gear opens the panel, and a setting changed in
+// the panel auto-saves through the same path as every other edit.
+describe("PhotoReportBuilder Report Settings (#550)", () => {
+  beforeEach(() => {
+    h.updateMock.mockClear();
+    h.manual = false;
+    h.resolvers = [];
+    vi.useFakeTimers();
+  });
+
+  it("measures the write-up against the report's resolved photos-per-page, not the 2-per-page default", () => {
+    // A 3-per-page report's intro shares its Section Title Page with one more
+    // photo row, so its budget is tighter: writeupLimitFor(3) = 400, not 750.
+    renderBuilder(
+      makeReport({
+        report_settings: { photosPerPage: 3 },
+        sections: [
+          { title: "Findings", description: "<p>Hello</p>", photo_ids: [] },
+        ],
+      }),
+    );
+
+    expect(screen.getByTestId("writeup-counter-0").textContent).toContain(
+      `5 / ${writeupLimitFor(3)}`,
+    );
+  });
+
+  it("relives the live write-up budget when photos-per-page is changed in the panel", () => {
+    // A 500-char intro fits at 2-per-page (cap 750) but overflows at 4-per-page
+    // (cap 260). Changing the density in the panel must move the budget live —
+    // proving the counter is bound to the current setting, not the value the
+    // report loaded with.
+    renderBuilder(
+      makeReport({
+        sections: [
+          {
+            title: "Findings",
+            description: `<p>${"a".repeat(500)}</p>`,
+            photo_ids: [],
+          },
+        ],
+      }),
+    );
+
+    const counter = () => screen.getByTestId("writeup-counter-0");
+    // Under the 2-per-page budget: fits, not red.
+    expect(counter().textContent).toContain(`500 / ${writeupLimitFor(2)}`);
+    expect(counter().textContent).not.toContain("over");
+    expect(counter().className).not.toMatch(/text-destructive/);
+
+    // Tighten the layout to 4-per-page in the panel.
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /report settings/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /4 per page/i }));
+    });
+
+    // The same unchanged write-up now overflows the tighter budget and goes red.
+    expect(counter().textContent).toContain(`500 / ${writeupLimitFor(4)}`);
+    expect(counter().textContent).toContain(`${500 - writeupLimitFor(4)} over`);
+    expect(counter().className).toMatch(/text-destructive/);
+  });
+
+  it("opens the Report Settings panel when the gear is clicked", () => {
+    renderBuilder();
+
+    // Closed on load — the gear is the only thing named "Report settings".
+    expect(
+      screen.queryByRole("dialog", { name: /report settings/i }),
+    ).toBeNull();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /report settings/i }));
+    });
+
+    expect(
+      screen.getByRole("dialog", { name: /report settings/i }),
+    ).toBeTruthy();
+  });
+
+  it("auto-saves the report_settings snapshot when photos-per-page is changed in the panel", async () => {
+    renderBuilder();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /report settings/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /4 per page/i }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // The layout change rides the same debounced write as a title/section edit,
+    // carrying the report's settings snapshot in the persisted row.
+    expect(h.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        report_settings: expect.objectContaining({ photosPerPage: 4 }),
+      }),
+    );
+  });
+
+  it("auto-saves the report_settings snapshot when a detail toggle is flipped in the panel", async () => {
+    renderBuilder();
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /report settings/i }));
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole("checkbox", { name: /photo tags/i }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // The six detail toggles default on, so flipping one persists it as false.
+    expect(h.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        report_settings: expect.objectContaining({ photoTags: false }),
+      }),
     );
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -37,42 +37,38 @@ import { cn } from "@/lib/utils";
 import { photoUrl } from "@/lib/jobs/photo-url";
 import { generateReportPDF } from "@/lib/generate-report-pdf";
 import TiptapEditor from "@/components/tiptap-editor";
+import ReportSettingsPanel from "@/components/report-settings-panel";
 import {
   initBuilderState,
   photoReportBuilderReducer,
   type PhotoReportBuilderState,
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
-import { measureWriteupFit } from "@/lib/section-writeup-fit";
+import { measureWriteupFit, writeupLimitFor } from "@/lib/section-writeup-fit";
 import {
   newSectionId,
   type ReportSection,
   type StoredReportSection,
 } from "@/lib/build-initial-sections";
-import type { Photo, PhotoReport } from "@/lib/types";
+import type { Photo, PhotoReport, ReportPhotosPerPage } from "@/lib/types";
 
 // How long to wait after the last edit before persisting (mirrors the
 // estimate builder's auto-save debounce).
 const DEBOUNCE_MS = 2000;
 
-type SaveStatus = "idle" | "saving" | "saved" | "error" | "blocked";
-
-// A report can't be persisted while any Section's write-up overflows its
-// one-page intro (issue #404). Every save path gates on this one rule — the
-// debounced auto-save, the unmount flush (#443), and the Generate flush (#441)
-// — so it lives in one place.
-function hasOverLimitSection(sections: ReportSection[]): boolean {
-  return sections.some((s) => !measureWriteupFit(s.description).fits);
-}
+type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 // The fields a save persists, plus the revision that snapshot belongs to. Built
 // in one place so the debounced auto-save and the Generate flush always persist
-// exactly the same shape. (issue #441)
+// exactly the same shape. (issue #441) Since #550 this also carries the report's
+// settings snapshot (photos-per-page + the six detail toggles) so layout changes
+// auto-save like every other edit.
 function snapshotOf(state: PhotoReportBuilderState) {
   return {
     title: state.title,
     reportDate: state.reportDate,
     sections: state.sections,
+    reportSettings: { photosPerPage: state.photosPerPage, ...state.details },
     revision: state.revision,
   };
 }
@@ -97,11 +93,18 @@ export default function PhotoReportBuilder({
       title: report.title,
       report_date: report.report_date,
       sections: report.sections as StoredReportSection[],
+      // The report's own layout snapshot (#550): initBuilderState resolves it to
+      // the chosen photos-per-page + detail toggles, falling back to the
+      // hardcoded 2-per-page/all-on defaults when a pre-0014 row has none.
+      report_settings: report.report_settings,
     },
     initBuilderState,
   );
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
   const [generating, setGenerating] = useState(false);
+  // Whether the gear's Report Settings panel is open (#550). Purely ephemeral
+  // UI state — the settings themselves live in the reducer and auto-save.
+  const [settingsOpen, setSettingsOpen] = useState(false);
   // The path of the most recently generated PDF, surfaced as a persistent
   // "Open PDF" link the user taps (issue #442). Seeded from the report so a
   // PDF generated in an earlier session is retrievable on load without
@@ -120,8 +123,8 @@ export default function PhotoReportBuilder({
 
   // The latest edit revision, mirrored into a ref so the async save tail can
   // tell whether a newer edit landed while it was in flight (its own captured
-  // `state` is stale by then). Without this, a slow valid save resolving after a
-  // newer over-limit edit would flip the badge from "blocked" back to "Saved".
+  // `state` is stale by then). Without this, a slow save resolving after a newer
+  // edit would flip the badge from "Saving…" back to "Saved" with stale state.
   const revisionRef = useRef(state.revision);
   // Holds the pending auto-save debounce timer so the Generate flush can cancel
   // it and write immediately, rather than racing the debounce. (issue #441)
@@ -145,6 +148,7 @@ export default function PhotoReportBuilder({
           title: snapshot.title,
           report_date: snapshot.reportDate,
           sections: snapshot.sections,
+          report_settings: snapshot.reportSettings,
         })
         .eq("id", report.id);
       if (error) {
@@ -153,8 +157,8 @@ export default function PhotoReportBuilder({
       }
       dispatch({ type: "markSaved", revision: snapshot.revision });
       // Only claim "Saved" if no newer edit landed while this write was in
-      // flight. If one did, its own effect run owns the status (e.g. it may have
-      // set "blocked"), so we must not overwrite it with a stale success.
+      // flight. If one did, its own effect run owns the status, so we must not
+      // overwrite it with a stale success.
       if (snapshot.revision === revisionRef.current) {
         setSaveStatus("saved");
       }
@@ -172,15 +176,11 @@ export default function PhotoReportBuilder({
   useEffect(() => {
     revisionRef.current = state.revision;
     if (!state.dirty) return;
-    // Save-time guard (issue #404): the whole report write is held back while
-    // any Section is over the limit, so the report stays dirty and saves itself
-    // once trimmed back under.
-    const overLimit = hasOverLimitSection(state.sections);
+    // A write-up that runs over its per-layout budget is no longer held back
+    // (#550): it renders on its own full Section Title Page, so mild overflow is
+    // tolerable (ADR 0014). The live counter turning red is the only warning;
+    // the report saves like any other edit.
     const timer = setTimeout(() => {
-      if (overLimit) {
-        setSaveStatus("blocked");
-        return;
-      }
       void writeReport(snapshotOf(state));
     }, DEBOUNCE_MS);
     saveTimerRef.current = timer;
@@ -202,9 +202,6 @@ export default function PhotoReportBuilder({
   const flushOnUnmountRef = useRef<() => void>(() => {});
   flushOnUnmountRef.current = () => {
     if (!state.dirty) return;
-    // Honour the same save-time over-limit guard (#404) as the debounced save:
-    // a flush must never sneak an over-limit write-up past it on teardown.
-    if (hasOverLimitSection(state.sections)) return;
     void fetch(`/api/jobs/${jobId}/reports/${report.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
@@ -212,6 +209,7 @@ export default function PhotoReportBuilder({
         title: state.title,
         report_date: state.reportDate,
         sections: state.sections,
+        report_settings: { photosPerPage: state.photosPerPage, ...state.details },
       }),
       keepalive: true,
     });
@@ -225,7 +223,7 @@ export default function PhotoReportBuilder({
   // "hidden" covers app-backgrounding (the common iOS exit, where pagehide is
   // unreliable). We flush only when the page is actually hidden — a change *to*
   // visible is the user returning, not leaving. The same flush ref is reused, so
-  // the over-limit (#404) and dirty guards still apply. Listeners are removed on
+  // the dirty guard still applies. Listeners are removed on
   // unmount so a torn-down builder can't keep flushing. iOS can fire both
   // visibilitychange→hidden AND pagehide in one teardown, re-running the flush;
   // the #478 PUT is idempotent and the flush no-ops once clean, so — as in #477
@@ -259,15 +257,6 @@ export default function PhotoReportBuilder({
   const availablePhotos = photos.filter((p) => !assignedIds.has(p.id));
 
   const handleGenerate = async () => {
-    // A write-up over the one-page limit was never persisted (the save guard
-    // holds it back), so generating now would render a stale, shorter PDF.
-    // Refuse with a clear message instead of silently producing it. (issue #441)
-    if (hasOverLimitSection(state.sections)) {
-      setSaveStatus("blocked");
-      toast.error("Write-up too long — shorten it before generating.");
-      return;
-    }
-
     setGenerating(true);
     try {
       // The PDF is rendered from the persisted row and auto-save is debounced,
@@ -311,24 +300,21 @@ export default function PhotoReportBuilder({
         <div className="flex-1" />
         <span
           className={`text-xs text-right ${
-            saveStatus === "blocked" || saveStatus === "error"
-              ? "text-destructive"
-              : "text-muted-foreground"
+            saveStatus === "error" ? "text-destructive" : "text-muted-foreground"
           }`}
         >
           {saveStatus === "saving" && "Saving…"}
           {saveStatus === "saved" && "Saved"}
           {saveStatus === "error" && "Save failed"}
-          {saveStatus === "blocked" && "Can't save — write-up too long"}
         </span>
-        {/* Desktop-only placeholders (#548): the gear opens Report Settings and
-            Preview shows the rendered PDF in later slices (#549+). Shipped
-            disabled so the top bar's final shape is in place from the start. */}
+        {/* The gear opens the in-builder Report Settings panel (#550): photos
+            per page + the six detail toggles. Preview (still a placeholder)
+            shows the rendered PDF in a later slice. */}
         <button
           type="button"
           aria-label="Report settings"
-          disabled
-          className="hidden lg:inline-flex items-center rounded-lg border border-border p-2 text-muted-foreground opacity-60"
+          onClick={() => setSettingsOpen(true)}
+          className="hidden lg:inline-flex items-center rounded-lg border border-border p-2 text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
         >
           <Settings size={16} />
         </button>
@@ -503,6 +489,7 @@ export default function PhotoReportBuilder({
                     photosById={photosById}
                     supabaseUrl={supabaseUrl}
                     dispatch={dispatch}
+                    photosPerPage={state.photosPerPage}
                     desktopSelected={selectedId === section.id}
                   />
                 ))}
@@ -525,6 +512,15 @@ export default function PhotoReportBuilder({
           </div>
         </div>
       </DndContext>
+
+      {settingsOpen && (
+        <ReportSettingsPanel
+          photosPerPage={state.photosPerPage}
+          details={state.details}
+          dispatch={dispatch}
+          onClose={() => setSettingsOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -619,6 +615,7 @@ function SortableSection({
   photosById,
   supabaseUrl,
   dispatch,
+  photosPerPage,
   desktopSelected,
 }: {
   index: number;
@@ -628,6 +625,12 @@ function SortableSection({
   dispatch: React.Dispatch<
     Parameters<typeof photoReportBuilderReducer>[1]
   >;
+  /**
+   * The report's chosen Photo Page density (#550). Sets the write-up character
+   * budget the live counter reads — fewer photos per page leaves more room for
+   * the intro write-up, so the cap is layout-dependent ({@link writeupLimitFor}).
+   */
+  photosPerPage: ReportPhotosPerPage;
   /**
    * Whether the desktop rail has this Section selected (#548). The center
    * editor shows one pane at a time, so an unselected card is `lg:hidden` —
@@ -669,9 +672,14 @@ function SortableSection({
     photosById.has(id),
   ).length;
 
-  // The write-up is capped to one PDF intro page (ADR 0009). measureWriteupFit
-  // is the single source of truth shared with the save-time guard.
-  const fit = measureWriteupFit(section.description);
+  // The write-up shares the Section Title Page with the layout, so its budget
+  // depends on the chosen density (#550): writeupLimitFor maps photos-per-page
+  // to the character cap (2→750, 3→400, 4→260). Going over no longer blocks the
+  // save — the counter just turns red (ADR 0014).
+  const fit = measureWriteupFit(
+    section.description,
+    writeupLimitFor(photosPerPage),
+  );
 
   return (
     <section
@@ -731,7 +739,8 @@ function SortableSection({
         placeholder="Write-up — what you found, what you did…"
       />
 
-      {/* Live one-page fit counter (issue #404), driven by measureWriteupFit. */}
+      {/* Live per-layout fit counter (#404, #550): measureWriteupFit against the
+          density-dependent budget (writeupLimitFor). Red past the cap, never blocks. */}
       <p
         data-testid={`writeup-counter-${index}`}
         className={`text-xs ${

--- a/src/components/report-settings-panel.test.tsx
+++ b/src/components/report-settings-panel.test.tsx
@@ -1,0 +1,115 @@
+// Issue #550 — the in-builder Report Settings panel behind the top-bar gear.
+//
+// The panel is a thin, controlled view over the report's resolved layout: it
+// shows the chosen photos-per-page and the six detail toggles, and turns a
+// click into the matching reducer action. Its tests exercise that public
+// behavior — what the user sees and what gets dispatched — not its markup.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+
+import ReportSettingsPanel from "./report-settings-panel";
+
+const ALL_ON = {
+  sectionTitlePages: true,
+  photoNumbers: true,
+  capturedBy: true,
+  location: true,
+  dateCaptured: true,
+  photoTags: true,
+};
+
+function renderPanel(
+  overrides: Partial<React.ComponentProps<typeof ReportSettingsPanel>> = {},
+) {
+  const dispatch = vi.fn();
+  const onClose = vi.fn();
+  render(
+    <ReportSettingsPanel
+      photosPerPage={2}
+      details={ALL_ON}
+      dispatch={dispatch}
+      onClose={onClose}
+      {...overrides}
+    />,
+  );
+  return { dispatch, onClose };
+}
+
+afterEach(cleanup);
+
+describe("ReportSettingsPanel", () => {
+  it("offers 2/3/4 photos-per-page and marks the current layout pressed", () => {
+    renderPanel({ photosPerPage: 3 });
+    expect(screen.getByRole("button", { name: /2 per page/i })).toBeDefined();
+    const three = screen.getByRole("button", { name: /3 per page/i });
+    expect(three).toBeDefined();
+    expect(screen.getByRole("button", { name: /4 per page/i })).toBeDefined();
+    expect(three.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("dispatches setPhotosPerPage when a density is picked", () => {
+    const { dispatch } = renderPanel({ photosPerPage: 2 });
+    fireEvent.click(screen.getByRole("button", { name: /4 per page/i }));
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "setPhotosPerPage",
+      photosPerPage: 4,
+    });
+  });
+
+  it("renders all six detail toggles, reflecting their on/off state", () => {
+    renderPanel({
+      details: { ...ALL_ON, photoNumbers: false },
+    });
+    const checkbox = (name: RegExp) =>
+      screen.getByRole("checkbox", { name }) as HTMLInputElement;
+    expect(checkbox(/section title pages/i).checked).toBe(true);
+    expect(checkbox(/photo numbers/i).checked).toBe(false);
+    expect(checkbox(/captured by/i).checked).toBe(true);
+    expect(checkbox(/location/i).checked).toBe(true);
+    expect(checkbox(/date captured/i).checked).toBe(true);
+    expect(checkbox(/photo tags/i).checked).toBe(true);
+  });
+
+  it("dispatches toggleReportField for the field whose toggle is clicked", () => {
+    const { dispatch } = renderPanel();
+    fireEvent.click(screen.getByRole("checkbox", { name: /date captured/i }));
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "toggleReportField",
+      field: "dateCaptured",
+    });
+  });
+
+  it("does not render a configurable Photo Page Header (dropped in #550)", () => {
+    renderPanel();
+    expect(screen.queryByText(/photo page header/i)).toBeNull();
+    expect(screen.queryByText(/header.*left/i)).toBeNull();
+  });
+
+  it("closes when the X button is pressed", () => {
+    const { onClose } = renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when Escape is pressed (WCAG 2.1 modal dismissal)", () => {
+    const { onClose } = renderPanel();
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes when the decorative backdrop is clicked", () => {
+    // The backdrop is aria-hidden (not a button), so it is queried by its click
+    // target, not a role: clicking the scrim behind the dialog dismisses it.
+    const { onClose } = renderPanel();
+    const dialog = screen.getByRole("dialog");
+    // The backdrop is the dialog's sibling fixed overlay; their shared parent
+    // wraps both. Scope to a *direct* child so the match can't fall through to
+    // the lucide X icon's own aria-hidden <svg> nested inside the dialog.
+    const backdrop = dialog.parentElement!.querySelector(
+      ':scope > [aria-hidden="true"]',
+    ) as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/report-settings-panel.tsx
+++ b/src/components/report-settings-panel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+// Issue #550 — the in-builder Report Settings panel behind the top-bar gear.
+//
+// A thin, controlled slide-over over the report's resolved layout: it shows the
+// chosen Photos-per-page density (2 / 3 / 4) and the six detail toggles (ADR
+// 0014), and turns each click into the matching builder action
+// (`setPhotosPerPage` / `toggleReportField`). It holds no state of its own — the
+// reducer owns the settings and auto-save persists them — so editing here flows
+// through exactly the same path as every other builder edit. The configurable
+// Photo Page Header (Left / Center / Right) of the original sketch was dropped
+// (#550); it is intentionally not here.
+
+import { useEffect } from "react";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import type { PhotoReportBuilderAction } from "@/lib/photo-report-builder";
+import type { ReportDetailToggles } from "@/lib/photo-report-settings";
+import type { ReportPhotosPerPage } from "@/lib/types";
+
+const PHOTOS_PER_PAGE_OPTIONS: ReportPhotosPerPage[] = [2, 3, 4];
+
+// The six detail toggles in display order, with the labels the report uses for
+// each (the canonical names from #550 / ADR 0014).
+const DETAIL_FIELDS: { field: keyof ReportDetailToggles; label: string }[] = [
+  { field: "sectionTitlePages", label: "Section Title Pages" },
+  { field: "photoNumbers", label: "Photo numbers" },
+  { field: "capturedBy", label: "Captured by" },
+  { field: "location", label: "Location" },
+  { field: "dateCaptured", label: "Date captured" },
+  { field: "photoTags", label: "Photo tags" },
+];
+
+interface ReportSettingsPanelProps {
+  photosPerPage: ReportPhotosPerPage;
+  details: ReportDetailToggles;
+  dispatch: React.Dispatch<PhotoReportBuilderAction>;
+  onClose: () => void;
+}
+
+export default function ReportSettingsPanel({
+  photosPerPage,
+  details,
+  dispatch,
+  onClose,
+}: ReportSettingsPanelProps) {
+  // Escape closes the dialog from anywhere — the standard modal affordance
+  // (WCAG 2.1 Level A). A document-level listener catches it wherever focus
+  // sits; the keydown bubbles, so a key pressed inside the panel reaches it too.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      {/* Backdrop — click anywhere off the panel to dismiss. It is purely
+          decorative (aria-hidden): keyboard users dismiss via Escape (above) or
+          the header's Close button, so it stays out of the tab/reader order. */}
+      <div
+        aria-hidden="true"
+        onClick={onClose}
+        className="absolute inset-0 h-full w-full cursor-default bg-black/30"
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="Report settings"
+        className="relative z-10 flex h-full w-80 max-w-[90vw] flex-col overflow-y-auto border-l border-border bg-card shadow-xl"
+      >
+        <header className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold text-foreground">
+            Report Settings
+          </h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="rounded-lg p-1 text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </header>
+
+        <div className="space-y-6 px-4 py-4">
+          <div>
+            <span className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Photos per page
+            </span>
+            <div className="flex gap-2">
+              {PHOTOS_PER_PAGE_OPTIONS.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  aria-pressed={photosPerPage === n}
+                  onClick={() =>
+                    dispatch({ type: "setPhotosPerPage", photosPerPage: n })
+                  }
+                  className={cn(
+                    "flex-1 rounded-lg border px-3 py-2 text-sm font-medium transition-all",
+                    photosPerPage === n
+                      ? "bg-[image:var(--gradient-primary)] text-white border-transparent shadow-sm"
+                      : "bg-card text-muted-foreground border-border hover:border-primary/30 hover:shadow-sm",
+                  )}
+                >
+                  {n} per page
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <span className="mb-1 block text-xs font-medium text-muted-foreground">
+              Show on photos
+            </span>
+            {DETAIL_FIELDS.map(({ field, label }) => (
+              <label
+                key={field}
+                className="flex cursor-pointer items-center justify-between rounded-lg px-1 py-2 text-sm text-foreground hover:bg-muted/50"
+              >
+                <span>{label}</span>
+                <input
+                  type="checkbox"
+                  checked={details[field]}
+                  onChange={() =>
+                    dispatch({ type: "toggleReportField", field })
+                  }
+                  className="h-4 w-4 accent-primary"
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/src/lib/photo-report-builder.test.ts
+++ b/src/lib/photo-report-builder.test.ts
@@ -104,6 +104,84 @@ describe("photoReportBuilderReducer", () => {
     expect(next.dirty).toBe(true);
   });
 
+  it("changing photos-per-page updates it and marks the report dirty", () => {
+    const before = loaded();
+    const next = photoReportBuilderReducer(before, {
+      type: "setPhotosPerPage",
+      photosPerPage: 4,
+    });
+    expect(next.photosPerPage).toBe(4);
+    expect(next.dirty).toBe(true);
+    expect(next.revision).toBeGreaterThan(before.revision);
+  });
+
+  it("treats re-picking the current photos-per-page as a no-op", () => {
+    // loaded() resolves to the 2-per-page default; re-selecting 2 must change
+    // nothing — same state object back, not dirtied (mirrors the photo no-ops).
+    const before = loaded();
+    expect(before.photosPerPage).toBe(2);
+    const next = photoReportBuilderReducer(before, {
+      type: "setPhotosPerPage",
+      photosPerPage: 2,
+    });
+    expect(next).toBe(before);
+  });
+
+  it("toggling a detail field flips it, leaving the others, and marks dirty", () => {
+    const before = loaded();
+    // loaded() resolves to all detail toggles on.
+    expect(before.details.photoNumbers).toBe(true);
+    expect(before.details.location).toBe(true);
+    const next = photoReportBuilderReducer(before, {
+      type: "toggleReportField",
+      field: "photoNumbers",
+    });
+    expect(next.details.photoNumbers).toBe(false);
+    expect(next.details.location).toBe(true);
+    expect(next.dirty).toBe(true);
+    expect(next.revision).toBeGreaterThan(before.revision);
+  });
+
+  it("toggling a detail field twice returns it to its starting value", () => {
+    const before = loaded();
+    const once = photoReportBuilderReducer(before, {
+      type: "toggleReportField",
+      field: "sectionTitlePages",
+    });
+    const twice = photoReportBuilderReducer(once, {
+      type: "toggleReportField",
+      field: "sectionTitlePages",
+    });
+    expect(once.details.sectionTitlePages).toBe(false);
+    expect(twice.details.sectionTitlePages).toBe(true);
+  });
+
+  it("seeds photos-per-page and detail toggles from the loaded report's snapshot", () => {
+    const state = initBuilderState({
+      title: "R",
+      report_date: "2026-06-04",
+      sections: [{ title: "Photos", description: "", photo_ids: [] }],
+      report_settings: { photosPerPage: 4, photoTags: false },
+    });
+    expect(state.photosPerPage).toBe(4);
+    expect(state.details.photoTags).toBe(false);
+    // Fields the snapshot omits fall through to the all-on default.
+    expect(state.details.location).toBe(true);
+  });
+
+  it("defaults a settings-less report to 2-per-page with every detail toggle on", () => {
+    const state = loaded();
+    expect(state.photosPerPage).toBe(2);
+    expect(state.details).toEqual({
+      sectionTitlePages: true,
+      photoNumbers: true,
+      capturedBy: true,
+      location: true,
+      dateCaptured: true,
+      photoTags: true,
+    });
+  });
+
   it("marking saved clears the dirty flag once the current revision lands", () => {
     const edited = photoReportBuilderReducer(loaded(), {
       type: "setTitle",

--- a/src/lib/photo-report-builder.ts
+++ b/src/lib/photo-report-builder.ts
@@ -21,6 +21,12 @@ import {
   type ReportSection,
   type StoredReportSection,
 } from "./build-initial-sections";
+import {
+  resolveReportSettings,
+  type ReportDetailToggles,
+  type StoredReportSettingsJson,
+} from "./photo-report-settings";
+import type { ReportPhotosPerPage } from "./types";
 
 /** Heading the lone starter Section gets until the user renames it. */
 const DEFAULT_SECTION_TITLE = "Photos";
@@ -53,6 +59,14 @@ export interface PhotoReportBuilderState {
   /** Editable report date, a `YYYY-MM-DD` calendar date. */
   reportDate: string;
   sections: ReportSection[];
+  /**
+   * The report's chosen Photo Page density (ADR 0014, #549/#550). Drives both
+   * the PDF layout and the per-layout write-up character budget the live
+   * counter reads ({@link writeupLimitFor}).
+   */
+  photosPerPage: ReportPhotosPerPage;
+  /** The six per-report detail toggles (ADR 0014). All default on. */
+  details: ReportDetailToggles;
   /** True once an edit has happened that has not yet been persisted. */
   dirty: boolean;
   /**
@@ -77,6 +91,12 @@ export interface LoadedPhotoReport {
    * always fully identified.
    */
   sections: StoredReportSection[];
+  /**
+   * The report's own settings snapshot (ADR 0014, #549). Absent on a pre-0014
+   * row, in which case `initBuilderState` resolves to the hardcoded defaults
+   * (2-per-page, every detail toggle on).
+   */
+  report_settings?: StoredReportSettingsJson | null;
 }
 
 export type PhotoReportBuilderAction =
@@ -89,6 +109,8 @@ export type PhotoReportBuilderAction =
   | { type: "reorderSection"; from: number; to: number }
   | { type: "assignPhotoToSection"; photoId: string; sectionIndex: number }
   | { type: "removePhotoFromReport"; photoId: string }
+  | { type: "setPhotosPerPage"; photosPerPage: ReportPhotosPerPage }
+  | { type: "toggleReportField"; field: keyof ReportDetailToggles }
   | { type: "markSaved"; revision: number };
 
 /**
@@ -98,10 +120,23 @@ export type PhotoReportBuilderAction =
 export function initBuilderState(
   report: LoadedPhotoReport,
 ): PhotoReportBuilderState {
+  // Resolve the report's look from its own snapshot, falling through to the
+  // hardcoded defaults (2-per-page, all detail toggles on) when absent. The
+  // Organization default is not threaded here (hence `null` below): a report is
+  // seeded with its own snapshot at creation (#549, ADR 0014). That snapshot is
+  // a one-way copy — later edits to the org default never propagate to existing
+  // reports, only to ones created after the change — so the builder never needs
+  // the org default as a live fallback.
+  const { photosPerPage, details } = resolveReportSettings(
+    { report_settings: report.report_settings ?? null },
+    null,
+  );
   return {
     title: report.title,
     reportDate: report.report_date,
     sections: ensureSectionIds(report.sections),
+    photosPerPage,
+    details,
     dirty: false,
     revision: 0,
   };
@@ -254,6 +289,26 @@ export function photoReportBuilderReducer(
         revision: state.revision + 1,
       };
     }
+    case "setPhotosPerPage":
+      // No-op when the layout is unchanged so re-picking the current density
+      // does not needlessly dirty the report (mirrors the photo no-ops above).
+      if (action.photosPerPage === state.photosPerPage) return state;
+      return {
+        ...state,
+        photosPerPage: action.photosPerPage,
+        dirty: true,
+        revision: state.revision + 1,
+      };
+    case "toggleReportField":
+      return {
+        ...state,
+        details: {
+          ...state.details,
+          [action.field]: !state.details[action.field],
+        },
+        dirty: true,
+        revision: state.revision + 1,
+      };
     case "markSaved":
       // Only clear dirty if the write that just landed was for the *current*
       // revision. If an edit happened while the save was in flight, the state


### PR DESCRIPTION
Closes #550.

Wires up the UI that shapes a report's look, on top of the #549 data-model slice (resolver, `writeupLimitFor`, autosave whitelist).

## What's in this slice

- **In-builder Report Settings panel** behind the top-bar **gear** — choose **Photos per page (2 / 3 / 4)** and toggle the six detail settings (**Section Title Pages, Photo numbers, Captured by, Location, Date captured, Photo tags**), all default **ON**. Clicks dispatch the new pure-reducer actions `setPhotosPerPage` / `toggleReportField` and persist through the existing autosave path.
- **Settings → Report Defaults admin UI** extended to the full layout default (2/3/4 + the six toggles) — the Organization seed every new report copies.
- **Per-layout write-up cap** — the live counter reads `writeupLimitFor(photosPerPage)` (2→750, 3→400, 4→260) and turns **red** past the cap as a **soft warning only**. Typing / save / flush / generate are never hard-blocked (per ADR 0014, the write-up renders on its own Section Title Page where mild overflow is tolerable).
- **Dropped** the configurable Photo Page Header (Left/Center/Right) per #550.

## Design notes

The panel is a thin **controlled slide-over**: it owns no state, the reducer owns the settings, so editing flows through the same `dirty`/`revision`/autosave path as every other builder edit. Modal affordances follow the sibling slide-over idiom — **Escape** + decorative **backdrop** dismissal, `role="dialog"` with `aria-modal="true"`, and `aria-pressed` density buttons.

## Acceptance criteria

- [x] Gear opens the panel; selecting 2/3/4 and toggling the six switches persists via autosave (`setPhotosPerPage` / `toggleReportField`).
- [x] Settings → Report Defaults lets an admin set the Organization default (2/3/4 + toggles); new reports inherit it via #549 seeding.
- [x] Write-up counter uses the per-layout cap and turns red past it **without** blocking further typing.
- [x] All settings default to **ON / 2-per-page** for a fresh report.
- [x] The configurable Photo Page Header is **not** present.
- [x] `setPhotosPerPage` / `toggleReportField` reducer actions covered by unit tests (next-state + dirty/revision).

## Verification

- All four touched test files green (**65/65**); full suite **2728/2728**.
- `tsc --noEmit`: 19 errors, all pre-existing (17 `*.pg.test.ts` + 2 camera), **zero in any touched file**.
- The changeset went through an adversarial multi-lens review (correctness / a11y / test-coupling / regression / completeness). Correctness, regression, and completeness came back clean; two low/nit a11y-and-test findings were folded in (`aria-modal="true"` on the dialog; the backdrop-click test selector scoped to a direct child so it can't fall through to the close-icon's `aria-hidden` svg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)