### PR TITLE
fix(photo-grid): enlarge date-group header text (#600)

### DIFF
--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -607,7 +607,7 @@ export default function JobPhotosTab({
                   onChange={() => toggleGroupSelect(group.photos)}
                   className="w-4 h-4 rounded border-2 border-muted-foreground/30 accent-[#2B5EA7] cursor-pointer"
                 />
-                <span className="text-[15px] font-semibold text-foreground">{group.label}</span>
+                <span className="text-lg font-semibold text-foreground">{group.label}</span>
               </div>
               {/* Photo grid */}
               <div


### PR DESCRIPTION
## Summary
The Job Photos tab date-group header (e.g. "Wednesday, May 27th, 2026") rendered at `text-[15px]`, which read small against the grid. Bump it to `text-lg` (18px) so the date-taken label is slightly larger and easier to scan — per the screenshot in #600.

One-line CSS change in the single date-header `<span>` (`src/components/job-photos-tab.tsx:610`). No test pins the class string; `job-photos-tab.test.tsx` passes (8/8).

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)