### PR TITLE
feat(estimate-builder): touch-accessible delete in the line-item editor (#630)

### DIFF
--- a/src/components/estimate-builder/estimate-builder.tsx
+++ b/src/components/estimate-builder/estimate-builder.tsx
@@ -1779,6 +1779,7 @@ export function EstimateBuilder({
                   onLineItemChange(selectedInvoiceItem.id, partial)
                 }
                 onClose={lineSelection.clear}
+                onDelete={() => onLineItemDelete(selectedInvoiceItem.id)}
                 readOnly={isVoided}
                 mode={invMode}
               />
@@ -1894,6 +1895,7 @@ export function EstimateBuilder({
                   onLineItemChange(selectedTemplateItem.id, partial)
                 }
                 onClose={lineSelection.clear}
+                onDelete={() => onLineItemDelete(selectedTemplateItem.id)}
                 mode={tmplMode}
               />
             )
@@ -2029,6 +2031,7 @@ export function EstimateBuilder({
               item={selectedItem}
               onChange={(partial) => onLineItemChange(selectedItem.id, partial)}
               onClose={lineSelection.clear}
+              onDelete={() => onLineItemDelete(selectedItem.id)}
               readOnly={isVoided}
               mode={mode}
             />

--- a/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
@@ -701,3 +701,85 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
     expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
   });
 });
+
+// Issue #630 — the editor panel's touch-accessible "Delete line item" button,
+// wired to the builder's delete handler at all three call sites. These prove the
+// button reaches the same optimistic-remove pathway the row's hover trash uses,
+// so a line can be deleted by tapping the panel — the only delete path on touch.
+//
+// The row ALSO carries a "Delete line item" button (the hover one), so the
+// panel button is queried scoped to the editor aside, never globally.
+describe("EstimateBuilder × editor delete button (#630)", () => {
+  function panelDeleteButton() {
+    return within(screen.getByTestId("builder-editor-panel")).getByRole(
+      "button",
+      { name: /delete line item/i },
+    );
+  }
+
+  it("deletes the selected estimate line via the panel button and closes the editor", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+    );
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    selectRowByName("Tear-off");
+    expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
+
+    fireEvent.click(panelDeleteButton());
+
+    // The line is optimistically removed from the document, and the selection
+    // clears as it leaves the live id set, so the panel unmounts.
+    const doc = screen.getByTestId("builder-document");
+    expect(within(doc).queryByText("Tear-off")).toBeNull();
+    expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("deletes the selected invoice line via the panel button and closes the editor", () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+    );
+    render(<EstimateBuilder entity={makeInvoiceEntity()} />);
+
+    selectRowByName("Soffit repair");
+    expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
+
+    fireEvent.click(panelDeleteButton());
+
+    const doc = screen.getByTestId("builder-document");
+    expect(within(doc).queryByText("Soffit repair")).toBeNull();
+    expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
+
+    vi.unstubAllGlobals();
+  });
+
+  it("deletes the selected template line via the panel button and closes the editor", () => {
+    // Template delete is local-only (no HTTP) — rootPut auto-save persists.
+    render(<EstimateBuilder entity={makeTemplateEntity()} />);
+
+    selectRowByName("Install shingles");
+    expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
+
+    fireEvent.click(panelDeleteButton());
+
+    const doc = screen.getByTestId("builder-document");
+    expect(within(doc).queryByText("Install shingles")).toBeNull();
+    expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
+  });
+
+  it("hides the panel delete button on a voided (read-only) estimate", () => {
+    render(<EstimateBuilder entity={makeVoidedEstimateEntity()} />);
+
+    // Disabled inputs swallow clicks — select via the row container.
+    clickRowContainer("Tear-off");
+
+    const panel = screen.getByTestId("builder-editor-panel");
+    expect(
+      within(panel).queryByRole("button", { name: /delete line item/i }),
+    ).toBeNull();
+  });
+});

--- a/src/components/estimate-builder/line-item-editor-panel.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.test.tsx
@@ -420,3 +420,89 @@ describe("LineItemEditorPanel", () => {
     );
   });
 });
+
+// Issue #630 — touch-accessible delete. The row's only delete control is a
+// hover-only trash icon, invisible on a touchscreen. The editor panel gains a
+// prominent "Delete line item" button so a line can be removed by tapping. This
+// slice ships WITHOUT a confirmation step (that's the #631 follow-up): the
+// button calls onDelete directly. Builder wiring (optimistic removal, totals,
+// rollback, toasts, editor auto-close) is the existing onLineItemDelete handler
+// and is exercised separately; here we pin the panel's affordance in isolation.
+describe("LineItemEditorPanel — delete affordance (#630)", () => {
+  it("renders a Delete line item button when onDelete is provided and editable", () => {
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /delete line item/i }),
+    ).toBeDefined();
+  });
+
+  it("calls onDelete exactly once when the button is tapped", () => {
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the delete button on a read-only (voided) entity", () => {
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+        readOnly
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /delete line item/i }),
+    ).toBeNull();
+  });
+
+  it("renders no delete button when onDelete is omitted", () => {
+    render(
+      <LineItemEditorPanel item={makeItem()} onChange={vi.fn()} onClose={vi.fn()} />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /delete line item/i }),
+    ).toBeNull();
+  });
+
+  it("shows the delete button in the phone slide-up sheet too, and it fires", () => {
+    setMatchMedia(false); // phone viewport
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    // The footer lives outside the desktop/phone class branch, so the
+    // destructive action is reachable in the slide-up sheet, not only the dock.
+    expect(
+      screen.getByTestId("line-item-editor-panel").getAttribute("data-variant"),
+    ).toBe("phone");
+    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/estimate-builder/line-item-editor-panel.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.tsx
@@ -9,7 +9,7 @@
 // scrim sits behind the sheet. (Built up test-first — fields/behaviors per cycle.)
 
 import { useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/format";
 import { MoneyInput } from "./money-input";
@@ -60,6 +60,14 @@ export interface LineItemEditorPanelProps {
   onChange: (partial: Partial<BuilderLineItem>) => void;
   /** Close the editor (clears selection). */
   onClose: () => void;
+  /**
+   * Delete the selected line (#630). Optional — callers that omit it (and the
+   * isolated field tests) simply render no delete control. Already bound to this
+   * line's id by the parent, which runs the optimistic-remove + persist +
+   * rollback + toast pathway. After a successful delete the selection clears as
+   * the line leaves the live id set, so the panel unmounts itself.
+   */
+  onDelete?: () => void;
   /** Voided / read-only entity — fields render disabled. */
   readOnly?: boolean;
   mode?: BuilderMode;
@@ -69,6 +77,7 @@ export function LineItemEditorPanel({
   item,
   onChange,
   onClose,
+  onDelete,
   readOnly = false,
 }: LineItemEditorPanelProps) {
   // Each field holds its own draft, seeded from the item, and commits on blur
@@ -337,6 +346,25 @@ export function LineItemEditorPanel({
             </span>
           </div>
         </div>
+
+        {/* ── Footer: delete (#630) ─────────────────────────────────────────
+            A pinned (shrink-0) footer outside the scrollable body so the
+            destructive action stays visible in both the desktop dock and the
+            phone slide-up sheet. A large, full-width finger target for touch.
+            Hidden on read-only entities and when no onDelete is supplied. This
+            slice deletes directly; the #631 confirmation guard wraps it next. */}
+        {onDelete && !readOnly && (
+          <div className="shrink-0 border-t border-border p-4">
+            <button
+              type="button"
+              onClick={onDelete}
+              className="flex w-full items-center justify-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/20"
+            >
+              <Trash2 size={16} />
+              Delete line item
+            </button>
+          </div>
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## What & why

iPad/touch users had **no way to delete a line item** in the Estimate Builder:
the only delete control is the per-row trash icon, which is `opacity-0
group-hover:opacity-100` — visible only on mouse hover, so permanently invisible
on a touchscreen.

This adds a prominent, full-width **"Delete line item"** button to the editor
panel footer (the surface you already open by tapping a row), present in **both**
responsive variants — the tablet/desktop dock and the phone slide-up sheet.

Closes #630.

## How

- `LineItemEditorPanel` gains an optional `onDelete?: () => void`. When supplied
  and the document is editable, a pinned (`shrink-0`) footer renders a large,
  finger-friendly destructive button outside the scrollable body, so it stays
  visible in both variants.
- Wired at all three builder call sites (estimate / invoice / template) to the
  existing `onLineItemDelete(id)` handler, which already does optimistic removal,
  totals recompute, persistence via the right delete endpoint, rollback on
  failure, and success/error toasts.
- Hidden on voided/read-only documents and when no handler is passed. After a
  successful delete the selection auto-clears (the line leaves the live id set),
  so the editor closes itself.
- The row's existing hover-to-delete behavior is unchanged.

This slice ships **without** a confirmation step — the "Delete line item?"
confirmation guard is the **#631** follow-up.

## Tests (TDD, red→green per behavior)

- **`line-item-editor-panel.test.tsx`** (unit, both variants via `matchMedia`):
  button present when editable + handler supplied; fires `onDelete` exactly once;
  absent when `readOnly`; absent when no handler; present + fires in the phone
  sheet.
- **`line-item-editor-panel.integration.test.tsx`** (mounted builder): deleting
  via the **panel** button removes the line and closes the editor in **estimate,
  invoice, and template** modes; button hidden on a voided estimate.

Verification: `vitest` across the full `estimate-builder/` dir — 222 tests pass;
`tsc --noEmit` and `eslint` clean on the touched files (no new errors against the
known-partially-red baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
