### PR TITLE
feat(phone): call recording + legal consent notice + playback (#315)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -115,6 +115,26 @@ business), whereas an untagged event on the same Personal number is
 owner-only — see [ADR 0005](docs/adr/0005-shared-and-personal-phone-numbers.md).
 _Avoid_: job link, attribution, assignment
 
+**Call recording**:
+The recorded audio of an _answered_ voice call (inbound or outbound bridge) —
+one `phone_recordings` row per call, with the audio copied into Nookleus's own
+storage so it outlives Twilio's retention and deletion is under the
+Organization's control. Distinct from a **Voicemail** (an unanswered call's
+left message, which has its own row and transcript). Recording is on by default
+per Organization (`recording_enabled_default`), with a per-call override on the
+outbound bridge; every recorded call plays the Recording consent notice at the
+start — see [ADR 0006](docs/adr/0006-twilio-as-telephony-backbone.md).
+_Avoid_: tape, capture, the call log
+
+**Recording consent notice**:
+The single, legally-required spoken line played to _both_ parties at the start
+of every recorded call: "This call may be recorded for quality and reference."
+Its one source of truth is `src/lib/phone/recording-consent.ts`, snapshot-pinned
+so the wording can never change silently; it covers all 50 states including
+two-party-consent jurisdictions. The initiating party hears it before the dial;
+the answering party hears the same line via a per-leg whisper.
+_Avoid_: disclaimer, warning, disclosure
+
 **Active job**:
 A job that is still alive — its status is neither `completed` nor `cancelled`,
 and it has not been trashed (`deleted_at IS NULL`). A cancelled job is dead,
@@ -301,6 +321,7 @@ _Avoid_: site integration, WP hookup, website sync
 - A **Phone number** belongs to one **Organization**; a **Personal phone number** is additionally owned by one **User**, a **Shared phone number** by none.
 - A **Conversation** is identified by the pair (one of the Organization's Phone numbers, one outside phone number) and groups its events on the Contact whose phone number matches the outside number.
 - A **Job tag** ties one text or call event to exactly zero or one **Job**. A single Conversation may contain events with several different Job tags (or none).
+- A **Call recording** belongs to exactly one answered voice call (one recording per call); deleting the call cascades the recording, and deleting the recording also hard-deletes it on Twilio. Whether a call records is governed per **Organization** by `recording_enabled_default`, overridable per call on the outbound bridge — see [ADR 0006](docs/adr/0006-twilio-as-telephony-backbone.md).
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 - A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).

--- a/src/app/api/phone/calls/route.test.ts
+++ b/src/app/api/phone/calls/route.test.ts
@@ -264,6 +264,73 @@ describe("POST /api/phone/calls — bridge dispatch", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 1b. Call recording + consent (#315) — the bridge records by org default,
+//     suppressible per call.
+// ---------------------------------------------------------------------------
+
+describe("POST /api/phone/calls — call recording + consent (#315)", () => {
+  it("records the bridge with consent when the org records calls by default", async () => {
+    vi.stubEnv(
+      "PHONE_RECORDING_CALLBACK_URL",
+      "https://example.com/api/phone/webhook/recording-completed",
+    );
+    vi.stubEnv(
+      "PHONE_RECORDING_WHISPER_URL",
+      "https://example.com/api/phone/webhook/recording-whisper",
+    );
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      organizations: [{ id: ORG, recording_enabled_default: true }],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({ outsideE164: "+15551234567", sourceContext: "phone-tab" }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(buildBridgeTwimlMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customerE164: "+15551234567",
+        callerId: "+15125550000",
+        recordCall: true,
+        callRecordingStatusCallback:
+          "https://example.com/api/phone/webhook/recording-completed",
+        consentWhisperUrl:
+          "https://example.com/api/phone/webhook/recording-whisper",
+      }),
+    );
+  });
+
+  it("suppresses recording for a single call when the payload overrides recordCall:false", async () => {
+    authed("user-1", "crew_lead");
+    const { client } = makeServiceClient({
+      phone_numbers: [SHARED_NUM_ROW],
+      user_profiles: [CREW_PROFILE],
+      organizations: [{ id: ORG, recording_enabled_default: true }],
+    });
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      sendReq({
+        outsideE164: "+15551234567",
+        sourceContext: "phone-tab",
+        recordCall: false,
+      }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(buildBridgeTwimlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ recordCall: false }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 2. Opt-out gate — refused BEFORE any Twilio call (TCPA).
 // ---------------------------------------------------------------------------
 

--- a/src/app/api/phone/calls/route.ts
+++ b/src/app/api/phone/calls/route.ts
@@ -52,6 +52,10 @@ interface Body {
   // Valid sources: 'phone-tab' / 'contact' / 'contact-card' (untagged) and
   // `{ kind: 'job', jobId }` (Job-page Call, auto-tagged to that Job).
   sourceContext?: unknown;
+  // Slice 11 (#315) — per-call recording override. Omitted → the org's
+  // recording_enabled_default. Explicit `false` suppresses both the consent
+  // notice and the recording for THIS call (the override the issue specifies).
+  recordCall?: unknown;
 }
 
 const E164_RE = /^\+[1-9]\d{6,14}$/;
@@ -291,12 +295,31 @@ export const POST = withRequestContext(
     });
     const jobTag = smartAttach.kind === "auto" ? smartAttach.jobId : null;
 
+    // Slice 11 (#315) — recording decision for this call. Default to the org's
+    // recording_enabled_default (NOT NULL default true); a per-call override in
+    // the payload (recordCall:false) suppresses recording for THIS call only.
+    // When on, the bridge speaks the consent notice to the crew lead, records
+    // the conversation dual-channel to the recording-completed webhook, and
+    // whispers the same notice to the customer leg.
+    const { data: orgRow } = await ctx.serviceClient!
+      .from("organizations")
+      .select("recording_enabled_default")
+      .eq("id", ctx.orgId)
+      .maybeSingle<{ recording_enabled_default: boolean }>();
+    const overrideRecord =
+      typeof body.recordCall === "boolean" ? body.recordCall : undefined;
+    const recordCall = overrideRecord ?? orgRow?.recording_enabled_default ?? false;
+
     // Dispatch via Twilio. The inline bridge TwiML presents the Nookleus
     // number to the customer; `placeBridgeCall` rings the crew lead's cell
     // (`to`) FROM the Nookleus number (`from`) and runs the TwiML on answer.
     const twiml = buildBridgeTwiml({
       customerE164: outsideE164,
       callerId: fromNumber.e164,
+      recordCall,
+      callRecordingStatusCallback:
+        process.env.PHONE_RECORDING_CALLBACK_URL || undefined,
+      consentWhisperUrl: process.env.PHONE_RECORDING_WHISPER_URL || undefined,
     });
     const statusCallback =
       process.env.PHONE_VOICE_STATUS_CALLBACK_URL || undefined;

--- a/src/app/api/phone/conversations/[id]/calls/route.test.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.test.ts
@@ -185,4 +185,86 @@ describe("GET /api/phone/conversations/[id]/calls", () => {
     const body = await res.json();
     expect(body[0].voicemail).toBeNull();
   });
+
+  // Slice 11 (#315) — an answered call carries its recording inline so the
+  // thread can render a play control on the call event. Same flatten as
+  // voicemail: PostgREST embeds the (0-or-1, UNIQUE per call) phone_recordings
+  // row; the route collapses it to a single `recording` field.
+  it("flattens an embedded recording onto the call as `recording`", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      {
+        id: "call-rec",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "out",
+        status: "completed",
+        duration_seconds: 42,
+        started_at: "2026-05-27T12:00:00Z",
+        ended_at: "2026-05-27T12:00:42Z",
+        phone_recordings: [
+          {
+            id: "rec-1",
+            audio_storage_path: "org-1/rec-1.mp3",
+            consent_notice_played: true,
+            duration_seconds: 42,
+          },
+        ],
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].recording).toEqual({
+      id: "rec-1",
+      audio_storage_path: "org-1/rec-1.mp3",
+      consent_notice_played: true,
+      duration_seconds: 42,
+    });
+    // The raw PostgREST embed key is gone — the client sees only `recording`.
+    expect("phone_recordings" in body[0]).toBe(false);
+  });
+
+  it("sets recording to null for a call with no recording", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      {
+        id: "call-norec",
+        organization_id: "org-1",
+        conversation_id: "conv-1",
+        direction: "out",
+        status: "completed",
+        duration_seconds: 30,
+        started_at: "2026-05-27T13:00:00Z",
+        ended_at: "2026-05-27T13:00:30Z",
+        phone_recordings: [],
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/conversations/conv-1/calls"),
+      params("conv-1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body[0].recording).toBeNull();
+  });
 });

--- a/src/app/api/phone/conversations/[id]/calls/route.ts
+++ b/src/app/api/phone/conversations/[id]/calls/route.ts
@@ -14,24 +14,26 @@ import { withRequestContext } from "@/lib/request-context/with-request-context";
 // it back.
 //
 // Slice 9 (#313) — each call also embeds its voicemail (recording +
-// transcript). The embed runs under the same User-client RLS, so a row the
-// caller can't see is simply absent. PostgREST returns the embed as an array
-// keyed off the child FK; since phone_voicemails is UNIQUE per call we
-// flatten it to a single `voicemail | null` for the client.
+// transcript). Slice 11 (#315) — and its call recording. Both embeds run under
+// the same User-client RLS, so a row the caller can't see is simply absent.
+// PostgREST returns each embed as an array keyed off the child FK; since both
+// children are UNIQUE per call we flatten each to a single `voicemail | null` /
+// `recording | null` for the client. A call can have BOTH (e.g. a recorded
+// answered call) or neither — the two flatten passes are independent.
 
 const FIELDS =
-  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at, phone_voicemails(id, audio_storage_path, transcript, transcript_status, duration_seconds)";
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at, phone_voicemails(id, audio_storage_path, transcript, transcript_status, duration_seconds), phone_recordings(id, audio_storage_path, consent_notice_played, duration_seconds)";
 
-// Flatten PostgREST's embed array (0-or-1 row, UNIQUE per call) into a single
-// `voicemail` field, dropping the raw embed key.
-function flattenVoicemail(row: Record<string, unknown>): Record<string, unknown> {
-  const { phone_voicemails, ...call } = row as {
-    phone_voicemails?: unknown;
-  } & Record<string, unknown>;
-  const voicemail = Array.isArray(phone_voicemails)
-    ? (phone_voicemails[0] ?? null)
-    : (phone_voicemails ?? null);
-  return { ...call, voicemail };
+// Collapse PostgREST's 0-or-1 embed array (UNIQUE per call) under `embedKey`
+// into a single `field` on the call, dropping the raw embed key.
+function flattenChild(
+  row: Record<string, unknown>,
+  embedKey: string,
+  field: string,
+): Record<string, unknown> {
+  const { [embedKey]: embed, ...rest } = row;
+  const value = Array.isArray(embed) ? (embed[0] ?? null) : (embed ?? null);
+  return { ...rest, [field]: value };
 }
 
 export const GET = withRequestContext(
@@ -46,8 +48,12 @@ export const GET = withRequestContext(
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
-    const calls = ((data ?? []) as Record<string, unknown>[]).map(
-      flattenVoicemail,
+    const calls = ((data ?? []) as Record<string, unknown>[]).map((row) =>
+      flattenChild(
+        flattenChild(row, "phone_voicemails", "voicemail"),
+        "phone_recordings",
+        "recording",
+      ),
     );
     return NextResponse.json(calls);
   },

--- a/src/app/api/phone/recording-settings/route.test.ts
+++ b/src/app/api/phone/recording-settings/route.test.ts
@@ -1,0 +1,170 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — org recording-default settings.
+//
+// GET  /api/phone/recording-settings  → { recording_enabled_default: boolean }
+//        (view_phone — any teammate can see whether calls record by default)
+// PATCH /api/phone/recording-settings → { ok: true }
+//        (admin only — changing org-wide call recording is a Shared-scope
+//         admin action per ADR 0005)
+//
+// The value lives on organizations.recording_enabled_default (migration-315),
+// read/written through the Service client scoped to the caller's Active Org.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET, PATCH } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+// A Service client over the organizations table with an update spy so a test
+// can assert the patched value.
+function instrumentedService(recordingEnabledDefault: boolean) {
+  const svc = fakeServiceClient({
+    tables: {
+      organizations: [
+        { id: "org-1", recording_enabled_default: recordingEnabledDefault },
+      ],
+    },
+  }) as unknown as { from: (table: string) => Record<string, unknown> };
+  const updateSpy = vi.fn();
+  const origFrom = svc.from.bind(svc);
+  svc.from = (table: string) => {
+    const builder = origFrom(table) as Record<string, unknown> & {
+      update: (...a: unknown[]) => unknown;
+    };
+    if (table === "organizations") {
+      const origUpdate = builder.update.bind(builder);
+      builder.update = (...a: unknown[]) => {
+        updateSpy(...a);
+        return origUpdate(...a);
+      };
+    }
+    return builder;
+  };
+  return { svc, updateSpy };
+}
+
+function patchReq(body: Record<string, unknown>) {
+  return new Request("http://test/api/phone/recording-settings", {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("GET /api/phone/recording-settings", () => {
+  it("returns the org's recording_enabled_default for a view_phone holder", async () => {
+    const { svc } = instrumentedService(true);
+    vi.mocked(createServiceClient).mockReturnValue(svc as never);
+    authed({
+      user: { id: "lead-1" },
+      tables: memberTables({
+        userId: "lead-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await GET(
+      new Request("http://test/api/phone/recording-settings"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ recording_enabled_default: true });
+  });
+
+  it("403 without view_phone", async () => {
+    const { svc } = instrumentedService(true);
+    vi.mocked(createServiceClient).mockReturnValue(svc as never);
+    authed({
+      user: { id: "m-1" },
+      tables: memberTables({ userId: "m-1", role: "crew_member", grants: [] }),
+    });
+
+    const res = await GET(
+      new Request("http://test/api/phone/recording-settings"),
+      noParams,
+    );
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("PATCH /api/phone/recording-settings", () => {
+  it("an admin turns the org default off", async () => {
+    const { svc, updateSpy } = instrumentedService(true);
+    vi.mocked(createServiceClient).mockReturnValue(svc as never);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await PATCH(patchReq({ recording_enabled_default: false }), noParams);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(updateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ recording_enabled_default: false }),
+    );
+  });
+
+  it("403 for a non-admin (view_phone is not enough)", async () => {
+    const { svc, updateSpy } = instrumentedService(true);
+    vi.mocked(createServiceClient).mockReturnValue(svc as never);
+    authed({
+      user: { id: "lead-1" },
+      tables: memberTables({
+        userId: "lead-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await PATCH(patchReq({ recording_enabled_default: false }), noParams);
+
+    expect(res.status).toBe(403);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("400 when recording_enabled_default is not a boolean", async () => {
+    const { svc, updateSpy } = instrumentedService(true);
+    vi.mocked(createServiceClient).mockReturnValue(svc as never);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await PATCH(patchReq({ recording_enabled_default: "nope" }), noParams);
+
+    expect(res.status).toBe(400);
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/phone/recording-settings/route.ts
+++ b/src/app/api/phone/recording-settings/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — org-level recording default.
+//
+// The "Record calls by default" toggle for Settings → Phone. The value lives
+// on organizations.recording_enabled_default (migration-315), which the inbound
+// voice webhook and the outbound bridge route read to decide whether to emit
+// the consent + recording stanza.
+//
+// GET is view_phone (any teammate can see whether calls record by default);
+// PATCH is admin-only — turning org-wide recording on/off is a Shared-scope
+// admin action (ADR 0005), not something every view_phone holder may do. Both
+// use the Service client scoped to the caller's Active Organization.
+
+export const GET = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (_request, ctx) => {
+    const { data } = await ctx.serviceClient!
+      .from("organizations")
+      .select("recording_enabled_default")
+      .eq("id", ctx.orgId)
+      .maybeSingle<{ recording_enabled_default: boolean }>();
+    return NextResponse.json({
+      recording_enabled_default: data?.recording_enabled_default ?? false,
+    });
+  },
+);
+
+export const PATCH = withRequestContext(
+  { adminOnly: true, serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as {
+      recording_enabled_default?: unknown;
+    } | null;
+    if (!body || typeof body.recording_enabled_default !== "boolean") {
+      return NextResponse.json(
+        { error: "recording_enabled_default (boolean) is required" },
+        { status: 400 },
+      );
+    }
+
+    const { error } = await ctx.serviceClient!
+      .from("organizations")
+      .update({ recording_enabled_default: body.recording_enabled_default })
+      .eq("id", ctx.orgId);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/phone/recordings/[id]/route.test.ts
+++ b/src/app/api/phone/recordings/[id]/route.test.ts
@@ -1,0 +1,378 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — delete-recording route.
+//
+// DELETE /api/phone/recordings/[id]
+// canManage-gated (mirrors the voicemail delete route): Shared is admin-only,
+// Personal is owner-or-admin. The number kind/owner is resolved by joining the
+// recording → its parent call → conversation → phone_number through the Service
+// client.
+//
+// Ordering: Twilio first, DB second, then a best-effort Storage cleanup. The
+// Twilio recording is the retention-relevant thing (PRD #304 story 54) — a
+// successful Twilio hard-delete + DB-write failure is recoverable (admin
+// retries; deleteRecording is idempotent on an already-gone SID). The reverse —
+// row gone, recording still on Twilio — silently strands a recording Nookleus
+// believes it deleted, so we refuse to touch the DB until Twilio confirms (502
+// on Twilio failure leaves the row untouched).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+const deleteRecordingMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  deleteRecording: (...args: unknown[]) => deleteRecordingMock(...args),
+  createTwilioClient: () => ({}),
+}));
+
+import { DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const idParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const RECORDING_ROW = {
+  id: "rec-1",
+  organization_id: "org-1",
+  phone_call_id: "call-1",
+  twilio_recording_sid: "REabc",
+  audio_storage_path: "org-1/rec-1.mp3",
+};
+const CALL_ROW = {
+  id: "call-1",
+  organization_id: "org-1",
+  conversation_id: "conv-1",
+};
+const CONVERSATION_ROW = {
+  id: "conv-1",
+  organization_id: "org-1",
+  phone_number_id: "num-1",
+};
+// Shared number — admin-only manage.
+const SHARED_NUMBER = {
+  id: "num-1",
+  organization_id: "org-1",
+  kind: "shared" as const,
+  user_id: null,
+};
+
+function instrumentedService(
+  overrides: {
+    recording?: Record<string, unknown> | null;
+    number?: Record<string, unknown>;
+  } = {},
+) {
+  const recording =
+    overrides.recording === undefined ? RECORDING_ROW : overrides.recording;
+  const tables: Record<string, Record<string, unknown>[]> = {
+    phone_recordings: recording ? [recording] : [],
+    phone_calls: [CALL_ROW],
+    phone_conversations: [CONVERSATION_ROW],
+    phone_numbers: [overrides.number ?? SHARED_NUMBER],
+  };
+  const svc = fakeServiceClient({ tables }) as unknown as {
+    from: (table: string) => Record<string, unknown>;
+    storage: unknown;
+  };
+  const deleteSpy = vi.fn();
+  const removeSpy = vi.fn(async () => ({ data: [], error: null }));
+  const origFrom = svc.from.bind(svc);
+  svc.from = (table: string) => {
+    const builder = origFrom(table) as Record<string, unknown> & {
+      delete: (...a: unknown[]) => unknown;
+    };
+    if (table === "phone_recordings") {
+      const origDelete = builder.delete.bind(builder);
+      builder.delete = (...a: unknown[]) => {
+        deleteSpy(...a);
+        return origDelete(...a);
+      };
+    }
+    return builder;
+  };
+  svc.storage = {
+    from: () => ({
+      remove: removeSpy,
+      async download() {
+        return { data: null, error: { message: "not found" } };
+      },
+      async upload() {
+        return { data: null, error: null };
+      },
+    }),
+  };
+  return { svc, deleteSpy, removeSpy };
+}
+
+function serviceReturns(svc: unknown) {
+  vi.mocked(createServiceClient).mockReturnValue(svc as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  serviceReturns(instrumentedService().svc);
+  deleteRecordingMock.mockResolvedValue(undefined);
+});
+
+describe("DELETE /api/phone/recordings/[id]", () => {
+  it("admin deletes a Shared recording: hard-deletes the Twilio recording, then 200", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteRecordingMock).toHaveBeenCalledWith(expect.anything(), "REabc");
+  });
+
+  it("403 when the caller lacks view_phone (before any lookup)", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("view_phone holder who is not an admin cannot delete a Shared recording: 403, DB untouched", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "lead-1" },
+      tables: memberTables({
+        userId: "lead-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("404 when the recording does not exist", async () => {
+    const { svc } = instrumentedService({ recording: null });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+  });
+
+  it("404 when the recording belongs to another org (no cross-org reach)", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      recording: { ...RECORDING_ROW, organization_id: "org-2" },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(404);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("Twilio failure → 502 and the DB row is left untouched", async () => {
+    const { svc, deleteSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    deleteRecordingMock.mockRejectedValue(new Error("Twilio 500"));
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(502);
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("recording with no Twilio sid: skips the Twilio hop, still deletes + 200", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      recording: { ...RECORDING_ROW, twilio_recording_sid: null },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("Personal-number owner (non-admin) can delete their own recording", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      number: {
+        id: "num-1",
+        organization_id: "org-1",
+        kind: "personal" as const,
+        user_id: "owner-1",
+      },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "owner-1" },
+      tables: memberTables({
+        userId: "owner-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("non-owner non-admin cannot delete someone else's Personal recording: 403", async () => {
+    const { svc, deleteSpy } = instrumentedService({
+      number: {
+        id: "num-1",
+        organization_id: "org-1",
+        kind: "personal" as const,
+        user_id: "owner-1",
+      },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "intruder-1" },
+      tables: memberTables({
+        userId: "intruder-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleteRecordingMock).not.toHaveBeenCalled();
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("also removes the stored audio copy from the phone-recordings bucket", async () => {
+    const { svc, removeSpy } = instrumentedService();
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(removeSpy).toHaveBeenCalledWith(["org-1/rec-1.mp3"]);
+  });
+
+  it("storage cleanup failure does not fail the delete (best-effort): still 200", async () => {
+    const { svc, removeSpy, deleteSpy } = instrumentedService();
+    removeSpy.mockRejectedValueOnce(new Error("storage offline"));
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleteSpy).toHaveBeenCalled();
+  });
+
+  it("recording with no stored audio path: skips storage cleanup, still 200", async () => {
+    const { svc, removeSpy } = instrumentedService({
+      recording: { ...RECORDING_ROW, audio_storage_path: null },
+    });
+    serviceReturns(svc);
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await DELETE(
+      new Request("http://test", { method: "DELETE" }),
+      idParams("rec-1"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(removeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/phone/recordings/[id]/route.ts
+++ b/src/app/api/phone/recordings/[id]/route.ts
@@ -1,0 +1,150 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { canManage } from "@/lib/phone/phone-event-access";
+import { createTwilioClient, deleteRecording } from "@/lib/phone/twilio-client";
+import { PHONE_RECORDINGS_BUCKET } from "@/lib/phone/recordings-storage";
+
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — delete a call recording.
+//
+// DELETE /api/phone/recordings/[id]
+//
+// Flow (mirrors the voicemail delete route — Twilio first, DB second):
+//   1. Look up the recording via the Service client (RLS bypassed). A
+//      recording carries no kind/owner of its own, so resolve the parent
+//      call → conversation → phone_number to learn them.
+//   2. Run `canManage` against the (caller, number): Shared is admin-only,
+//      Personal is owner-or-admin (ADR 0005). Cross-org callers are denied as
+//      404 (privacy-preserving); wrong role inside the org is 403.
+//   3. Twilio first: hard-delete the recording (PRD #304 story 54 — Nookleus
+//      owns retention). A transient Twilio error returns 502 and leaves the DB
+//      row untouched (admin retries). The reverse — row gone, recording still
+//      on Twilio — silently strands a recording, so we refuse to touch the DB
+//      until Twilio confirms. deleteRecording is idempotent on an already-gone
+//      SID (Twilio 404). A recording with no twilio_recording_sid (demo /
+//      already gone) skips the Twilio hop.
+//   4. Delete the phone_recordings row, then best-effort drop the stored MP3.
+
+interface RecordingRow {
+  id: string;
+  organization_id: string;
+  phone_call_id: string;
+  twilio_recording_sid: string | null;
+  audio_storage_path: string | null;
+}
+
+interface CallRow {
+  id: string;
+  organization_id: string;
+  conversation_id: string;
+}
+
+interface ConversationRow {
+  id: string;
+  organization_id: string;
+  phone_number_id: string;
+}
+
+interface PhoneNumberRow {
+  id: string;
+  organization_id: string;
+  kind: "shared" | "personal";
+  user_id: string | null;
+}
+
+export const DELETE = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (_request, ctx, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params;
+
+    const { data: rec } = await ctx.serviceClient!
+      .from("phone_recordings")
+      .select(
+        "id, organization_id, phone_call_id, twilio_recording_sid, audio_storage_path",
+      )
+      .eq("id", id)
+      .maybeSingle<RecordingRow>();
+    if (!rec || rec.organization_id !== ctx.orgId) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    // Resolve the number kind / owner so canManage can apply the ADR 0005
+    // matrix: recording → call → conversation → number.
+    const { data: call } = await ctx.serviceClient!
+      .from("phone_calls")
+      .select("id, organization_id, conversation_id")
+      .eq("id", rec.phone_call_id)
+      .maybeSingle<CallRow>();
+    if (!call) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { data: conv } = await ctx.serviceClient!
+      .from("phone_conversations")
+      .select("id, organization_id, phone_number_id")
+      .eq("id", call.conversation_id)
+      .maybeSingle<ConversationRow>();
+    if (!conv) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    const { data: num } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .select("id, organization_id, kind, user_id")
+      .eq("id", conv.phone_number_id)
+      .maybeSingle<PhoneNumberRow>();
+    if (!num) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const allowed = canManage(
+      {
+        userId: ctx.userId,
+        organizationId: ctx.orgId ?? "",
+        role: ctx.role,
+      },
+      {
+        kind: num.kind,
+        organizationId: num.organization_id,
+        userId: num.user_id,
+      },
+    );
+    if (!allowed) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    // Twilio first. A null sid (demo recording / already gone) skips the hop.
+    if (rec.twilio_recording_sid) {
+      try {
+        await deleteRecording(createTwilioClient(), rec.twilio_recording_sid);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Twilio error";
+        return NextResponse.json(
+          { error: `Twilio: ${message}` },
+          { status: 502 },
+        );
+      }
+    }
+
+    const { error } = await ctx.serviceClient!
+      .from("phone_recordings")
+      .delete()
+      .eq("id", id);
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    // Best-effort: drop the Nookleus storage copy so a deleted recording leaves
+    // no playable audio. The row is already gone and Twilio's recording is
+    // hard-deleted, so a storage hiccup here is cosmetic (orphaned object in a
+    // private bucket, no row to sign it). Don't let it fail the request.
+    if (rec.audio_storage_path) {
+      try {
+        await ctx.serviceClient!.storage
+          .from(PHONE_RECORDINGS_BUCKET)
+          .remove([rec.audio_storage_path]);
+      } catch {
+        // swallow — orphaned object, retryable out-of-band
+      }
+    }
+
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/phone/webhook/recording-completed/route.test.ts
+++ b/src/app/api/phone/webhook/recording-completed/route.test.ts
@@ -1,0 +1,315 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording-completed webhook.
+//
+// Twilio POSTs here when an answered call's <Dial record> finishes (the
+// inbound voice webhook and the outbound bridge wire this as the dial's
+// recordingStatusCallback). The callback carries:
+//   CallSid           — matches the `twilio_call_sid` we stored on phone_calls
+//   RecordingSid      — Twilio's handle for the recording (RE...)
+//   RecordingUrl      — the Twilio-hosted media URL
+//   RecordingDuration — length in seconds
+//
+// The route looks up the parent phone_calls row by CallSid (to inherit its
+// org + id) and inserts a phone_recordings row with consent_notice_played=true
+// (the consent notice always fires when recording is enabled — the boolean is
+// the audit-trail record). It then copies the audio out of Twilio into the
+// phone-recordings bucket. Unauthenticated; gated solely by X-Twilio-Signature.
+// Service-client writes — no auth user, so RLS would otherwise refuse.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  validateTwilioSignature: (...args: unknown[]) => validateSignatureMock(...args),
+}));
+
+const createServiceClientMock = vi.fn();
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: () => createServiceClientMock(),
+}));
+
+import { POST } from "./route";
+
+type Row = Record<string, unknown>;
+
+function makeServiceClient(
+  seed: Record<string, Row[]>,
+  opts: { uploadError?: { message: string } } = {},
+) {
+  const tables: Record<string, Row[]> = {
+    phone_calls: [],
+    phone_recordings: [],
+    ...seed,
+  };
+  const inserts: { table: string; row: Row; onConflict?: string }[] = [];
+  const updates: { table: string; patch: Row; filters: Row }[] = [];
+  const uploads: { path: string; options: unknown }[] = [];
+
+  function builder(table: string) {
+    let rows = tables[table] ?? [];
+    const ctx: { filters: Row } = { filters: {} };
+    let pendingInsert: Row | null = null;
+    let pendingUpdate: Row | null = null;
+    const b: Record<string, unknown> = {};
+    b.select = () => b;
+    b.eq = (col: string, val: unknown) => {
+      ctx.filters[col] = val;
+      rows = rows.filter((r) => r[col] === val);
+      return b;
+    };
+    b.insert = (row: Row) => {
+      pendingInsert = row;
+      inserts.push({ table, row });
+      return b;
+    };
+    b.upsert = (row: Row, opt?: { onConflict?: string }) => {
+      pendingInsert = row;
+      inserts.push({ table, row, onConflict: opt?.onConflict });
+      return b;
+    };
+    b.update = (patch: Row) => {
+      pendingUpdate = patch;
+      return b;
+    };
+    b.maybeSingle = async () => ({ data: rows[0] ?? null, error: null });
+    b.then = (resolve: (v: { data: unknown; error: null }) => unknown) => {
+      if (pendingUpdate) {
+        updates.push({ table, patch: pendingUpdate, filters: { ...ctx.filters } });
+        return resolve({ data: null, error: null });
+      }
+      if (pendingInsert) return resolve({ data: null, error: null });
+      return resolve({ data: rows, error: null });
+    };
+    return b;
+  }
+
+  const storage = {
+    from: () => ({
+      upload: async (path: string, _body: unknown, uploadOpts: unknown) => {
+        uploads.push({ path, options: uploadOpts });
+        return { data: opts.uploadError ? null : { path }, error: opts.uploadError ?? null };
+      },
+      createSignedUrl: async (path: string) => ({
+        data: { signedUrl: `https://signed.example/${path}` },
+        error: null,
+      }),
+    }),
+  };
+
+  return { client: { from: builder, storage }, tables, inserts, updates, uploads };
+}
+
+function recForm(opts: {
+  CallSid?: string;
+  RecordingSid?: string;
+  RecordingUrl?: string;
+  RecordingDuration?: string;
+}): Request {
+  const params = new URLSearchParams();
+  if (opts.CallSid !== undefined) params.set("CallSid", opts.CallSid);
+  if (opts.RecordingSid !== undefined) params.set("RecordingSid", opts.RecordingSid);
+  if (opts.RecordingUrl !== undefined) params.set("RecordingUrl", opts.RecordingUrl);
+  if (opts.RecordingDuration !== undefined)
+    params.set("RecordingDuration", opts.RecordingDuration);
+  return new Request("http://test/api/phone/webhook/recording-completed", {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "x-twilio-signature": "valid",
+    },
+    body: params.toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/phone/webhook/recording-completed — persist (tracer)", () => {
+  it("inserts a phone_recordings row with consent_notice_played=true, keyed to the parent call", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      recForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+        RecordingDuration: "42",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const ins = inserts.find((i) => i.table === "phone_recordings");
+    expect(ins).toBeDefined();
+    expect(ins!.row).toMatchObject({
+      phone_call_id: "call-1",
+      organization_id: "org-1",
+      twilio_recording_sid: "RE-1",
+      twilio_recording_url: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      duration_seconds: 42,
+      consent_notice_played: true,
+    });
+  });
+});
+
+describe("POST /api/phone/webhook/recording-completed — signature + guards", () => {
+  it("returns 403 when the Twilio signature is invalid", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const { client, inserts } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(recForm({ CallSid: "CA-1", RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(403);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("returns 400 when CallSid is missing", async () => {
+    const { client, inserts } = makeServiceClient({});
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(recForm({ RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(400);
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("returns 200 and inserts nothing when CallSid matches no call (silent drop)", async () => {
+    const { client, inserts } = makeServiceClient({ phone_calls: [] });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(recForm({ CallSid: "CA-unknown", RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(200);
+    expect(inserts.find((i) => i.table === "phone_recordings")).toBeUndefined();
+  });
+
+  it("is idempotent — upserts on the phone_call_id unique key so a Twilio retry can't violate it", async () => {
+    const { client, inserts } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(recForm({ CallSid: "CA-1", RecordingSid: "RE-1" }));
+
+    expect(res.status).toBe(200);
+    const ins = inserts.find((i) => i.table === "phone_recordings");
+    expect(ins).toBeDefined();
+    expect(ins!.onConflict).toBe("phone_call_id");
+  });
+});
+
+describe("POST /api/phone/webhook/recording-completed — audio copy", () => {
+  it("fetches the Twilio MP3, uploads it to phone-recordings, and sets audio_storage_path", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([7, 8, 9]).buffer,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, updates, uploads } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      recForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String((fetchMock.mock.calls[0] as unknown[])[0])).toBe(
+      "https://api.twilio.com/2010-04-01/Recordings/RE-1.mp3",
+    );
+    expect(uploads).toHaveLength(1);
+    expect(uploads[0].path).toMatch(/^org-1\/[0-9a-f-]+\.mp3$/);
+    const upd = updates.find((u) => u.table === "phone_recordings");
+    expect(upd).toBeDefined();
+    expect(upd!.filters).toMatchObject({ phone_call_id: "call-1" });
+    expect(upd!.patch.audio_storage_path).toEqual(uploads[0].path);
+  });
+
+  it("skips the copy on a redelivery whose recording already has audio_storage_path (no orphan upload)", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([7, 8, 9]).buffer,
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, uploads, updates } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+      phone_recordings: [
+        {
+          phone_call_id: "call-1",
+          organization_id: "org-1",
+          audio_storage_path: "org-1/already-copied.mp3",
+        },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      recForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(uploads).toHaveLength(0);
+    expect(
+      updates.find(
+        (u) => u.table === "phone_recordings" && "audio_storage_path" in u.patch,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("swallows a copy failure — the row still persists with no audio_storage_path update", async () => {
+    const fetchMock = vi.fn(async () => ({ ok: false, status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { client, inserts, updates } = makeServiceClient({
+      phone_calls: [
+        { id: "call-1", organization_id: "org-1", twilio_call_sid: "CA-1" },
+      ],
+    });
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(
+      recForm({
+        CallSid: "CA-1",
+        RecordingSid: "RE-1",
+        RecordingUrl: "https://api.twilio.com/2010-04-01/Recordings/RE-1",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(inserts.find((i) => i.table === "phone_recordings")).toBeDefined();
+    expect(
+      updates.find(
+        (u) => u.table === "phone_recordings" && "audio_storage_path" in u.patch,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/src/app/api/phone/webhook/recording-completed/route.ts
+++ b/src/app/api/phone/webhook/recording-completed/route.ts
@@ -1,0 +1,136 @@
+import type { NextRequest } from "next/server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { validateTwilioSignature } from "@/lib/phone/twilio-client";
+import { uploadPhoneRecording } from "@/lib/phone/recordings-storage";
+
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording-completed webhook.
+//
+// Twilio POSTs here when an answered call's <Dial record> finishes (the
+// inbound voice webhook and the outbound bridge wire this as the dial's
+// recordingStatusCallback). The callback carries CallSid (the parent call),
+// RecordingSid / RecordingUrl (Twilio's handle + media URL), and
+// RecordingDuration. We look up the parent phone_calls row by CallSid to
+// inherit its org + id, then insert a phone_recordings row with
+// consent_notice_played=true — the consent notice always fires when recording
+// is enabled, so the boolean is the audit-trail record, not a runtime gate.
+// The audio is then copied into the org-scoped phone-recordings bucket so
+// playback outlives Twilio's media retention and deletion is under Nookleus's
+// control (PRD #304 story 54).
+//
+// Mirrors voicemail-completed: unauthenticated, gated solely by
+// X-Twilio-Signature; Service-client writes (no auth user, RLS would refuse);
+// unknown CallSid → 200 silent drop; idempotent upsert on phone_call_id +
+// re-copy guard so a Twilio retry can't orphan a second uploaded object.
+
+// Fetch the recording's MP3 from Twilio. Twilio serves the WAV at the bare
+// RecordingUrl and an MP3 at the `.mp3` suffix; we store the smaller,
+// browser-playable MP3, authenticated with the account credentials.
+async function fetchRecordingMp3(recordingUrl: string): Promise<Uint8Array> {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const headers: Record<string, string> = {};
+  if (accountSid && authToken) {
+    headers.Authorization =
+      "Basic " + Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+  }
+  const res = await fetch(`${recordingUrl}.mp3`, { headers });
+  if (!res.ok) {
+    throw new Error(`twilio recording fetch failed: ${res.status}`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  const callSid = params.CallSid;
+  if (!callSid) {
+    return new Response("CallSid required", { status: 400 });
+  }
+
+  const supabase = createServiceClient();
+
+  // Look up the parent call to inherit its org + id. Unknown CallSid → 200
+  // silent drop so Twilio stops retrying (the call may predate this feature
+  // or have been deleted).
+  const { data: call } = await supabase
+    .from("phone_calls")
+    .select("id, organization_id")
+    .eq("twilio_call_sid", callSid)
+    .maybeSingle<{ id: string; organization_id: string }>();
+
+  if (!call) {
+    return new Response("", { status: 200 });
+  }
+
+  const durationRaw = params.RecordingDuration;
+  let duration_seconds: number | null = null;
+  if (durationRaw !== undefined && durationRaw !== "") {
+    const seconds = Number.parseInt(durationRaw, 10);
+    if (Number.isFinite(seconds)) duration_seconds = seconds;
+  }
+
+  // Upsert on the phone_call_id unique key: a Twilio retry of the same
+  // recordingStatusCallback must conflict-drop, not raise a unique violation
+  // (which would 500 and trigger further Twilio retries). consent_notice_played
+  // is true — the consent notice fires whenever recording is enabled.
+  await supabase.from("phone_recordings").upsert(
+    {
+      organization_id: call.organization_id,
+      phone_call_id: call.id,
+      twilio_recording_sid: params.RecordingSid ?? null,
+      twilio_recording_url: params.RecordingUrl ?? null,
+      duration_seconds,
+      consent_notice_played: true,
+    },
+    { onConflict: "phone_call_id", ignoreDuplicates: true },
+  );
+
+  // Re-copy guard: if the FIRST delivery already copied the audio, do NOT copy
+  // again — uploadPhoneRecording mints a fresh UUID per call (upsert:false), so
+  // a re-copy would orphan the original object and clobber the stored path. A
+  // copy that previously FAILED left audio_storage_path null, so a retry can
+  // still finish it.
+  const { data: existing } = await supabase
+    .from("phone_recordings")
+    .select("audio_storage_path")
+    .eq("phone_call_id", call.id)
+    .maybeSingle<{ audio_storage_path: string | null }>();
+
+  if (existing?.audio_storage_path) {
+    return new Response("", { status: 200 });
+  }
+
+  // Copy the audio out of Twilio into the org-scoped phone-recordings bucket.
+  // A copy failure is SWALLOWED: the recording row already persists, so we 200
+  // (no Twilio retry storm) and leave audio_storage_path null — a later Twilio
+  // redelivery retries the copy.
+  const recordingUrl = params.RecordingUrl;
+  if (recordingUrl) {
+    try {
+      const bytes = await fetchRecordingMp3(recordingUrl);
+      const { storagePath } = await uploadPhoneRecording(supabase, {
+        orgId: call.organization_id,
+        bytes,
+      });
+      await supabase
+        .from("phone_recordings")
+        .update({ audio_storage_path: storagePath })
+        .eq("phone_call_id", call.id);
+    } catch (err) {
+      console.error("recording-completed: audio copy failed", err);
+    }
+  }
+
+  return new Response("", { status: 200 });
+}

--- a/src/app/api/phone/webhook/recording-whisper/route.test.ts
+++ b/src/app/api/phone/webhook/recording-whisper/route.test.ts
@@ -1,0 +1,58 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording-consent whisper.
+//
+// Twilio fetches this endpoint via each recorded call's `<Number url>` whisper
+// and plays the returned TwiML to the ANSWERING party before bridging — so
+// both parties hear the consent notice (the initiating party hears it via the
+// <Say> before the <Dial>). Like every Twilio-facing endpoint it is gated
+// solely by the X-Twilio-Signature HMAC.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { RECORDING_CONSENT_NOTICE } from "@/lib/phone/recording-consent";
+
+const validateSignatureMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", async (importOriginal) => {
+  // Keep buildConsentWhisperTwiml REAL so the test pins that the actual consent
+  // notice reaches the wire; mock only the signature check.
+  const actual =
+    await importOriginal<typeof import("@/lib/phone/twilio-client")>();
+  return {
+    ...actual,
+    validateTwilioSignature: (...a: unknown[]) => validateSignatureMock(...a),
+  };
+});
+
+import { POST } from "./route";
+
+function whisperReq(signature: string | null = "valid"): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/x-www-form-urlencoded",
+  };
+  if (signature !== null) headers["x-twilio-signature"] = signature;
+  return new Request("http://test/api/phone/webhook/recording-whisper", {
+    method: "POST",
+    headers,
+    body: new URLSearchParams({ CallSid: "CA-1" }).toString(),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  validateSignatureMock.mockReturnValue(true);
+});
+
+describe("recording-whisper webhook (#315)", () => {
+  it("serves the consent-notice TwiML on a valid Twilio signature", async () => {
+    const res = await POST(whisperReq());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/xml");
+    const body = await res.text();
+    expect(body).toContain("<Say");
+    expect(body).toContain(RECORDING_CONSENT_NOTICE);
+  });
+
+  it("403s on an invalid Twilio signature", async () => {
+    validateSignatureMock.mockReturnValue(false);
+    const res = await POST(whisperReq("bad"));
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/phone/webhook/recording-whisper/route.ts
+++ b/src/app/api/phone/webhook/recording-whisper/route.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server";
+import {
+  validateTwilioSignature,
+  buildConsentWhisperTwiml,
+} from "@/lib/phone/twilio-client";
+
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording-consent whisper.
+//
+// On a recorded call, each dialed <Number> carries a `url` pointing here.
+// Twilio fetches this TwiML and plays it to the ANSWERING party before
+// bridging, so both parties hear the legally-required consent notice (the
+// initiating party already heard it via the <Say> before the <Dial>). The
+// response is pure, static TwiML — the notice text is the single source of
+// truth in recording-consent.ts, built into TwiML by twilio-client (the only
+// file allowed to import the Twilio SDK).
+//
+// Like every Twilio-facing endpoint this is unauthenticated and gated solely
+// by the X-Twilio-Signature HMAC — 403 on an invalid signature.
+
+function twimlResponse(xml: string, status = 200): Response {
+  return new Response(xml, {
+    status,
+    headers: { "content-type": "text/xml; charset=utf-8" },
+  });
+}
+
+export async function POST(request: NextRequest | Request): Promise<Response> {
+  const url = request.url;
+  const signature = request.headers.get("x-twilio-signature");
+  const bodyText = await request.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(bodyText)) {
+    params[k] = v;
+  }
+
+  if (!validateTwilioSignature(url, signature, params)) {
+    return new Response("forbidden", { status: 403 });
+  }
+
+  return twimlResponse(buildConsentWhisperTwiml());
+}

--- a/src/app/api/phone/webhook/voice-inbound/route.test.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.test.ts
@@ -23,6 +23,7 @@
 // run, so the TwiML and persistence are asserted end-to-end.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { RECORDING_CONSENT_NOTICE } from "@/lib/phone/recording-consent";
 
 const validateSignatureMock = vi.fn();
 vi.mock("@/lib/phone/twilio-client", async (importOriginal) => {
@@ -52,6 +53,9 @@ interface BuilderTables {
   phone_number_round_robin: Row[];
   phone_conversations: Row[];
   phone_calls: Row[];
+  // Slice 11 (#315) — the org's recording_enabled_default. Absent here for the
+  // slice-8 tests (the webhook reads it as "off"), seeded in the recording tests.
+  organizations?: Row[];
 }
 
 function makeServiceClient(tables: BuilderTables) {
@@ -337,6 +341,50 @@ describe("POST /api/phone/webhook/voice-inbound — Personal number", () => {
     expect(xml).toContain("<Record");
     expect(xml).not.toContain("<Dial");
     expect(inserts.find((i) => i.table === "phone_calls")).toBeDefined();
+  });
+});
+
+describe("POST /api/phone/webhook/voice-inbound — call recording + consent (#315)", () => {
+  it("speaks consent and records the dial when the org records calls by default", async () => {
+    vi.stubEnv(
+      "PHONE_RECORDING_CALLBACK_URL",
+      "https://app.test/api/phone/webhook/recording-completed",
+    );
+    vi.stubEnv(
+      "PHONE_RECORDING_WHISPER_URL",
+      "https://app.test/api/phone/webhook/recording-whisper",
+    );
+    const tables = ringAllTables();
+    tables.organizations = [{ id: "org-1", recording_enabled_default: true }];
+    const { client } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    // The inbound caller hears the consent notice; the bridged call records.
+    expect(xml).toContain(RECORDING_CONSENT_NOTICE);
+    expect(xml).toContain('record="record-from-answer-dual"');
+    expect(xml).toContain(
+      'recordingStatusCallback="https://app.test/api/phone/webhook/recording-completed"',
+    );
+    // Each answering cell gets the whisper so it hears the notice too.
+    expect(xml).toContain(
+      'url="https://app.test/api/phone/webhook/recording-whisper"',
+    );
+  });
+
+  it("omits consent + recording when the org has recording disabled", async () => {
+    const tables = ringAllTables();
+    tables.organizations = [{ id: "org-1", recording_enabled_default: false }];
+    const { client } = makeServiceClient(tables);
+    createServiceClientMock.mockReturnValue(client);
+
+    const res = await POST(voiceForm({}));
+    const xml = await res.text();
+
+    expect(xml).not.toContain(RECORDING_CONSENT_NOTICE);
+    expect(xml).not.toContain("record=");
   });
 });
 

--- a/src/app/api/phone/webhook/voice-inbound/route.ts
+++ b/src/app/api/phone/webhook/voice-inbound/route.ts
@@ -199,6 +199,21 @@ export async function POST(request: NextRequest | Request): Promise<Response> {
     }
   }
 
+  // Slice 11 (#315) — does this Organization record calls by default? The
+  // column is NOT NULL default true, so a real org always carries a value; a
+  // missing row falls back to "don't record" (fail-safe for consent). When on,
+  // buildVoiceTwiml speaks the consent notice on the answered (dial) branches,
+  // records the bridge dual-channel, and whispers consent to each answering
+  // cell. Recording is orthogonal to the voicemail branch (which the builder
+  // leaves unchanged). Per-number / per-call inbound overrides are out of scope
+  // for this slice (issue #315).
+  const { data: orgRow } = await supabase
+    .from("organizations")
+    .select("recording_enabled_default")
+    .eq("id", numberRow.organization_id)
+    .maybeSingle<{ recording_enabled_default: boolean }>();
+  const recordCall = orgRow?.recording_enabled_default ?? false;
+
   // Slice 9 (#313) — voicemail callback URLs. Passed on every call (the
   // builder ignores them in the dial branches); the <Record> verb in the
   // voicemail branch posts the finished recording to voicemail-completed and
@@ -208,6 +223,13 @@ export async function POST(request: NextRequest | Request): Promise<Response> {
     callerId: toE164,
     recordingStatusCallback: process.env.PHONE_VOICEMAIL_CALLBACK_URL || undefined,
     transcribeCallback: process.env.PHONE_TRANSCRIPTION_CALLBACK_URL || undefined,
+    // Slice 11 (#315) — answered-call recording + consent (no-op in the
+    // voicemail branch). callRecordingStatusCallback → recording-completed
+    // webhook; consentWhisperUrl → the per-leg consent whisper.
+    recordCall,
+    callRecordingStatusCallback:
+      process.env.PHONE_RECORDING_CALLBACK_URL || undefined,
+    consentWhisperUrl: process.env.PHONE_RECORDING_WHISPER_URL || undefined,
   });
 
   // 4. Persist the ringing call row, threaded on the conversation.

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -1117,6 +1117,7 @@ describe("PhonePageClient — call events (#312)", () => {
   function setupThread(opts: {
     messages?: Array<Record<string, unknown>>;
     calls?: Array<Record<string, unknown>>;
+    recordingUrl?: string;
   }) {
     mockFetch.mockImplementation(async (input: RequestInfo) => {
       const url = typeof input === "string" ? input : (input as Request).url;
@@ -1126,6 +1127,15 @@ describe("PhonePageClient — call events (#312)", () => {
       }
       if (path === "/api/phone/conversations/conv-1/calls") {
         return { ok: true, status: 200, json: async () => opts.calls ?? [] };
+      }
+      if (path.startsWith("/api/phone/recordings")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            url: opts.recordingUrl ?? "https://signed/rec.mp3",
+          }),
+        };
       }
       throw new Error(`unmocked fetch: ${path}`);
     });
@@ -1304,23 +1314,32 @@ describe("PhonePageClient — call events (#312)", () => {
     ).toBeDefined();
   });
 
-  it("opens a slice-11 recording placeholder when a call row is clicked", async () => {
+  // Slice 11 (#315) — a recorded call plays inline on the call event (the
+  // slice-8 "Recording playback will land in slice 11" placeholder is gone).
+  it("plays a call recording inline on the call event (no placeholder)", async () => {
     setupThread({
       messages: [],
+      recordingUrl: "https://signed/phone-recordings/org-1/rec-1.mp3",
       calls: [
         {
-          id: "c-click",
+          id: "c-rec",
           conversation_id: "conv-1",
           direction: "in",
           status: "completed",
           duration_seconds: 30,
           started_at: "2026-05-27T10:00:00Z",
           ended_at: "2026-05-27T10:00:30Z",
+          recording: {
+            id: "rec-1",
+            audio_storage_path: "org-1/rec-1.mp3",
+            consent_notice_played: true,
+            duration_seconds: 30,
+          },
         },
       ],
     });
 
-    render(
+    const { container } = render(
       <PhonePageClient
         organizationId="org-1"
         initialConversations={[
@@ -1329,15 +1348,23 @@ describe("PhonePageClient — call events (#312)", () => {
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /alice/i }));
-    const callRow = await screen.findByText(/incoming call/i);
+    await screen.findByText(/incoming call/i);
 
-    // Nothing about slice 11 until the row is clicked…
+    // The legacy placeholder is gone — recording playback has landed.
     expect(screen.queryByText(/slice 11/i)).toBeNull();
-    // …recording playback ships in slice 11, so for now the click reveals
-    // a placeholder pointing there (AC: "Click on a row opens a future
-    // placeholder").
-    fireEvent.click(callRow);
-    expect(await screen.findByText(/slice 11/i)).toBeDefined();
+    // The recording plays inline, signed from the same endpoint as voicemail.
+    await waitFor(() => {
+      const audio = container.querySelector('audio[aria-label="Call recording"]');
+      expect(audio?.getAttribute("src")).toBe(
+        "https://signed/phone-recordings/org-1/rec-1.mp3",
+      );
+    });
+    const signedCall = mockFetch.mock.calls.find(([input]) =>
+      String(input).includes("/api/phone/recordings"),
+    );
+    expect(String(signedCall![0])).toContain(
+      `path=${encodeURIComponent("org-1/rec-1.mp3")}`,
+    );
   });
 });
 

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -79,6 +79,16 @@ interface PhoneVoicemail {
 // conversation as the messages; `started_at` is its timeline anchor.
 // `status`/`duration_seconds` are null until the status-callback webhook
 // advances the row (a 'ringing' insert has neither yet).
+// Slice 11 (#315) — a call recording attached to an answered call. Like
+// voicemail, `audio_storage_path` is the Nookleus-hosted MP3 the player signs a
+// URL for; it can lag the row briefly while the copy-from-Twilio finishes.
+interface PhoneRecording {
+  id: string;
+  audio_storage_path: string | null;
+  consent_notice_played: boolean;
+  duration_seconds: number | null;
+}
+
 interface PhoneCall {
   id: string;
   conversation_id: string;
@@ -89,6 +99,8 @@ interface PhoneCall {
   ended_at: string | null;
   // Slice 9 (#313) — present when the call went to voicemail.
   voicemail?: PhoneVoicemail | null;
+  // Slice 11 (#315) — present when the answered call was recorded.
+  recording?: PhoneRecording | null;
 }
 
 // Slice 6 (#310) — a staged attachment in the compose strip. Either the
@@ -154,10 +166,6 @@ export function PhonePageClient({
   // Slice 6 (#310) — lightbox state: the storage_path of the image
   // currently being shown full-size, or null.
   const [lightboxPath, setLightboxPath] = useState<string | null>(null);
-  // Slice 8 (#312) — the call whose detail placeholder is open, or null.
-  // Recording playback ships in slice 11; until then a click on a call row
-  // opens this placeholder.
-  const [callDetail, setCallDetail] = useState<PhoneCall | null>(null);
   // #309 outbound surfaces are gated on the A2P 10DLC feature flag.
   // Computed once at mount — the flag flips by env-var redeploy, not at
   // runtime, so we never need to re-evaluate. The read path (thread,
@@ -777,33 +785,6 @@ export function PhonePageClient({
         />
       ) : null}
 
-      {/* Slice 8 (#312) — call-detail placeholder. Recording playback
-          lands in slice 11 (#11); until then a tapped call row shows this. */}
-      {callDetail ? (
-        <div
-          role="dialog"
-          aria-label="Call details"
-          onClick={() => setCallDetail(null)}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className="max-w-sm rounded-lg bg-background p-6 text-center shadow-lg"
-          >
-            <p className="text-sm text-muted-foreground">
-              Recording playback will land in slice 11.
-            </p>
-            <button
-              type="button"
-              onClick={() => setCallDetail(null)}
-              className="mt-4 rounded-md bg-[var(--brand-primary)] px-4 py-2 text-sm font-medium text-white"
-            >
-              Close
-            </button>
-          </div>
-        </div>
-      ) : null}
-
       {/* Right pane — selected thread */}
       <section className="flex-1 flex flex-col">
         {selected ? (
@@ -849,11 +830,7 @@ export function PhonePageClient({
               {threadItems.map((item) => {
                 if (item.kind === "call") {
                   return (
-                    <CallRow
-                      key={`call-${item.call.id}`}
-                      call={item.call}
-                      onOpen={() => setCallDetail(item.call)}
-                    />
+                    <CallRow key={`call-${item.call.id}`} call={item.call} />
                   );
                 }
                 const m = item.message;
@@ -1121,17 +1098,16 @@ function formatDuration(seconds: number): string {
 // like a system row (distinct from the left/right message bubbles). Slice 9
 // (#313) — when the call went to voicemail, its recording + transcript render
 // inline beneath the call pill.
-function CallRow({ call, onOpen }: { call: PhoneCall; onOpen: () => void }) {
+function CallRow({ call }: { call: PhoneCall }) {
   const incoming = call.direction === "in";
   const label = incoming ? "Incoming call" : "Outgoing call";
   const DirectionIcon = incoming ? PhoneIncoming : PhoneOutgoing;
   return (
     <div className="flex flex-col items-center gap-1">
-      <button
-        type="button"
-        onClick={onOpen}
-        className="inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground hover:bg-muted/70"
-      >
+      {/* A call renders as a centered status pill. Slice 11 (#315) replaced the
+          tap-to-open placeholder with inline recording playback below the pill,
+          so the pill is no longer interactive. */}
+      <div className="inline-flex items-center gap-2 rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
         <DirectionIcon size={12} aria-hidden="true" />
         <span>{label}</span>
         {call.status && <span>{formatCallStatus(call.status)}</span>}
@@ -1144,8 +1120,9 @@ function CallRow({ call, onOpen }: { call: PhoneCall; onOpen: () => void }) {
             minute: "2-digit",
           })}
         </span>
-      </button>
+      </div>
       {call.voicemail ? <VoicemailBlock voicemail={call.voicemail} /> : null}
+      {call.recording ? <RecordingBlock recording={call.recording} /> : null}
     </div>
   );
 }
@@ -1199,6 +1176,48 @@ function VoicemailPlayer({ storagePath }: { storagePath: string }) {
       controls
       src={url ?? undefined}
       aria-label="Voicemail recording"
+      className="w-full"
+    />
+  );
+}
+
+// Slice 11 (#315) — the call recording shown under an answered call. Mirrors
+// VoicemailBlock: the player renders once the audio copy has landed
+// (audio_storage_path set); until then the row simply shows no player (the
+// recording-completed webhook fills the path moments after the call ends).
+function RecordingBlock({ recording }: { recording: PhoneRecording }) {
+  if (!recording.audio_storage_path) return null;
+  return (
+    <div className="w-full max-w-sm rounded-lg border border-border bg-background p-2 text-xs">
+      <RecordingPlayer storagePath={recording.audio_storage_path} />
+    </div>
+  );
+}
+
+// Slice 11 (#315) — <audio> player for a stored call recording. Identical to
+// VoicemailPlayer (recordings share the phone-recordings bucket and the same
+// signed-URL route); only the aria-label differs.
+function RecordingPlayer({ storagePath }: { storagePath: string }) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/recordings?path=${encodeURIComponent(storagePath)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storagePath]);
+  return (
+    <audio
+      controls
+      src={url ?? undefined}
+      aria-label="Call recording"
       className="w-full"
     />
   );

--- a/src/app/settings/phone/page.tsx
+++ b/src/app/settings/phone/page.tsx
@@ -3,10 +3,11 @@
 import { SettingsTabs } from "@/components/settings/settings-tabs";
 import { PhoneNumbersTab } from "./phone-numbers-tab";
 import { OptOutsTab } from "./opt-outs-tab";
+import { RecordingSettingsTab } from "./recording-settings-tab";
 
 // PRD #304 — Nookleus Phone. Slice 3 (#307) opened the page with a single
-// Numbers tab. Slice 5 (#309) adds an Opt-outs tab; slice 8 will add an
-// Inbound-rule editor.
+// Numbers tab. Slice 5 (#309) adds an Opt-outs tab; slice 11 (#315) adds the
+// org-level call-recording default.
 
 export default function PhoneSettingsPage() {
   return (
@@ -15,6 +16,11 @@ export default function PhoneSettingsPage() {
       tabs={[
         { key: "numbers", label: "Numbers", content: <PhoneNumbersTab /> },
         { key: "opt-outs", label: "Opt-outs", content: <OptOutsTab /> },
+        {
+          key: "recording",
+          label: "Recording",
+          content: <RecordingSettingsTab />,
+        },
       ]}
     />
   );

--- a/src/app/settings/phone/recording-settings-tab.test.tsx
+++ b/src/app/settings/phone/recording-settings-tab.test.tsx
@@ -1,0 +1,105 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315).
+//
+// Settings → Phone → Recording tab. The org-level "Record calls by default"
+// toggle. Any teammate sees the current state (read-only); only an admin can
+// flip it (ADR 0005 — org-wide recording is a Shared-scope admin action).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: vi.fn(),
+}));
+
+import { RecordingSettingsTab } from "./recording-settings-tab";
+import { useAuth } from "@/lib/auth-context";
+
+const mockFetch = vi.fn();
+
+function authAs(role: "admin" | "crew_lead") {
+  vi.mocked(useAuth).mockReturnValue({ profile: { role } } as never);
+}
+
+// Route GET → the current value; PATCH → success. Returns the spy so a test
+// can inspect the PATCH body.
+function stubFetch(current: boolean) {
+  mockFetch.mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.includes("/api/phone/recording-settings") && init?.method === "PATCH") {
+      return { ok: true, status: 200, json: async () => ({ ok: true }) };
+    }
+    if (url.includes("/api/phone/recording-settings")) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ recording_enabled_default: current }),
+      };
+    }
+    throw new Error(`unmocked fetch: ${url}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = mockFetch as never;
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("RecordingSettingsTab", () => {
+  it("reflects the current org default (checked when recording is on)", async () => {
+    authAs("admin");
+    stubFetch(true);
+
+    render(<RecordingSettingsTab />);
+
+    const toggle = (await screen.findByRole("checkbox", {
+      name: /record calls by default/i,
+    })) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it("an admin toggles the default on and PATCHes the new value", async () => {
+    authAs("admin");
+    stubFetch(false);
+
+    render(<RecordingSettingsTab />);
+
+    const toggle = await screen.findByRole("checkbox", {
+      name: /record calls by default/i,
+    });
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      const patch = mockFetch.mock.calls.find(
+        ([, init]) => (init as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patch).toBeDefined();
+      expect(JSON.parse(String((patch![1] as RequestInit).body))).toEqual({
+        recording_enabled_default: true,
+      });
+    });
+  });
+
+  it("disables the toggle for a non-admin", async () => {
+    authAs("crew_lead");
+    stubFetch(true);
+
+    render(<RecordingSettingsTab />);
+
+    const toggle = (await screen.findByRole("checkbox", {
+      name: /record calls by default/i,
+    })) as HTMLInputElement;
+    expect(toggle.disabled).toBe(true);
+  });
+
+  it("quotes the canonical consent notice so admins know what callers hear", async () => {
+    authAs("admin");
+    stubFetch(true);
+
+    render(<RecordingSettingsTab />);
+
+    expect(
+      await screen.findByText(/this call may be recorded for quality and reference/i),
+    ).toBeDefined();
+  });
+});

--- a/src/app/settings/phone/recording-settings-tab.tsx
+++ b/src/app/settings/phone/recording-settings-tab.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth } from "@/lib/auth-context";
+import { RECORDING_CONSENT_NOTICE } from "@/lib/phone/recording-consent";
+
+// PRD #304 — Nookleus Phone. Slice 11 (#315).
+//
+// Settings → Phone → Recording tab. The org-level "Record calls by default"
+// toggle, backed by organizations.recording_enabled_default. Any teammate with
+// view_phone sees the current state; only an admin can flip it (ADR 0005 —
+// org-wide recording is a Shared-scope admin action). Existing recordings are
+// unaffected by toggling off; only NEW calls stop recording.
+
+export function RecordingSettingsTab() {
+  const { profile } = useAuth();
+  const isAdmin = profile?.role === "admin";
+
+  const [enabled, setEnabled] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/phone/recording-settings");
+      if (!res.ok) {
+        setError("Failed to load recording setting");
+        return;
+      }
+      const body = (await res.json()) as { recording_enabled_default: boolean };
+      setEnabled(body.recording_enabled_default);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onToggle = useCallback(async () => {
+    if (!isAdmin || saving) return;
+    const next = !enabled;
+    setEnabled(next); // optimistic
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/phone/recording-settings", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ recording_enabled_default: next }),
+      });
+      if (!res.ok) {
+        setEnabled(!next); // revert
+        setError("Failed to save");
+      }
+    } catch {
+      setEnabled(!next); // revert
+      setError("Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }, [enabled, isAdmin, saving]);
+
+  if (loading) {
+    return <p className="p-4 text-sm text-muted-foreground">Loading…</p>;
+  }
+
+  return (
+    <div className="space-y-3 p-4">
+      {error ? (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      ) : null}
+      <label className="flex items-center gap-3 text-sm">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={!isAdmin || saving}
+          onChange={() => void onToggle()}
+          aria-label="Record calls by default"
+          className="h-4 w-4"
+        />
+        <span className="font-medium text-foreground">
+          Record calls by default
+        </span>
+      </label>
+      <p className="text-xs text-muted-foreground">
+        When on, every voice call is recorded and both parties hear a consent
+        notice at the start: “{RECORDING_CONSENT_NOTICE}” Turning it off stops
+        new calls from recording; existing recordings are unaffected.
+        {isAdmin ? "" : " Only an admin can change this."}
+      </p>
+    </div>
+  );
+}

--- a/src/lib/phone/recording-consent.test.ts
+++ b/src/lib/phone/recording-consent.test.ts
@@ -1,0 +1,29 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording-consent legal pin.
+//
+// The consent notice is legally load-bearing (ADR 0006: "the beep + spoken
+// consent notice played at the start of every recorded call"; PRD stories
+// 38/39 — legal across all 50 states incl. two-party-consent jurisdictions).
+// This file is the legal-text pin: it snapshots the canonical wording so the
+// notice can never change silently — editing the wording is a deliberate
+// snapshot update, reviewed on its own. Nothing else in slice 11 touches this
+// file's snapshots.
+
+import { describe, it, expect } from "vitest";
+import { RECORDING_CONSENT_NOTICE } from "./recording-consent";
+import { buildConsentWhisperTwiml } from "./twilio-client";
+
+describe("recording-consent — legal-text pin (#315)", () => {
+  it("pins the canonical spoken/display consent notice", () => {
+    expect(RECORDING_CONSENT_NOTICE).toMatchInlineSnapshot(
+      `"This call may be recorded for quality and reference."`,
+    );
+  });
+
+  // The consent notice as it actually reaches the answering party of a
+  // recorded call — the TwiML the recording-whisper endpoint serves. Pinned
+  // here so the spoken fragment and the display string change together, never
+  // silently.
+  it("pins the consent notice as the spoken TwiML fragment", () => {
+    expect(buildConsentWhisperTwiml()).toMatchInlineSnapshot(`"<?xml version="1.0" encoding="UTF-8"?><Response><Say>This call may be recorded for quality and reference.</Say></Response>"`);
+  });
+});

--- a/src/lib/phone/recording-consent.ts
+++ b/src/lib/phone/recording-consent.ts
@@ -1,0 +1,19 @@
+// PRD #304 — Nookleus Phone. Slice 11 (#315) — recording consent notice.
+//
+// The single source of truth for the legally-required consent notice spoken
+// at the start of every recorded call (PRD stories 38/39; ADR 0006 — "the
+// beep + spoken consent notice played at the start of every recorded call").
+// One short, plain sentence that covers all 50 states, including two-party-
+// consent jurisdictions.
+//
+// Both recorded-call TwiML paths speak THIS exact text: the inbound voice
+// webhook and the outbound bridge call (buildVoiceTwiml / buildBridgeTwiml in
+// twilio-client.ts) say it to the initiating party, and the per-leg "whisper"
+// TwiML (buildConsentWhisperTwiml) plays it to the answering party. Settings
+// copy quotes it too. Keeping the wording here — and nowhere else — means the
+// two legal surfaces can never drift, and recording-consent.test.ts pins it so
+// a wording change is always a deliberate, reviewed snapshot update.
+
+/** The canonical spoken + displayed call-recording consent notice. */
+export const RECORDING_CONSENT_NOTICE =
+  "This call may be recorded for quality and reference.";

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   buildBridgeTwiml,
+  buildConsentWhisperTwiml,
   buildVoiceTwiml,
   createTwilioClient,
   deleteRecording,
@@ -23,6 +24,7 @@ import {
   sendSms,
   type TwilioClientLike,
 } from "./twilio-client";
+import { RECORDING_CONSENT_NOTICE } from "./recording-consent";
 
 function fakeClient(opts: {
   listResult?: unknown[];
@@ -588,6 +590,70 @@ describe("buildBridgeTwiml — outbound bridge (#314)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Slice 11 (#315) — call recording + consent on the outbound bridge. When
+// recording is enabled, the Crew Lead (the answered originating leg) hears the
+// consent notice before the dial, the bridged conversation is recorded
+// dual-channel and posts to the recording-completed webhook, and the customer
+// (the answering leg) hears the same notice via the <Number> whisper URL.
+// Disabled → byte-for-byte the slice-10 bridge dial.
+// ---------------------------------------------------------------------------
+describe("buildBridgeTwiml — call recording + consent (#315)", () => {
+  it("speaks consent, records the bridge, and whispers consent to the customer when recording is enabled", () => {
+    const xml = buildBridgeTwiml({
+      customerE164: "+15551234567",
+      callerId: "+15125550000",
+      recordCall: true,
+      callRecordingStatusCallback:
+        "https://app.example.com/api/phone/webhook/recording-completed",
+      consentWhisperUrl:
+        "https://app.example.com/api/phone/webhook/recording-whisper",
+    });
+    // The Crew Lead (originating leg) hears the notice before the dial.
+    expect(xml).toContain("<Say");
+    expect(xml).toContain(RECORDING_CONSENT_NOTICE);
+    // The bridged conversation is recorded dual-channel with the callback.
+    expect(xml).toContain('record="record-from-answer-dual"');
+    expect(xml).toContain(
+      'recordingStatusCallback="https://app.example.com/api/phone/webhook/recording-completed"',
+    );
+    // The customer (answering leg) hears the SAME notice via the whisper URL.
+    expect(xml).toContain(
+      'url="https://app.example.com/api/phone/webhook/recording-whisper"',
+    );
+    expect(xml).toContain("+15551234567");
+  });
+
+  it("emits no consent notice and no recording when recording is disabled", () => {
+    const xml = buildBridgeTwiml({
+      customerE164: "+15551234567",
+      callerId: "+15125550000",
+      recordCall: false,
+    });
+    expect(xml).not.toContain("<Say");
+    expect(xml).not.toContain("record=");
+    expect(xml).not.toContain(RECORDING_CONSENT_NOTICE);
+    expect(xml).toContain("<Number>+15551234567</Number>");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 11 (#315) — buildConsentWhisperTwiml is the static TwiML the
+// recording-whisper endpoint serves: it plays the canonical consent notice to
+// the answering party of a recorded call (via each <Number url=...> whisper),
+// so both parties hear it. Sourced from the recording-consent module so it can
+// never drift from the spoken-to-the-caller notice.
+// ---------------------------------------------------------------------------
+describe("buildConsentWhisperTwiml — answering-party consent whisper (#315)", () => {
+  it("plays only the canonical consent notice", () => {
+    const xml = buildConsentWhisperTwiml();
+    expect(xml).toContain("<Say");
+    expect(xml).toContain(RECORDING_CONSENT_NOTICE);
+    // A whisper plays to the callee and returns — it never dials anyone.
+    expect(xml).not.toContain("<Dial");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Slice 10 (#314) — placeBridgeCall. Rings the Crew Lead's cell (`to`) from
 // the Nookleus number (`from`), executing the inline bridge `twiml` on answer.
 // Returns the outer-leg CallSid + initial status; the route stores that SID so
@@ -754,5 +820,74 @@ describe("buildVoiceTwiml — voicemail recording callbacks (#313)", () => {
     const xml = buildVoiceTwiml({ kind: "voicemail" });
     expect(xml).toContain('playBeep="true"');
     expect(xml).toContain('maxLength="120"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 11 (#315) — call recording + consent on the inbound dial branches.
+// When recording is enabled, every answered inbound call (ring-all / forward /
+// round-robin) speaks the legally-required consent notice to the caller, then
+// records the bridged conversation (dual channel) and posts the finished
+// recording to the recording-completed webhook. The answering team member
+// hears the same notice via the per-leg whisper URL on each <Number>. When
+// recording is NOT enabled the TwiML is byte-for-byte the slice-8 dial (the
+// existing ring-all/forward/round-robin tests above are the regression guard).
+// ---------------------------------------------------------------------------
+describe("buildVoiceTwiml — call recording + consent (#315)", () => {
+  it("speaks the consent notice and records the dial when recording is enabled", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "forward", cell: "+15125550009" },
+      {
+        callerId: "+15125550000",
+        recordCall: true,
+        callRecordingStatusCallback:
+          "https://app.example.com/api/phone/webhook/recording-completed",
+        consentWhisperUrl:
+          "https://app.example.com/api/phone/webhook/recording-whisper",
+      },
+    );
+    // The inbound caller (originating leg) hears the consent notice before the dial.
+    expect(xml).toContain("<Say");
+    expect(xml).toContain(RECORDING_CONSENT_NOTICE);
+    // The bridged conversation is recorded dual-channel with the recording-completed callback.
+    expect(xml).toContain('record="record-from-answer-dual"');
+    expect(xml).toContain(
+      'recordingStatusCallback="https://app.example.com/api/phone/webhook/recording-completed"',
+    );
+    // The answering team member hears the SAME notice via the per-leg whisper URL.
+    expect(xml).toContain(
+      'url="https://app.example.com/api/phone/webhook/recording-whisper"',
+    );
+    expect(xml).toContain("+15125550009");
+  });
+
+  it("emits no consent notice and no recording when recording is disabled", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "forward", cell: "+15125550009" },
+      { callerId: "+15125550000", recordCall: false },
+    );
+    expect(xml).not.toContain("<Say");
+    expect(xml).not.toContain("record=");
+    expect(xml).not.toContain(RECORDING_CONSENT_NOTICE);
+    // Identical to the slice-8 bare dial.
+    expect(xml).toContain("<Number>+15125550009</Number>");
+  });
+
+  it("whispers the consent notice to every cell on a ring-all (consent said once to the caller)", () => {
+    const xml = buildVoiceTwiml(
+      { kind: "ring-all", cells: ["+15125550001", "+15125550002"] },
+      {
+        callerId: "+15125550000",
+        recordCall: true,
+        consentWhisperUrl:
+          "https://app.example.com/api/phone/webhook/recording-whisper",
+      },
+    );
+    // The caller hears the notice exactly once before the parallel ring.
+    expect(xml.match(/<Say/g)).toHaveLength(1);
+    // Every reachable cell carries the whisper URL.
+    expect(
+      xml.match(/url="https:\/\/app\.example\.com\/api\/phone\/webhook\/recording-whisper"/g),
+    ).toHaveLength(2);
   });
 });

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -18,6 +18,7 @@
 
 import twilio, { validateRequest } from "twilio";
 import { createFakeTwilioClient } from "./fake-twilio-client";
+import { RECORDING_CONSENT_NOTICE } from "./recording-consent";
 import type { DecideSharedResult } from "./route-shared-call";
 
 // A narrowed slice of an item returned by `availablePhoneNumbers.list` —
@@ -352,6 +353,18 @@ export interface VoiceTwimlOptions {
   // RecordingSid). The route supplies the transcription-completed webhook URL
   // from env; transcription is off when this is omitted.
   transcribeCallback?: string;
+  // Slice 11 (#315) — call recording + consent on the answered (dial) branches.
+  // When `recordCall` is set, the inbound caller hears the consent notice
+  // before the dial, the bridged conversation is recorded dual-channel, and
+  // Twilio posts the finished recording to `callRecordingStatusCallback` (our
+  // recording-completed webhook). `consentWhisperUrl` is played to the
+  // answering team member via each <Number>'s `url` whisper, so BOTH parties
+  // hear the notice. All three are omitted when recording is disabled, leaving
+  // the slice-8 dial TwiML byte-for-byte unchanged. (The consent text itself
+  // is the single source of truth in recording-consent.ts — never inlined.)
+  recordCall?: boolean;
+  callRecordingStatusCallback?: string;
+  consentWhisperUrl?: string;
 }
 
 // Spoken when an inbound call falls through to voicemail and no custom
@@ -363,6 +376,38 @@ const DEFAULT_VOICEMAIL_GREETING =
 // to start speaking; the cap bounds Twilio recording/storage cost and matches
 // a typical voicemail length (2 minutes).
 const VOICEMAIL_MAX_LENGTH_SECONDS = 120;
+
+// Slice 11 (#315) — the dial-level recording config shared by the inbound dial
+// branches (buildVoiceTwiml) and the outbound bridge (buildBridgeTwiml).
+// Centralized so the two legally-relevant recording surfaces can never drift:
+// both capture the whole bridged conversation dual-channel and post the
+// finished recording to the recording-completed webhook.
+type VoiceDialAttributes = NonNullable<
+  Parameters<InstanceType<typeof twilio.twiml.VoiceResponse>["dial"]>[0]
+>;
+type VoiceDial = ReturnType<
+  InstanceType<typeof twilio.twiml.VoiceResponse>["dial"]
+>;
+
+function recordingDialAttributes(statusCallback?: string): VoiceDialAttributes {
+  const attrs: VoiceDialAttributes = { record: "record-from-answer-dual" };
+  if (statusCallback) {
+    attrs.recordingStatusCallback = statusCallback;
+    attrs.recordingStatusCallbackEvent = ["completed"];
+  }
+  return attrs;
+}
+
+// Dial a number, attaching the consent "whisper" URL when recording so the
+// answering party hears the notice too; a bare <Number> otherwise.
+function dialNumberWithConsent(
+  dial: VoiceDial,
+  number: string,
+  whisperUrl?: string,
+): void {
+  if (whisperUrl) dial.number({ url: whisperUrl }, number);
+  else dial.number(number);
+}
 
 /**
  * Build the inbound-call TwiML for a `decideShared` decision. Each decision
@@ -381,14 +426,28 @@ export function buildVoiceTwiml(
   opts: VoiceTwimlOptions = {},
 ): string {
   const vr = new twilio.twiml.VoiceResponse();
+  // Slice 11 (#315): when recording is enabled, the answered call is recorded
+  // dual-channel and posts to the recording-completed webhook. Off → exactly
+  // the slice-8 `{ callerId }` dial.
+  const dialAttrs: VoiceDialAttributes = { callerId: opts.callerId };
+  if (opts.recordCall) {
+    Object.assign(
+      dialAttrs,
+      recordingDialAttributes(opts.callRecordingStatusCallback),
+    );
+  }
+  // The consent whisper plays to each answering cell only when recording.
+  const whisperUrl = opts.recordCall ? opts.consentWhisperUrl : undefined;
   if (decision.kind === "ring-all") {
-    const dial = vr.dial({ callerId: opts.callerId });
+    if (opts.recordCall) vr.say(RECORDING_CONSENT_NOTICE);
+    const dial = vr.dial(dialAttrs);
     for (const cell of decision.cells) {
-      dial.number(cell);
+      dialNumberWithConsent(dial, cell, whisperUrl);
     }
   } else if (decision.kind === "forward" || decision.kind === "round-robin") {
-    const dial = vr.dial({ callerId: opts.callerId });
-    dial.number(decision.cell);
+    if (opts.recordCall) vr.say(RECORDING_CONSENT_NOTICE);
+    const dial = vr.dial(dialAttrs);
+    dialNumberWithConsent(dial, decision.cell, whisperUrl);
   } else {
     vr.say(DEFAULT_VOICEMAIL_GREETING);
     const record: NonNullable<Parameters<typeof vr.record>[0]> = {
@@ -424,12 +483,50 @@ export interface BridgeTwimlInput {
   customerE164: string;
   // The Nookleus number presented to the customer as caller ID.
   callerId: string;
+  // Slice 11 (#315) — call recording + consent. When `recordCall` is set, the
+  // Crew Lead (the answered originating leg) hears the consent notice before
+  // the bridge, the conversation is recorded dual-channel and posted to
+  // `callRecordingStatusCallback` (the recording-completed webhook), and the
+  // customer hears the same notice via the <Number> whisper URL — so BOTH
+  // parties are notified. Omitted → the slice-10 bare bridge dial, unchanged.
+  recordCall?: boolean;
+  callRecordingStatusCallback?: string;
+  consentWhisperUrl?: string;
 }
 
 export function buildBridgeTwiml(input: BridgeTwimlInput): string {
   const vr = new twilio.twiml.VoiceResponse();
-  const dial = vr.dial({ callerId: input.callerId });
-  dial.number(input.customerE164);
+  const dialAttrs: VoiceDialAttributes = { callerId: input.callerId };
+  if (input.recordCall) {
+    // The Crew Lead hears the notice before the customer is dialed.
+    vr.say(RECORDING_CONSENT_NOTICE);
+    Object.assign(
+      dialAttrs,
+      recordingDialAttributes(input.callRecordingStatusCallback),
+    );
+  }
+  // The customer hears the same notice via the whisper on answer, before being
+  // bridged — so both parties are notified on a recorded call.
+  const dial = vr.dial(dialAttrs);
+  dialNumberWithConsent(
+    dial,
+    input.customerE164,
+    input.recordCall ? input.consentWhisperUrl : undefined,
+  );
+  return vr.toString();
+}
+
+/**
+ * Build the consent "whisper" TwiML — the static document the recording-whisper
+ * endpoint serves. Twilio executes it on the answering party's leg (via each
+ * recorded <Number url=...>) before bridging, so BOTH parties hear the consent
+ * notice on a recorded call (PRD stories 38/39; ADR 0006). The notice text is
+ * the single source of truth in recording-consent.ts, so the whisper can never
+ * drift from the notice spoken to the initiating party.
+ */
+export function buildConsentWhisperTwiml(): string {
+  const vr = new twilio.twiml.VoiceResponse();
+  vr.say(RECORDING_CONSENT_NOTICE);
   return vr.toString();
 }
 

--- a/supabase/migration-315-phone-recordings.sql
+++ b/supabase/migration-315-phone-recordings.sql
@@ -1,0 +1,162 @@
+-- issue #315 (PRD #304, ADR 0005 + ADR 0006) — phone_recordings +
+-- organizations.recording_enabled_default.
+--
+-- Purpose:   Call recording for Nookleus Phone. One row per recorded voice
+--            call — the answered/bridged conversation, distinct from a
+--            voicemail (which has its own phone_voicemails row). Every voice
+--            call is auto-recorded by default with a legally-required consent
+--            notice played at the start (PRD stories 38/39/40, ADR 0006). The
+--            recording-completed webhook inserts the row at recording-end,
+--            keyed to its parent phone_calls row via Twilio's CallSid, and
+--            copies the audio out of Twilio into the org-scoped
+--            `phone-recordings` Storage bucket (created by migration-313 and
+--            REUSED here — NOT recreated) so playback outlives Twilio's media
+--            retention and deletion is under Nookleus's control (PRD story 54).
+--            audio_storage_path is that Nookleus-hosted copy;
+--            twilio_recording_url is the original Twilio URL (provenance).
+--
+--            recording_enabled_default is the per-Organization toggle that
+--            governs whether the consent <Say> + <Dial record> stanza is
+--            emitted on inbound and outbound calls. Default TRUE (spec: every
+--            voice call auto-records; the consent notice is the legal
+--            mitigation). A per-call override on the outbound bridge route can
+--            suppress recording for a single call.
+--
+-- Shape:     Mirrors phone_voicemails (migration-313) — the established
+--            phone_calls-child shape: org FK, phone_call_id FK CASCADE,
+--            twilio_recording_sid (so delete hard-deletes on Twilio by SID),
+--            twilio_recording_url (provenance), audio_storage_path (the
+--            Nookleus copy, NULL until/if the copy succeeds), duration_seconds,
+--            created_at. UNIQUE(phone_call_id): one recording per call (a
+--            single <Dial record> yields one recording), so the parent call is
+--            the natural key and the recording-completed webhook's upsert
+--            conflict target. Plus consent_notice_played — pinned TRUE by the
+--            webhook (the notice always fires when recording is enabled; the
+--            boolean is the audit-trail record, not a runtime gate). No
+--            updated_at / update trigger — like phone_calls/phone_voicemails,
+--            the lifecycle is webhook-written.
+--
+-- RLS:       phone_recordings SELECT DELEGATES to phone_calls visibility,
+--            exactly like phone_voicemails_select: a recording is visible iff
+--            its PARENT call is. `organization_id = active_organization_id()
+--            AND EXISTS(select 1 from phone_calls call where call.id =
+--            phone_call_id)` — RLS applies to phone_calls inside the subquery,
+--            so the whole ADR-0005 Shared/Personal/Job matrix is INHERITED from
+--            phone_calls_select and self-heals when that policy changes.
+--
+--            Do NOT re-express the matrix here by joining phone_numbers /
+--            phone_conversations: RLS filters the Personal-number rows out of
+--            the subquery for a non-owner, the join comes back empty, and the
+--            nested job_tag escape hatch never fires — wrongly hiding a
+--            Job-tagged Personal recording from the team (the migration-313
+--            header documents this trap; migration-315-smoke-test.sql pins it).
+--            Like phone_calls the policy does NOT check view_phone — the
+--            feature gate is applied at the route via withRequestContext.
+--
+--            There is no authenticated INSERT / UPDATE / DELETE policy. Every
+--            write path is the Service client: the recording-completed webhook
+--            (no auth user) and the canManage-gated DELETE route
+--            (serviceClient: true, mirroring voicemails/[id]). RLS is ENABLED
+--            so the table is otherwise locked — the only user-facing path is
+--            the SELECT embed the conversation Calls route issues on the User
+--            client.
+--
+-- Indexes:   UNIQUE(phone_call_id) doubles as the lookup index for the
+--            conversation Calls route's nested embed and the
+--            recording-completed insert's conflict target.
+--            idx_phone_recordings_twilio_recording_sid — partial on non-null
+--            sid, for SID-keyed lookups.
+--
+-- Bucket:    REUSES the existing private `phone-recordings` Storage bucket
+--            (created by migration-313, whose header anticipates this reuse).
+--            This migration does NOT (re)create the bucket or its read policy —
+--            call recordings land under the same {organization_id}/{uuid}.{ext}
+--            path as voicemail audio and are signed through the same
+--            /api/phone/recordings route.
+--
+-- Depends on: schema.sql (organizations), migration-312 (phone_calls),
+--            migration-313 (the phone-recordings bucket), and
+--            `nookleus.active_organization_id()`.
+--
+-- Smoke test: supabase/migration-315-smoke-test.sql exercises every cell of
+--            the ADR 0005 matrix on phone_recordings through the parent call,
+--            mirroring migration-313-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. phone_recordings. One row per recorded call, on a phone_calls row.
+-- ---------------------------------------------------------------------------
+create table if not exists public.phone_recordings (
+  id                    uuid primary key default gen_random_uuid(),
+  organization_id       uuid not null references public.organizations(id) on delete cascade,
+  -- The recording's parent call. UNIQUE: one recording per call (a single
+  -- <Dial record> yields one recording). on delete cascade — a recording has
+  -- no meaning without its call (PRD story 54: deleting the call removes it).
+  phone_call_id         uuid not null references public.phone_calls(id) on delete cascade,
+  -- Twilio's RecordingSid. The delete path hard-deletes the recording on
+  -- Twilio by this SID.
+  twilio_recording_sid  text,
+  -- The original Twilio media URL (provenance / re-fetch). Playback uses the
+  -- Nookleus-hosted copy below, not this.
+  twilio_recording_url  text,
+  -- The Nookleus-hosted copy in the phone-recordings bucket
+  -- ({organization_id}/{uuid}.{ext}). NULL if the copy failed (the row still
+  -- persists — see the recording-completed webhook).
+  audio_storage_path    text,
+  -- Recording length in seconds (Twilio's RecordingDuration).
+  duration_seconds      integer,
+  -- The legal-consent <Say> was played before recording began. Pinned TRUE by
+  -- the recording-completed webhook (the notice fires unconditionally when
+  -- recording is enabled); this column is the audit-trail record of that.
+  consent_notice_played boolean not null default true,
+  created_at            timestamptz not null default now(),
+  unique (phone_call_id)
+);
+
+create index if not exists idx_phone_recordings_twilio_recording_sid
+  on public.phone_recordings (twilio_recording_sid)
+  where twilio_recording_sid is not null;
+
+-- ---------------------------------------------------------------------------
+-- 2. Per-Organization recording default. Governs whether inbound + outbound
+--    calls emit the consent <Say> + <Dial record> stanza. Default TRUE: every
+--    voice call auto-records (spec), with the consent notice as the legal
+--    mitigation; a per-call override on the outbound bridge route can suppress
+--    a single call. NOT NULL default backfills every existing org to TRUE.
+-- ---------------------------------------------------------------------------
+alter table public.organizations
+  add column if not exists recording_enabled_default boolean not null default true;
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS. SELECT delegates to phone_calls visibility — a recording is visible
+--    exactly when its parent call is (see the RLS note in the header for why
+--    delegation rather than a restated OR-tree). No authenticated INSERT /
+--    UPDATE / DELETE policy: every write is the Service client (the
+--    recording-completed webhook + the canManage-gated DELETE route).
+-- ---------------------------------------------------------------------------
+alter table public.phone_recordings enable row level security;
+
+drop policy if exists phone_recordings_select on public.phone_recordings;
+create policy phone_recordings_select on public.phone_recordings
+  for select to authenticated
+  using (
+    -- Fast org guard / defense-in-depth: the recording's own org must match
+    -- the caller's Active Organization.
+    organization_id = nookleus.active_organization_id()
+    -- Inherit the parent call's visibility. RLS applies to phone_calls inside
+    -- this subquery, so the EXISTS is true iff phone_calls_select admits the
+    -- parent call — the whole Shared/Personal/Job matrix, one hop out.
+    and exists (
+      select 1
+        from public.phone_calls call
+       where call.id = phone_recordings.phone_call_id
+    )
+  );
+
+-- ROLLBACK ---
+-- drop policy if exists phone_recordings_select on public.phone_recordings;
+-- alter table public.phone_recordings disable row level security;
+-- alter table public.organizations drop column if exists recording_enabled_default;
+-- drop index if exists public.idx_phone_recordings_twilio_recording_sid;
+-- drop table if exists public.phone_recordings;

--- a/supabase/migration-315-smoke-test.sql
+++ b/supabase/migration-315-smoke-test.sql
@@ -1,0 +1,228 @@
+-- issue #315 (PRD #304, ADR 0005) — phone_recordings access-matrix smoke test.
+--
+-- Purpose:   Verify that the migration-315 phone_recordings RLS policy encodes
+--            every cell of the ADR 0005 read-path matrix at the database —
+--            reached through the PARENT call — in the SAME shape
+--            migration-313-smoke-test.sql pins for phone_voicemails. A
+--            recording is visible exactly when its parent call is, so the
+--            matrix is identical; the seed hangs one recording off each of the
+--            four matrix-covering calls and asserts the same visible sets. This
+--            is the load-bearing test that the RLS delegation (EXISTS over
+--            phone_calls) inherits the lifted Job-tag visibility branch — so a
+--            Job-tagged Personal recording stays team-visible.
+--
+--            Matrix exercised (phone_recordings SELECT, via parent call):
+--              - Shared untagged          → every same-org member sees
+--              - Shared Job-tagged        → every same-org member sees
+--              - Personal untagged, owner → owner sees
+--              - Personal untagged, other → hidden (incl. admin)
+--              - Personal Job-tagged, any → sees (Job-visible team)
+--              - Cross-org caller         → never sees
+--
+-- Shape:     One transaction, rolled back at the end. Service-role seeds two
+--            orgs, four users, two phone_numbers (Shared + Personal), two
+--            conversations, one Job, four phone_calls covering the matrix, and
+--            one phone_recordings row per call. Each assertion block sets the
+--            JWT claims, switches to `authenticated`, runs a SELECT, and
+--            asserts the row-count + (where it discriminates) the visible set
+--            via string_agg over twilio_recording_sid (the matrix label).
+--
+-- Run:       Via Supabase MCP `execute_sql` against the target project (with
+--            migration-315 applied). Mirrors migration-313-smoke-test.sql.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed. Service-role bypass for orgs / users / memberships.
+--      Org 1: smoke-315-org-1
+--        User A — admin
+--        User B — crew_lead (non-owner of any Personal number)
+--        User C — crew_lead (owner of the Personal number)
+--      Org 2: smoke-315-org-2
+--        User D — admin
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('31500000-0000-0000-0000-000000000001', 'smoke-315-org-1', 'smoke-315-org-1'),
+  ('31500000-0000-0000-0000-000000000002', 'smoke-315-org-2', 'smoke-315-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('31500000-0000-0000-0000-000000000010', 'smoke-315-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31500000-0000-0000-0000-000000000011', 'smoke-315-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31500000-0000-0000-0000-000000000012', 'smoke-315-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('31500000-0000-0000-0000-000000000013', 'smoke-315-d@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('31500000-0000-0000-0000-000000000010', '31500000-0000-0000-0000-000000000001', 'admin'),
+  ('31500000-0000-0000-0000-000000000011', '31500000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31500000-0000-0000-0000-000000000012', '31500000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('31500000-0000-0000-0000-000000000013', '31500000-0000-0000-0000-000000000002', 'admin');
+
+-- Two phone numbers in org-1: one Shared, one Personal owned by User C.
+insert into public.phone_numbers
+  (id, organization_id, twilio_sid, e164, kind, user_id)
+values
+  ('31500000-0000-0000-0000-0000000000a1', '31500000-0000-0000-0000-000000000001',
+   'PN-smoke315-shared', '+15125550100', 'shared', null),
+  ('31500000-0000-0000-0000-0000000000a2', '31500000-0000-0000-0000-000000000001',
+   'PN-smoke315-personal', '+15125550101', 'personal',
+   '31500000-0000-0000-0000-000000000012');
+
+-- Two conversations — one on each number.
+insert into public.phone_conversations
+  (id, organization_id, phone_number_id, outside_e164)
+values
+  ('31500000-0000-0000-0000-0000000000b1', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000a1', '+15551110101'),
+  ('31500000-0000-0000-0000-0000000000b2', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000a2', '+15551110102');
+
+-- One Job in org-1 for the Job-tagged cases. Contact is a placeholder.
+insert into public.contacts (id, organization_id, full_name)
+values ('31500000-0000-0000-0000-0000000000c1',
+        '31500000-0000-0000-0000-000000000001', 'smoke-315-contact');
+
+insert into public.jobs
+  (id, organization_id, contact_id, damage_type, property_address)
+values
+  ('31500000-0000-0000-0000-0000000000d1', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000c1', 'water', '1 smoke st');
+
+-- Four calls cover the matrix.
+--   call1: Shared, untagged
+--   call2: Shared, tagged (job d1)
+--   call3: Personal (owner C), untagged
+--   call4: Personal (owner C), tagged (job d1)
+insert into public.phone_calls
+  (id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, job_tag)
+values
+  ('31500000-0000-0000-0000-0000000000f1', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'CA-smoke315-1', 'completed', null),
+  ('31500000-0000-0000-0000-0000000000f2', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000b1', 'in', '+15551110101', '+15125550100', 'CA-smoke315-2', 'completed',
+   '31500000-0000-0000-0000-0000000000d1'),
+  ('31500000-0000-0000-0000-0000000000f3', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'CA-smoke315-3', 'completed', null),
+  ('31500000-0000-0000-0000-0000000000f4', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000b2', 'in', '+15551110102', '+15125550101', 'CA-smoke315-4', 'completed',
+   '31500000-0000-0000-0000-0000000000d1');
+
+-- One recording per call. twilio_recording_sid carries the matrix label so the
+-- assertions can string_agg the visible set (mirrors migration-313's transcript).
+insert into public.phone_recordings
+  (id, organization_id, phone_call_id, twilio_recording_sid, duration_seconds)
+values
+  ('31500000-0000-0000-0000-000000000091', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000f1', 'shared-untagged', 30),
+  ('31500000-0000-0000-0000-000000000092', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000f2', 'shared-tagged', 30),
+  ('31500000-0000-0000-0000-000000000093', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000f3', 'personal-untagged', 30),
+  ('31500000-0000-0000-0000-000000000094', '31500000-0000-0000-0000-000000000001',
+   '31500000-0000-0000-0000-0000000000f4', 'personal-tagged', 30);
+
+-- ---------------------------------------------------------------------------
+-- 1. User A (admin, org-1) — sees Shared-untagged, Shared-tagged,
+--    Personal-tagged (Job-visible), but NOT Personal-untagged (admin cannot
+--    read untagged Personal content per ADR 0005).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31500000-0000-0000-0000-000000000010","active_organization_id":"31500000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(twilio_recording_sid, ',' order by twilio_recording_sid)
+    into v_count, v_ids
+    from public.phone_recordings;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-315 smoke (case 1: admin): expected 3 visible recordings, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-315 smoke (case 1: admin): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-315 smoke (case 1: admin) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. User B (crew_lead, org-1, NOT owner of any Personal number) — sees
+--    Shared-untagged, Shared-tagged, Personal-tagged, NOT Personal-untagged.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+  v_ids text;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31500000-0000-0000-0000-000000000011","active_organization_id":"31500000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), string_agg(twilio_recording_sid, ',' order by twilio_recording_sid)
+    into v_count, v_ids
+    from public.phone_recordings;
+
+  reset role;
+
+  if v_count <> 3 then
+    raise exception 'migration-315 smoke (case 2: crew_lead non-owner): expected 3 visible recordings, got % (%)', v_count, v_ids;
+  end if;
+  if v_ids <> 'personal-tagged,shared-tagged,shared-untagged' then
+    raise exception 'migration-315 smoke (case 2: crew_lead non-owner): wrong rows visible — got %', v_ids;
+  end if;
+  raise notice 'migration-315 smoke (case 2: crew_lead non-owner) — sees Shared+Personal-tagged, not Personal-untagged';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. User C (crew_lead, org-1, OWNER of Personal +15125550101) — sees all 4.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31500000-0000-0000-0000-000000000012","active_organization_id":"31500000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_recordings;
+
+  reset role;
+
+  if v_count <> 4 then
+    raise exception 'migration-315 smoke (case 3: Personal owner): expected 4 visible recordings, got %', v_count;
+  end if;
+  raise notice 'migration-315 smoke (case 3: Personal owner) — sees all 4 of own + Shared rows';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. User D (admin, org-2) — cross-org. Should see 0 recordings.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_count int;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"31500000-0000-0000-0000-000000000013","active_organization_id":"31500000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*) into v_count from public.phone_recordings;
+
+  reset role;
+
+  if v_count <> 0 then
+    raise exception 'migration-315 smoke (case 4: cross-org admin): expected 0 visible recordings, got %', v_count;
+  end if;
+  raise notice 'migration-315 smoke (case 4: cross-org admin) — sees nothing';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Done.
+-- ---------------------------------------------------------------------------
+rollback;

--- a/tests/integration/phone-recordings-schema.sql
+++ b/tests/integration/phone-recordings-schema.sql
@@ -1,0 +1,39 @@
+-- Self-contained schema for the embedded-postgres phone_recordings harness
+-- (#315). Loaded by phone-recordings.pg.test.ts into a throwaway cluster.
+--
+-- This is NOT the Supabase stack: there is no PostgREST, and RLS is NOT
+-- enforced (the harness connects as the cluster superuser, which bypasses row
+-- security). It is the smallest schema that lets the LIVE migration-315 apply
+-- verbatim — no copy-paste drift — so the pg suite can pin the structural
+-- contract (FK CASCADE, UNIQUE(phone_call_id), the consent_notice_played and
+-- organizations.recording_enabled_default defaults). The ADR-0005 RLS matrix
+-- is pinned separately by supabase/migration-315-smoke-test.sql (run via the
+-- Supabase MCP, where SET ROLE authenticated actually exercises the policy).
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- The nookleus helper schema. migration-315's SELECT policy references
+-- nookleus.active_organization_id(); stub it so `create policy` parses. (Its
+-- return value is irrelevant here — RLS isn't enforced under the superuser.)
+CREATE SCHEMA IF NOT EXISTS nookleus;
+CREATE OR REPLACE FUNCTION nookleus.active_organization_id() RETURNS uuid
+  LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
+
+-- Minimal organizations: the FK target for phone_recordings.organization_id
+-- and the table migration-315 ALTERs to add recording_enabled_default.
+CREATE TABLE public.organizations (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       text,
+  slug       text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Minimal phone_calls: the parent the recording FK-cascades from and the RLS
+-- subquery reads. Only the columns the cascade test touches (prod shape lives
+-- in supabase/migration-312-phone-calls.sql).
+CREATE TABLE public.phone_calls (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);

--- a/tests/integration/phone-recordings.pg.test.ts
+++ b/tests/integration/phone-recordings.pg.test.ts
@@ -1,0 +1,203 @@
+// Integration coverage for the phone_recordings table + organizations
+// recording-default column — migration-315-phone-recordings.sql (#315,
+// PRD #304 story 38/40, ADR 0005/0006).
+//
+// Harness. The repo's blessed integration harness (tests/integration/
+// global-setup.ts) boots Supabase via `supabase start`, which needs Docker +
+// hardware virtualization — unavailable on this machine. The thing under test
+// here is plain DDL (a table, its FK CASCADE, a UNIQUE, two column defaults),
+// so we boot a throwaway embedded-postgres cluster, load a focused schema +
+// the LIVE migration SQL verbatim (no copy-paste drift), and drive it through
+// a raw `pg` client. Nothing touches the network, Docker, or the local PG
+// service. Run with `npm run test:pg`.
+//
+// RLS is NOT exercised here (the harness connects as the superuser, which
+// bypasses row security) — the ADR-0005 visibility matrix is pinned by
+// supabase/migration-315-smoke-test.sql, run via the Supabase MCP.
+
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import { randomUUID } from "node:crypto";
+
+import EmbeddedPostgres from "embedded-postgres";
+import type { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SCHEMA_SQL = readFileSync(
+  join(process.cwd(), "tests", "integration", "phone-recordings-schema.sql"),
+  "utf8",
+);
+const MIGRATION_SQL = readFileSync(
+  join(process.cwd(), "supabase", "migration-315-phone-recordings.sql"),
+  "utf8",
+);
+
+/** A free ephemeral port so the cluster never collides with a local 5432. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.once("error", reject);
+    srv.listen(0, () => {
+      const { port } = srv.address() as AddressInfo;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+let pgServer: EmbeddedPostgres;
+let dataDir: string;
+let client: Client;
+
+const TEST_DB = "phone_recordings_test";
+
+beforeAll(async () => {
+  // Data dir under the OS temp root, NOT the OneDrive-synced project tree
+  // (OneDrive interferes with initdb's file locking).
+  dataDir = mkdtempSync(join(tmpdir(), "nookleus-pg-"));
+  pgServer = new EmbeddedPostgres({
+    databaseDir: dataDir,
+    port: await freePort(),
+    user: "postgres",
+    password: "postgres",
+    persistent: false,
+    // Match prod: a UTF8 cluster. Without this, initdb inherits the Windows
+    // WIN1252 locale and chokes on the UTF-8 box-drawing in the real migration
+    // comments. `--locale=C` keeps UTF8 valid on Windows.
+    initdbFlags: ["--encoding=UTF8", "--locale=C"],
+    onLog: () => {},
+    onError: () => {},
+  });
+
+  await pgServer.initialise();
+  await pgServer.start();
+  await pgServer.createDatabase(TEST_DB);
+
+  client = pgServer.getPgClient(TEST_DB);
+  await client.connect();
+
+  // migration-315's policy is `for select to authenticated`; create the role
+  // Supabase provides but a bare cluster doesn't, so the SQL loads verbatim.
+  await client.query(
+    "DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated; END IF; END $$;",
+  );
+  await client.query(SCHEMA_SQL);
+  await client.query(MIGRATION_SQL);
+}, 120_000);
+
+afterAll(async () => {
+  if (client) await client.end().catch(() => {});
+  if (pgServer) await pgServer.stop().catch(() => {});
+  if (dataDir) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort temp-dir cleanup; Windows may still hold a handle */
+    }
+  }
+});
+
+/** The migration's own commented `-- ROLLBACK ---` block, un-commented and
+ *  ready to execute — so the test pins that the documented revert is valid and
+ *  complete (no drift between the comment and reality). */
+function rollbackSql(): string {
+  const marker = "-- ROLLBACK ---";
+  const block = MIGRATION_SQL.slice(MIGRATION_SQL.indexOf(marker) + marker.length);
+  return block
+    .split("\n")
+    .map((l) => l.replace(/^--\s?/, "").trim())
+    .filter((l) => l.length > 0)
+    .join("\n");
+}
+
+async function seedOrg(): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    "INSERT INTO organizations (name, slug) VALUES ('Org', 'org-' || $1) RETURNING id",
+    [randomUUID()],
+  );
+  return rows[0].id;
+}
+
+async function seedCall(orgId: string): Promise<string> {
+  const { rows } = await client.query<{ id: string }>(
+    "INSERT INTO phone_calls (organization_id) VALUES ($1) RETURNING id",
+    [orgId],
+  );
+  return rows[0].id;
+}
+
+describe("phone_recordings migration (#315)", () => {
+  // Tracer: the two slice-defining defaults. recording_enabled_default true so
+  // existing + new orgs record by default (spec); consent_notice_played true so
+  // a webhook-written row documents that the notice fired.
+  it("defaults recording_enabled_default and consent_notice_played to true", async () => {
+    const { rows: orgRows } = await client.query<{
+      recording_enabled_default: boolean;
+    }>(
+      "INSERT INTO organizations (name, slug) VALUES ('Org', 'org-' || $1) RETURNING recording_enabled_default",
+      [randomUUID()],
+    );
+    expect(orgRows[0].recording_enabled_default).toBe(true);
+
+    const orgId = await seedOrg();
+    const callId = await seedCall(orgId);
+    const { rows } = await client.query<{ consent_notice_played: boolean }>(
+      "INSERT INTO phone_recordings (organization_id, phone_call_id) VALUES ($1, $2) RETURNING consent_notice_played",
+      [orgId, callId],
+    );
+    expect(rows[0].consent_notice_played).toBe(true);
+  });
+
+  it("cascade-deletes the recording when its parent call is deleted", async () => {
+    const orgId = await seedOrg();
+    const callId = await seedCall(orgId);
+    await client.query(
+      "INSERT INTO phone_recordings (organization_id, phone_call_id) VALUES ($1, $2)",
+      [orgId, callId],
+    );
+    await client.query("DELETE FROM phone_calls WHERE id = $1", [callId]);
+    const { rows } = await client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM phone_recordings WHERE phone_call_id = $1",
+      [callId],
+    );
+    expect(rows[0].n).toBe(0);
+  });
+
+  it("enforces one recording per call (UNIQUE phone_call_id)", async () => {
+    const orgId = await seedOrg();
+    const callId = await seedCall(orgId);
+    await client.query(
+      "INSERT INTO phone_recordings (organization_id, phone_call_id) VALUES ($1, $2)",
+      [orgId, callId],
+    );
+    await expect(
+      client.query(
+        "INSERT INTO phone_recordings (organization_id, phone_call_id) VALUES ($1, $2)",
+        [orgId, callId],
+      ),
+    ).rejects.toThrow();
+  });
+
+  // AC: "phone_recordings migration applies and rolls back cleanly." Run the
+  // migration's OWN commented revert block — it must drop the table, the index,
+  // the policy, and the organizations column without error. Re-apply afterwards
+  // so the cluster is restored for any tests added later (this runs last).
+  it("rolls back cleanly via its own -- ROLLBACK -- block", async () => {
+    await client.query(rollbackSql());
+
+    const { rows: tbl } = await client.query<{ t: string | null }>(
+      "SELECT to_regclass('public.phone_recordings') AS t",
+    );
+    expect(tbl[0].t).toBeNull();
+
+    const { rows: col } = await client.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM information_schema.columns WHERE table_name = 'organizations' AND column_name = 'recording_enabled_default'",
+    );
+    expect(col[0].n).toBe(0);
+
+    // Restore so the schema is intact if more tests join this file later.
+    await client.query(MIGRATION_SQL);
+  });
+});


### PR DESCRIPTION
## Phone slice 11 — Call recording + legal consent notice + playback

Closes #315. PRD #304, ADR 0005/0006. Built test-first (TDD).

Every answered voice call — inbound and outbound bridge — is auto-recorded by default per Organization, with a legally-required consent notice played to **both** parties at the start, and plays back inline on the call event in the Phone-tab thread.

### What's here
- **`recording-consent`** — single source of truth for the notice (`"This call may be recorded for quality and reference."`), snapshot-pinned (display string + rendered `<Say>` fragment) so the wording can't change silently.
- **`migration-315-phone-recordings.sql`** — `phone_recordings` table mirroring `phone_voicemails` (RLS delegates SELECT to `phone_calls`; reuses the slice-9 `phone-recordings` bucket) + `organizations.recording_enabled_default boolean not null default true`. Plus `migration-315-smoke-test.sql` (RLS matrix, run via Supabase MCP).
- **TwiML** — `buildVoiceTwiml` (inbound dial branches) + `buildBridgeTwiml` (outbound) speak consent and record dual-channel; a `recording-whisper` endpoint + `buildConsentWhisperTwiml` play the same notice to the **answering** leg so both parties hear it.
- **`recording-completed` webhook** — inserts the row with `consent_notice_played=true`, copies the MP3 to storage, idempotent on Twilio retries.
- **Wiring** — inbound webhook + outbound calls route read the org default (+ per-call override on the bridge) and thread the recording options through.
- **Inline playback** — calls thread route embeds/flattens the recording; `RecordingPlayer` plays it inline (the slice-8 "will land in slice 11" placeholder is removed).
- **`DELETE /api/phone/recordings/[id]`** — Twilio-first hard-delete (PRD story 54), `canManage`-gated.
- **Settings → Phone "Recording" tab** + `/api/phone/recording-settings` (GET `view_phone` / PATCH admin-only).

### Acceptance criteria
- [x] `phone_recordings` migration applies and rolls back cleanly (pg test)
- [x] Both parties hear the consent notice at the start of every recorded call
- [x] `recording-consent` TwiML fragment + display string snapshot-tested
- [x] Inbound + outbound recorded calls insert a `phone_recordings` row with `consent_notice_played=true`
- [x] Per-call override suppresses both the consent notice and the recording
- [x] Recording plays inline in the Phone-tab thread
- [x] Deleting a recording also deletes it on Twilio's side
- [x] Org-level "recording enabled by default" toggle in Settings → Phone
- [x] Vitest snapshot test, route tests, RTL test
- [x] Stories 38, 39, 40 (+54 deletion)

### Decisions
Org default lives on an `organizations` column (clean org-scoping); default **ON** (consent notice is the legal mitigation); consent reaches the answering party via a per-leg `<Number url>` whisper.

### Verification
160 unit/RTL tests across 12 suites + 4 embedded-postgres tests pass; `tsc --noEmit` clean for all slice-11 files; ESLint clean. The migration is **not yet applied** to any database, and `migration-315-smoke-test.sql` should be run via the Supabase MCP against a project with migration-315 applied (it exercises the RLS matrix the pg harness can't).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
