### PR TITLE
fix(photo-grid): square grid preview crop (#596)

### DIFF
--- a/src/app/photos/page.test.tsx
+++ b/src/app/photos/page.test.tsx
@@ -72,7 +72,7 @@ describe("/photos — grid thumbnails request the grid variant (#418)", () => {
 
     const img = (await screen.findByAltText("Kitchen before")) as HTMLImageElement;
     expect(img.getAttribute("src")).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 
@@ -100,7 +100,7 @@ describe("/photos — grid thumbnails request the grid variant (#418)", () => {
 
     const img = (await screen.findByAltText("Kitchen before")) as HTMLImageElement;
     expect(img.getAttribute("src")).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 });

--- a/src/lib/jobs/cover-photo.test.ts
+++ b/src/lib/jobs/cover-photo.test.ts
@@ -67,7 +67,7 @@ describe("resolveCoverPhotoUrl — resized preview (#420)", () => {
       SUPABASE_URL,
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 
@@ -78,7 +78,7 @@ describe("resolveCoverPhotoUrl — resized preview (#420)", () => {
       SUPABASE_URL,
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 });

--- a/src/lib/jobs/photo-preload.test.ts
+++ b/src/lib/jobs/photo-preload.test.ts
@@ -95,7 +95,7 @@ describe("pickPreloadUrls — uses the resolver's grid variant", () => {
       12,
     );
     expect(urls).toEqual([
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&height=400&quality=60&resize=cover",
     ]);
   });
 });

--- a/src/lib/jobs/photo-url.test.ts
+++ b/src/lib/jobs/photo-url.test.ts
@@ -28,7 +28,7 @@ describe("photoUrl — grid variant, resize flag on", () => {
       "grid",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 });
@@ -42,7 +42,7 @@ describe("photoUrl — annotated photo", () => {
       "grid",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 
@@ -54,7 +54,7 @@ describe("photoUrl — annotated photo", () => {
       "grid",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=400&height=400&quality=60&resize=cover",
     );
   });
 });
@@ -138,7 +138,7 @@ describe("photoUrl — unsupported format (grid, resize on)", () => {
       "grid",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/IMG_0042.JPG?width=400&quality=60&resize=cover",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/IMG_0042.JPG?width=400&height=400&quality=60&resize=cover",
     );
   });
 });

--- a/src/lib/jobs/photo-url.ts
+++ b/src/lib/jobs/photo-url.ts
@@ -11,9 +11,12 @@ export type PhotoVariant = "grid" | "full";
 const PHOTOS_OBJECT_PREFIX = "/storage/v1/object/public/photos/";
 const PHOTOS_RENDER_PREFIX = "/storage/v1/render/image/public/photos/";
 
-// Grid-preview transform parameters. Sensible starting point per ADR 0008
-// (~grid-square width, moderate quality, square crop); tune at go-live.
-const GRID_PREVIEW_QUERY = "?width=400&quality=60&resize=cover";
+// Grid-preview transform parameters (ADR 0008): a 400×400 square center-crop at
+// moderate quality, matching the aspect-square grid tile. Both width AND height
+// are required — `resize=cover` with only one dimension degenerates into a
+// full-height center strip (e.g. 400×4032 for a 3024×4032 portrait), which the
+// tile's CSS `object-cover` then zooms into hard (issue #596).
+const GRID_PREVIEW_QUERY = "?width=400&height=400&quality=60&resize=cover";
 
 // Formats Supabase image transformation can resize. A Photo's stored file
 // may be something the transformer rejects — a HEIC original from a web


### PR DESCRIPTION
Closes #596.

## Problem

Photo-grid previews render "highly zoomed in" — see the screenshot in #596.

**Root cause.** The grid-preview transform URL was `?width=400&quality=60&resize=cover` — `resize=cover` with only a **width** and no **height**. Supabase's image transform can't form a target box from one dimension, so it degenerates into a full-height center *strip*. A 3024×4032 portrait original came back as **400×4032**. The grid tile is `aspect-square` with CSS `object-cover`, so that tall sliver gets scaled to fill the square and anchored to the top → the extreme zoom.

Verified against a real prod photo:

| URL | Returned |
|---|---|
| Original | 3024×4032 (portrait) |
| Old grid `?width=400&…&resize=cover` | **400×4032** (164 KB) — broken strip |
| New grid `?width=400&height=400&…&resize=cover` | **400×400** square (32 KB) |

## Fix

Add `height=400` to the grid-preview query in `src/lib/jobs/photo-url.ts` — the single seam all grid URLs flow through (ADR 0008). `resize=cover` now has both dimensions and returns a proper 400×400 center-crop matching the square tile. Side benefit: ~5× smaller previews (32 KB vs 164 KB), which also helps the load-speed goal ADR 0008 originally targeted.

Updated the 5 test files that pin the exact query string; 41 affected tests pass.

## Rollout note

Only active where `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED=true` (Supabase Pro image transformation). The render endpoint is already serving 200s on prod, so the fix reaches live grids on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)