### PR TITLE
fix(photo-report): precise drop targeting on tall Section cards (#584)

### DIFF
--- a/src/components/photo-report-builder.tsx
+++ b/src/components/photo-report-builder.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import Link from "next/link";
 import {
   DndContext,
-  closestCenter,
   KeyboardSensor,
   PointerSensor,
   useDraggable,
@@ -45,6 +44,7 @@ import {
   type PhotoReportBuilderState,
 } from "@/lib/photo-report-builder";
 import { resolvePhotoReportDragEnd } from "@/lib/photo-report-drag";
+import { photoReportCollisionDetection } from "@/lib/photo-report-collision";
 import { AddPhotosDialog } from "@/components/photo-report-add-photos-dialog";
 import { measureWriteupFit, writeupLimitFor } from "@/lib/section-writeup-fit";
 import {
@@ -420,7 +420,7 @@ export default function PhotoReportBuilder({
           onDragEnd. */}
       <DndContext
         sensors={sensors}
-        collisionDetection={closestCenter}
+        collisionDetection={photoReportCollisionDetection}
         onDragEnd={handleDragEnd}
       >
         <div className="lg:flex lg:items-start lg:gap-6 lg:px-4 lg:py-6">
@@ -606,11 +606,11 @@ export default function PhotoReportBuilder({
               Slice-2b drag wiring. Sections are keyed (React key + dnd-kit
               sortable id) off their stable `id` (#467), so editing a Section then
               reordering it keeps input focus/caret pinned to that Section and the
-              reorder animates smoothly. One known low-severity follow-up remains,
-              left for a later slice: closestCenter targets the nearest section
-              *center*, so on very tall section cards a photo dropped near an edge
-              can land in the neighbouring section; a pointer-based strategy would
-              be more precise.
+              reorder animates smoothly. Drop targeting uses
+              photoReportCollisionDetection (#584): pointerWithin first, so a
+              photo dropped anywhere within a Section card's bounds — including
+              near the edge of a very tall card — lands in *that* Section, with
+              closestCenter as the keyboard-drag fallback.
             */}
             {/* Sections */}
             <SortableContext

--- a/src/lib/photo-report-collision.test.ts
+++ b/src/lib/photo-report-collision.test.ts
@@ -1,0 +1,87 @@
+// Issue #584 — precise drop targeting on tall Section cards.
+//
+// The shared DndContext in the Photo Report builder used closestCenter, which
+// targets the nearest droppable *center*. On a very tall Section card a photo
+// dropped near the card's edge could resolve to a neighbouring Section whose
+// center is geometrically closer (#467/#552 follow-up). photoReportCollisionDetection
+// replaces it with the standard dnd-kit composite for mixed-size droppables:
+// pointerWithin first (what the pointer is actually over), closestCenter as a
+// fallback for the no-pointer keyboard-drag path. These tests drive that
+// behaviour against the real dnd-kit algorithms, so they describe collision
+// *outcomes*, not the wiring.
+
+import { closestCenter, type Active, type CollisionDetection, type ClientRect } from "@dnd-kit/core";
+import type { Coordinates } from "@dnd-kit/utilities";
+import { describe, expect, it } from "vitest";
+
+import { photoReportCollisionDetection } from "./photo-report-collision";
+
+type CollisionArgs = Parameters<CollisionDetection>[0];
+
+function rect(left: number, top: number, width: number, height: number): ClientRect {
+  return { left, top, width, height, right: left + width, bottom: top + height };
+}
+
+// A minimal stand-in for dnd-kit's runtime collision args. Both algorithms read
+// only `id` off each droppable container (the rect comes from droppableRects)
+// and ignore `active`, so those two fields are cast rather than fully built.
+function args(opts: {
+  containers: Array<{ id: string; rect: ClientRect }>;
+  collisionRect: ClientRect;
+  pointer: Coordinates | null;
+}): CollisionArgs {
+  return {
+    active: { id: "dragged" } as unknown as Active,
+    collisionRect: opts.collisionRect,
+    droppableRects: new Map(opts.containers.map((c) => [c.id, c.rect])),
+    droppableContainers: opts.containers.map((c) => ({
+      id: c.id,
+    })) as unknown as CollisionArgs["droppableContainers"],
+    pointerCoordinates: opts.pointer,
+  };
+}
+
+describe("photoReportCollisionDetection", () => {
+  it("targets the card the pointer is over, not the neighbour whose center is closer", () => {
+    // A tall Section card with a short card stacked directly below it. The photo
+    // is dropped near the tall card's bottom edge — inside the tall card, but
+    // its rect's center is nearer the short card's center.
+    const tall = rect(0, 0, 300, 400); // center (150, 200)
+    const short = rect(0, 400, 300, 100); // center (150, 450)
+    const collisionArgs = args({
+      containers: [
+        { id: "tall", rect: tall },
+        { id: "short", rect: short },
+      ],
+      collisionRect: rect(110, 350, 80, 80), // dragged photo, center (150, 390)
+      pointer: { x: 150, y: 390 }, // inside `tall`, above `short`
+    });
+
+    // Guard: the old strategy reproduces the bug here — closestCenter mis-picks
+    // the neighbour because (150,390) is 60px from short's center but 190px from
+    // tall's. The composite must not.
+    expect(closestCenter(collisionArgs)[0]?.id).toBe("short");
+    expect(photoReportCollisionDetection(collisionArgs)[0]?.id).toBe("tall");
+  });
+
+  it("falls back to closestCenter when there is no pointer (keyboard drag)", () => {
+    // Keyboard drags (the rail's KeyboardSensor) carry no pointer, so
+    // pointerWithin finds nothing. The drop must still resolve — to the
+    // nearest droppable by center, exactly as before this change.
+    const tall = rect(0, 0, 300, 400);
+    const short = rect(0, 400, 300, 100);
+    const collisionArgs = args({
+      containers: [
+        { id: "tall", rect: tall },
+        { id: "short", rect: short },
+      ],
+      collisionRect: rect(110, 350, 80, 80), // center (150, 390), nearest short
+      pointer: null,
+    });
+
+    expect(photoReportCollisionDetection(collisionArgs)).toEqual(
+      closestCenter(collisionArgs),
+    );
+    expect(photoReportCollisionDetection(collisionArgs)[0]?.id).toBe("short");
+  });
+});

--- a/src/lib/photo-report-collision.ts
+++ b/src/lib/photo-report-collision.ts
@@ -1,0 +1,25 @@
+// Issue #584 — precise drop targeting on tall Section cards.
+//
+// The collision strategy for the Photo Report builder's shared DndContext. The
+// builder mixes droppables of very different sizes (a tall Section card next to
+// a short one), and closestCenter alone targets the nearest *center*, so a photo
+// dropped near a tall card's edge could land in a neighbour whose center is
+// geometrically closer (#467/#552 follow-up).
+//
+// This is the standard dnd-kit composite for mixed-size droppables: prefer what
+// the pointer is actually over (pointerWithin), and fall back to closestCenter
+// for the keyboard-drag path, which carries no pointer.
+
+import {
+  closestCenter,
+  pointerWithin,
+  type CollisionDetection,
+} from "@dnd-kit/core";
+
+export const photoReportCollisionDetection: CollisionDetection = (args) => {
+  const pointerCollisions = pointerWithin(args);
+  if (pointerCollisions.length > 0) {
+    return pointerCollisions;
+  }
+  return closestCenter(args);
+};


### PR DESCRIPTION
## What

Closes #584. The Photo Report builder's shared `DndContext` used `collisionDetection={closestCenter}`, which targets the nearest droppable **center**. On a very tall Section card a photo dropped near the card's edge could resolve to the **neighbouring** Section, because the neighbour's center is geometrically closer than the tall card's own center (the long-standing #467/#552 follow-up).

## How

Replace the single `closestCenter` with the standard dnd-kit composite for mixed-size droppables — a new `photoReportCollisionDetection` in `src/lib/photo-report-collision.ts`:

- **`pointerWithin` first** — resolves to what the pointer is actually over, so a photo dropped anywhere within a Section card's bounds (including near the edge of a very tall card) lands in **that** Section.
- **`closestCenter` fallback** — for the keyboard-drag path (the rail's `KeyboardSensor`), which carries no pointer; behaviour-preserving.

Kept in its own module so the dnd-kit-runtime-free resolver in `photo-report-drag.ts` stays untouched — the resolver needed no changes, as the issue predicted. The stale "known follow-up remains" comment in the builder is retired.

## Acceptance

> dropping a photo anywhere within a Section card's bounds — including near the edge of a tall card — assigns it to **that** card's Section.

## Tests (TDD, red→green)

New `src/lib/photo-report-collision.test.ts` drives behaviour against the **real** dnd-kit algorithms:

1. **Tall-card edge precision** — pointer inside a tall card near its bottom edge with a shorter neighbour whose center is closer; the composite returns the tall card. A guard assertion confirms plain `closestCenter` mis-picks the neighbour, proving the scenario reproduces the bug.
2. **Keyboard / no-pointer fallback** — `pointerCoordinates: null` falls back to `closestCenter`.

Regression: existing `photo-report-drag.test.ts` + `photo-report-builder.test.tsx` + `photo-report-builder-desktop.test.tsx` stay green (**71 tests pass** total). `tsc` adds zero new errors vs. clean HEAD; `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)