### PR TITLE
feat(phone): send outbound SMS via A2P Messaging Service when configured (#305)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,17 @@ STRIPE_CONNECT_CLIENT_SECRET=
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
 
+# A2P 10DLC Messaging Service SID — slice 1 (#305). LEAVE BLANK until the
+# Customer Care campaign clears The Campaign Registry (carrier review is
+# 1–3 weeks). The day it's approved: create/identify the Messaging Service
+# bound to the campaign, add the org's outbound number(s) to its sender pool,
+# then set this to the MG… SID. When set, POST /api/phone/messages sends
+# through the Service so US carriers associate the message with the approved
+# campaign and deliver it. When blank, outbound SMS is a bare per-number send
+# (fine for demo/dev; not deliverable to US handsets at scale pre-campaign).
+# Registration runbook: docs/runbooks/a2p-10dlc-registration.md.
+TWILIO_MESSAGING_SERVICE_SID=
+
 # Phone demo / dev mode — slice 15 (#368). Server-side flag. When 'true',
 # createTwilioClient() returns an in-process fake provider (no carrier, no
 # Twilio account needed) and POST /api/phone/dev/simulate-inbound becomes

--- a/docs/runbooks/a2p-10dlc-registration.md
+++ b/docs/runbooks/a2p-10dlc-registration.md
@@ -1,0 +1,211 @@
+# Runbook — A2P 10DLC brand + campaign registration (#305)
+
+> **This is paperwork, not engineering.** It is the longest-lead-time item in
+> PRD [#304](https://github.com/ericdaniels22/Nookleus/issues/304) — carrier
+> review runs **1–3 weeks** — and no outbound SMS reaches a real US handset at
+> scale until it clears. Start the day the issue is grabbed.
+>
+> The **code** that consumes this work is already merged and waiting behind a
+> flag (see [Code wiring](#code-wiring-already-in-place)). This document is the
+> recipe for the **carrier-side** steps a human runs in the Twilio Console +
+> The Campaign Registry (TCR), which no agent can do.
+
+## Why outbound SMS is gated on this
+
+US mobile carriers (AT&T, Verizon, T-Mobile, …) filter **A2P** (application-to-
+person) traffic at the gateway. Business SMS from an unregistered sender is
+silently dropped or heavily throttled. To deliver, the message must be sent
+through a **Twilio Messaging Service** that is bound to an **A2P campaign**
+registered with **TCR** under a **vetted brand**. That chain — brand → campaign
+→ messaging service → our sending numbers — is what this runbook builds.
+
+## The chain to build
+
+```
+AAA Disaster Recovery (legal entity)
+   └─ Brand          (TCR-vetted, Standard tier or higher)
+        └─ Campaign   (use-case: Customer Care)
+             └─ Messaging Service   (TWILIO_MESSAGING_SERVICE_SID)
+                  └─ sender pool: the org's outbound phone_numbers
+```
+
+---
+
+## Step 1 — Register the brand
+
+Twilio Console → **Messaging → Regulatory Compliance → A2P 10DLC → Brands**.
+Register under **AAA Disaster Recovery**'s legal entity (AAA is the prototype
+customer for the multi-tenant build, per the PRD).
+
+Fill from AAA's official records — these must match the IRS/Secretary-of-State
+filing exactly or vetting fails:
+
+| Field | Value |
+| --- | --- |
+| Legal company name | `AAA Disaster Recovery` _(confirm exact registered name)_ |
+| EIN / Tax ID | `__________` _(AAA's federal EIN — required)_ |
+| Business type | _(LLC / Corp / Sole-prop — per filing)_ |
+| Registered address | `__________` |
+| Website | `__________` |
+| Contact email / phone | `__________` |
+
+Submit for vetting. **Target: Standard tier or higher** (AC). Standard-tier
+vetting unlocks materially higher throughput than the unvetted/low tiers.
+
+- [ ] Brand submitted with EIN, legal name, address
+- [ ] Brand passes vetting at **Standard tier or higher**
+
+---
+
+## Step 2 — Register the campaign (use-case: Customer Care)
+
+Twilio Console → **A2P 10DLC → Campaigns** → new campaign under the vetted brand.
+
+**Use-case: `Customer Care`** — transactional + relationship messaging with
+**consenting customers**: quotes, job-status updates, photo replies, and
+voicemail-from-Nookleus notifications.
+
+### Campaign description (draft — tighten to AAA's reality)
+
+> Nookleus is the field-operations app AAA Disaster Recovery uses to
+> communicate with its own customers about active jobs. Messages are sent by
+> AAA staff to customers who have an existing service relationship: estimate /
+> quote delivery, job-status updates, replies that include job-site photos, and
+> notifications that a voicemail was left. Customers reply in the same thread.
+
+### Consent / opt-in (Customer Care)
+
+Describe how consent is captured. Customers are existing AAA service contacts;
+the first message is staff-initiated within an active service relationship, not
+bulk marketing. **Document the real opt-in mechanism** (intake form, signed
+work authorization, verbal-at-intake, etc.) — TCR requires a truthful opt-in
+description, and this is AAA-specific information the runbook can't fill in.
+
+- [ ] Opt-in flow described truthfully for AAA's intake
+
+### Opt-out / HELP behavior — declare what the app actually does
+
+These are the behaviors the carrier campaign description must match. Note the
+two have different gating in code:
+
+- **STOP** (and `UNSUBSCRIBE / END / QUIT / CANCEL / STOPALL`) → **unconditional
+  today.** The sender is added to the org-wide opt-out registry and **all**
+  further outbound to that number is refused. The app sends **no** auto-reply
+  on STOP — Twilio emits the carrier-mandated opt-out confirmation. (See
+  `opt-out-registry.ts`, `ingest-inbound.ts` — runs before any flag check.)
+- **HELP / INFO** → the app auto-replies, **but only once outbound is enabled**
+  (`ingest-inbound.ts` gates it on `isPhoneOutboundEnabled()` — the same
+  `NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED` flag Step 4 flips). Until then no HELP
+  reply is sent. At go-live it replies with, verbatim:
+
+  > `<Org name>: Reply STOP to unsubscribe. Standard message rates apply.`
+
+  (`ingest-inbound.ts` — `helpReplyBody`.)
+
+### Sample message bodies — must match what slices 5/6 actually send
+
+Paste representative samples that mirror real sends (quotes, status, photo-MMS,
+voicemail notice, and the HELP reply). Suggested set:
+
+1. `AAA Disaster Recovery: your quote for the water-damage cleanup is ready — reply here with any questions.`
+2. `Update on your job: our crew is scheduled to arrive tomorrow between 9–11am. Reply STOP to unsubscribe.`
+3. `Here are photos from today's work at your property.` _(MMS — slice 6 / #310, image attached)_
+4. `You have a new voicemail from AAA Disaster Recovery. Open the Nookleus thread to listen.`
+5. `AAA Disaster Recovery: Reply STOP to unsubscribe. Standard message rates apply.` _(HELP auto-reply, verbatim)_
+
+> Keep at least one sample showing the **opt-out language** (`Reply STOP …`) —
+> reviewers look for it. Samples should read like the free-text a Crew Lead
+> actually types from the compose box, not marketing copy.
+
+- [ ] Campaign registered under **Customer Care** with sample bodies matching slices 5/6
+- [ ] Campaign **approved by TCR**
+
+---
+
+## Step 3 — Messaging Service + capture the SID
+
+Twilio Console → **Messaging → Services**.
+
+1. Create (or identify) a **Messaging Service** and **attach the approved
+   campaign** to it.
+2. Add the org's outbound number(s) — the rows in `phone_numbers` Nookleus
+   sends from — to the Service's **sender pool**. The send keeps its specific
+   `from` number (Nookleus selects Personal-if-any-else-Shared), and Twilio
+   requires that `from` be in the Service's pool, so **every number Nookleus
+   sends from must be added here.**
+3. Copy the Service SID (`MG…`).
+
+### Set the env var
+
+Set in the deployment environment (e.g. Vercel) **and** `.env.local` for any
+local real-carrier testing:
+
+```bash
+TWILIO_MESSAGING_SERVICE_SID=MGxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+When set, `POST /api/phone/messages` sends through the Service so carriers
+associate each message with the approved campaign. When blank, the send is a
+bare per-number dispatch (correct for demo/dev; **not** deliverable at scale).
+This is a plain server-side env var (not `NEXT_PUBLIC_`), so a runtime change +
+restart is enough — no rebuild required.
+
+- [ ] Messaging Service created and bound to the approved campaign
+- [ ] Org's outbound number(s) added to the Service's sender pool
+- [ ] `TWILIO_MESSAGING_SERVICE_SID` set in environment config
+
+---
+
+## Step 4 — Flip outbound on
+
+Outbound SMS is *also* behind the slice-5 feature flag
+(`NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED`, see
+[`src/lib/phone/feature-flags.ts`](../../src/lib/phone/feature-flags.ts) and
+[`src/lib/phone/README.md`](../../src/lib/phone/README.md)). The two are
+independent:
+
+| Var | Effect | Change requires |
+| --- | --- | --- |
+| `TWILIO_MESSAGING_SERVICE_SID` | A2P campaign association on send | restart |
+| `NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED=true` | Reveals the outbound UI + lifts the route's 503 gate | **rebuild** (inlined into the client bundle at build time) |
+
+The day the campaign clears: set **both**, redeploy, and outbound is live and
+deliverable.
+
+- [ ] `NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED=true` set and redeployed
+
+---
+
+## Step 5 — Document the outcome on #305 (AC)
+
+Post a final comment on issue #305 recording, for future-us:
+
+- **Approval date** of the campaign.
+- **Per-month / per-day throughput tier** granted (the T-tier message limits the
+  brand/campaign was approved for — this is what we're rate-limited to).
+- The **Messaging Service SID** (or where it's stored).
+
+- [ ] Approval date + throughput tier documented in #305's final comment
+
+---
+
+## Code wiring already in place
+
+Future-us: the application side is **done and tested** — only the carrier steps
+above remain. Nothing else needs to change in code to go live.
+
+- [`src/lib/phone/twilio-client.ts`](../../src/lib/phone/twilio-client.ts) —
+  `sendSms` forwards `messagingServiceSid` to Twilio when supplied, keeping
+  `from` for deterministic sender selection (the A2P "dual form").
+- [`src/app/api/phone/messages/route.ts`](../../src/app/api/phone/messages/route.ts) —
+  reads `TWILIO_MESSAGING_SERVICE_SID` and threads it into every send.
+- [`src/lib/phone/feature-flags.ts`](../../src/lib/phone/feature-flags.ts) —
+  the `NEXT_PUBLIC_PHONE_OUTBOUND_ENABLED` gate.
+- Tests: `twilio-client.test.ts` (forwarding + dual form),
+  `messages/route.test.ts` (env threaded in when set, omitted when unset).
+
+## Related
+
+- ADR [0006](../adr/0006-twilio-as-telephony-backbone.md) — Twilio as the telephony backbone.
+- ADR [0005](../adr/0005-shared-and-personal-phone-numbers.md) — Shared vs Personal numbers (the `from` selection rule).
+- PRD [#304](https://github.com/ericdaniels22/Nookleus/issues/304); slices #309 (outbound SMS), #310 (MMS), #368 (demo mode).

--- a/src/app/api/phone/messages/route.test.ts
+++ b/src/app/api/phone/messages/route.test.ts
@@ -257,6 +257,57 @@ describe("POST /api/phone/messages — feature flag", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 0b. A2P 10DLC Messaging Service (#305).
+//
+// Once the Customer Care campaign clears carrier review, outbound SMS must be
+// sent through the campaign's Messaging Service or US carriers drop it. The
+// route reads the Service SID from TWILIO_MESSAGING_SERVICE_SID and threads it
+// into the Twilio dispatch. When the env var is unset (today, and in demo
+// mode) the send stays a bare per-number send — no behavior change.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/messages — A2P Messaging Service (#305)", () => {
+  it("passes TWILIO_MESSAGING_SERVICE_SID into the Twilio send when set", async () => {
+    vi.stubEnv(
+      "TWILIO_MESSAGING_SERVICE_SID",
+      "MG0123456789abcdef0123456789abcdef",
+    );
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({ phone_numbers: [SHARED_NUM_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", body: "your quote is ready" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(sendSmsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        messagingServiceSid: "MG0123456789abcdef0123456789abcdef",
+      }),
+    );
+  });
+
+  it("omits messagingServiceSid from the Twilio send when the env var is unset (pre-A2P / demo mode)", async () => {
+    vi.stubEnv("TWILIO_MESSAGING_SERVICE_SID", "");
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({ phone_numbers: [SHARED_NUM_ROW] });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", body: "hi" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    const sendArgs = sendSmsMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(sendArgs).not.toHaveProperty("messagingServiceSid");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 1. Permission gate
 // ---------------------------------------------------------------------------
 

--- a/src/app/api/phone/messages/route.ts
+++ b/src/app/api/phone/messages/route.ts
@@ -386,6 +386,13 @@ export const POST = withRequestContext(
 
     // Dispatch via Twilio.
     const statusCallback = process.env.PHONE_STATUS_CALLBACK_URL || undefined;
+    // Slice 1 (#305) — A2P 10DLC. The day the Customer Care campaign clears
+    // carrier review, set TWILIO_MESSAGING_SERVICE_SID so every outbound send
+    // is associated with the approved campaign's Messaging Service (US
+    // carriers drop A2P traffic that isn't). Until then the var is unset and
+    // this is a bare per-number dispatch — unchanged behavior.
+    const messagingServiceSid =
+      process.env.TWILIO_MESSAGING_SERVICE_SID || undefined;
     let dispatch: { sid: string; status: string };
     try {
       dispatch = await sendSms(createTwilioClient(), {
@@ -394,6 +401,7 @@ export const POST = withRequestContext(
         body: messageBody,
         statusCallback,
         ...(mediaUrl ? { mediaUrl } : {}),
+        ...(messagingServiceSid ? { messagingServiceSid } : {}),
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Twilio error";

--- a/src/lib/phone/fake-twilio-client.ts
+++ b/src/lib/phone/fake-twilio-client.ts
@@ -111,6 +111,9 @@ export function createFakeTwilioClient(): TwilioClientLike {
         body: string;
         statusCallback?: string;
         mediaUrl?: string[];
+        // Slice 1 (#305) — accepted for interface parity. The fake reaches no
+        // carrier, so there is no campaign to associate; the SID is ignored.
+        messagingServiceSid?: string;
       }) {
         return {
           sid: `SM${fakeSidTail()}`,

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -382,6 +382,69 @@ describe("sendSms", () => {
       }),
     ).rejects.toThrow(/body|media/i);
   });
+
+  // Slice 1 (#305) — A2P 10DLC. US carriers only deliver outbound business
+  // SMS that is associated with the registered campaign's Messaging Service.
+  // When a messagingServiceSid is supplied it rides along in the SDK call so
+  // Twilio attaches the message to the approved campaign.
+  it("includes the messagingServiceSid in the SDK call when provided (#305 A2P campaign association)", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMa2p", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "your quote is ready",
+      messagingServiceSid: "MG0123456789abcdef0123456789abcdef",
+    });
+    const payload = (messageCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      messagingServiceSid: "MG0123456789abcdef0123456789abcdef",
+    });
+  });
+
+  // The A2P dual form: a messagingServiceSid does NOT replace `from`. Nookleus
+  // selects a specific outbound number (Personal-if-any-else-Shared), so the
+  // send must keep that `from` (Twilio requires it be in the Service's sender
+  // pool) AND carry the Service SID for the campaign association.
+  it("keeps `from` alongside the messagingServiceSid (deterministic sender + campaign association)", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMa2p", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "your quote is ready",
+      messagingServiceSid: "MG0123456789abcdef0123456789abcdef",
+    });
+    const payload = (messageCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toMatchObject({
+      from: "+15125550000",
+      messagingServiceSid: "MG0123456789abcdef0123456789abcdef",
+    });
+  });
+
+  // Mirrors the statusCallback / mediaUrl omit tests above: a falsy
+  // messagingServiceSid must NOT reach the SDK as a present-but-empty key
+  // (an explicit blank Service SID is not the same as omitting it).
+  it("omits messagingServiceSid from the SDK call when none is provided", async () => {
+    const messageCreateSpy = vi.fn(async () => ({ sid: "SMa", status: "queued" }));
+    const client = fakeClient({ messageCreateSpy });
+    await sendSms(client, {
+      from: "+15125550000",
+      to: "+15551234567",
+      body: "hi",
+    });
+    const payload = (messageCreateSpy.mock.calls[0] as unknown[])[0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).not.toHaveProperty("messagingServiceSid");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -68,6 +68,9 @@ export interface TwilioClientLike {
       body: string;
       statusCallback?: string;
       mediaUrl?: string[];
+      // Slice 1 (#305) — A2P 10DLC. Associates the message with the
+      // registered campaign's Messaging Service so US carriers deliver it.
+      messagingServiceSid?: string;
     }): Promise<{ sid: string; status: string }>;
   };
   // Slice 10 (#314) — outbound bridge calling. We use the inline-`twiml`
@@ -200,6 +203,12 @@ export interface SendSmsParams {
   // URL Twilio downloads from; pass an empty/undefined array for plain SMS.
   // An MMS may carry an empty body provided at least one mediaUrl is set.
   mediaUrl?: string[];
+  // Slice 1 (#305) — A2P 10DLC. The SID of the Messaging Service bound to the
+  // approved Customer Care campaign. When set, the message is sent through the
+  // Service (alongside `from`, which must be in the Service's sender pool) so
+  // US carriers associate it with the campaign and deliver it. Omitted until
+  // the campaign clears carrier review — see TWILIO_MESSAGING_SERVICE_SID.
+  messagingServiceSid?: string;
 }
 
 export interface SendSmsResult {
@@ -242,6 +251,7 @@ export async function sendSms(
     body: string;
     statusCallback?: string;
     mediaUrl?: string[];
+    messagingServiceSid?: string;
   } = {
     from: params.from,
     to: params.to,
@@ -249,6 +259,10 @@ export async function sendSms(
   };
   if (params.statusCallback) payload.statusCallback = params.statusCallback;
   if (hasMedia) payload.mediaUrl = params.mediaUrl;
+  // Slice 1 (#305) — A2P campaign association, when configured.
+  if (params.messagingServiceSid) {
+    payload.messagingServiceSid = params.messagingServiceSid;
+  }
   const created = await client.messages.create(payload);
   return { sid: created.sid, status: created.status };
 }


### PR DESCRIPTION
## Summary

Relates to #305 — the **engineering portion**. #305 is fundamentally A2P 10DLC **carrier paperwork** (brand + campaign registration via the Twilio Console / The Campaign Registry, with a 1–3 week carrier review), which can't be done in code, so this PR does **not** close the issue. It implements the one real code gap #305 exposes, plus the env slot + runbook, so the day the campaign clears is a flip-the-flag day rather than a build day.

**The gap:** the slice-5 outbound route sent from a bare `from` number with no Messaging Service. Once the Customer Care campaign clears, traffic still wouldn't be associated with it and US carriers would drop it.

**The wiring:**
- `sendSms` forwards `messagingServiceSid` to Twilio when supplied, keeping `from` alongside it — the A2P "dual form" (the number must be in the Service's sender pool; the Service carries the campaign association).
- `POST /api/phone/messages` reads `TWILIO_MESSAGING_SERVICE_SID` and threads it in when set. When unset (today / demo mode) behavior is unchanged: a bare per-number send.
- The in-process fake Twilio provider is kept at interface parity.
- `.env.example` documents the new var; `docs/runbooks/a2p-10dlc-registration.md` is the registration recipe — brand/campaign/Service steps, Customer Care copy, sample message bodies matching what slices 5/6 actually send, and an AC-mirrored go-live checklist.

## Still human-only (not in this PR)

Brand + campaign submission with AAA Disaster Recovery's EIN, TCR approval, the real `MG…` SID, and the approval-date/throughput comment on #305 — all need a live Twilio account + carrier review. The runbook is the fill-in-the-blank for these.

## Test plan

- `twilio-client.test.ts` — `sendSms` forwards the SID / keeps `from` (dual form) / omits when absent.
- `messages/route.test.ts` — route passes the env var when set / omits when unset.
- **70/70 green against current `main`**; `tsc` clean for changed files; ESLint clean.
- Reviewed via a multi-agent adversarial pass: 3 low/nit findings fixed, 1 rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
