### PR TITLE
feat(compose): floating window chrome — maximize / minimize / mobile sheet (#638)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -1,19 +1,28 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef } from "react";
-import { flushSync } from "react-dom";
+import { useState, useEffect, useMemo, useRef, useReducer } from "react";
 import { Input } from "@/components/ui/input";
 import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Loader2, Send, ChevronDown, ChevronUp, Paperclip, X, FileIcon, Save } from "lucide-react";
+  Loader2,
+  Send,
+  ChevronDown,
+  ChevronUp,
+  Paperclip,
+  X,
+  FileIcon,
+  Save,
+  Minus,
+  Maximize2,
+  Minimize2,
+} from "lucide-react";
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
 import { htmlToText } from "@/lib/email/html-to-text";
+import {
+  composeWindowReducer,
+  initialComposeWindowState,
+} from "@/components/email/compose-window-state";
 
 interface EmailAccountData {
   id: string;
@@ -84,6 +93,10 @@ export default function ComposeEmailModal({
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
   const [editorKey, setEditorKey] = useState(0);
+  const [windowState, dispatchWindow] = useReducer(
+    composeWindowReducer,
+    initialComposeWindowState,
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const toRef = useRef<EmailAddressInputHandle>(null);
   const ccRef = useRef<EmailAddressInputHandle>(null);
@@ -127,6 +140,8 @@ export default function ComposeEmailModal({
 
   useEffect(() => {
     if (open) {
+      // Each fresh open starts as the corner-docked panel.
+      dispatchWindow({ type: "reset" });
       setSubject(defaultSubject);
       setUploadedFiles(defaultAttachments);
       setDraftId(initialDraftId || null);
@@ -353,13 +368,83 @@ export default function ComposeEmailModal({
   const title =
     mode === "reply" ? "Reply" : mode === "forward" ? "Forward" : "Compose Email";
 
+  if (!open) return null;
+
+  const isMaximized = windowState.mode === "maximized";
+  const isMinimized = windowState.mode === "minimized";
+
+  const panelClass = [
+    "fixed z-50 flex flex-col bg-white shadow-2xl border border-gray-200 overflow-hidden",
+    isMinimized
+      ? "bottom-0 left-0 right-0 sm:left-auto sm:right-6 sm:w-[600px] rounded-t-xl"
+      : isMaximized
+        ? "inset-0 sm:inset-4 sm:rounded-xl"
+        : "inset-0 sm:inset-auto sm:bottom-0 sm:right-6 sm:w-[600px] sm:h-[85vh] sm:max-h-[760px] sm:rounded-t-xl",
+  ].join(" ");
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSend} className="space-y-3">
+    <div
+      role="dialog"
+      aria-modal={false}
+      aria-label={title}
+      className={panelClass}
+    >
+      {/* Title bar — window chrome with minimize / maximize / close */}
+      <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-[#2B5EA7] text-white shrink-0 select-none">
+        {isMinimized ? (
+          <button
+            type="button"
+            onClick={() => dispatchWindow({ type: "restore" })}
+            className="min-w-0 flex-1 text-left text-sm font-semibold truncate"
+            title="Restore"
+          >
+            {title}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1 text-sm font-semibold truncate">
+            {title}
+          </span>
+        )}
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() =>
+              dispatchWindow({ type: isMinimized ? "restore" : "minimize" })
+            }
+            title={isMinimized ? "Restore" : "Minimize"}
+            aria-label={isMinimized ? "Restore" : "Minimize"}
+            className="p-1.5 rounded hover:bg-white/15 transition-colors"
+          >
+            {isMinimized ? <ChevronUp size={15} /> : <Minus size={15} />}
+          </button>
+          <button
+            type="button"
+            onClick={() => dispatchWindow({ type: "toggleMaximize" })}
+            title={isMaximized ? "Restore down" : "Maximize"}
+            aria-label={isMaximized ? "Restore down" : "Maximize"}
+            className="p-1.5 rounded hover:bg-white/15 transition-colors"
+          >
+            {isMaximized ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+          </button>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            title="Close"
+            aria-label="Close"
+            className="p-1.5 rounded hover:bg-white/15 transition-colors"
+          >
+            <X size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Body + footer stay mounted while minimized (hidden via CSS) so the
+          in-progress draft — recipients, subject, body, attachments — survives. */}
+      <form
+        onSubmit={handleSend}
+        className={`flex-1 min-h-0 flex flex-col ${isMinimized ? "hidden" : ""}`}
+      >
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-3">
           {/* From account */}
           <div>
             <label className="block text-sm font-medium text-[#333] mb-1">
@@ -492,56 +577,57 @@ export default function ComposeEmailModal({
             </p>
           )}
 
-          {/* Actions */}
-          <div className="flex items-center gap-3 pt-2">
-            <button
-              type="submit"
-              disabled={sending || uploading || accounts.length === 0}
-              className="px-5 py-2.5 bg-[#2B5EA7] text-white rounded-lg text-sm font-medium hover:bg-[#234b87] disabled:opacity-50 flex items-center gap-2"
-            >
-              {sending ? (
-                <Loader2 size={16} className="animate-spin" />
-              ) : (
-                <Send size={16} />
-              )}
-              Send Email
-            </button>
-            <button
-              type="button"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={uploading}
-              className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5 disabled:opacity-50"
-            >
-              {uploading ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Paperclip size={14} />
-              )}
-              Attach
-            </button>
-            <button
-              type="button"
-              onClick={handleSaveDraft}
-              disabled={savingDraft || accounts.length === 0}
-              className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5 disabled:opacity-50"
-            >
-              {savingDraft ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Save size={14} />
-              )}
-              Save Draft
-            </button>
-            <button
-              type="button"
-              onClick={() => onOpenChange(false)}
-              className="px-5 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50"
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
+        </div>
+
+        {/* Footer action / send bar */}
+        <div className="shrink-0 flex items-center gap-3 px-4 py-3 border-t border-gray-200 bg-white">
+          <button
+            type="submit"
+            disabled={sending || uploading || accounts.length === 0}
+            className="px-5 py-2.5 bg-[#2B5EA7] text-white rounded-lg text-sm font-medium hover:bg-[#234b87] disabled:opacity-50 flex items-center gap-2"
+          >
+            {sending ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <Send size={16} />
+            )}
+            Send Email
+          </button>
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5 disabled:opacity-50"
+          >
+            {uploading ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Paperclip size={14} />
+            )}
+            Attach
+          </button>
+          <button
+            type="button"
+            onClick={handleSaveDraft}
+            disabled={savingDraft || accounts.length === 0}
+            className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5 disabled:opacity-50"
+          >
+            {savingDraft ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Save size={14} />
+            )}
+            Save Draft
+          </button>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="px-5 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
   );
 }

--- a/src/components/email/compose-window-state.test.ts
+++ b/src/components/email/compose-window-state.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import {
+  composeWindowReducer,
+  initialComposeWindowState,
+} from "./compose-window-state";
+
+describe("composeWindowReducer", () => {
+  it("maximizes from the docked state", () => {
+    const next = composeWindowReducer(initialComposeWindowState, {
+      type: "toggleMaximize",
+    });
+    expect(next.mode).toBe("maximized");
+  });
+
+  it("toggles back to docked from maximized", () => {
+    const maximized = composeWindowReducer(initialComposeWindowState, {
+      type: "toggleMaximize",
+    });
+    const restored = composeWindowReducer(maximized, { type: "toggleMaximize" });
+    expect(restored.mode).toBe("docked");
+  });
+
+  it("minimizes the docked window and restores back to docked", () => {
+    const minimized = composeWindowReducer(initialComposeWindowState, {
+      type: "minimize",
+    });
+    expect(minimized.mode).toBe("minimized");
+    const restored = composeWindowReducer(minimized, { type: "restore" });
+    expect(restored.mode).toBe("docked");
+  });
+
+  it("remembers maximized when minimizing, and restores back to maximized", () => {
+    const maximized = composeWindowReducer(initialComposeWindowState, {
+      type: "toggleMaximize",
+    });
+    const minimized = composeWindowReducer(maximized, { type: "minimize" });
+    expect(minimized.mode).toBe("minimized");
+    const restored = composeWindowReducer(minimized, { type: "restore" });
+    expect(restored.mode).toBe("maximized");
+  });
+
+  it("expands a minimized window via the maximize control to its prior mode", () => {
+    const maximized = composeWindowReducer(initialComposeWindowState, {
+      type: "toggleMaximize",
+    });
+    const minimized = composeWindowReducer(maximized, { type: "minimize" });
+    const expanded = composeWindowReducer(minimized, { type: "toggleMaximize" });
+    expect(expanded.mode).toBe("maximized");
+  });
+
+  it("treats minimize as idempotent", () => {
+    const once = composeWindowReducer(initialComposeWindowState, {
+      type: "minimize",
+    });
+    const twice = composeWindowReducer(once, { type: "minimize" });
+    expect(twice).toEqual(once);
+  });
+
+  it("ignores restore when not minimized", () => {
+    const docked = composeWindowReducer(initialComposeWindowState, {
+      type: "restore",
+    });
+    expect(docked).toBe(initialComposeWindowState);
+  });
+
+  it("resets back to the docked default", () => {
+    const maximized = composeWindowReducer(initialComposeWindowState, {
+      type: "toggleMaximize",
+    });
+    const reset = composeWindowReducer(maximized, { type: "reset" });
+    expect(reset).toEqual(initialComposeWindowState);
+  });
+});

--- a/src/components/email/compose-window-state.ts
+++ b/src/components/email/compose-window-state.ts
@@ -1,0 +1,63 @@
+// Windowing state machine for the floating compose window (issue #638).
+//
+// The compose surface can be displayed three ways:
+//   - "docked"     — the default corner-docked panel (full-screen sheet on mobile)
+//   - "maximized"  — fills the screen
+//   - "minimized"  — collapsed to a title strip
+//
+// Minimize is reversible: restoring returns to whichever expanded mode
+// (docked or maximized) was showing before the collapse, so we remember it in
+// `restoreMode`. Keeping this logic as a pure reducer lets the windowing
+// behavior be unit-tested independently of the React component.
+
+export type ComposeWindowMode = "docked" | "maximized" | "minimized";
+
+/** The expanded modes we can restore to after un-minimizing. */
+export type ComposeWindowRestoreMode = "docked" | "maximized";
+
+export interface ComposeWindowState {
+  mode: ComposeWindowMode;
+  /** The expanded mode to return to when restoring from "minimized". */
+  restoreMode: ComposeWindowRestoreMode;
+}
+
+export type ComposeWindowAction =
+  | { type: "toggleMaximize" }
+  | { type: "minimize" }
+  | { type: "restore" }
+  | { type: "reset" };
+
+export const initialComposeWindowState: ComposeWindowState = {
+  mode: "docked",
+  restoreMode: "docked",
+};
+
+export function composeWindowReducer(
+  state: ComposeWindowState,
+  action: ComposeWindowAction,
+): ComposeWindowState {
+  switch (action.type) {
+    case "toggleMaximize": {
+      // From minimized, the maximize control expands back to the remembered mode.
+      if (state.mode === "minimized") {
+        return { mode: state.restoreMode, restoreMode: state.restoreMode };
+      }
+      const next: ComposeWindowRestoreMode =
+        state.mode === "maximized" ? "docked" : "maximized";
+      return { mode: next, restoreMode: next };
+    }
+    case "minimize": {
+      if (state.mode === "minimized") return state;
+      // state.mode is "docked" | "maximized" here — remember it for restore.
+      return { mode: "minimized", restoreMode: state.mode };
+    }
+    case "restore": {
+      if (state.mode !== "minimized") return state;
+      return { mode: state.restoreMode, restoreMode: state.restoreMode };
+    }
+    case "reset":
+      return initialComposeWindowState;
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
## What this does

Slice 1 of the Outlook-inspired email-drafting redesign (#634): replaces the
blocking centered Base UI dialog with a **non-modal floating compose window**.

This slice is the **container reskin only** — the existing From/To/Subject form,
attachments, and rich-text editor render and function inside the new window
unchanged. The point is a demoable floating, maximizable, minimizable compose
surface that still sends mail.

### Highlights

- **Non-modal floating panel** — corner-docked on desktop, full-screen sheet on
  mobile. No backdrop, so the inbox/page behind stays visible and interactive.
- **Window chrome** — title bar with **minimize** (collapse to a title strip),
  **maximize** (fill the screen), restore, and **close**, plus a footer
  action/send bar that will host status and overflow controls in later slices.
- **Draft survives minimize** — the body and footer stay mounted while minimized
  (hidden via CSS), so recipients, subject, body, and attachments are preserved
  across a minimize/restore cycle.
- **Built as a positioned panel, not a Base UI `Dialog`** — avoids the
  auto-focus-first-tabbable and capture-phase arrow-key footguns that would
  interfere with the rich-text editor in later slices.
- **Windowing is a pure reducer** (`composeWindowReducer`: docked / maximized /
  minimized with restore memory), unit-tested in isolation — this is the
  "compose UI shell" test target from the PRD.

The component's prop contract is unchanged, so both call sites (email inbox and
job detail) keep working without edits, and the shared rich-text editor is
untouched.

## Acceptance criteria

- [x] Compose opens as a non-modal floating panel docked to the corner on desktop; the page behind remains visible.
- [x] On a mobile-width viewport, compose renders as a full-screen sheet.
- [x] Title bar exposes maximize, minimize, and close; maximize fills the screen, minimize collapses to a title strip, restore returns to the docked panel.
- [x] Minimizing preserves the in-progress draft state (recipients, subject, body, attachments) when restored.
- [x] Existing behavior still works: From account, recipients, subject, body, attachments, send.
- [x] Both call sites (email inbox, job detail) still open compose with their existing props.
- [x] No regression to the contracts/estimate editors that share the rich-text component (the shared editor was not modified).

## Testing

- New `composeWindowReducer` suite — 8 unit tests covering maximize/restore, minimize-remembers-prior-mode, restore, idempotency, and reset (all green).
- `tsc --noEmit` clean on the touched files; ESLint clean on the touched files.
- All `src/components/email/` tests pass (23).

Exact visual layout (mobile sheet, docked sizing, maximize fill) is best
eyeballed on the Vercel preview attached to this PR.

## Linked issues

- Implements #638
- Parent: #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
