### PR TITLE
feat(photo-report): on-demand Preview pane — real PDF, shared no-drift producer (#554)

### DIFF
--- a/src/components/photo-report-builder-desktop.test.tsx
+++ b/src/components/photo-report-builder-desktop.test.tsx
@@ -28,6 +28,9 @@ import type { Photo, PhotoReport } from "@/lib/types";
 
 const h = vi.hoisted(() => ({
   updateMock: vi.fn<(payload: Record<string, unknown>) => void>(),
+  // When set, the auto-save write resolves with an error so a test can exercise
+  // the failed-flush path (#441: a failed flush must not yield a render).
+  errorOnSave: false,
 }));
 
 vi.mock("@/lib/supabase", () => ({
@@ -35,7 +38,12 @@ vi.mock("@/lib/supabase", () => ({
     from: () => ({
       update: (payload: Record<string, unknown>) => {
         h.updateMock(payload);
-        return { eq: () => Promise.resolve({ error: null }) };
+        return {
+          eq: () =>
+            Promise.resolve({
+              error: h.errorOnSave ? { message: "save failed" } : null,
+            }),
+        };
       },
     }),
   }),
@@ -45,6 +53,20 @@ vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 vi.mock("@/lib/generate-report-pdf", () => ({
   generateReportPDF: vi.fn(async () => "job-1/report-1.pdf"),
+  renderReportPdfBlob: vi.fn(
+    async () => new Blob(["%PDF"], { type: "application/pdf" }),
+  ),
+}));
+
+// The on-demand Preview pane (#554) feeds the shared producer's blob into the
+// in-app react-pdf viewer (PdfPreviewFrame). That island can't run in jsdom
+// (react-pdf evaluates pdfjs-dist at import), so stand in a stub echoing the
+// src/title the builder hands it — the frame's own pass-through is unit-tested
+// in pdf-preview-frame.test.tsx.
+vi.mock("@/components/documents/pdf-preview-frame", () => ({
+  PdfPreviewFrame: ({ src, title }: { src: string; title: string }) => (
+    <div data-testid="report-preview-frame" data-src={src} data-title={title} />
+  ),
 }));
 
 vi.mock("@/components/tiptap-editor", () => ({
@@ -106,7 +128,9 @@ vi.mock("@dnd-kit/sortable", async () => {
 });
 
 import React from "react";
+import { toast } from "sonner";
 import PhotoReportBuilder from "./photo-report-builder";
+import { renderReportPdfBlob } from "@/lib/generate-report-pdf";
 
 function makeReport(overrides: Partial<PhotoReport> = {}): PhotoReport {
   return {
@@ -156,14 +180,33 @@ function renderBuilder(report = makeReport(), photos: Photo[] = []) {
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
+// jsdom ships no Blob URL machinery, but the Preview pane (#554) turns the
+// rendered PDF blob into an object URL. Stand in deterministic blob: URLs so a
+// test can assert the viewer was fed one (and, later, that stale ones are
+// revoked). Restored after each test to keep the worker hermetic.
+const realCreateObjectURL = globalThis.URL.createObjectURL;
+const realRevokeObjectURL = globalThis.URL.revokeObjectURL;
+const createObjectURL = vi.fn<(blob: Blob) => string>();
+const revokeObjectURL = vi.fn<(url: string) => void>();
+let objectUrlSeq = 0;
+
 beforeEach(() => {
   h.updateMock.mockClear();
+  h.errorOnSave = false;
+  vi.mocked(renderReportPdfBlob).mockClear();
+  vi.mocked(toast.error).mockClear();
   capturedOnDragEnd = null;
   capturedSortableIds = [];
   fetchMock = vi.fn(() =>
     Promise.resolve({ ok: true, status: 200, json: async () => ({}) } as Response),
   );
   vi.stubGlobal("fetch", fetchMock);
+
+  objectUrlSeq = 0;
+  createObjectURL.mockReset().mockImplementation(() => `blob:mock/${++objectUrlSeq}`);
+  revokeObjectURL.mockReset();
+  globalThis.URL.createObjectURL = createObjectURL;
+  globalThis.URL.revokeObjectURL = revokeObjectURL;
 });
 
 afterEach(() => {
@@ -171,6 +214,8 @@ afterEach(() => {
   // (#443) hits the inert mock (see photo-report-builder.test.tsx).
   cleanup();
   vi.unstubAllGlobals();
+  globalThis.URL.createObjectURL = realCreateObjectURL;
+  globalThis.URL.revokeObjectURL = realRevokeObjectURL;
 });
 
 function getRail() {
@@ -375,13 +420,13 @@ describe("PhotoReportBuilder — rail selection stays keyboard-reachable (#548)"
   });
 });
 
-describe("PhotoReportBuilder — desktop top-bar placeholders (#548)", () => {
-  it("offers desktop-only gear and Preview controls while Generate stays the one real action", () => {
+describe("PhotoReportBuilder — desktop top-bar controls (#548, #554)", () => {
+  it("offers desktop-only gear, Preview, and the single Generate action", () => {
     renderBuilder();
 
     // Both are desktop-only (hidden on phone, shown at lg). #550 wired the gear
-    // up to open Report Settings, so it is now a real action; Preview is still a
-    // disabled placeholder a later slice fills in.
+    // up to open Report Settings; #554 wired Preview up to render the on-demand
+    // pane — neither is a disabled placeholder any longer.
     const gear = screen.getByRole("button", { name: "Report settings" });
     const preview = screen.getByRole("button", { name: "Preview" });
     for (const el of [gear, preview]) {
@@ -390,7 +435,7 @@ describe("PhotoReportBuilder — desktop top-bar placeholders (#548)", () => {
       expect(t).toContain("lg:inline-flex");
     }
     expect((gear as HTMLButtonElement).disabled).toBe(false);
-    expect((preview as HTMLButtonElement).disabled).toBe(true);
+    expect((preview as HTMLButtonElement).disabled).toBe(false);
 
     // Generate keeps today's behavior — one button, both surfaces share it.
     expect(
@@ -675,5 +720,183 @@ describe("PhotoReportBuilder — within-Section photo reorder (#552)", () => {
       sections: Array<{ photo_ids: string[] }>;
     };
     expect(payload.sections[0].photo_ids).toEqual(["p2", "p3", "p1"]);
+  });
+});
+
+describe("PhotoReportBuilder — on-demand Preview pane (#554)", () => {
+  it("renders the real report PDF in a pane when Preview is clicked", async () => {
+    renderBuilder();
+
+    // On demand, not live: nothing renders until the author asks for it.
+    expect(screen.queryByTestId("report-preview-frame")).toBeNull();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+
+    // The shared no-drift producer rendered THIS report; its blob is handed to
+    // the in-app viewer as a blob: URL — byte-identical to what Generate uploads.
+    const frame = await screen.findByTestId("report-preview-frame");
+    expect(vi.mocked(renderReportPdfBlob)).toHaveBeenCalledWith("report-1");
+    expect(frame.getAttribute("data-src")).toMatch(/^blob:/);
+  });
+
+  it("refreshes only on click — an edit never re-renders, the Refresh control does", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+    const frame = await screen.findByTestId("report-preview-frame");
+    expect(vi.mocked(renderReportPdfBlob)).toHaveBeenCalledTimes(1);
+    const firstSrc = frame.getAttribute("data-src");
+
+    // Editing the report leaves the open pane untouched — preview is on demand,
+    // not a live re-render on every keystroke (criterion b).
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Edited title" },
+      });
+    });
+    expect(vi.mocked(renderReportPdfBlob)).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByTestId("report-preview-frame").getAttribute("data-src"),
+    ).toBe(firstSrc);
+
+    // The pane's Refresh control re-renders with the latest report, on demand.
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh preview" }));
+    });
+    expect(vi.mocked(renderReportPdfBlob)).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByTestId("report-preview-frame").getAttribute("data-src"),
+    ).not.toBe(firstSrc);
+  });
+
+  it("flushes a pending edit before rendering, so the preview reflects it (#441)", async () => {
+    renderBuilder();
+
+    // Edit the title but don't let the 2s auto-save debounce elapse.
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Latest title" },
+      });
+    });
+    expect(h.updateMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+    await screen.findByTestId("report-preview-frame");
+
+    // The producer re-reads the persisted row, so the edit was written first…
+    expect(h.updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Latest title" }),
+    );
+    // …BEFORE the producer ran — Preview == Generate, never a stale render (#441).
+    expect(h.updateMock.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(renderReportPdfBlob).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not render a preview when flushing the pending edit fails (#441)", async () => {
+    h.errorOnSave = true;
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText("Report title"), {
+        target: { value: "Latest title" },
+      });
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+
+    // The flush failed; the producer (which would render the older persisted row)
+    // must not run — better no preview than a stale one. The pane stays closed.
+    expect(vi.mocked(renderReportPdfBlob)).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("report-preview-frame")).toBeNull();
+    expect(vi.mocked(toast.error)).toHaveBeenCalled();
+  });
+
+  it("refreshing revokes the stale object URL before showing the new render", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+    const firstSrc = (
+      await screen.findByTestId("report-preview-frame")
+    ).getAttribute("data-src");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Refresh preview" }));
+    });
+
+    // The new render mints a fresh blob URL and the one it replaced is revoked,
+    // so stale renders don't pile up in memory while the pane stays open.
+    const nextSrc = screen
+      .getByTestId("report-preview-frame")
+      .getAttribute("data-src");
+    expect(nextSrc).not.toBe(firstSrc);
+    expect(revokeObjectURL).toHaveBeenCalledWith(firstSrc);
+  });
+
+  it("closing the pane clears it and revokes its object URL (no leak)", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+    const frame = await screen.findByTestId("report-preview-frame");
+    const openSrc = frame.getAttribute("data-src");
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Close preview" }));
+    });
+
+    // The pane is gone and the blob URL it held is revoked — the browser frees
+    // the rendered PDF rather than leaking it for the tab's lifetime.
+    expect(screen.queryByTestId("report-preview-frame")).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith(openSrc);
+  });
+
+  it("opens as a slide-over: a fixed right-anchored panel over a dimmed backdrop", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+
+    // Option B: the pane overlays the editor (criterion d) instead of reflowing
+    // the page — a fixed panel pinned to the right, identical at every width.
+    const dialog = await screen.findByRole("dialog", {
+      name: "Report preview",
+    });
+    expect(dialog.className).toContain("fixed");
+    expect(dialog.className).toContain("right-0");
+
+    // A dimmed backdrop sits behind it, separating the slide-over from the editor.
+    expect(screen.getByTestId("preview-backdrop")).toBeTruthy();
+  });
+
+  it("dismisses the slide-over when the dimmed backdrop is clicked", async () => {
+    renderBuilder();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Preview" }));
+    });
+    const openSrc = (
+      await screen.findByTestId("report-preview-frame")
+    ).getAttribute("data-src");
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("preview-backdrop"));
+    });
+
+    // Tapping outside the panel dismisses it, just like the ✕ — and frees the blob.
+    expect(screen.queryByTestId("report-preview-frame")).toBeNull();
+    expect(revokeObjectURL).toHaveBeenCalledWith(openSrc);
   });
 });

--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -27,6 +27,7 @@ import {
   GripVertical,
   Loader2,
   Plus,
+  RefreshCw,
   Settings,
   Trash2,
   X,
@@ -36,9 +37,10 @@ import { toast } from "sonner";
 import { createClient } from "@/lib/supabase";
 import { cn } from "@/lib/utils";
 import { photoUrl } from "@/lib/jobs/photo-url";
-import { generateReportPDF } from "@/lib/generate-report-pdf";
+import { generateReportPDF, renderReportPdfBlob } from "@/lib/generate-report-pdf";
 import TiptapEditor from "@/components/tiptap-editor";
 import ReportSettingsPanel from "@/components/report-settings-panel";
+import { PdfPreviewFrame } from "@/components/documents/pdf-preview-frame";
 import {
   initBuilderState,
   photoReportBuilderReducer,
@@ -163,6 +165,12 @@ export default function PhotoReportBuilder({
   // PDF generated in an earlier session is retrievable on load without
   // regenerating.
   const [pdfPath, setPdfPath] = useState<string | null>(report.pdf_path);
+  // The on-demand Preview pane (#554): the object URL of the most recently
+  // rendered PDF blob while the pane is open, or null when closed. It changes
+  // only when the author asks — a Preview/refresh click, never a keystroke — so
+  // the pane shows the real report on demand, not a live re-render. See
+  // handlePreview.
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
   // Which pane the desktop rail has selected for the center editor (#548).
   // `null` means the pinned Cover Page. Purely ephemeral UI state — never in
   // the reducer, never persisted. Resolved against the live sections below so
@@ -317,22 +325,36 @@ export default function PhotoReportBuilder({
   const assignedIds = new Set(state.sections.flatMap((s) => s.photo_ids));
   const availablePhotos = photos.filter((p) => !assignedIds.has(p.id));
 
+  // Both Generate and Preview render from the *persisted* row, but auto-save is
+  // debounced — so a just-made edit may not be on disk yet. Flush it first
+  // (cancelling the pending debounce) so the output reflects what is on screen.
+  // Returns false — with a message already shown — when the flush failed, so the
+  // caller bails rather than render a stale row. (issue #441)
+  const flushPendingEdits = async (): Promise<boolean> => {
+    if (!state.dirty) return true;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    const saved = await writeReport(snapshotOf(state));
+    if (!saved) {
+      toast.error("Couldn't save your latest edits — try again.");
+      return false;
+    }
+    return true;
+  };
+
+  // Swap the preview to a freshly-rendered blob, or clear it (null). Always
+  // revokes the object URL it replaces so the browser frees the stale blob
+  // instead of leaking it for the tab's lifetime.
+  const swapPreview = (blob: Blob | null) => {
+    setPreviewSrc((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return blob ? URL.createObjectURL(blob) : null;
+    });
+  };
+
   const handleGenerate = async () => {
     setGenerating(true);
     try {
-      // The PDF is rendered from the persisted row and auto-save is debounced,
-      // so a just-made edit may not be on disk yet. Flush it first (cancelling
-      // the pending debounce) so the PDF reflects what is on screen. (issue #441)
-      if (state.dirty) {
-        if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-        const saved = await writeReport(snapshotOf(state));
-        // If the flush failed, the persisted row is still the old one. Better to
-        // produce no PDF than a stale one — bail with a message. (issue #441)
-        if (!saved) {
-          toast.error("Couldn't save your latest edits — try again.");
-          return;
-        }
-      }
+      if (!(await flushPendingEdits())) return;
       const generatedPath = await generateReportPDF(report.id);
       setPdfPath(generatedPath);
       toast.success("PDF generated.");
@@ -342,6 +364,24 @@ export default function PhotoReportBuilder({
       setGenerating(false);
     }
   };
+
+  // Open (or refresh) the on-demand Preview pane (#554). Renders the report to a
+  // PDF blob through the SAME shared producer Generate uses — so the preview is
+  // byte-identical to the generated PDF — and feeds it to the in-app viewer as
+  // an object URL. Fires only on an explicit click, never on edits.
+  const handlePreview = async () => {
+    try {
+      if (!(await flushPendingEdits())) return;
+      const blob = await renderReportPdfBlob(report.id);
+      swapPreview(blob);
+    } catch {
+      toast.error("Failed to render preview.");
+    }
+  };
+
+  // Dismiss the pane and revoke its object URL — the rendered PDF is freed
+  // rather than held until the tab closes.
+  const handleClosePreview = () => swapPreview(null);
 
   return (
     // The builder sits inside the normal AppShell chrome (#548 restored the
@@ -369,8 +409,8 @@ export default function PhotoReportBuilder({
           {saveStatus === "error" && "Save failed"}
         </span>
         {/* The gear opens the in-builder Report Settings panel (#550): photos
-            per page + the six detail toggles. Preview (still a placeholder)
-            shows the rendered PDF in a later slice. */}
+            per page + the six detail toggles. Preview (#554) renders the real
+            report PDF on demand in a slide-over pane. */}
         <button
           type="button"
           aria-label="Report settings"
@@ -381,8 +421,8 @@ export default function PhotoReportBuilder({
         </button>
         <button
           type="button"
-          disabled
-          className="hidden lg:inline-flex items-center gap-1.5 rounded-lg border border-border px-4 py-1.5 text-sm font-semibold text-muted-foreground opacity-60"
+          onClick={handlePreview}
+          className="hidden lg:inline-flex items-center gap-1.5 rounded-lg border border-border px-4 py-1.5 text-sm font-semibold text-foreground hover:border-foreground/40 transition-colors"
         >
           <Eye size={14} />
           Preview
@@ -660,6 +700,53 @@ export default function PhotoReportBuilder({
           dispatch={dispatch}
           onClose={() => setSettingsOpen(false)}
         />
+      )}
+      {/* On-demand Preview pane (#554): the real report PDF — byte-identical to
+          Generate — rendered in the in-app viewer. Option B slide-over: a fixed
+          right-anchored panel over a dimmed backdrop, identical at every width,
+          overlaying the editor rather than reflowing it. Refresh re-runs the
+          shared producer with the latest edits; the pane never re-renders on its
+          own; the backdrop or ✕ dismisses it. */}
+      {previewSrc && (
+        <>
+          <div
+            data-testid="preview-backdrop"
+            aria-hidden="true"
+            onClick={handleClosePreview}
+            className="fixed inset-0 z-40 bg-foreground/40"
+          />
+          <div
+            role="dialog"
+            aria-label="Report preview"
+            className="fixed inset-y-0 right-0 z-50 flex w-full max-w-2xl flex-col bg-card shadow-2xl"
+          >
+            <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+              <span className="text-sm font-semibold text-foreground">
+                Preview
+              </span>
+              <div className="flex-1" />
+              <button
+                type="button"
+                aria-label="Refresh preview"
+                onClick={handlePreview}
+                className="inline-flex items-center rounded-lg border border-border p-2 text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+              >
+                <RefreshCw size={14} />
+              </button>
+              <button
+                type="button"
+                aria-label="Close preview"
+                onClick={handleClosePreview}
+                className="inline-flex items-center rounded-lg border border-border p-2 text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div className="flex-1 overflow-auto p-4">
+              <PdfPreviewFrame src={previewSrc} title={state.title} />
+            </div>
+          </div>
+        </>
       )}
       {/* The "+ Add Photos" picker (#552): adds a multi-selection of the Job's
           photos into the Section whose button opened it. */}

--- a/src/lib/generate-report-pdf.test.tsx
+++ b/src/lib/generate-report-pdf.test.tsx
@@ -172,11 +172,21 @@ vi.mock("@/lib/report-render-model", () => ({
   })),
 }));
 
-import { generateReportPDF } from "./generate-report-pdf";
+import { generateReportPDF, renderReportPdfBlob } from "./generate-report-pdf";
 import { buildReportRenderModel } from "@/lib/report-render-model";
 
 function modelArg() {
   return vi.mocked(buildReportRenderModel).mock.calls[0][0];
+}
+
+function resetState() {
+  vi.clearAllMocks();
+  h.state.companySettingsValue = "4";
+  h.state.fromTables = [];
+  h.state.companySettingsKeys = [];
+  h.state.uploads = [];
+  h.state.templateQueried = false;
+  vi.stubEnv("NEXT_PUBLIC_SUPABASE_URL", "https://test.supabase.co");
 }
 
 describe("generateReportPDF — render-model wiring", () => {
@@ -256,5 +266,31 @@ describe("generateReportPDF — render-model wiring", () => {
     expect(h.state.uploads).toEqual([
       { bucket: "reports", path: `${h.JOB_NUMBER}/${h.REPORT_ID}.pdf` },
     ]);
+  });
+});
+
+describe("renderReportPdfBlob — shared no-drift producer (#554)", () => {
+  beforeEach(resetState);
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns a PDF blob without uploading or updating the report row", async () => {
+    const blob = await renderReportPdfBlob(h.REPORT_ID);
+
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe("application/pdf");
+    // Pure render: the Preview path must not touch storage or the report row.
+    expect(h.state.uploads).toEqual([]);
+  });
+
+  it("feeds buildReportRenderModel the exact same args Generate does (no drift)", async () => {
+    await renderReportPdfBlob(h.REPORT_ID);
+    const previewArgs = modelArg();
+
+    vi.mocked(buildReportRenderModel).mockClear();
+    await generateReportPDF(h.REPORT_ID);
+    const generateArgs = vi.mocked(buildReportRenderModel).mock.calls[0][0];
+
+    // Identical render-model input => identical PDF. Preview == Generate.
+    expect(previewArgs).toEqual(generateArgs);
   });
 });

--- a/src/lib/generate-report-pdf.tsx
+++ b/src/lib/generate-report-pdf.tsx
@@ -94,10 +94,16 @@ async function resolveCoverPhotoUrl(
 }
 
 /**
- * Generate a PDF for a photo report, upload to Supabase storage,
- * and update the report record with the pdf_path and status.
+ * The shared PDF producer behind both Preview and Generate. Fetches the report,
+ * its Job, company settings, and photos; resolves the report's effective look;
+ * assembles the complete render model; and renders it to a PDF blob. It performs
+ * NO writes — Preview consumes the blob directly, Generate uploads it — so both
+ * paths render from one identical model and cannot drift (#554). Returns the
+ * Job's number alongside the blob, which Generate needs for the storage path.
  */
-export async function generateReportPDF(reportId: string): Promise<string> {
+async function assembleReportPdf(
+  reportId: string,
+): Promise<{ blob: Blob; jobNumber: string }> {
   const supabase = createClient();
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 
@@ -243,8 +249,30 @@ export async function generateReportPDF(reportId: string): Promise<string> {
     />,
   ).toBlob();
 
+  return { blob, jobNumber: job.job_number };
+}
+
+/**
+ * Render a photo report to a PDF blob without persisting anything — the
+ * on-demand Preview pane (#554) feeds this blob straight into the viewer. Shares
+ * one producer with {@link generateReportPDF}, so Preview renders byte-identical
+ * to Generate.
+ */
+export async function renderReportPdfBlob(reportId: string): Promise<Blob> {
+  const { blob } = await assembleReportPdf(reportId);
+  return blob;
+}
+
+/**
+ * Generate a PDF for a photo report, upload to Supabase storage,
+ * and update the report record with the pdf_path and status.
+ */
+export async function generateReportPDF(reportId: string): Promise<string> {
+  const supabase = createClient();
+  const { blob, jobNumber } = await assembleReportPdf(reportId);
+
   // 8. Upload PDF to Supabase Storage
-  const pdfPath = `${job.job_number}/${reportId}.pdf`;
+  const pdfPath = `${jobNumber}/${reportId}.pdf`;
   const { error: uploadErr } = await supabase.storage
     .from("reports")
     .upload(pdfPath, blob, {


### PR DESCRIPTION
Closes #554.

Adds a top-bar **Preview** button that renders the real report PDF in a slide-over pane beside the editor, reusing the shared render-model + PDF document from #553 so **Preview is byte-identical to Generate** — no drift.

## The no-drift seam
Extracted a private `assembleReportPdf(reportId)` that does the full fetch → resolve look → `buildReportRenderModel` → `pdf().toBlob()` with **no writes**. Both paths delegate to it:
- `renderReportPdfBlob()` → returns the blob (Preview)
- `generateReportPDF()` → uploads it + updates the row (Generate)

A test asserts `buildReportRenderModel` receives identical args from both paths, so Preview cannot diverge from Generate.

## Behavior (acceptance criteria)
- **(a)** Preview renders the real report in a pane matching Generate ✅
- **(b)** refreshes only on click — an edit never re-renders the open pane ✅
- **(c)** Preview + Generate share one render-model, no divergence ✅
- **(d)** pane coexists with the editor at desktop widths — **Option B slide-over**: a fixed right-anchored panel over a dimmed backdrop, identical at every width, overlaying the editor ✅

Plus:
- Flushes the debounced auto-save **before** rendering and bails with a toast on failure — the same #441 stale-render guard Generate uses.
- Revokes the prior `blob:` object URL on every refresh and on close (no leak); backdrop or ✕ dismisses.

## Refactor
- Shared `flushPendingEdits()` (was duplicated in Generate + Preview).
- `swapPreview(blob | null)` centralizing object-URL create/revoke.

## Tests / gates
- Preview-pane desktop tests: 24/24; affected files 76/76.
- Full vitest suite: **2842/2842** (349 files).
- tsc: 0 new errors (19 pre-existing, verified via clean-HEAD stash). eslint: 0 errors on changed files.

Built TDD red→green→refactor across 6 vertical slices.

## Not yet verified by automation
The react-pdf viewer is stubbed in jsdom (pdfjs-dist evaluates on import), so the **live react-pdf render inside the slide-over** is the one piece tests can't cover. The frame itself (`PdfPreviewFrame`) is reused unchanged (already `next/dynamic ssr:false`), so the new surface is just the slide-over layout around it — worth an eyeball on the preview deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)