### PR TITLE
fix(estimate-builder): docked line-item editor follows scroll on tablet/desktop (#629)

### DIFF
--- a/src/components/estimate-builder/builder-layout.test.tsx
+++ b/src/components/estimate-builder/builder-layout.test.tsx
@@ -42,6 +42,29 @@ describe("BuilderLayout — document body", () => {
   });
 });
 
+describe("BuilderLayout — sticky-editor travel room (#629)", () => {
+  it("does not pin the document/editor row to content height", () => {
+    // Acceptance (#629): the docked editor uses `position: sticky` and can only
+    // travel within its parent's box. The row that holds the document <main> and
+    // the editor <aside> must NOT align its children to the top (`items-start`),
+    // which would collapse the <aside> to content height and leave the sticky
+    // editor with zero room to travel — so it scrolls away instead of pinning.
+    // Default `stretch` alignment lets the <aside> span the document height.
+    //
+    // jsdom computes no layout, so the pinned-while-scrolling behavior itself is
+    // verified in the browser; this guards the layout contract from regressing,
+    // mirroring the `max-w-`/`mx-auto` negation guard above.
+    render(
+      <BuilderLayout editorSlot={<p>Editor</p>}>
+        <p>doc</p>
+      </BuilderLayout>,
+    );
+
+    const row = screen.getByTestId("builder-document").parentElement;
+    expect(row?.className).not.toContain("items-start");
+  });
+});
+
 describe("BuilderLayout — editor panel slot", () => {
   it("renders the editor panel content when an editorSlot is provided", () => {
     render(

--- a/src/components/estimate-builder/builder-layout.tsx
+++ b/src/components/estimate-builder/builder-layout.tsx
@@ -24,7 +24,13 @@ export function BuilderLayout({
 }: BuilderLayoutProps) {
   return (
     <div className="flex flex-col">
-      <div className="flex flex-col lg:flex-row lg:items-start gap-4">
+      {/*
+        Default `items-stretch` (no `items-start`): the <aside> stretches to the
+        document column's full height so the docked editor's `sticky top-6` has
+        room to travel and pin while scrolling (#629). With `items-start` the
+        aside collapses to content height and the sticky editor scrolls away.
+      */}
+      <div className="flex flex-col lg:flex-row gap-4">
         <main
           data-testid="builder-document"
           onClick={onBackgroundClick}


### PR DESCRIPTION
## What & why

On tablet/desktop widths (≥1024px — which includes all iPads in landscape), the docked line-item editor in the Estimate Builder scrolled away with the page, so editing a line selected lower down a long estimate meant scrolling all the way back to the top.

Root cause: the editor panel is `position: sticky` (`top-6`), but its parent flex row used `lg:items-start`, which collapses the editor's `<aside>` to content height. A sticky element can only travel within its parent's box → zero travel room → it scrolls off. Fix: drop `lg:items-start` so the row uses the default `items-stretch`; the `<aside>` now spans the document column's full height and the sticky editor pins near the top and follows the scroll. Same pattern the live layout panel already uses.

The totals bar is a sibling outside this row (unaffected), and the desktop mouse flow + phone bottom-sheet variant are unchanged. All three builders (estimate/invoice/template) share this shell, so all benefit.

## Verification

- **Unit:** new regression guard in `builder-layout.test.tsx` asserts the row no longer pins children to content height (mirrors the existing `max-w-`/`mx-auto` negation guard). Full file green (8 tests). Lint clean; no new `tsc` errors in touched files.
- **Browser A/B** on the real estimate builder at iPad-landscape (desktop-dock) width, a 38-line estimate scrolled to the bottom:
  - Before (`items-start` present): editor `top: −2974px` — off-screen, unreachable.
  - After (`items-start` removed): editor `top: 24px` — pinned near the top, fully visible.
  - Totals bar unaffected. No prod data mutated.

Parent PRD: #628

Closes #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)
