### PR TITLE
docs(marketing): ADR 0015 + Showcase/Website-connection glossary terms (#538)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -267,6 +267,30 @@ deliberate user click — no automated promotions. Active is the only
 status that makes the row a Referral Partner in the strict sense.
 _Avoid_: stage, pipeline status, partner status
 
+**Showcase**:
+A public-facing story of one Job — selected Photos plus a write-up — that
+markets the Organization's work. The write-up is AI-drafted on request,
+human-edited, and published as a real post on the Organization's connected
+WordPress site; a published Showcase is also the source material social
+posts are drafted from. At most one per Job, started manually from the Job
+(any status) — never auto-created; the Marketing area nudges by listing
+recently-completed Jobs without one. Drafts scrub identifying customer
+details by default (city-level location only, no names or exact addresses),
+and publishing requires a one-click confirmation that the customer is OK
+with the photos going public.
+_Avoid_: portfolio item, case study, project post (those are renderings of
+a Showcase, not the thing itself)
+
+**Website connection**:
+An Organization's credentialed link to its own public marketing website,
+which Showcase publishing writes posts onto. WordPress-only at first: the
+site URL plus a WordPress Application Password scoped to writing posts —
+created by the business, pasted into Nookleus settings, revocable from
+WordPress at any time, stored encrypted. Same trust shape as a QuickBooks
+connection or an Email account: per-Organization, opt-in, never a shared
+admin login. An Organization without one simply has no site publishing.
+_Avoid_: site integration, WP hookup, website sync
+
 ## Relationships
 
 - A **User** belongs to one or more **Organizations**; each membership carries a role.
@@ -283,6 +307,7 @@ _Avoid_: stage, pipeline status, partner status
 - An **Estimate** or **Invoice** has zero or one **PDF layout** of its own; with none it renders using its Organization's **default preset**. A document's own layout always wins over the default, resolved by a pure precedence rule, and is locked once the document is frozen (Estimate converted, Invoice paid or voided). A **PDF preset** belongs to one **Organization** and seeds a document's layout; applying one copies its preferences in, it is not a binding link.
 - A **Job** has zero or more **Photo Reports**; each Photo Report belongs to exactly one Job, gathers that Job's **Photos** into ordered **Sections**, and is created and edited only from within the Job. Reports are numbered per Job (Report #1, #2, …). Each Photo Report also owns a per-report **Cover Page** and per-report **Report Settings**, seeded from the Organization at creation (the settings from the **Report layout default**, the cover photo from the Job) and editable per report thereafter — a later change to the Organization default does not rewrite an existing report.
 - A **Photo Report template** belongs to one **Organization** and seeds a new Photo Report's **Sections**; applying one is a starting point, not a binding link.
+- A **Job** has zero or one **Showcase**; a Showcase belongs to exactly one Job and gathers that Job's **Photos** plus a write-up for public marketing.
 - An **Organization** has one **Report layout default**; it seeds every new Photo Report's **Report Settings** at creation and is not a binding link (the report keeps its own copy). Distinct from a **Photo Report template**, which seeds Sections rather than look.
 
 ## Example dialogue

--- a/docs/adr/0015-marketing-suite-publishes-to-own-site-direct-google-apis.md
+++ b/docs/adr/0015-marketing-suite-publishes-to-own-site-direct-google-apis.md
@@ -1,0 +1,68 @@
+# Marketing suite publishes to the org's own website and goes direct to Google; social aggregator deferred
+
+**Status:** Accepted
+**Date:** 2026-06-10 (grilling session for issue #538)
+
+## Context
+
+Issue #538 ("Marketing Suite Upgrade") proposes four pillars: Showcases
+(portfolio), social publishing, review management, and insights — plus
+Google Business Profile sync and a Google Ads question. The half-built
+`/marketing` tab already AI-drafts social copy into `marketing_drafts`,
+but nothing publishes anywhere. The grilling session resolved where
+content lives and which integrations carry the first slices.
+
+## Decision
+
+1. **A Showcase publishes onto the Organization's own website, not a
+   Nookleus-hosted page.** Via a **Website connection** (WordPress REST
+   API + a posts-scoped Application Password; see CONTEXT.md). The SEO
+   value of fresh, geo-tagged project content must accrue to the org's
+   own domain (for AAA: aaadisasterrecovery.com) — Nookleus is a content
+   feeder, never a web host. Orgs without WordPress simply have no site
+   publishing for now.
+2. **Google integrations are direct, not via an aggregator.** One
+   per-org Google OAuth connection carries GBP reviews (the first
+   slice: read + AI-drafted human-approved replies), GBP posts, GBP
+   performance, Search Console, Google Ads, and Local Services Ads
+   reporting (both read-only). Review scope is **Google-only** —
+   Facebook needs the deferred Meta app review; Yelp has no reply API.
+3. **Social publishing (FB/IG/LinkedIn/TikTok/X) is deferred.** It is
+   the lowest-priority pillar. When it comes, the plan is **hybrid**: a
+   middleman aggregator (e.g. Ayrshare) rather than six per-platform
+   API approval processes (realistically 1–3 months before the first
+   automated post). The deferral is deliberate — do not "finish" the
+   marketing_drafts platforms by building direct Meta/TikTok/X
+   integrations.
+4. **Showcase privacy is a product rule, not reviewer discretion.**
+   Drafts scrub identifying customer details by default (city-level
+   location only — also what local SEO wants); publishing requires a
+   one-click "customer is OK with these photos" confirmation.
+
+## Considered options
+
+- **Nookleus-hosted public portfolio pages.** Rejected: the SEO accrues
+  to Nookleus's domain instead of the customer's, and it makes Nookleus
+  a public web host (custom domains, uptime, indexing) for no gain.
+- **Embed widget on the org's site.** Rejected as primary: JS-served
+  content is weaker for indexing and styling; may return as a
+  homepage strip later.
+- **Direct social APIs now.** Rejected: months of Meta/LinkedIn/TikTok/X
+  approvals for the pillar the owner ranked last.
+- **Aggregator for everything, including reviews.** Rejected: a monthly
+  fee for capability Google grants directly, and the wanted GBP depth
+  (hours, services, performance) needs the direct API regardless.
+
+## Consequences
+
+- Confirmed build order: ① Google connection + reviews, ② Showcases →
+  WordPress, ③ Showcase → GBP post (free extra channel on the same
+  API), ④ Insights v1 answering cost-per-lead by source. Deferred:
+  social aggregator, GBP hours/services editing, campaign management.
+- Google Cloud project + API access applications (GBP API, Ads
+  developer token) must be filed on day one of slice ①; approvals
+  take days to weeks and gate live data, not the build.
+- Review requests are **manual-only**: a button on the job page (no
+  auto-send, no nudge list) — the owner keeps per-customer judgment.
+- A one-time, non-product task accompanies slice ②: add a "Recent
+  Projects" nav item + post template to the `aaa-website-wp` theme.


### PR DESCRIPTION
Records the #538 grilling-session decisions: **Showcase** and **Website connection** glossary terms in CONTEXT.md, and [ADR 0015](docs/adr/0015-marketing-suite-publishes-to-own-site-direct-google-apis.md) (showcases publish to the org's own WordPress site; Google APIs direct; social aggregator deferred).

PRD: #603 · Slices: #604–#616 (their ADR links resolve once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)