### PR TITLE
feat(phone): adopt already-ported numbers without repurchasing (#318)

### DIFF
--- a/src/app/api/phone/numbers/adopt/route.test.ts
+++ b/src/app/api/phone/numbers/adopt/route.test.ts
@@ -1,0 +1,230 @@
+// PRD #304 — Nookleus Phone. Slice 14 (#318) — adopt an already-ported number.
+//
+//   POST /api/phone/numbers/adopt — register a number whose carrier port onto
+//   the Twilio account has completed (e.g. the legacy CallRail line). Unlike
+//   the provision route (`POST /api/phone/numbers`), this BUYS NOTHING: it
+//   looks up the existing Twilio SID via `adoptPortedNumber` and inserts the
+//   Shared row pointing at it. Admin-only (canManage on Shared, ADR 0003).
+//
+// The Twilio dependency is mocked at the module boundary
+// (`@/lib/phone/twilio-client`); the route never imports `twilio` directly.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+const adoptPortedNumberMock = vi.fn();
+const createTwilioClientMock = vi.fn();
+vi.mock("@/lib/phone/twilio-client", () => ({
+  adoptPortedNumber: (...args: unknown[]) => adoptPortedNumberMock(...args),
+  createTwilioClient: () => createTwilioClientMock(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeServiceClient,
+  fakeUserClient,
+  memberTables,
+} from "@/app/api/email/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq(body: Record<string, unknown> = {}) {
+  return new Request("http://test", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+// The row the service client "returns" from .single() post-insert. Seeding
+// the table to this row is how the queryBuilder fake echoes an inserted row.
+function adoptedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "row-1",
+    organization_id: "org-1",
+    twilio_sid: "PNported",
+    e164: "+15125559999",
+    label: "Main line (ported)",
+    kind: "shared",
+    user_id: null,
+    inbound_rule: { kind: "ring-all", users: [] },
+    monthly_cost_cents: null,
+    released_at: null,
+    created_at: "2026-06-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// A service client whose `insert` records its payload — the shared
+// `fakeServiceClient` treats insert as a no-op passthrough, so we can't assert
+// on what the route wrote. This minimal capturing builder mirrors the chain
+// the route uses: .insert(payload).select(...).single() → the seeded row.
+function capturingServiceClient(seedRow: Record<string, unknown>) {
+  const insertSpy = vi.fn();
+  const builder: Record<string, unknown> = {
+    insert: (payload: unknown) => {
+      insertSpy(payload);
+      return builder;
+    },
+    select: () => builder,
+    single: async () => ({ data: seedRow, error: null }),
+  };
+  return { client: { from: () => builder }, insertSpy };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+  vi.mocked(createServiceClient).mockReturnValue(
+    fakeServiceClient({ tables: { phone_numbers: [] } }) as never,
+  );
+  createTwilioClientMock.mockReturnValue({ /* unused — adoptPortedNumber mocked */ });
+});
+
+describe("POST /api/phone/numbers/adopt — admin-only adoption (canManage)", () => {
+  const VALID_ADOPT = {
+    phoneNumber: "+15125559999",
+    label: "Main line (ported)",
+  };
+
+  it("adopts the existing Twilio number and inserts a Shared row (no purchase)", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    adoptPortedNumberMock.mockResolvedValue({
+      sid: "PNported",
+      phoneNumber: "+15125559999",
+    });
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({ tables: { phone_numbers: [adoptedRow()] } }) as never,
+    );
+
+    const res = await POST(postReq(VALID_ADOPT), noParams);
+
+    expect(res.status).toBe(201);
+    expect(adoptPortedNumberMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "+15125559999",
+    );
+    const body = await res.json();
+    expect(body).toMatchObject({
+      twilio_sid: "PNported",
+      e164: "+15125559999",
+      kind: "shared",
+    });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+
+    const res = await POST(postReq(VALID_ADOPT), noParams);
+
+    expect(res.status).toBe(401);
+    expect(adoptPortedNumberMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when caller is a crew_lead with view_phone (admin-only)", async () => {
+    authed({
+      user: { id: "user-1" },
+      tables: memberTables({
+        userId: "user-1",
+        role: "crew_lead",
+        grants: ["view_phone"],
+      }),
+    });
+
+    const res = await POST(postReq(VALID_ADOPT), noParams);
+
+    expect(res.status).toBe(403);
+    // A denied request must never reach Twilio.
+    expect(adoptPortedNumberMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when phoneNumber is missing", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(postReq({ label: "Main line (ported)" }), noParams);
+
+    expect(res.status).toBe(400);
+    expect(adoptPortedNumberMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the Twilio lookup fails (port not complete) and does NOT insert a row", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    adoptPortedNumberMock.mockRejectedValue(
+      new Error("no number on the Twilio account (port not complete)"),
+    );
+
+    const res = await POST(postReq(VALID_ADOPT), noParams);
+
+    expect(res.status).toBe(502);
+  });
+
+  it("validates a supplied ring-all inbound_rule and writes it on the row", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+    adoptPortedNumberMock.mockResolvedValue({
+      sid: "PNported",
+      phoneNumber: "+15125559999",
+    });
+    const ring = { kind: "ring-all", users: ["user-9"] };
+    const { client, insertSpy } = capturingServiceClient(
+      adoptedRow({ inbound_rule: ring }),
+    );
+    vi.mocked(createServiceClient).mockReturnValue(client as never);
+
+    const res = await POST(
+      postReq({ ...VALID_ADOPT, inbound_rule: ring }),
+      noParams,
+    );
+
+    expect(res.status).toBe(201);
+    expect(insertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ inbound_rule: ring }),
+    );
+  });
+
+  it("rejects a malformed inbound_rule with 400 before reaching Twilio", async () => {
+    authed({
+      user: { id: "admin-1" },
+      tables: memberTables({ userId: "admin-1", role: "admin", grants: [] }),
+    });
+
+    const res = await POST(
+      postReq({ ...VALID_ADOPT, inbound_rule: { kind: "nonsense" } }),
+      noParams,
+    );
+
+    expect(res.status).toBe(400);
+    // Input validation precedes the side effect — no wasted Twilio lookup.
+    expect(adoptPortedNumberMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/phone/numbers/adopt/route.ts
+++ b/src/app/api/phone/numbers/adopt/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { canManage } from "@/lib/phone/phone-event-access";
+import { parseInboundRule } from "@/lib/phone/parse-inbound-rule";
+import type { InboundRule } from "@/lib/phone/route-shared-call";
+import { adoptPortedNumber, createTwilioClient } from "@/lib/phone/twilio-client";
+
+// PRD #304 — Nookleus Phone. Slice 14 (#318) — adopt an already-ported number.
+//
+// POST /api/phone/numbers/adopt
+//   Register a number whose carrier port onto the Twilio account has already
+//   completed — the legacy CallRail line, or any DID transferred in. The
+//   provision route (`POST /api/phone/numbers`) BUYS a new number via
+//   `incomingPhoneNumbers.create`; this route buys NOTHING. It looks up the
+//   existing Twilio SID with `adoptPortedNumber` and inserts the Shared row
+//   pointing at it, so the line the business already owns is wired into
+//   Nookleus without a second purchase or a duplicate number.
+//
+// Like the provision route, Shared numbers are admin-only (canManage,
+// ADR 0003) and the inbound rule defaults to ring-all — matching the
+// all-hands behavior the CallRail line had before the port.
+//
+// Ordering mirrors the provision route: Twilio lookup first, DB insert
+// second. A lookup failure (port not landed, auth) surfaces 502 with no row
+// written, so the admin can retry once the port completes without DB cleanup.
+
+const PHONE_NUMBER_FIELDS =
+  "id, organization_id, twilio_sid, e164, label, kind, user_id, inbound_rule, voicemail_greeting_url, monthly_cost_cents, is_active, released_at, created_at, updated_at";
+
+export const POST = withRequestContext(
+  { permission: "view_phone", serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as
+      | { phoneNumber?: string; label?: string; inbound_rule?: unknown }
+      | null;
+    const phoneNumber = body?.phoneNumber;
+    const label = body?.label;
+
+    if (!phoneNumber || typeof phoneNumber !== "string") {
+      return NextResponse.json(
+        { error: "phoneNumber (E.164) is required" },
+        { status: 400 },
+      );
+    }
+
+    // ADR 0003 admin-only Shared rule — adopted numbers are Shared.
+    const allowed = canManage(
+      {
+        userId: ctx.userId,
+        organizationId: ctx.orgId ?? "",
+        role: ctx.role,
+      },
+      { kind: "shared", organizationId: ctx.orgId ?? "", userId: null },
+    );
+    if (!allowed) {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+
+    // A ported CallRail line rang everyone; default the inbound rule to
+    // ring-all so adoption preserves that all-hands behavior. A caller may
+    // override it, but only through the same parseInboundRule trust boundary
+    // the PATCH editor uses — a malformed shape is a 400 client error and
+    // never reaches Twilio (input is validated before the side effect).
+    let inboundRule: InboundRule = { kind: "ring-all", users: [] };
+    if (body?.inbound_rule !== undefined && body?.inbound_rule !== null) {
+      const parsed = parseInboundRule(body.inbound_rule);
+      if (!parsed.ok) {
+        return NextResponse.json({ error: parsed.error }, { status: 400 });
+      }
+      inboundRule = parsed.rule;
+    }
+
+    // Twilio lookup first. A throw here (port not landed on the account yet,
+    // auth failure) surfaces 502 — the row is never inserted, so the admin
+    // can retry once the port completes without any DB cleanup.
+    let adopted: { sid: string; phoneNumber: string };
+    try {
+      adopted = await adoptPortedNumber(createTwilioClient(), phoneNumber);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Twilio error";
+      return NextResponse.json({ error: `Twilio: ${message}` }, { status: 502 });
+    }
+
+    const { data, error } = await ctx.serviceClient!
+      .from("phone_numbers")
+      .insert({
+        organization_id: ctx.orgId,
+        twilio_sid: adopted.sid,
+        e164: adopted.phoneNumber,
+        label: label ?? null,
+        kind: "shared",
+        user_id: null,
+        inbound_rule: inboundRule,
+      })
+      .select(PHONE_NUMBER_FIELDS)
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(data, { status: 201 });
+  },
+);

--- a/src/lib/phone/fake-twilio-client.ts
+++ b/src/lib/phone/fake-twilio-client.ts
@@ -85,6 +85,18 @@ export function createFakeTwilioClient(): TwilioClientLike {
           phoneNumber: opts.phoneNumber,
         };
       },
+      // Slice 14 (#318) — adopt an already-ported number. The demo provider has
+      // no real carrier account to query, so it pretends the requested number
+      // is already ported and returns a synthetic existing SID for it. This
+      // lets the adopt path run end-to-end in demo mode without a purchase.
+      async list(opts: { phoneNumber: string }) {
+        return [
+          {
+            sid: `PN${fakeSidTail()}`,
+            phoneNumber: opts.phoneNumber,
+          },
+        ];
+      },
     },
   );
 

--- a/src/lib/phone/twilio-client.test.ts
+++ b/src/lib/phone/twilio-client.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
+  adoptPortedNumber,
   buildBridgeTwiml,
   buildConsentWhisperTwiml,
   buildVoiceTwiml,
@@ -35,6 +36,10 @@ function fakeClient(opts: {
   callCreateResult?: { sid: string; status: string };
   callCreateImpl?: (params: unknown) => Promise<unknown>;
   recordingRemoveImpl?: () => Promise<void>;
+  // Slice 14 (#318) — incomingPhoneNumbers.list, used by adoptPortedNumber to
+  // look up an already-ported number's existing SID (instead of buying one).
+  incomingListResult?: Array<{ sid: string; phoneNumber: string }>;
+  incomingListSpy?: ReturnType<typeof vi.fn>;
   listSpy?: ReturnType<typeof vi.fn>;
   createSpy?: ReturnType<typeof vi.fn>;
   removeSpy?: ReturnType<typeof vi.fn>;
@@ -46,6 +51,8 @@ function fakeClient(opts: {
   const create =
     opts.createSpy ??
     vi.fn(async () => opts.createResult ?? { sid: "PNxxx", phoneNumber: "+15555550100" });
+  const incomingList =
+    opts.incomingListSpy ?? vi.fn(async () => opts.incomingListResult ?? []);
   const remove = opts.removeSpy ?? vi.fn(opts.removeImpl ?? (async () => undefined));
   const recordingRemove =
     opts.recordingRemoveSpy ??
@@ -67,7 +74,7 @@ function fakeClient(opts: {
   // can stay byte-identical between fake and real client.
   const incomingPhoneNumbers = Object.assign(
     (_sid: string) => ({ remove }),
-    { create },
+    { create, list: incomingList },
   );
   return {
     availablePhoneNumbers: (_country: string) => ({ local: { list } }),
@@ -168,6 +175,49 @@ describe("provisionNumber", () => {
       /E\.164/i,
     );
     await expect(provisionNumber(client, "")).rejects.toThrow(/E\.164/i);
+  });
+});
+
+// Slice 14 (#318) — adopt a number already ported onto the Twilio account.
+// Unlike `provisionNumber` (which BUYS a new line via `.create`), a ported
+// number already lives on the account; we only need to look up its existing
+// SID with `incomingPhoneNumbers.list({phoneNumber})`. No purchase, no charge.
+describe("adoptPortedNumber", () => {
+  it("looks up an already-ported number by E.164 and returns its existing sid (no purchase)", async () => {
+    const incomingListSpy = vi.fn(async () => [
+      { sid: "PNported", phoneNumber: "+15125559999" },
+    ]);
+    const createSpy = vi.fn();
+    const client = fakeClient({ incomingListSpy, createSpy });
+
+    const result = await adoptPortedNumber(client, "+15125559999");
+
+    expect(result).toEqual({ sid: "PNported", phoneNumber: "+15125559999" });
+    expect(incomingListSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ phoneNumber: "+15125559999" }),
+    );
+    // Adoption must never buy a number — `.create` would incur a charge.
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-E.164 phone numbers (defense before hitting Twilio)", async () => {
+    const incomingListSpy = vi.fn(async () => []);
+    const client = fakeClient({ incomingListSpy });
+
+    await expect(adoptPortedNumber(client, "5125551234")).rejects.toThrow(
+      /E\.164/i,
+    );
+    await expect(adoptPortedNumber(client, "")).rejects.toThrow(/E\.164/i);
+    // The guard runs before the lookup — no wasted Twilio round-trip.
+    expect(incomingListSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when the number is not on the account yet (port not complete)", async () => {
+    const client = fakeClient({ incomingListResult: [] });
+
+    await expect(
+      adoptPortedNumber(client, "+15125559999"),
+    ).rejects.toThrow(/port not complete/i);
   });
 });
 

--- a/src/lib/phone/twilio-client.ts
+++ b/src/lib/phone/twilio-client.ts
@@ -55,6 +55,13 @@ export interface TwilioClientLike {
       sid: string;
       phoneNumber: string;
     }>;
+    // Slice 14 (#318) — adopt an already-ported number. `list({ phoneNumber })`
+    // finds a number ALREADY on the Twilio account (a completed port) and
+    // returns its existing SID, so adoption reuses the line instead of buying
+    // a new one via `.create`.
+    list(opts: { phoneNumber: string }): Promise<
+      Array<{ sid: string; phoneNumber: string }>
+    >;
   };
   // Slice 10 (#313) — voicemail deletion. The SDK's `recordings` is the same
   // callable-single-resource shape: `client.recordings(sid).remove()` issues
@@ -140,6 +147,38 @@ export async function provisionNumber(
   }
   const created = await client.incomingPhoneNumbers.create({ phoneNumber });
   return { sid: created.sid, phoneNumber: created.phoneNumber };
+}
+
+/**
+ * Adopt a number that has ALREADY been ported onto the Twilio account —
+ * e.g. a CallRail / legacy line whose carrier port has completed. Unlike
+ * `provisionNumber`, this never calls `.create`, so it incurs no purchase
+ * and no monthly charge: the line already exists on the account; we only
+ * need its Twilio SID to store in `phone_numbers.twilio_sid`.
+ *
+ * Looks the number up by exact E.164 via `incomingPhoneNumbers.list`. Throws
+ * if no match is found — the expected signal that the port has not landed on
+ * the account yet (so the caller can surface "port not complete" rather than
+ * silently provisioning a fresh, wrong number).
+ */
+export async function adoptPortedNumber(
+  client: TwilioClientLike,
+  phoneNumber: string,
+): Promise<ProvisionedNumber> {
+  if (!E164_RE.test(phoneNumber)) {
+    throw new Error(
+      `twilio-client: invalid phoneNumber "${phoneNumber}" (must be E.164, e.g. +15125551234)`,
+    );
+  }
+  const matches = await client.incomingPhoneNumbers.list({ phoneNumber });
+  const existing = matches[0];
+  if (!existing) {
+    throw new Error(
+      `twilio-client: no number "${phoneNumber}" on the Twilio account ` +
+        "(port not complete — the line must already be ported before it can be adopted)",
+    );
+  }
+  return { sid: existing.sid, phoneNumber: existing.phoneNumber };
 }
 
 /**


### PR DESCRIPTION
## What & why

Closes #318. Porting the legacy CallRail line onto the Twilio account leaves a number that **already exists** on the account. The provision route (`POST /api/phone/numbers`) calls `incomingPhoneNumbers.create`, which would buy a *second, wrong* number. This adds an **adopt** path that looks up the existing SID and wires it into Nookleus — no purchase, no duplicate.

(The rest of #318 — the port request, carrier paperwork, A2P association — is HITL and already supported; this PR is the one genuine code gap.)

## Changes

**Helper** — `src/lib/phone/twilio-client.ts`
- New `adoptPortedNumber(client, e164)`: E.164 guard → `incomingPhoneNumbers.list({ phoneNumber })` → reuse the existing `{ sid, phoneNumber }`. Throws *"port not complete"* when no match (the line isn't on the account yet). **Never calls `.create`**, so it incurs no purchase or monthly charge.
- Grew `TwilioClientLike.incomingPhoneNumbers` with `list(...)`.

**Route** — `src/app/api/phone/numbers/adopt/route.ts` (new `POST`)
- Admin-only via `canManage` on Shared (ADR 0003); inserts `kind='shared'` pointing at the existing SID.
- `inbound_rule` defaults to **ring-all** (matches CallRail's all-hands behavior). An override is validated through the `parseInboundRule` trust boundary — malformed → **400 before** the Twilio lookup.
- Twilio-first / DB-second ordering mirrors the provision route: a lookup failure → **502** with no row written, so the admin can retry once the port lands.

**Demo provider** — `src/lib/phone/fake-twilio-client.ts`: taught the fake `list` so the adopt path runs carrier-free in `NOOKLEUS_PHONE_DEMO_MODE`.

## Tests (built test-first, vertical slices)

| | behavior |
|---|---|
| Helper T1–T3 | look-up-by-E.164 reuses SID & asserts `.create` *not* called · non-E.164 reject · no-match throw |
| Route T4–T8 | admin 201 (twilio_sid = existing SID, kind=shared) · 401/403 with Twilio not called · missing phoneNumber 400 · lookup-fail 502 · ring-all validated+written / malformed 400 |

## Verification
- **86 phone-area tests pass** (10 new); no regressions across provision / `[id]` / fake suites.
- `tsc --noEmit` clean for these changes (the 2 remaining errors are pre-existing & unrelated — `mobile/camera-view` zoom plugin, present on `main`).
- Lint: **0 errors** (the 8 warnings are the pre-existing `_sid`/`_opts` underscore-param convention; new code adds none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)