### PR TITLE
fix(phone): unique realtime channel per usePhoneSync mount — Job-page crash (P0)

### DIFF
--- a/src/lib/phone/use-phone-sync.test.tsx
+++ b/src/lib/phone/use-phone-sync.test.tsx
@@ -1,0 +1,88 @@
+// Regression test for the Job-page production crash (2026-06-10): the Job
+// page mounts TWO usePhoneSync consumers for the same org — Messages (N)
+// (slice 7, #311) and Calls (N) (slice 12, #316/#620). RealtimeClient dedupes
+// channels by topic, so when both hooks named their channel
+// `phone-messages-${organizationId}`, the second mount got back the first
+// mount's already-subscribed channel instance — and realtime-js (2.101.x)
+// THROWS from `.on("postgres_changes", …)` once a channel is joining/joined:
+//   "cannot add `postgres_changes` callbacks for … after `subscribe()`."
+// The throw escaped the hook's effect into the route error boundary and took
+// down every Job page for every view_phone user.
+//
+// The existing section tests never caught this because they mock usePhoneSync
+// itself; this test deliberately uses the REAL hook and the REAL realtime-js
+// channel machinery (only the WebSocket transport is a no-network stand-in;
+// the bug fires synchronously in `.on()` before any I/O).
+
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { createClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { usePhoneSync } from "./use-phone-sync";
+
+// Minimal constructible transport: the connection never opens, which is fine
+// because subscribe() marks the channel "joining" synchronously and that
+// state alone is what triggered the production throw.
+class FakeWebSocket {
+  onopen: ((ev: unknown) => void) | null = null;
+  onclose: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+  readyState = 0;
+  constructor(public url: string) {}
+  send() {}
+  close() {}
+}
+
+function makeRealtimeClient(): SupabaseClient {
+  return createClient("http://localhost:54321", "test-anon-key", {
+    realtime: { transport: FakeWebSocket as unknown as new (url: string) => WebSocket },
+  });
+}
+
+// Shaped like JobMessagesSection's subscription (message insert + update).
+function MessagesLikeConsumer({ supabase }: { supabase: SupabaseClient }) {
+  usePhoneSync({
+    supabase,
+    organizationId: "org-1",
+    onNewMessage: () => {},
+    onMessageUpdate: () => {},
+  });
+  return null;
+}
+
+// Shaped like JobCallsSection's subscription (calls + voicemail callbacks).
+function CallsLikeConsumer({ supabase }: { supabase: SupabaseClient }) {
+  usePhoneSync({
+    supabase,
+    organizationId: "org-1",
+    onNewMessage: () => {},
+    onNewCall: () => {},
+    onCallUpdate: () => {},
+    onVoicemailUpdate: () => {},
+  });
+  return null;
+}
+
+describe("usePhoneSync", () => {
+  it("two consumers for the same org can mount on one page (Job page: Messages + Calls)", () => {
+    const supabase = makeRealtimeClient();
+    expect(() =>
+      render(
+        <>
+          <MessagesLikeConsumer supabase={supabase} />
+          <CallsLikeConsumer supabase={supabase} />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it("a consumer can mount after an earlier one already subscribed", () => {
+    const supabase = makeRealtimeClient();
+    const first = render(<MessagesLikeConsumer supabase={supabase} />);
+    expect(() =>
+      render(<CallsLikeConsumer supabase={supabase} />),
+    ).not.toThrow();
+    first.unmount();
+  });
+});

--- a/src/lib/phone/use-phone-sync.ts
+++ b/src/lib/phone/use-phone-sync.ts
@@ -85,6 +85,16 @@ export interface UsePhoneSyncInput {
   onVoicemailUpdate?: (row: PhoneVoicemailRow) => void;
 }
 
+// Channel topics must be unique PER HOOK MOUNT, not per org. RealtimeClient
+// dedupes channels by topic, so two mounts sharing a topic (the Job page
+// mounts Messages (N) and Calls (N), both syncing the active org) would hand
+// the second mount the first's already-subscribed channel — and realtime-js
+// throws from `.on("postgres_changes", …)` once a channel is joining/joined,
+// which took down every Job page (prod incident 2026-06-10). The suffix costs
+// one extra realtime subscription per mount; postgres_changes filtering is
+// per-binding, so behavior is otherwise identical.
+let channelSeq = 0;
+
 export function usePhoneSync(input: UsePhoneSyncInput): void {
   const onNewMessageRef = useRef(input.onNewMessage);
   const onMessageUpdateRef = useRef(input.onMessageUpdate);
@@ -122,7 +132,7 @@ export function usePhoneSync(input: UsePhoneSyncInput): void {
     if (!organizationId) return;
     const orgFilter = `organization_id=eq.${organizationId}`;
     let channel = supabase
-      .channel(`phone-messages-${organizationId}`)
+      .channel(`phone-messages-${organizationId}-${++channelSeq}`)
       .on(
         "postgres_changes",
         {


### PR DESCRIPTION
## P0 — every Job page crashes for every `view_phone` user

Since #620 deployed (2026-06-10 ~13:30 CDT), opening any `/jobs/[id]` renders the route error boundary ("Something went wrong"). Reproduced on a fresh load in prod as Admin and as Crew Lead. Console:

```
Error: cannot add `postgres_changes` callbacks for realtime:phone-messages-<orgId> after `subscribe()`.
```

## Root cause

The Job page mounts **two** `usePhoneSync` consumers for the same org — `JobMessagesSection` (slice 7, #311) and `JobCallsSection` (slice 12, #316 / #620) — and both named their channel `phone-messages-${organizationId}`.

`RealtimeClient.channel(topic)` **dedupes by topic**, so the second mount received the first mount's already-subscribed channel instance. realtime-js 2.101.x throws from `.on("postgres_changes", …)` once a channel is joining/joined (`RealtimeChannel.on` state check, `dist/main/RealtimeChannel.js:377-381`). The throw escaped the hook's `useEffect` into the error boundary.

The collision shipped with #620 because the section tests **mock `usePhoneSync`** — no test exercised the real channel-sharing machinery.

## Fix

Suffix the channel topic with a module-level sequence (`phone-messages-${organizationId}-${seq}`) so every hook mount owns its own channel. Topics are client-side labels; `postgres_changes` filtering is per-binding, so behavior is unchanged apart from one extra realtime subscription per mount.

## Regression test

`src/lib/phone/use-phone-sync.test.tsx` mounts two consumers shaped like the Job page's Messages + Calls sections against the **real** realtime-js (no-network `transport` stand-in — the bug fires synchronously in `.on()` before any I/O). Before the fix it failed with the exact prod error; after, both cases pass.

## Verification

- New regression test: failed pre-fix with the exact prod error, passes post-fix.
- All 23 phone-area test files (291 tests) pass in this branch — `src/lib/phone`, `job-calls-section`, `job-messages-section`, `job-text-contacts`.

## Related finding (separate, NOT this PR)

Prod Supabase is missing `migration-315-phone-recordings.sql` (drift): `phone_recordings` + `organizations.recording_enabled_default` are absent, so `GET /api/phone/calls` 500s (swallowed client-side — Calls renders empty, no crash). The migration still needs to be applied to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
