### PR TITLE
feat(estimate-builder): collapsed section headers show their $ total (#591)

### DIFF
--- a/src/components/estimate-builder/grouped-line-item-table.test.tsx
+++ b/src/components/estimate-builder/grouped-line-item-table.test.tsx
@@ -117,6 +117,54 @@ describe("GroupedLineItemTable", () => {
     expect(within(table).getByText("0 items")).toBeDefined();
   });
 
+  it("shows the $ total on a collapsed section header, and hides it again on expand (#591)", () => {
+    renderTable();
+    const roof = screen.getByText("Roof").closest("li") as HTMLElement;
+
+    // Expanded → no header total (line totals are already visible below).
+    expect(screen.queryByText("$1,400.00")).toBeNull();
+
+    // Collapsed → the header shows the section's total: the 7 × $100 direct
+    // item plus the 7 × $100 item inside the Flashing subsection.
+    fireEvent.click(
+      within(roof).getByRole("button", { name: /collapse section/i }),
+    );
+    expect(within(roof).getByText("$1,400.00")).toBeDefined();
+
+    fireEvent.click(
+      within(roof).getByRole("button", { name: /expand section/i }),
+    );
+    expect(screen.queryByText("$1,400.00")).toBeNull();
+  });
+
+  it("shows the $ total on a collapsed subsection header (#591)", () => {
+    renderTable();
+    // Scoped to the header row div — the Tear-off and Step flashing item rows
+    // render the same $700.00 as their line totals.
+    const header = screen.getByText("Flashing").closest("div") as HTMLElement;
+
+    fireEvent.click(
+      within(header).getByRole("button", { name: /collapse subsection/i }),
+    );
+    expect(within(header).getByText("$700.00")).toBeDefined();
+
+    fireEvent.click(
+      within(header).getByRole("button", { name: /expand subsection/i }),
+    );
+    expect(within(header).queryByText("$700.00")).toBeNull();
+  });
+
+  it("shows a $0.00 total on empty sections under Collapse all (#591)", () => {
+    renderTable();
+
+    fireEvent.click(screen.getByRole("button", { name: /collapse all/i }));
+
+    const roof = screen.getByText("Roof").closest("li") as HTMLElement;
+    const gutters = screen.getByText("Gutters").closest("li") as HTMLElement;
+    expect(within(roof).getByText("$1,400.00")).toBeDefined();
+    expect(within(gutters).getByText("$0.00")).toBeDefined();
+  });
+
   it("collapses and expands a section, hiding its subsection and item rows", () => {
     renderTable();
 

--- a/src/components/estimate-builder/grouped-line-item-table.tsx
+++ b/src/components/estimate-builder/grouped-line-item-table.tsx
@@ -54,6 +54,9 @@ import { Input } from "@/components/ui/input";
 import { buildNumberIndex } from "./number-section-tree";
 import { resolveLineItemDropTarget } from "./move-line-item";
 import { LineItemRow, type BuilderLineItem } from "./line-item-row";
+import { cn } from "@/lib/utils";
+import { formatCurrency } from "@/lib/format";
+import { sumLineItemsFromSections } from "@/lib/estimates-calc";
 import type { EstimateSection, InvoiceSection } from "@/lib/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -440,10 +443,24 @@ function SubsectionGroup({
         <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
           {entryCountLabel(subsection.items.length)}
         </span>
+        {/* Collapsed → surface the subsection's $ total on the header, since
+            the line totals it sums are hidden (#591). */}
+        {collapsed && (
+          <span className="ml-auto shrink-0 font-mono tabular-nums text-xs text-foreground">
+            {formatCurrency(
+              sumLineItemsFromSections([
+                { items: subsection.items, subsections: [] },
+              ]),
+            )}
+          </span>
+        )}
         <button
           type="button"
           onClick={onToggleCollapsed}
-          className="ml-auto p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+          className={cn(
+            "p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0",
+            !collapsed && "ml-auto",
+          )}
           aria-label={collapsed ? "Expand subsection" : "Collapse subsection"}
           title={collapsed ? "Expand" : "Collapse"}
         >
@@ -628,10 +645,21 @@ function SectionGroup({
         <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
           {entryCountLabel(section.items.length + subsectionItemCount)}
         </span>
+        {/* Collapsed → surface the section's $ total (direct items plus every
+            subsection's items) on the header, since the line totals it sums
+            are hidden (#591). Same summation as the document subtotal. */}
+        {collapsed && (
+          <span className="ml-auto shrink-0 font-mono tabular-nums text-sm font-medium text-foreground">
+            {formatCurrency(sumLineItemsFromSections([section]))}
+          </span>
+        )}
         <button
           type="button"
           onClick={() => onToggleCollapsed(section.id)}
-          className="ml-auto p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+          className={cn(
+            "p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0",
+            !collapsed && "ml-auto",
+          )}
           aria-label={collapsed ? "Expand section" : "Collapse section"}
           title={collapsed ? "Expand" : "Collapse"}
         >


### PR DESCRIPTION
Closes #591.

## What

Collapsed ("condensed") section and subsection headers in the estimate/invoice builder's grouped line-item table now show their dollar total, right-aligned next to the collapse chevron — exactly where the issue's screenshot circled the empty space.

- **Section headers** show the sum of their direct items plus every subsection's items.
- **Subsection headers** show the sum of their own items.
- **Expanded headers are unchanged** — line totals are already visible below, so the header total appears only while the rows are hidden.
- Empty sections show `$0.00` when collapsed rather than hiding the figure.

## How

The sum reuses `sumLineItemsFromSections` (`src/lib/estimates-calc.ts`) — the same `quantity × unit_price` + `round2` summation that feeds the totals card — so a collapsed header always agrees with the document subtotal. Both builder modes get this for free since estimate and invoice line items share the `quantity`/`unit_price` fields the table reads.

Note: the issue screenshot shows the pre-#573 per-section card stack; this lands the same behavior in the grouped table that replaced it on main.

## Tests

Three new tests in `grouped-line-item-table.test.tsx` (written red-first):
- collapsed section header shows `$1,400.00` (direct + subsection items), hidden again on expand
- collapsed subsection header shows its own `$700.00`
- Collapse all shows totals on every section header, including `$0.00` for an empty section

`npx vitest run src/components/estimate-builder` → 20 files / 211 tests pass. ESLint clean on touched files; no tsc errors in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
