### PR TITLE
feat(phone): add Job-page Calls (N) section (#316)

### DIFF
--- a/src/app/api/phone/calls/route.test.ts
+++ b/src/app/api/phone/calls/route.test.ts
@@ -49,7 +49,7 @@ vi.mock("@/lib/phone/twilio-client", () => ({
   createTwilioClient: () => createTwilioClientMock(),
 }));
 
-import { POST } from "./route";
+import { GET, POST } from "./route";
 import { createServerSupabaseClient } from "@/lib/supabase-server";
 import { createServiceClient } from "@/lib/supabase-api";
 import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
@@ -841,5 +841,113 @@ describe("POST /api/phone/calls — Twilio failure", () => {
 
     expect(res.status).toBe(502);
     expect(inserts.find((i) => i.table === "phone_calls")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 10. GET ?jobId= — Slice 12 (#316). The Job-page Calls (N) section reads
+//     every call tagged to a Job here, mirroring the messages GET: a thin RLS
+//     pass-through over the User client (no Service client) that filters by
+//     job_tag, embeds + flattens the voicemail/recording children, and orders
+//     by started_at. RLS (migration-312) enforces the ADR 0003 matrix — a
+//     caller who cannot see a row simply doesn't get it back. The section and
+//     this endpoint are both hidden from anyone without view_phone.
+// ---------------------------------------------------------------------------
+
+describe("GET /api/phone/calls?jobId= — Job-page Calls section (#316)", () => {
+  it("returns only this job's calls, with voicemail + recording flattened, for a view_phone caller", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    tables.phone_calls = [
+      // Tagged to job-1 — answered + recorded.
+      {
+        id: "call-rec",
+        organization_id: ORG,
+        conversation_id: "conv-1",
+        direction: "out",
+        from_e164: "+15125550000",
+        to_e164: "+15551234567",
+        status: "completed",
+        duration_seconds: 42,
+        job_tag: "job-1",
+        started_at: "2026-05-27T12:00:00Z",
+        ended_at: "2026-05-27T12:00:42Z",
+        phone_recordings: [
+          {
+            id: "rec-1",
+            audio_storage_path: "org-1/rec-1.mp3",
+            consent_notice_played: true,
+            duration_seconds: 42,
+          },
+        ],
+        phone_voicemails: [],
+      },
+      // Tagged to a DIFFERENT job — must be filtered out by job_tag.
+      {
+        id: "call-other",
+        organization_id: ORG,
+        conversation_id: "conv-9",
+        direction: "in",
+        from_e164: "+15559998888",
+        to_e164: "+15125550000",
+        status: "completed",
+        duration_seconds: 10,
+        job_tag: "job-2",
+        started_at: "2026-05-27T09:00:00Z",
+        ended_at: "2026-05-27T09:00:10Z",
+        phone_recordings: [],
+        phone_voicemails: [],
+      },
+    ];
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/calls?jobId=job-1"),
+      noParams,
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({
+      id: "call-rec",
+      direction: "out",
+      status: "completed",
+      job_tag: "job-1",
+    });
+    expect(body[0].recording).toEqual({
+      id: "rec-1",
+      audio_storage_path: "org-1/rec-1.mp3",
+      consent_notice_played: true,
+      duration_seconds: 42,
+    });
+    expect(body[0].voicemail).toBeNull();
+    // The raw PostgREST embed keys are gone — the client sees only the
+    // flattened `recording` / `voicemail` fields.
+    expect("phone_recordings" in body[0]).toBe(false);
+    expect("phone_voicemails" in body[0]).toBe(false);
+  });
+
+  it("400s when jobId is missing — the section always scopes to one Job", async () => {
+    const tables = memberTables({
+      userId: "u-1",
+      role: "crew_lead",
+      grants: ["view_phone"],
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: { id: "u-1" }, tables }) as never,
+    );
+
+    const res = await GET(
+      new Request("http://test/api/phone/calls"),
+      noParams,
+    );
+
+    expect(res.status).toBe(400);
   });
 });

--- a/src/app/api/phone/calls/route.ts
+++ b/src/app/api/phone/calls/route.ts
@@ -60,6 +60,23 @@ interface Body {
 
 const E164_RE = /^\+[1-9]\d{6,14}$/;
 
+// Slice 12 (#316) — Job-page Calls section. The same call shape the Phone-tab
+// thread route (conversations/[id]/calls) returns: every field the row carries
+// plus its voicemail + recording embeds, each flattened from PostgREST's 0-or-1
+// array (UNIQUE per call) to a single `voicemail | null` / `recording | null`.
+const JOB_CALL_FIELDS =
+  "id, organization_id, conversation_id, direction, from_e164, to_e164, twilio_call_sid, status, duration_seconds, job_tag, tagged_by_user_id, initiated_by_user_id, started_at, ended_at, created_at, phone_voicemails(id, audio_storage_path, transcript, transcript_status, duration_seconds), phone_recordings(id, audio_storage_path, consent_notice_played, duration_seconds)";
+
+function flattenChild(
+  row: Record<string, unknown>,
+  embedKey: string,
+  field: string,
+): Record<string, unknown> {
+  const { [embedKey]: embed, ...rest } = row;
+  const value = Array.isArray(embed) ? (embed[0] ?? null) : (embed ?? null);
+  return { ...rest, [field]: value };
+}
+
 function parseSourceContext(input: unknown): SmartAttachSource {
   if (typeof input === "string") {
     if (input === "phone-tab") return { kind: "phone-tab" };
@@ -84,6 +101,37 @@ function parseSourceContext(input: unknown): SmartAttachSource {
   }
   return { kind: "phone-tab" };
 }
+
+// Slice 12 (#316) — Job-page Calls section. Returns every voice call tagged to
+// the given Job (job_tag), chronological, with voicemail + recording flattened.
+// User-client only: RLS (migration-312) enforces the ADR 0003 access matrix, so
+// a row the caller can't see is simply absent — no serviceClient. view_phone
+// gates the section (Crew Members lack it and never reach this route).
+export const GET = withRequestContext(
+  { permission: "view_phone" },
+  async (request, ctx) => {
+    const jobId = new URL(request.url).searchParams.get("jobId");
+    if (!jobId) {
+      return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+    }
+    const { data, error } = await ctx.supabase
+      .from("phone_calls")
+      .select(JOB_CALL_FIELDS)
+      .eq("job_tag", jobId)
+      .order("started_at", { ascending: true });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    const calls = ((data ?? []) as Record<string, unknown>[]).map((row) =>
+      flattenChild(
+        flattenChild(row, "phone_voicemails", "voicemail"),
+        "phone_recordings",
+        "recording",
+      ),
+    );
+    return NextResponse.json(calls);
+  },
+);
 
 export const POST = withRequestContext(
   { permission: "view_phone", serviceClient: true },

--- a/src/app/phone/phone-page-client.test.tsx
+++ b/src/app/phone/phone-page-client.test.tsx
@@ -1590,3 +1590,84 @@ describe("PhonePageClient — voicemail render (#313)", () => {
     expect(screen.queryByText(/transcribing/i)).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Slice 12 (#316) — deep link from the Job-page Calls section. A call row
+// links to /phone?conversation=<id>&call=<id>; landing on the Phone tab with
+// those params auto-selects the thread and scrolls the named call into view.
+// ---------------------------------------------------------------------------
+describe("PhonePageClient — deep link to a call (#316)", () => {
+  it("auto-selects the conversation named in ?conversation= without a click", async () => {
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": {
+        ok: true,
+        body: [
+          {
+            id: "m-deep",
+            conversation_id: "conv-1",
+            direction: "in",
+            body: "Deep linked thread",
+            sent_at: "2026-05-27T10:00:00Z",
+            job_tag: null,
+          },
+        ],
+      },
+      "/api/phone/conversations/conv-1/calls": { ok: true, body: [] },
+    });
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("conversation=conv-1"),
+    );
+
+    render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[convo({ id: "conv-1" })]}
+      />,
+    );
+
+    // No fireEvent.click — the URL param drove the selection.
+    expect(await screen.findByText("Deep linked thread")).toBeDefined();
+  });
+
+  it("scrolls the call named in ?call= into view once its thread loads", async () => {
+    const scrollSpy = vi.fn();
+    (
+      Element.prototype as unknown as { scrollIntoView: () => void }
+    ).scrollIntoView = scrollSpy;
+
+    respondWith({
+      "/api/phone/conversations/conv-1/messages": { ok: true, body: [] },
+      "/api/phone/conversations/conv-1/calls": {
+        ok: true,
+        body: [
+          {
+            id: "call-deep",
+            conversation_id: "conv-1",
+            direction: "in",
+            status: "completed",
+            duration_seconds: 30,
+            started_at: "2026-05-27T10:00:00Z",
+            ended_at: "2026-05-27T10:00:30Z",
+          },
+        ],
+      },
+    });
+    searchParamsMock.mockReturnValue(
+      new URLSearchParams("conversation=conv-1&call=call-deep"),
+    );
+
+    const { container } = render(
+      <PhonePageClient
+        organizationId="org-1"
+        initialConversations={[convo({ id: "conv-1" })]}
+      />,
+    );
+
+    await waitFor(() => {
+      // The CallRow rendered with a stable anchor id…
+      expect(container.querySelector("#call-row-call-deep")).not.toBeNull();
+      // …and the page scrolled it into view.
+      expect(scrollSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/phone/phone-page-client.tsx
+++ b/src/app/phone/phone-page-client.tsx
@@ -147,7 +147,15 @@ export function PhonePageClient({
   const [conversations, setConversations] = useState(
     sortConversations(initialConversations),
   );
-  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+  // Slice 12 (#316) — deep link from the Job-page Calls section. `conversation`
+  // pre-selects the thread on mount; `call` is the call to scroll into view
+  // once that thread's calls load.
+  const deepLinkConversation = searchParams?.get("conversation") ?? null;
+  const deepLinkCallId = searchParams?.get("call") ?? null;
+  const [selectedId, setSelectedId] = useState<string | null>(
+    deepLinkConversation,
+  );
   const [messages, setMessages] = useState<PhoneMessage[]>([]);
   const [calls, setCalls] = useState<PhoneCall[]>([]);
   const [loadingThread, setLoadingThread] = useState(false);
@@ -172,7 +180,6 @@ export function PhonePageClient({
   // chips, save-as-contact) remains visible either way.
   const outboundEnabled = isPhoneOutboundEnabled();
 
-  const searchParams = useSearchParams();
   const initialTo = searchParams?.get("to") ?? null;
   const [newConv, setNewConv] = useState<null | { to: string; body: string }>(
     outboundEnabled && initialTo ? { to: initialTo, body: "" } : null,
@@ -221,6 +228,21 @@ export function PhonePageClient({
     void loadMessages(selectedId);
     void loadCalls(selectedId);
   }, [selectedId, loadMessages, loadCalls]);
+
+  // Slice 12 (#316) — after a deep-linked thread's calls load, scroll the call
+  // named in `?call=` into view (once). Each CallRow renders a stable
+  // `call-row-<id>` anchor; we wait until that call is present before scrolling.
+  const didScrollToDeepLinkRef = useRef(false);
+  useEffect(() => {
+    if (didScrollToDeepLinkRef.current) return;
+    if (!deepLinkCallId) return;
+    if (!calls.some((c) => c.id === deepLinkCallId)) return;
+    const el = document.getElementById(`call-row-${deepLinkCallId}`);
+    if (el) {
+      el.scrollIntoView({ block: "center", behavior: "smooth" });
+      didScrollToDeepLinkRef.current = true;
+    }
+  }, [calls, deepLinkCallId]);
 
   const threadItems = useMemo(
     () => mergeThreadItems(messages, calls),
@@ -1103,7 +1125,7 @@ function CallRow({ call }: { call: PhoneCall }) {
   const label = incoming ? "Incoming call" : "Outgoing call";
   const DirectionIcon = incoming ? PhoneIncoming : PhoneOutgoing;
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div id={`call-row-${call.id}`} className="flex flex-col items-center gap-1">
       {/* A call renders as a centered status pill. Slice 11 (#315) replaced the
           tap-to-open placeholder with inline recording playback below the pill,
           so the pill is no longer interactive. */}

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -32,6 +32,7 @@ import ComposeEmailModal from "@/components/compose-email";
 import { JobEmailRow } from "@/components/email/job-email-row";
 import { buildQuotedReply } from "@/components/email/build-quoted-reply";
 import { JobMessagesSection } from "@/components/job-detail/job-messages-section";
+import { JobCallsSection } from "@/components/job-detail/job-calls-section";
 import { buildJobTextContacts } from "@/components/job-detail/job-text-contacts";
 import JarvisJobPanel from "@/components/jarvis/JarvisJobPanel";
 import JobFiles from "@/components/job-files";
@@ -1027,6 +1028,15 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           view_phone; renders every text tagged to this Job across all
           numbers (Shared + Personal). PRD #304, slice 7 (#311). */}
       <JobMessagesSection
+        jobId={jobId}
+        organizationId={job.organization_id}
+        contacts={buildJobTextContacts(job)}
+      />
+
+      {/* Calls — mirrors Messages. Hidden from users without view_phone;
+          renders every voice call tagged to this Job across all numbers, each
+          deep-linking to its Phone-tab thread. PRD #304, slice 12 (#316). */}
+      <JobCallsSection
         jobId={jobId}
         organizationId={job.organization_id}
         contacts={buildJobTextContacts(job)}

--- a/src/components/job-detail/job-calls-section.test.tsx
+++ b/src/components/job-detail/job-calls-section.test.tsx
@@ -1,0 +1,367 @@
+// PRD #304 — Nookleus Phone. Slice 12 (#316) — Job-page Calls (N) section.
+//
+// RTL integration tests for the Calls section that sits alongside the
+// Messages (N) and Emails (N) sections on every Job page. AC bullets pinned
+// here:
+//   - "Job page renders Calls (N) for view_phone users"
+//   - "Section hidden for users without view_phone"
+//   - "(N) = count of phone_calls whose job_tag = current job"
+//   - "each call shows direction, counterparty, status/duration, time"
+//   - "a recorded call plays its recording; a voicemail plays + shows transcript"
+//   - "a new Job-tagged call surfaces live"
+//
+// The section is a client component; we mock useAuth (the view_phone gate),
+// fetch (the GET /api/phone/calls?jobId= read and the per-recording signed
+// URL), and usePhoneSync (the realtime subscription).
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+const auth = vi.hoisted(() => ({
+  value: {
+    loading: false,
+    hasPermission: (_k: string) => false as boolean,
+  },
+}));
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => auth.value,
+}));
+
+// Capture the realtime subscription the section wires up so a test can fire
+// INSERT/UPDATE events at it. The section feeds usePhoneSync a browser
+// Supabase client; we stub createClient so the client component can mount
+// under jsdom without a real connection.
+const sync = vi.hoisted(() => ({
+  input: null as {
+    organizationId: string | null;
+    onNewCall?: (row: unknown) => void;
+    onCallUpdate?: (row: unknown) => void;
+    onVoicemailUpdate?: (row: unknown) => void;
+  } | null,
+}));
+vi.mock("@/lib/phone/use-phone-sync", () => ({
+  usePhoneSync: (input: unknown) => {
+    sync.input = input as typeof sync.input;
+  },
+}));
+vi.mock("@/lib/supabase", () => ({
+  createClient: () => ({}) as never,
+}));
+
+import { JobCallsSection } from "./job-calls-section";
+
+type Voicemail = {
+  id: string;
+  audio_storage_path: string | null;
+  transcript: string | null;
+  transcript_status: "pending" | "ready" | "failed";
+  duration_seconds: number | null;
+};
+type Recording = {
+  id: string;
+  audio_storage_path: string | null;
+  consent_notice_played: boolean;
+  duration_seconds: number | null;
+};
+type CallRow = {
+  id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  status: string | null;
+  duration_seconds: number | null;
+  started_at: string;
+  ended_at: string | null;
+  job_tag: string | null;
+  voicemail?: Voicemail | null;
+  recording?: Recording | null;
+};
+
+function call(overrides: Partial<CallRow> = {}): CallRow {
+  return {
+    id: "call-1",
+    conversation_id: "conv-1",
+    direction: "in",
+    from_e164: "+15125550001",
+    to_e164: "+15125559999",
+    status: "completed",
+    duration_seconds: 42,
+    started_at: "2026-06-01T10:00:00Z",
+    ended_at: "2026-06-01T10:00:42Z",
+    job_tag: "job-1",
+    voicemail: null,
+    recording: null,
+    ...overrides,
+  };
+}
+
+function asViewPhone() {
+  auth.value = {
+    loading: false,
+    hasPermission: (k: string) => k === "view_phone",
+  };
+}
+function asNoPhone() {
+  auth.value = { loading: false, hasPermission: () => false };
+}
+
+function stubCalls(rows: CallRow[]) {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+const contacts = [{ id: "c1", name: "Homer Owner", phone: "+15125550001" }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sync.input = null;
+});
+
+describe("JobCallsSection — render", () => {
+  it("renders Calls (N) with the job's calls for a view_phone user", async () => {
+    asViewPhone();
+    stubCalls([
+      call({ id: "c-a", direction: "in" }),
+      call({ id: "c-b", direction: "out" }),
+    ]);
+
+    render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    expect(await screen.findByText("Calls (2)")).toBeDefined();
+  });
+
+  it("renders nothing — and does not even fetch — for a user without view_phone", () => {
+    asNoPhone();
+    const spy = stubCalls([call()]);
+
+    const { container } = render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    expect(container.querySelector("h3")).toBeNull();
+    expect(screen.queryByText(/Calls \(/)).toBeNull();
+    expect(spy).not.toHaveBeenCalled();
+    // …and it withholds the realtime subscription end-to-end: the section
+    // feeds usePhoneSync organizationId:null when the user lacks view_phone,
+    // so the hook (proven by its own null-org test) opens no channel.
+    expect(sync.input?.organizationId).toBeNull();
+  });
+
+  it("shows Calls (0) and an empty-state when the job has no calls", async () => {
+    asViewPhone();
+    stubCalls([]);
+
+    render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    expect(await screen.findByText("Calls (0)")).toBeDefined();
+    expect(screen.getByText(/no (phone )?calls/i)).toBeDefined();
+  });
+});
+
+describe("JobCallsSection — call rows", () => {
+  it("renders each call with its counterparty label and duration, and 'no answer' for an unanswered call", async () => {
+    asViewPhone();
+    stubCalls([
+      // inbound, answered, from a known contact → his name + talk time
+      call({
+        id: "c-in",
+        direction: "in",
+        from_e164: "+15125550001",
+        to_e164: "+15125559999",
+        status: "completed",
+        duration_seconds: 42,
+      }),
+      // outbound, answered, to an unknown number → the formatted number + time
+      call({
+        id: "c-out",
+        direction: "out",
+        from_e164: "+15125559999",
+        to_e164: "+15125557777",
+        status: "completed",
+        duration_seconds: 95,
+      }),
+      // inbound, unanswered (no_answer) → "no answer", and NO duration
+      call({
+        id: "c-missed",
+        direction: "in",
+        from_e164: "+15125558888",
+        to_e164: "+15125559999",
+        status: "no_answer",
+        duration_seconds: null,
+      }),
+    ]);
+
+    render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    expect(await screen.findByText("Calls (3)")).toBeDefined();
+    // Counterparty: known contact by name, unknown by formatted number.
+    expect(screen.getByText("Homer Owner")).toBeDefined();
+    expect(screen.getByText("(512) 555-7777")).toBeDefined();
+    expect(screen.getByText("(512) 555-8888")).toBeDefined();
+    // Answered calls show talk time (mm:ss); the unanswered call says so.
+    expect(screen.getByText("0:42")).toBeDefined();
+    expect(screen.getByText("1:35")).toBeDefined();
+    expect(screen.getByText(/no answer/i)).toBeDefined();
+    // A null duration must NOT render as "0:00".
+    expect(screen.queryByText("0:00")).toBeNull();
+  });
+
+  it("plays a recorded call's recording, signed from the recordings endpoint", async () => {
+    asViewPhone();
+    const spy = vi.fn(async (url: string) => {
+      if (String(url).includes("/api/phone/recordings")) {
+        return new Response(
+          JSON.stringify({ url: "https://signed/org-1/rec-1.mp3" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify([
+          call({
+            id: "c-rec",
+            direction: "out",
+            recording: {
+              id: "rec-1",
+              audio_storage_path: "org-1/rec-1.mp3",
+              consent_notice_played: true,
+              duration_seconds: 30,
+            },
+          }),
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", spy);
+
+    const { container } = render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    await screen.findByText("Calls (1)");
+    await waitFor(() => {
+      const audio = container.querySelector(
+        'audio[aria-label="Call recording"]',
+      );
+      expect(audio?.getAttribute("src")).toBe("https://signed/org-1/rec-1.mp3");
+    });
+    const signed = spy.mock.calls.find(([u]) =>
+      String(u).includes("/api/phone/recordings"),
+    );
+    expect(String(signed![0])).toContain(
+      `path=${encodeURIComponent("org-1/rec-1.mp3")}`,
+    );
+  });
+
+  it("plays a voicemail and shows its transcript when the call went to voicemail", async () => {
+    asViewPhone();
+    const spy = vi.fn(async (url: string) => {
+      if (String(url).includes("/api/phone/recordings")) {
+        return new Response(
+          JSON.stringify({ url: "https://signed/org-1/vm-1.mp3" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify([
+          call({
+            id: "c-vm",
+            direction: "in",
+            status: "no_answer",
+            duration_seconds: null,
+            voicemail: {
+              id: "vm-1",
+              audio_storage_path: "org-1/vm-1.mp3",
+              transcript: "Call me back about the roof",
+              transcript_status: "ready",
+              duration_seconds: 12,
+            },
+          }),
+        ]),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    vi.stubGlobal("fetch", spy);
+
+    const { container } = render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    await screen.findByText("Calls (1)");
+    expect(
+      await screen.findByText("Call me back about the roof"),
+    ).toBeDefined();
+    await waitFor(() => {
+      const audio = container.querySelector(
+        'audio[aria-label="Voicemail recording"]',
+      );
+      expect(audio?.getAttribute("src")).toBe("https://signed/org-1/vm-1.mp3");
+    });
+  });
+});
+
+describe("JobCallsSection — deep link", () => {
+  it("links each call to its Phone-tab thread, scrolled to that call", async () => {
+    asViewPhone();
+    stubCalls([call({ id: "c-1", conversation_id: "conv-7", direction: "out" })]);
+
+    render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    await screen.findByText("Calls (1)");
+    const link = screen.getByRole("link");
+    expect(link.getAttribute("href")).toBe(
+      "/phone?conversation=conv-7&call=c-1",
+    );
+  });
+});
+
+describe("JobCallsSection — realtime", () => {
+  it("subscribes for the org and bumps the count when a new Job-tagged call arrives", async () => {
+    asViewPhone();
+
+    // First GET: one call. After the realtime INSERT fires, the refetch
+    // returns the freshly-tagged second call.
+    let getCount = 0;
+    const spy = vi.fn(async () => {
+      getCount += 1;
+      const rows =
+        getCount === 1
+          ? [call({ id: "c-1" })]
+          : [call({ id: "c-1" }), call({ id: "c-2", direction: "out" })];
+      return new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", spy);
+
+    render(
+      <JobCallsSection jobId="job-1" organizationId="org-1" contacts={contacts} />,
+    );
+
+    expect(await screen.findByText("Calls (1)")).toBeDefined();
+    // The section wired a realtime subscription scoped to the active org.
+    expect(sync.input?.organizationId).toBe("org-1");
+
+    // A new outbound call to this Job lands over realtime → the section
+    // refetches and the count climbs.
+    sync.input!.onNewCall!({ id: "c-2", job_tag: "job-1" });
+
+    expect(await screen.findByText("Calls (2)")).toBeDefined();
+  });
+});

--- a/src/components/job-detail/job-calls-section.tsx
+++ b/src/components/job-detail/job-calls-section.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Phone } from "lucide-react";
+import { useAuth } from "@/lib/auth-context";
+import { createClient } from "@/lib/supabase";
+import { findContactByPhone, formatPhoneNumber } from "@/lib/phone";
+import { usePhoneSync } from "@/lib/phone/use-phone-sync";
+import {
+  JobCallRow,
+  type JobCallVoicemail,
+  type JobCallRecording,
+} from "@/components/phone/job-call-row";
+import type { JobMessageContact } from "./job-messages-section";
+
+// PRD #304 — Nookleus Phone. Slice 12 (#316) — Job-page Calls (N) section.
+//
+// Mirrors the Messages (N) / Emails (N) sections on every Job page. Renders
+// every voice call tagged to this Job — across all numbers (Shared and
+// Personal) and all teammates — read through GET /api/phone/calls?jobId=
+// (RLS enforces per-call visibility). The whole section is hidden from anyone
+// without `view_phone`. Read-only: placing a call is the Messages section's
+// Call button (slice 10); this section is the history.
+
+export interface JobCall {
+  id: string;
+  conversation_id: string;
+  direction: "in" | "out";
+  from_e164: string;
+  to_e164: string;
+  status: string | null;
+  duration_seconds: number | null;
+  started_at: string;
+  ended_at: string | null;
+  job_tag: string | null;
+  voicemail?: JobCallVoicemail | null;
+  recording?: JobCallRecording | null;
+}
+
+export function JobCallsSection({
+  jobId,
+  organizationId,
+  contacts,
+}: {
+  jobId: string;
+  organizationId: string | null;
+  contacts: JobMessageContact[];
+}) {
+  const { hasPermission, loading } = useAuth();
+  const canView = !loading && hasPermission("view_phone");
+  const [calls, setCalls] = useState<JobCall[]>([]);
+
+  const fetchCalls = useCallback(async () => {
+    const res = await fetch(
+      `/api/phone/calls?jobId=${encodeURIComponent(jobId)}`,
+    );
+    if (!res.ok) return;
+    const data = (await res.json()) as JobCall[];
+    setCalls(Array.isArray(data) ? data : []);
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!canView) return;
+    void fetchCalls();
+  }, [canView, fetchCalls]);
+
+  const supabase = useMemo(() => createClient(), []);
+  usePhoneSync({
+    supabase,
+    organizationId: canView ? organizationId : null,
+    onNewMessage: () => {},
+    onNewCall: () => void fetchCalls(),
+    onCallUpdate: () => void fetchCalls(),
+    onVoicemailUpdate: () => void fetchCalls(),
+  });
+
+  if (!canView) return null;
+
+  return (
+    <div className="bg-card rounded-xl border border-border p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-base font-semibold text-foreground">
+          <Phone size={16} className="inline mr-2 -mt-0.5" />
+          Calls ({calls.length})
+        </h3>
+      </div>
+      {calls.length > 0 && (
+        <div className="space-y-3">
+          {calls.map((c) => {
+            const number = c.direction === "in" ? c.from_e164 : c.to_e164;
+            const contact = findContactByPhone(contacts, number);
+            return (
+              <JobCallRow
+                key={c.id}
+                call={{
+                  id: c.id,
+                  conversationId: c.conversation_id,
+                  direction: c.direction,
+                  status: c.status,
+                  duration_seconds: c.duration_seconds,
+                  started_at: c.started_at,
+                  counterpartyLabel: contact
+                    ? contact.name
+                    : formatPhoneNumber(number),
+                  voicemail: c.voicemail,
+                  recording: c.recording,
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+      {calls.length === 0 && (
+        <div className="text-center py-6">
+          <Phone size={32} className="mx-auto text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground/60">
+            No phone calls linked to this job yet.
+          </p>
+          <p className="text-xs text-muted-foreground/40 mt-1">
+            Call a contact using the button on the Messages section.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/phone/job-call-row.tsx
+++ b/src/components/phone/job-call-row.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { format } from "date-fns";
+import { PhoneIncoming, PhoneOutgoing } from "lucide-react";
+
+// PRD #304 — Nookleus Phone. Slice 12 (#316) — Job-page call row.
+//
+// One voice call in the Job-page Calls section. Parallels JobMessageRow: a
+// per-row context header (counterparty + when) because the section spans many
+// conversations and numbers, then a compact meta line (direction, outcome,
+// talk time) and — when present — inline players for the call recording and/or
+// voicemail. The players fetch a short-lived signed URL for the stored MP3,
+// mirroring the Phone-tab thread's RecordingPlayer/VoicemailPlayer (a parallel
+// small player, so the Phone-tab component is untouched).
+
+export interface JobCallVoicemail {
+  id: string;
+  audio_storage_path: string | null;
+  transcript: string | null;
+  transcript_status: "pending" | "ready" | "failed";
+  duration_seconds: number | null;
+}
+
+export interface JobCallRecording {
+  id: string;
+  audio_storage_path: string | null;
+  consent_notice_played: boolean;
+  duration_seconds: number | null;
+}
+
+export interface JobCallRowData {
+  id: string;
+  conversationId: string;
+  direction: "in" | "out";
+  status: string | null;
+  duration_seconds: number | null;
+  started_at: string;
+  counterpartyLabel: string;
+  voicemail?: JobCallVoicemail | null;
+  recording?: JobCallRecording | null;
+}
+
+// Title-case a status token: "no_answer" → "No answer".
+function formatCallStatus(status: string): string {
+  const words = status.replace(/_/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+// seconds → mm:ss (e.g. 125 → "2:05").
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}`;
+}
+
+export function JobCallRow({ call }: { call: JobCallRowData }) {
+  const incoming = call.direction === "in";
+  const DirectionIcon = incoming ? PhoneIncoming : PhoneOutgoing;
+  // Answered calls carry talk time; an unanswered/abnormal call has none, so
+  // we surface its outcome label instead (e.g. "No answer", "Busy").
+  const answered = call.duration_seconds !== null;
+  return (
+    <div className="flex flex-col gap-1">
+      {/* The summary header deep-links to this call in the Phone tab (select
+          the thread + scroll to the call). The inline players below sit
+          OUTSIDE the link so their controls don't trigger navigation. */}
+      <Link
+        href={`/phone?conversation=${call.conversationId}&call=${call.id}`}
+        className="flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <DirectionIcon
+          size={14}
+          aria-label={incoming ? "Incoming call" : "Outgoing call"}
+        />
+        <span className="font-medium text-foreground/70">
+          {call.counterpartyLabel}
+        </span>
+        <span>{format(new Date(call.started_at), "MMM d, h:mm a")}</span>
+        {answered ? (
+          <span>{formatDuration(call.duration_seconds as number)}</span>
+        ) : call.status ? (
+          <span>{formatCallStatus(call.status)}</span>
+        ) : null}
+      </Link>
+      {call.recording?.audio_storage_path ? (
+        <CallAudioPlayer
+          storagePath={call.recording.audio_storage_path}
+          label="Call recording"
+        />
+      ) : null}
+      {call.voicemail ? (
+        <div className="w-full max-w-sm rounded-lg border border-border bg-background p-2 text-xs">
+          {call.voicemail.audio_storage_path ? (
+            <CallAudioPlayer
+              storagePath={call.voicemail.audio_storage_path}
+              label="Voicemail recording"
+            />
+          ) : null}
+          {call.voicemail.transcript_status === "ready" &&
+          call.voicemail.transcript ? (
+            <p className="mt-1 text-foreground">{call.voicemail.transcript}</p>
+          ) : null}
+          {call.voicemail.transcript_status === "pending" ? (
+            <p className="mt-1 italic text-muted-foreground">Transcribing…</p>
+          ) : null}
+          {call.voicemail.transcript_status === "failed" ? (
+            <p className="mt-1 italic text-muted-foreground">
+              Transcript unavailable
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// <audio> player for a stored recording/voicemail MP3. Fetches a short-lived
+// signed URL on mount (the same /api/phone/recordings?path= route the Phone-tab
+// players use) and renders the native control once it resolves.
+function CallAudioPlayer({
+  storagePath,
+  label,
+}: {
+  storagePath: string;
+  label: string;
+}) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(
+        `/api/phone/recordings?path=${encodeURIComponent(storagePath)}`,
+      );
+      if (!res.ok) return;
+      const body = (await res.json()) as { url: string };
+      if (!cancelled) setUrl(body.url);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storagePath]);
+  return (
+    <audio controls src={url ?? undefined} aria-label={label} className="w-full" />
+  );
+}


### PR DESCRIPTION
Closes #316 — Phone slice 12.

Every Job page now shows a **Calls (N)** section alongside Messages (N) / Emails (N): the full voice-call history tagged to that Job, across all numbers (Shared + Personal) and all teammates. Read-only — placing a call stays on the Messages section's Call button (slice 10); this is the history.

## What's in it

- **GET `/api/phone/calls?jobId=`** — User-client read (RLS enforces per-call visibility, no service client), flattens the `phone_voicemails` / `phone_recordings` embeds to single `voicemail` / `recording` fields. Returns 400 on missing `jobId`.
- **`JobCallsSection`** — gated on `view_phone` (renders nothing without it), count header + empty state, refreshes in realtime via `usePhoneSync` (new call / call update / voicemail update).
- **`JobCallRow`** — per-row context header (counterparty + when, because the section spans many conversations), answered talk-time vs. outcome label (e.g. "No answer"), and inline players for the recording and/or voicemail. Uses a small parallel signed-URL `<audio>` player so the Phone-tab thread's players are untouched.
- **Deep link** — each row links to `/phone?conversation=<id>&call=<id>`; the Phone page auto-selects the thread **and** scrolls the matching call into view.
- Composed into the Job page beside the existing Messages/Emails sections.

## Scope decisions honored
- Deep-link: full (select + scroll-to-call).
- RLS coverage: relies on the existing `migration-312-smoke-test.sql` case 2 — no new SQL/pg test.
- Playback: parallel player in `JobCallRow` (phone-page-client's players unchanged).

## Testing
Built strictly via TDD (one test → one impl, per slice). **73/73 tests green**:
- `api/phone/calls/route.test.ts` — 23 (GET route, flatten, missing-jobId)
- `job-detail/job-calls-section.test.tsx` — 8 (section + row behavior through the public section interface)
- `phone/phone-page-client.test.tsx` — 38 (incl. deep-link select + scroll)
- `phone/phone-page-client.calls.test.tsx` — 4 (regression)

`tsc` clean for all changed/new files. `eslint` findings on changed files are limited to `react-hooks/set-state-in-effect` and `no-unused-vars`, both mirroring the existing committed `JobMessagesSection`/its test — matched rather than diverged per CLAUDE.md ("write code that reads like the surrounding code").

🤖 Generated with [Claude Code](https://claude.com/claude-code)