### PR TITLE
fix(photos): tile time caption shows capture time, not upload time (#622 follow-up)

### DIFF
--- a/src/components/job-photos-tab.test.tsx
+++ b/src/components/job-photos-tab.test.tsx
@@ -16,6 +16,8 @@ import {
 } from "@testing-library/react";
 import React from "react";
 
+import { format } from "date-fns";
+
 import type { Photo } from "@/lib/types";
 import { toast } from "sonner";
 
@@ -324,5 +326,46 @@ describe("JobPhotosTab — New report entry point", () => {
       );
     });
     expect(await screen.findByText(/No templates yet/i)).toBeTruthy();
+  });
+});
+
+describe("JobPhotosTab — tile time caption uses the capture time (#622)", () => {
+  beforeEach(() => {
+    h.photos = [];
+    h.templates = [];
+    h.push.mockClear();
+    fetchMock = vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) }));
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubGlobal("IntersectionObserver", IO);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  // #622 made taken_at the organizing date: the day-group headers use it, so a
+  // tile's time caption must agree with its header — a camera-roll photo taken
+  // June 1st but uploaded June 10th reads "June 1st … <capture time>", not the
+  // upload time. Expected values are computed with the same date-fns format the
+  // component uses, so the assertion holds in any test-runner timezone.
+  it("captions the tile with taken_at, not the created_at upload time", async () => {
+    const takenAt = "2026-06-01T12:34:00Z";
+    const createdAt = "2026-06-10T09:01:00Z";
+    h.photos = [{ ...makePhoto("p1"), taken_at: takenAt, created_at: createdAt }];
+    renderTab();
+
+    await screen.findByRole("img");
+    expect(screen.getByText(format(new Date(takenAt), "h:mm a"))).toBeTruthy();
+    expect(screen.queryByText(format(new Date(createdAt), "h:mm a"))).toBeNull();
+  });
+
+  it("falls back to created_at for pre-#622 rows with no taken_at", async () => {
+    const createdAt = "2026-06-10T09:01:00Z";
+    h.photos = [{ ...makePhoto("p1"), taken_at: null, created_at: createdAt }];
+    renderTab();
+
+    await screen.findByRole("img");
+    expect(screen.getByText(format(new Date(createdAt), "h:mm a"))).toBeTruthy();
   });
 });

--- a/src/components/job-photos-tab.tsx
+++ b/src/components/job-photos-tab.tsx
@@ -706,7 +706,7 @@ export default function JobPhotosTab({
                       {/* Meta */}
                       <div className="pt-1 px-0.5">
                         <span className="text-[11px] text-muted-foreground">
-                          {format(new Date(photo.created_at), "h:mm a")}
+                          {format(new Date(photo.taken_at ?? photo.created_at), "h:mm a")}
                         </span>
                         <span className="text-[11px] text-muted-foreground/60"> · </span>
                         <span className="text-[11px] text-muted-foreground/60">{photo.taken_by}</span>


### PR DESCRIPTION
Follow-up to #623 (issue #622).

## Problem

#623 made `taken_at` the organizing date — day-group headers, sorting, and filters all use it — but the Job Photos tab **tile time caption** still rendered `created_at`. The result after deploy: a camera-roll photo correctly grouped under "Monday, June 1st" still read "4:30 PM" (its June 10th upload time). Spotted live on the Connor Brady job right after the #623 production deploy.

## Change

One line in `job-photos-tab.tsx`: the caption now formats `taken_at ?? created_at`, the same coalesce the day-group headers use. Pre-#622 rows with no `taken_at` keep showing upload time.

Checked the other photo time displays — no other changes needed:
- Photo viewer "Uploaded:" lines are explicitly labeled as upload time → `created_at` is correct there.
- Report PDF "Date captured" already flows from `taken_at` (`generate-report-pdf.tsx` → `report-render-model.ts`).

## Verification

- TDD: new test failed on the old code, passes after the fix. Expected strings are computed with the same date-fns format the component uses, so the assertions hold in any test-runner timezone. A second test pins the `null → created_at` fallback.
- `npx vitest run src/components/job-photos-tab.test.tsx`: **10/10 pass** (8 existing + 2 new).
- `tsc --noEmit`: no errors mentioning the touched files; `eslint` on both files: identical problem count to clean main (the pre-existing repo-wide `set-state-in-effect` error + `no-img-element` warning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
