### PR TITLE
fix(photo-report): shrink generated PDF so reports are emailable

### DIFF
--- a/src/lib/generate-report-pdf.test.tsx
+++ b/src/lib/generate-report-pdf.test.tsx
@@ -279,7 +279,7 @@ describe("generateReportPDF — render-model wiring", () => {
     await generateReportPDF(h.REPORT_ID);
 
     expect(modelArg().photos["photo-1"].url).toBe(
-      "https://test.supabase.co/storage/v1/render/image/public/photos/p/photo-1.jpg?width=1600&quality=80",
+      "https://test.supabase.co/storage/v1/render/image/public/photos/p/photo-1.jpg?width=1600&quality=72",
     );
   });
 });

--- a/src/lib/jobs/photo-url.test.ts
+++ b/src/lib/jobs/photo-url.test.ts
@@ -84,7 +84,7 @@ describe("photoUrl — pdf variant (report photo embed, #625)", () => {
       "pdf",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=1600&quality=80",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/abc.jpg?width=1600&quality=72",
     );
   });
 
@@ -120,7 +120,7 @@ describe("photoUrl — pdf variant (report photo embed, #625)", () => {
       "pdf",
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.png?width=1600&quality=80",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/abc.png?width=1600&quality=72",
     );
   });
 });
@@ -146,25 +146,50 @@ describe("reportCoverPhotoUrl — the PDF cover photo", () => {
     expect(reportCoverPhotoUrl(null, SUPABASE_URL)).toBeNull();
   });
 
-  it("uses the annotated copy at full resolution when the cover is annotated", () => {
-    // Resize on must not shrink the cover: reports stay print-quality.
+  it("embeds the annotated cover as a bounded 2000px render when resize is on", () => {
+    // The cover is the report's full-page hero. A full-resolution original adds
+    // 3–7 MB of uncompressed JPEG to the PDF on its own; a bounded 2000px render
+    // stays crisp yet keeps the download emailable (well under ~10 MB).
     vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
     const url = reportCoverPhotoUrl(
       { annotated_path: "annotated/cover.jpg", storage_path: "originals/cover.jpg" },
       SUPABASE_URL,
     );
     expect(url).toBe(
-      "https://proj.supabase.co/storage/v1/object/public/photos/annotated/cover.jpg",
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/annotated/cover.jpg?width=2000&quality=80",
     );
   });
 
-  it("falls back to the stored original when the cover has no annotation", () => {
+  it("embeds the stored original as a bounded render when the cover has no annotation", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = reportCoverPhotoUrl(
+      { annotated_path: null, storage_path: "originals/cover.jpg" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/render/image/public/photos/originals/cover.jpg?width=2000&quality=80",
+    );
+  });
+
+  it("serves the original object URL when resize is disabled", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "");
     const url = reportCoverPhotoUrl(
       { annotated_path: null, storage_path: "originals/cover.jpg" },
       SUPABASE_URL,
     );
     expect(url).toBe(
       "https://proj.supabase.co/storage/v1/object/public/photos/originals/cover.jpg",
+    );
+  });
+
+  it("serves the original for a cover the resizer can't transform (HEIC)", () => {
+    vi.stubEnv("NEXT_PUBLIC_PHOTO_RESIZE_ENABLED", "true");
+    const url = reportCoverPhotoUrl(
+      { annotated_path: null, storage_path: "originals/cover.heic" },
+      SUPABASE_URL,
+    );
+    expect(url).toBe(
+      "https://proj.supabase.co/storage/v1/object/public/photos/originals/cover.heic",
     );
   });
 });

--- a/src/lib/jobs/photo-url.ts
+++ b/src/lib/jobs/photo-url.ts
@@ -5,9 +5,10 @@ export interface PhotoUrlSource {
 }
 
 // Where the URL is used: the grid wants a small preview; the report PDF wants a
-// print-sized-but-bounded render; everywhere else (single-photo detail,
+// print-sized-but-bounded render ("pdf" for the 2/3/4-up body photos, "cover"
+// for the larger full-page hero); everywhere else (single-photo detail,
 // annotator) wants the full-resolution original.
-export type PhotoVariant = "grid" | "full" | "pdf";
+export type PhotoVariant = "grid" | "full" | "pdf" | "cover";
 
 const PHOTOS_OBJECT_PREFIX = "/storage/v1/object/public/photos/";
 const PHOTOS_RENDER_PREFIX = "/storage/v1/render/image/public/photos/";
@@ -19,15 +20,28 @@ const PHOTOS_RENDER_PREFIX = "/storage/v1/render/image/public/photos/";
 // tile's CSS `object-cover` then zooms into hard (issue #596).
 const GRID_PREVIEW_QUERY = "?width=400&height=400&quality=60&resize=cover";
 
-// Report-PDF embed transform (#625). @react-pdf embeds JPEGs as raw DCTDecode
-// streams with no recompression, so a report of full-resolution iPhone originals
-// (3–7 MB each) renders a PDF tens of MB large and the upload to Storage 400s
-// past Supabase's 50 MB cap. A 1600px-wide, quality-80 render is sharp at the
-// report's 2/3/4-per-page layout yet ~4× smaller, keeping even large reports
-// well under the cap. Width-only (no height/resize) scales the whole image down
-// without cropping; the server-side re-encode also strips Apple HDR gain-map
-// tails, so resized embeds never hit the jay-peg desync that blanks frames.
-const PDF_EMBED_QUERY = "?width=1600&quality=80";
+// Report-PDF embed transform (#625; quality tuned down for emailability).
+// @react-pdf
+// embeds JPEGs as raw DCTDecode streams with no recompression, so the PDF's byte
+// size is essentially the sum of its embedded JPEGs — a report of full-resolution
+// iPhone originals (3–7 MB each) blows past Supabase Storage's 50 MB upload cap,
+// and even a downscaled report can land ~14 MB, too large to email. A 1600px-wide
+// render is sharp at the report's 2/3/4-per-page layout; quality 72 (down from
+// 80) trims a further ~25–30% off each photo with no visible loss at that display
+// size, keeping the download comfortably emailable. Width-only (no height/resize)
+// scales the whole image down without cropping; the server-side re-encode also
+// strips Apple HDR gain-map tails, so resized embeds never hit the jay-peg desync
+// that blanks frames.
+const PDF_EMBED_QUERY = "?width=1600&quality=72";
+
+// Cover-photo embed transform. The cover is the report's full-page hero,
+// so it gets more pixels than a 2/3/4-up body photo — 2000px wide keeps it crisp
+// edge-to-edge — but it was previously embedded as the full-resolution original
+// (the "full" variant), adding 3–7 MB of uncompressed JPEG to every report on its
+// own. Routing it through a bounded render drops that to well under 1 MB while
+// staying print-sharp, and (as a bonus) the re-encode strips any Apple HDR
+// gain-map tail the original cover carried.
+const COVER_EMBED_QUERY = "?width=2000&quality=80";
 
 // Formats Supabase image transformation can resize. A Photo's stored file
 // may be something the transformer rejects — a HEIC original from a web
@@ -50,9 +64,10 @@ function isResizeEnabled(): boolean {
  * Resolve the public image URL for a job's Photo.
  *
  * The single place Photo grid/detail URLs are built (see ADR 0008). The
- * "grid" variant returns a small resized preview and "pdf" a print-sized
- * (1600px) render when image transformation is enabled, otherwise the original;
- * "full" always returns the original.
+ * "grid" variant returns a small resized preview, "pdf" a print-sized (1600px)
+ * body-photo render, and "cover" a larger (2000px) full-page hero render — each
+ * when image transformation is enabled, otherwise the original; "full" always
+ * returns the original.
  */
 export function photoUrl(
   source: PhotoUrlSource,
@@ -65,6 +80,9 @@ export function photoUrl(
   }
   if (variant === "pdf" && isResizeEnabled() && isResizable(path)) {
     return `${supabaseUrl}${PHOTOS_RENDER_PREFIX}${path}${PDF_EMBED_QUERY}`;
+  }
+  if (variant === "cover" && isResizeEnabled() && isResizable(path)) {
+    return `${supabaseUrl}${PHOTOS_RENDER_PREFIX}${path}${COVER_EMBED_QUERY}`;
   }
   return `${supabaseUrl}${PHOTOS_OBJECT_PREFIX}${path}`;
 }
@@ -97,13 +115,16 @@ export interface CoverPhotoSource {
 }
 
 /**
- * Resolve the full-resolution URL for a report's cover Photo, or `null` when
- * the job has no usable cover.
+ * Resolve the embed URL for a report's cover Photo, or `null` when the job has
+ * no usable cover.
  *
- * Like the "full" variant of {@link photoUrl}, it prefers the annotated copy
- * when present; but a job may have no cover photo at all (or only empty paths),
- * in which case the PDF must render its cover page without a photo rather than
- * point at a broken URL.
+ * Uses the "cover" variant of {@link photoUrl}: a bounded 2000px render when
+ * image transformation is enabled (so the hero stays crisp without dragging the
+ * full-resolution original's 3–7 MB into the PDF), falling back to the
+ * original when transformation is off or the format is unresizable. It prefers
+ * the annotated copy when present; but a job may have no cover photo at all (or
+ * only empty paths), in which case the PDF must render its cover page without a
+ * photo rather than point at a broken URL.
  */
 export function reportCoverPhotoUrl(
   cover: CoverPhotoSource | null,
@@ -111,5 +132,5 @@ export function reportCoverPhotoUrl(
 ): string | null {
   const path = cover?.annotated_path || cover?.storage_path;
   if (!path) return null;
-  return photoUrl({ annotated_path: null, storage_path: path }, supabaseUrl, "full");
+  return photoUrl({ annotated_path: null, storage_path: path }, supabaseUrl, "cover");
 }


### PR DESCRIPTION
## Problem

Downloaded photo reports were landing around **14 MB** — far too large to attach to an email.

`@react-pdf` embeds JPEGs as raw streams with no recompression, so a report's file size is essentially the sum of its embedded photos. The recent 50 MB upload-cap fix (#625) shrank body photos to 1600px, but two things still bloat the download:

- the **cover photo** was still embedded at full resolution (3–7 MB of uncompressed JPEG on its own), and
- the body photos sat at quality 80, leaving easy headroom.

## Changes

- **Lower body-photo embed quality 80 → 72** (keeping the 1600px width) — trims ~25–30% per photo with no visible loss at the 2/3/4-per-page layout.
- **Bound the cover photo** through a new `"cover"` image variant (2000px render) instead of the full-resolution original — keeps the full-page hero crisp while dropping it to well under 1 MB. As a bonus, the re-encode strips any Apple HDR gain-map tail the original cover carried.

Both are gated behind the same `NEXT_PUBLIC_PHOTO_RESIZE_ENABLED` transform flag as #625 and affect only **newly generated** PDFs.

## Expected impact

On the 14 MB example, this should land roughly **5–7 MB** (the cover fix alone accounts for most of it). Exact savings depend on the report; the quality-72 number is an easy one-line nudge if a real report still comes out tight.

## Testing

- Updated unit tests in `photo-url.test.ts` (embed quality + bounded cover render: resize on/off, HEIC fallback) and the integration assertion in `generate-report-pdf.test.tsx`, test-first (watched red → green).
- `npx vitest run` on the touched files + the Apple-JPEG embed test: **all pass**.
- `tsc --noEmit` and eslint clean on the changed files.

## Note

Existing reports won't shrink until they're re-generated (the change only affects new PDF generation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
