### PR TITLE
feat(estimate-builder): confirm before deleting a line item (#631)

### DIFF
--- a/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
@@ -707,14 +707,27 @@ describe("EstimateBuilder × LineItemEditorPanel (#544)", () => {
 // button reaches the same optimistic-remove pathway the row's hover trash uses,
 // so a line can be deleted by tapping the panel — the only delete path on touch.
 //
-// The row ALSO carries a "Delete line item" button (the hover one), so the
-// panel button is queried scoped to the editor aside, never globally.
+// Since #631 the panel button opens a confirmation first, so these drive the
+// full guarded flow: tap the panel button, then confirm. (The trigger reads
+// "Delete line item"; the confirm button reads "Delete", so the two never
+// collide.) The row ALSO carries a "Delete line item" button (the hover one),
+// so the panel button is queried scoped to the editor aside, never globally.
 describe("EstimateBuilder × editor delete button (#630)", () => {
   function panelDeleteButton() {
     return within(screen.getByTestId("builder-editor-panel")).getByRole(
       "button",
       { name: /delete line item/i },
     );
+  }
+
+  // Confirm the #631 guard: the panel's confirmation lives inside the editor
+  // aside, with a "Delete" confirm button distinct from the trigger.
+  function confirmPanelDelete() {
+    const dialog = within(screen.getByTestId("builder-editor-panel")).getByRole(
+      "dialog",
+      { name: /delete line item/i },
+    );
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
   }
 
   it("deletes the selected estimate line via the panel button and closes the editor", () => {
@@ -727,11 +740,14 @@ describe("EstimateBuilder × editor delete button (#630)", () => {
     selectRowByName("Tear-off");
     expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
 
+    // First tap only opens the #631 guard — the line is still present.
     fireEvent.click(panelDeleteButton());
-
-    // The line is optimistically removed from the document, and the selection
-    // clears as it leaves the live id set, so the panel unmounts.
     const doc = screen.getByTestId("builder-document");
+    expect(within(doc).queryByText("Tear-off")).not.toBeNull();
+
+    // Confirming runs the optimistic removal; the selection clears as the line
+    // leaves the live id set, so the panel unmounts.
+    confirmPanelDelete();
     expect(within(doc).queryByText("Tear-off")).toBeNull();
     expect(screen.queryByTestId("builder-editor-panel")).toBeNull();
 
@@ -749,6 +765,7 @@ describe("EstimateBuilder × editor delete button (#630)", () => {
     expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
 
     fireEvent.click(panelDeleteButton());
+    confirmPanelDelete();
 
     const doc = screen.getByTestId("builder-document");
     expect(within(doc).queryByText("Soffit repair")).toBeNull();
@@ -765,6 +782,7 @@ describe("EstimateBuilder × editor delete button (#630)", () => {
     expect(screen.getByTestId("builder-editor-panel")).toBeDefined();
 
     fireEvent.click(panelDeleteButton());
+    confirmPanelDelete();
 
     const doc = screen.getByTestId("builder-document");
     expect(within(doc).queryByText("Install shingles")).toBeNull();

--- a/src/components/estimate-builder/line-item-editor-panel.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.test.tsx
@@ -423,11 +423,10 @@ describe("LineItemEditorPanel", () => {
 
 // Issue #630 — touch-accessible delete. The row's only delete control is a
 // hover-only trash icon, invisible on a touchscreen. The editor panel gains a
-// prominent "Delete line item" button so a line can be removed by tapping. This
-// slice ships WITHOUT a confirmation step (that's the #631 follow-up): the
-// button calls onDelete directly. Builder wiring (optimistic removal, totals,
-// rollback, toasts, editor auto-close) is the existing onLineItemDelete handler
-// and is exercised separately; here we pin the panel's affordance in isolation.
+// prominent "Delete line item" button so a line can be removed by tapping.
+// These cases pin the panel's affordance in isolation — that it renders, and
+// when it's gated. What tapping it *does* (open the #631 confirm, then run the
+// existing onLineItemDelete pathway) is covered by the #631 block below.
 describe("LineItemEditorPanel — delete affordance (#630)", () => {
   it("renders a Delete line item button when onDelete is provided and editable", () => {
     render(
@@ -442,21 +441,6 @@ describe("LineItemEditorPanel — delete affordance (#630)", () => {
     expect(
       screen.getByRole("button", { name: /delete line item/i }),
     ).toBeDefined();
-  });
-
-  it("calls onDelete exactly once when the button is tapped", () => {
-    const onDelete = vi.fn();
-    render(
-      <LineItemEditorPanel
-        item={makeItem()}
-        onChange={vi.fn()}
-        onClose={vi.fn()}
-        onDelete={onDelete}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
-    expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
   it("hides the delete button on a read-only (voided) entity", () => {
@@ -485,7 +469,121 @@ describe("LineItemEditorPanel — delete affordance (#630)", () => {
     ).toBeNull();
   });
 
-  it("shows the delete button in the phone slide-up sheet too, and it fires", () => {
+  it("shows the delete button in the phone slide-up sheet too", () => {
+    setMatchMedia(false); // phone viewport
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    // The footer lives outside the desktop/phone class branch, so the
+    // destructive action is reachable in the slide-up sheet, not only the dock.
+    // (What tapping it does — open the confirm guard — is covered by #631.)
+    expect(
+      screen.getByTestId("line-item-editor-panel").getAttribute("data-variant"),
+    ).toBe("phone");
+    expect(
+      screen.getByRole("button", { name: /delete line item/i }),
+    ).toBeDefined();
+  });
+});
+
+// Issue #631 — confirmation guard. The #630 delete button now opens a shared
+// "Delete line item?" confirm instead of deleting on the first tap, so an
+// accidental touch can't silently remove work. Cancel aborts; Confirm runs the
+// existing delete pathway. The confirm renders inside the panel's own stacking
+// context so it layers above both the docked editor and the z-50 phone sheet.
+describe("LineItemEditorPanel — delete confirmation (#631)", () => {
+  function deleteButton() {
+    return screen.getByRole("button", { name: /delete line item/i });
+  }
+
+  it("opens a confirmation instead of deleting on the first tap", () => {
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(deleteButton());
+
+    // Nothing is deleted yet — the destructive action is guarded.
+    expect(onDelete).not.toHaveBeenCalled();
+    // A confirmation appears, stating the action can't be undone.
+    const dialog = screen.getByRole("dialog", { name: /delete line item/i });
+    expect(within(dialog).getByText(/can't be undone/i)).toBeDefined();
+  });
+
+  it("deletes the line exactly once when the confirmation is confirmed", () => {
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(deleteButton());
+    const dialog = screen.getByRole("dialog", { name: /delete line item/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
+
+    // Confirm runs the delete pathway exactly once and dismisses the prompt.
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog", { name: /delete line item/i })).toBeNull();
+  });
+
+  it("closes the confirmation without deleting when cancelled", () => {
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(deleteButton());
+    const dialog = screen.getByRole("dialog", { name: /delete line item/i });
+    fireEvent.click(within(dialog).getByRole("button", { name: /cancel/i }));
+
+    // Cancel aborts: no delete, and the prompt is gone (the line survives).
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(screen.queryByRole("dialog", { name: /delete line item/i })).toBeNull();
+  });
+
+  it("renders the confirmation within the editor panel's stacking context", () => {
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(deleteButton());
+
+    // The confirm is a descendant of the panel — not a detached sibling — so it
+    // inherits the panel's stacking context and paints above it in both the
+    // docked variant and the z-50 phone sheet (real layering isn't observable in
+    // jsdom; DOM containment is the structural contract that guarantees it).
+    const panel = screen.getByTestId("line-item-editor-panel");
+    const dialog = screen.getByRole("dialog", { name: /delete line item/i });
+    expect(panel.contains(dialog)).toBe(true);
+  });
+
+  it("guards delete in the phone slide-up sheet too", () => {
     setMatchMedia(false); // phone viewport
     const onDelete = vi.fn();
     render(
@@ -497,12 +595,15 @@ describe("LineItemEditorPanel — delete affordance (#630)", () => {
       />,
     );
 
-    // The footer lives outside the desktop/phone class branch, so the
-    // destructive action is reachable in the slide-up sheet, not only the dock.
-    expect(
-      screen.getByTestId("line-item-editor-panel").getAttribute("data-variant"),
-    ).toBe("phone");
-    fireEvent.click(screen.getByRole("button", { name: /delete line item/i }));
+    const panel = screen.getByTestId("line-item-editor-panel");
+    expect(panel.getAttribute("data-variant")).toBe("phone");
+
+    fireEvent.click(deleteButton());
+    const dialog = screen.getByRole("dialog", { name: /delete line item/i });
+    // Nested in the z-50 sheet's stacking context — not hidden behind it.
+    expect(panel.contains(dialog)).toBe(true);
+
+    fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/estimate-builder/line-item-editor-panel.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from "react";
 import { Trash2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { formatCurrency } from "@/lib/format";
+import ConfirmDialog from "@/components/contracts/confirm-dialog";
 import { MoneyInput } from "./money-input";
 import type { BuilderLineItem } from "./line-item-row";
 import type { BuilderMode } from "@/lib/types";
@@ -112,6 +113,10 @@ export function LineItemEditorPanel({
   }
 
   const isDesktop = useIsDesktop();
+
+  // #631: the delete button opens a confirmation rather than deleting on the
+  // first tap, so an accidental touch can't silently remove work.
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   // Opening the panel (and swapping to another line) drops the cursor into the
   // name field so the user can type immediately — required for the add-line flow
@@ -351,13 +356,13 @@ export function LineItemEditorPanel({
             A pinned (shrink-0) footer outside the scrollable body so the
             destructive action stays visible in both the desktop dock and the
             phone slide-up sheet. A large, full-width finger target for touch.
-            Hidden on read-only entities and when no onDelete is supplied. This
-            slice deletes directly; the #631 confirmation guard wraps it next. */}
+            Hidden on read-only entities and when no onDelete is supplied. The
+            #631 confirmation guard sits in front: a tap opens the confirm. */}
         {onDelete && !readOnly && (
           <div className="shrink-0 border-t border-border p-4">
             <button
               type="button"
-              onClick={onDelete}
+              onClick={() => setConfirmOpen(true)}
               className="flex w-full items-center justify-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/20"
             >
               <Trash2 size={16} />
@@ -365,6 +370,24 @@ export function LineItemEditorPanel({
             </button>
           </div>
         )}
+
+        {/* ── Delete confirmation (#631) ──────────────────────────────────
+            Rendered INSIDE the panel (not as a detached sibling) so it joins
+            the panel's stacking context and paints above it in both the docked
+            variant and the z-50 phone slide-up sheet. The fixed-overlay confirm
+            still covers the viewport; nesting only governs which layer wins. */}
+        <ConfirmDialog
+          open={confirmOpen}
+          ariaLabel="Delete line item"
+          title="Delete line item?"
+          body="This removes the line item. This can't be undone."
+          confirmLabel="Delete"
+          onCancel={() => setConfirmOpen(false)}
+          onConfirm={() => {
+            setConfirmOpen(false);
+            onDelete?.();
+          }}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## What & why

Final slice of PRD #628 (from #627 — iPad-landscape Estimate Builder).

The touch-accessible delete button shipped in #630 removed a line on the
**first tap**, so an accidental touch on an iPad could silently drop work.
This puts a confirmation guard in front of it.

Tapping **"Delete line item"** now opens the shared destructive-confirm modal
("**Delete line item?**", noting the action can't be undone):

- **Cancel** aborts with no change.
- **Confirm** runs the existing delete pathway from #630 — optimistic removal,
  totals recompute, persist + rollback-on-failure, toast — and the editor
  auto-closes as the line leaves the live id set.

The confirm renders **inside the panel's own stacking context** (not a detached
sibling), so it layers above both the docked editor and the `z-50` phone
slide-up sheet rather than hiding behind them. Reuses the same `ConfirmDialog`
already backing DeleteDraftDialog / PermanentlyDeleteDialog.

The row's hover trash icon is unchanged (still a direct delete — out of scope).

## Tests (TDD, red→green per behavior)

- **Unit** (`line-item-editor-panel.test.tsx`): first tap opens the confirm and
  does **not** delete; Confirm deletes exactly once and dismisses; Cancel aborts
  without deleting; the confirm is contained within the panel; the guard works
  in the phone slide-up sheet too.
- Reconciled the #630 unit/integration cases to the guarded flow (tap → confirm)
  now that the button no longer deletes directly.

## Verification

- `line-item-editor-panel` unit + integration: **49 tests** pass
- full `estimate-builder/` suite: **226** pass
- `tsc --noEmit` and `eslint`: clean on the touched files

A prod browser smoke isn't applicable: this isn't deployed yet, and prod
currently runs the un-guarded #630 button, so a live tap would delete a real
line. The confirm/cancel behavior is fully observable in jsdom; real-device
layering is the same proven `ConfirmDialog` overlay used elsewhere.

Closes #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
