### PR TITLE
feat(email-templates): Organization + Personal templates store with scope-gated CRUD (#639)

### DIFF
--- a/src/app/api/email/templates/[id]/route.test.ts
+++ b/src/app/api/email/templates/[id]/route.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({ createServerSupabaseClient: vi.fn() }));
+vi.mock("@/lib/supabase-api", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/supabase/get-active-org", () => ({ getActiveOrganizationId: vi.fn() }));
+
+import { PUT, DELETE } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+const params = (id: string) => ({ params: Promise.resolve({ id }) });
+
+function putReq(body: unknown = { name: "Updated" }) {
+  return new Request("http://test", { method: "PUT", body: JSON.stringify(body) });
+}
+const delReq = () => new Request("http://test", { method: "DELETE" });
+
+// A caller's seeded tables: membership/grants plus one Organization-wide and
+// one Personal template the caller owns.
+function tablesFor(opts: { userId: string; role: string; grants?: string[] }) {
+  return {
+    ...memberTables(opts),
+    email_templates: [
+      { id: "t-org", owner_user_id: null, organization_id: "org-1", name: "Shared" },
+      { id: "t-mine", owner_user_id: opts.userId, organization_id: "org-1", name: "Mine" },
+    ],
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// PUT/DELETE derive the template's scope from the existing row, then apply the
+// same scope-conditional gate as create: Organization-wide mutations require
+// manage_email_templates (admins auto-pass); Personal ones are always the
+// owner's. RLS guarantees a row that loads is one the caller may at least see.
+describe("PUT /api/email/templates/[id] — scope-conditional permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+    expect((await PUT(putReq(), params("t-org"))).status).toBe(401);
+  });
+
+  it("returns 404 when the template does not exist (or is invisible)", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({ userId: "u", role: "admin", grants: ["access_settings"] }),
+    });
+    expect((await PUT(putReq(), params("missing"))).status).toBe(404);
+  });
+
+  it("denies editing an Organization-wide template without manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect((await PUT(putReq(), params("t-org"))).status).toBe(403);
+  });
+
+  it("allows editing an Organization-wide template with manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({
+        userId: "u",
+        role: "crew_lead",
+        grants: ["access_settings", "manage_email_templates"],
+      }),
+    });
+    expect((await PUT(putReq(), params("t-org"))).status).not.toBe(403);
+  });
+
+  it("allows editing the caller's own Personal template without the key", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect((await PUT(putReq(), params("t-mine"))).status).not.toBe(403);
+  });
+});
+
+describe("DELETE /api/email/templates/[id] — scope-conditional permission", () => {
+  it("denies deleting an Organization-wide template without manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect((await DELETE(delReq(), params("t-org"))).status).toBe(403);
+  });
+
+  it("allows deleting an Organization-wide template with manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({
+        userId: "u",
+        role: "crew_lead",
+        grants: ["access_settings", "manage_email_templates"],
+      }),
+    });
+    expect((await DELETE(delReq(), params("t-org"))).status).not.toBe(403);
+  });
+
+  it("allows deleting the caller's own Personal template without the key", async () => {
+    authed({
+      user: { id: "u" },
+      tables: tablesFor({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect((await DELETE(delReq(), params("t-mine"))).status).not.toBe(403);
+  });
+});

--- a/src/app/api/email/templates/[id]/route.ts
+++ b/src/app/api/email/templates/[id]/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import {
+  authorizeTemplateMutation,
+  type EmailTemplateScope,
+} from "@/lib/email/authorize-template-mutation";
+
+// Both handlers derive the template's scope from the existing row (owner_user_id
+// NULL → Organization-wide; set → Personal), then apply the same scope gate as
+// create. RLS guarantees the loaded row is one the caller may at least see, so a
+// 404 here means "not visible to you" as much as "absent". A shared helper keeps
+// the load → scope → authorize preamble identical across PUT and DELETE.
+async function loadAndAuthorize(
+  supabase: import("@supabase/supabase-js").SupabaseClient,
+  id: string,
+  facts: { role: string | null; grantedPermissions: string[] },
+): Promise<
+  | { ok: true; scope: EmailTemplateScope }
+  | { ok: false; response: Response }
+> {
+  const { data: existing, error } = await supabase
+    .from("email_templates")
+    .select("id, owner_user_id")
+    .eq("id", id)
+    .single();
+
+  if (error || !existing) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Template not found" }, { status: 404 }),
+    };
+  }
+
+  const scope: EmailTemplateScope =
+    existing.owner_user_id === null ? "organization" : "personal";
+
+  if (!authorizeTemplateMutation(scope, facts)) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Permission denied" }, { status: 403 }),
+    };
+  }
+
+  return { ok: true, scope };
+}
+
+// PUT /api/email/templates/[id] — edit a template's name and/or body. Scope and
+// owner are immutable here; only name and body_html may change.
+export const PUT = withRequestContext<{ id: string }>(
+  { permission: "access_settings" },
+  async (request, ctx, { params }) => {
+    const { id } = await params;
+    const gate = await loadAndAuthorize(ctx.supabase, id, {
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    });
+    if (!gate.ok) return gate.response;
+
+    const body = await request.json().catch(() => ({}));
+    const patch: Record<string, unknown> = {};
+    if (typeof body?.name === "string") patch.name = body.name.trim().slice(0, 200);
+    if (typeof body?.body_html === "string") patch.body_html = body.body_html;
+
+    const { data, error } = await ctx.supabase
+      .from("email_templates")
+      .update(patch)
+      .eq("id", id)
+      .select()
+      .single();
+
+    if (error) return apiDbError(error.message, "PUT /api/email/templates/[id]");
+    return NextResponse.json(data);
+  },
+);
+
+// DELETE /api/email/templates/[id] — remove a template.
+export const DELETE = withRequestContext<{ id: string }>(
+  { permission: "access_settings" },
+  async (_request, ctx, { params }) => {
+    const { id } = await params;
+    const gate = await loadAndAuthorize(ctx.supabase, id, {
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    });
+    if (!gate.ok) return gate.response;
+
+    const { error } = await ctx.supabase
+      .from("email_templates")
+      .delete()
+      .eq("id", id);
+
+    if (error) return apiDbError(error.message, "DELETE /api/email/templates/[id]");
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/app/api/email/templates/route.test.ts
+++ b/src/app/api/email/templates/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({ createServerSupabaseClient: vi.fn() }));
+vi.mock("@/lib/supabase-api", () => ({ createServiceClient: vi.fn() }));
+vi.mock("@/lib/supabase/get-active-org", () => ({ getActiveOrganizationId: vi.fn() }));
+
+import { GET, POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeUserClient,
+  memberTables,
+} from "../__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+
+function authed(opts: Parameters<typeof fakeUserClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(
+    fakeUserClient(opts) as never,
+  );
+}
+
+function postReq(body: unknown) {
+  return new Request("http://test", { method: "POST", body: JSON.stringify(body) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// GET lists Organization-wide + own Personal templates; RLS enforces the
+// visibility rule, so the route only needs the Settings-reach gate.
+describe("GET /api/email/templates — gated on access_settings", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+    expect((await GET(new Request("http://test"), noParams)).status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks access_settings", async () => {
+    authed({
+      user: { id: "u" },
+      tables: memberTables({ userId: "u", role: "crew_member", grants: [] }),
+    });
+    expect((await GET(new Request("http://test"), noParams)).status).toBe(403);
+  });
+
+  it("lists when the caller holds access_settings", async () => {
+    authed({
+      user: { id: "u" },
+      tables: memberTables({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect((await GET(new Request("http://test"), noParams)).status).toBe(200);
+  });
+});
+
+// POST is where the scope-conditional gate lives: an Organization-wide
+// template requires `manage_email_templates` (admins auto-pass), while a
+// Personal template is always the caller's to create. The route gate is the
+// looser `access_settings` (you must be able to reach Settings); the
+// per-scope permission is enforced inside via authorizeTemplateMutation.
+describe("POST /api/email/templates — scope-conditional permission", () => {
+  it("returns 401 when unauthenticated", async () => {
+    authed({ user: null });
+    expect((await POST(postReq({ scope: "personal", name: "T" }), noParams)).status).toBe(401);
+  });
+
+  it("denies an Organization-wide create when the caller lacks manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      // Has Settings access but NOT the templates-management permission.
+      tables: memberTables({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect(
+      (await POST(postReq({ scope: "organization", name: "Shared" }), noParams)).status,
+    ).toBe(403);
+  });
+
+  it("allows an Organization-wide create when the caller holds manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: memberTables({
+        userId: "u",
+        role: "crew_lead",
+        grants: ["access_settings", "manage_email_templates"],
+      }),
+    });
+    // The fake User client cannot return an inserted row, so the insert
+    // surfaces a db error rather than a 201 — but never a 403, proving the
+    // scope gate let the Organization-wide write through.
+    expect(
+      (await POST(postReq({ scope: "organization", name: "Shared" }), noParams)).status,
+    ).not.toBe(403);
+  });
+
+  it("admins may create Organization-wide without holding the key", async () => {
+    authed({
+      user: { id: "a" },
+      tables: memberTables({ userId: "a", role: "admin", grants: ["access_settings"] }),
+    });
+    expect(
+      (await POST(postReq({ scope: "organization", name: "Shared" }), noParams)).status,
+    ).not.toBe(403);
+  });
+
+  it("allows a Personal create even without manage_email_templates", async () => {
+    authed({
+      user: { id: "u" },
+      tables: memberTables({ userId: "u", role: "crew_member", grants: ["access_settings"] }),
+    });
+    expect(
+      (await POST(postReq({ scope: "personal", name: "Mine" }), noParams)).status,
+    ).not.toBe(403);
+  });
+});

--- a/src/app/api/email/templates/route.ts
+++ b/src/app/api/email/templates/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { apiDbError } from "@/lib/api-errors";
+import {
+  authorizeTemplateMutation,
+  type EmailTemplateScope,
+} from "@/lib/email/authorize-template-mutation";
+
+// GET /api/email/templates — list the templates this Request Context may see:
+// Organization-wide templates for the Active Organization plus the caller's
+// own Personal templates. The visibility rule itself is enforced by RLS
+// (migration-572); the route only needs the Settings-reach gate.
+export const GET = withRequestContext({ permission: "access_settings" }, async (_request, ctx) => {
+  const { data, error } = await ctx.supabase
+    .from("email_templates")
+    .select("id, name, body_html, owner_user_id, created_by, created_at, updated_at")
+    .eq("organization_id", ctx.orgId)
+    .order("updated_at", { ascending: false });
+
+  if (error) return apiDbError(error.message, "GET /api/email/templates");
+  return NextResponse.json(data ?? []);
+});
+
+// POST /api/email/templates — create a template in one of two scopes:
+//   { scope: "organization" } → org-wide; requires manage_email_templates
+//   { scope: "personal" }     → owned by the caller; always allowed
+// The route gate is the looser access_settings (reaching the feature at all);
+// the scope-specific permission is decided by authorizeTemplateMutation, the
+// one rule RLS cannot enforce because Nookleus' granular grants aren't in the
+// JWT. The owner is computed server-side, never honored from the request body.
+export const POST = withRequestContext({ permission: "access_settings" }, async (request, ctx) => {
+  const body = await request.json().catch(() => ({}));
+  const scope: EmailTemplateScope =
+    body?.scope === "organization" ? "organization" : "personal";
+
+  if (
+    !authorizeTemplateMutation(scope, {
+      role: ctx.role,
+      grantedPermissions: ctx.grantedPermissions,
+    })
+  ) {
+    return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+  }
+
+  const name = (body?.name ?? "").toString().trim();
+  if (!name) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  const { data, error } = await ctx.supabase
+    .from("email_templates")
+    .insert({
+      organization_id: ctx.orgId,
+      owner_user_id: scope === "organization" ? null : ctx.userId,
+      name: name.slice(0, 200),
+      body_html: (body?.body_html ?? "").toString(),
+      created_by: ctx.userId,
+    })
+    .select()
+    .single();
+
+  if (error) return apiDbError(error.message, "POST /api/email/templates insert");
+  return NextResponse.json(data, { status: 201 });
+});

--- a/src/app/settings/email/page.tsx
+++ b/src/app/settings/email/page.tsx
@@ -3,6 +3,7 @@
 import { SettingsTabs } from "@/components/settings/settings-tabs";
 import { AccountsTab } from "./accounts-tab";
 import { SignaturesTab } from "./signatures-tab";
+import { TemplatesTab } from "./templates-tab";
 
 export default function EmailSettingsPage() {
   return (
@@ -11,6 +12,7 @@ export default function EmailSettingsPage() {
       tabs={[
         { key: "accounts", label: "Accounts", content: <AccountsTab /> },
         { key: "signatures", label: "Signatures", content: <SignaturesTab /> },
+        { key: "templates", label: "Templates", content: <TemplatesTab /> },
       ]}
     />
   );

--- a/src/app/settings/email/templates-tab.tsx
+++ b/src/app/settings/email/templates-tab.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  Mail,
+  Loader2,
+  Lock,
+  Building2,
+  User,
+  MoreHorizontal,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useAuth } from "@/lib/auth-context";
+import TiptapEditor from "@/components/tiptap-editor";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+type Scope = "organization" | "personal";
+
+interface EmailTemplate {
+  id: string;
+  name: string;
+  body_html: string;
+  owner_user_id: string | null;
+  updated_at: string;
+}
+
+// The active editor target. `id` absent → creating; present → editing.
+interface EditorState {
+  id?: string;
+  scope: Scope;
+  name: string;
+  body_html: string;
+}
+
+export function TemplatesTab() {
+  const { hasPermission } = useAuth();
+  // Org-wide templates are visible to every member; only managing them needs
+  // the permission. Personal templates are always the owner's to manage.
+  const canManageOrg = hasPermission("manage_email_templates");
+
+  const [templates, setTemplates] = useState<EmailTemplate[] | null>(null);
+  const [editor, setEditor] = useState<EditorState | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const res = await fetch("/api/email/templates");
+    if (res.ok) {
+      setTemplates((await res.json()) as EmailTemplate[]);
+    } else {
+      toast.error("Failed to load templates");
+      setTemplates([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function openEditor(state: EditorState) {
+    setEditor(state);
+    setEditorKey((k) => k + 1);
+  }
+
+  async function handleSave() {
+    if (!editor) return;
+    const name = editor.name.trim();
+    if (!name) {
+      toast.error("Give the template a name");
+      return;
+    }
+    setSaving(true);
+    const res = editor.id
+      ? await fetch(`/api/email/templates/${editor.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, body_html: editor.body_html }),
+        })
+      : await fetch("/api/email/templates", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ scope: editor.scope, name, body_html: editor.body_html }),
+        });
+    setSaving(false);
+
+    if (res.ok) {
+      toast.success(editor.id ? "Template saved" : "Template created");
+      setEditor(null);
+      refresh();
+    } else if (res.status === 403) {
+      toast.error("You don't have permission to manage organization templates");
+    } else {
+      toast.error("Failed to save template");
+    }
+  }
+
+  async function handleDelete(t: EmailTemplate) {
+    const res = await fetch(`/api/email/templates/${t.id}`, { method: "DELETE" });
+    if (res.ok) {
+      toast.success("Template deleted");
+      if (editor?.id === t.id) setEditor(null);
+      refresh();
+    } else if (res.status === 403) {
+      toast.error("You don't have permission to delete this template");
+    } else {
+      toast.error("Failed to delete template");
+    }
+  }
+
+  const orgTemplates = (templates ?? []).filter((t) => t.owner_user_id === null);
+  const personalTemplates = (templates ?? []).filter((t) => t.owner_user_id !== null);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Email Templates</h2>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Reusable email bodies you can drop into a new message. Organization
+          templates are shared with your whole team; personal templates are
+          only yours.
+        </p>
+      </div>
+
+      {templates === null ? (
+        <div className="text-center py-12 text-muted-foreground">
+          <Loader2 size={20} className="inline animate-spin mr-2" /> Loading templates…
+        </div>
+      ) : (
+        <>
+          <TemplateSection
+            icon={<Building2 size={16} className="text-[var(--brand-primary)]" />}
+            title="Organization templates"
+            description="Shared across everyone in your organization."
+            templates={orgTemplates}
+            canManage={canManageOrg}
+            lockedHint={
+              <span>
+                Viewing only. Managing organization templates needs
+                <span className="font-mono text-xs"> manage_email_templates</span>.
+              </span>
+            }
+            onNew={() => openEditor({ scope: "organization", name: "", body_html: "" })}
+            onEdit={(t) =>
+              openEditor({ id: t.id, scope: "organization", name: t.name, body_html: t.body_html })
+            }
+            onDelete={handleDelete}
+            editingId={editor?.id}
+          />
+
+          <TemplateSection
+            icon={<User size={16} className="text-[var(--brand-primary)]" />}
+            title="Personal templates"
+            description="Private to you — no one else can see or use them."
+            templates={personalTemplates}
+            canManage={true}
+            onNew={() => openEditor({ scope: "personal", name: "", body_html: "" })}
+            onEdit={(t) =>
+              openEditor({ id: t.id, scope: "personal", name: t.name, body_html: t.body_html })
+            }
+            onDelete={handleDelete}
+            editingId={editor?.id}
+          />
+        </>
+      )}
+
+      {/* Inline editor */}
+      {editor && (
+        <div className="bg-card rounded-xl border border-border p-6 space-y-4">
+          <div className="flex items-center gap-2">
+            {editor.scope === "organization" ? (
+              <Building2 size={16} className="text-[var(--brand-primary)]" />
+            ) : (
+              <User size={16} className="text-[var(--brand-primary)]" />
+            )}
+            <h3 className="text-sm font-semibold text-foreground">
+              {editor.id ? "Edit" : "New"}{" "}
+              {editor.scope === "organization" ? "organization" : "personal"} template
+            </h3>
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">
+              Name
+            </label>
+            <input
+              type="text"
+              value={editor.name}
+              onChange={(e) => setEditor({ ...editor, name: e.target.value })}
+              placeholder="e.g. Follow-up after estimate"
+              className="w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:border-primary/40 focus:outline-none"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-muted-foreground mb-1">
+              Body
+            </label>
+            <TiptapEditor
+              key={editorKey}
+              content={editor.body_html}
+              onChange={(html) => setEditor((prev) => (prev ? { ...prev, body_html: html } : prev))}
+              placeholder="Write the email body…"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setEditor(null)}
+              disabled={saving}
+              className="px-4 py-2 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 hover:shadow-md disabled:opacity-50 transition-all"
+            >
+              {saving && <Loader2 size={16} className="animate-spin" />}
+              {saving ? "Saving…" : editor.id ? "Save template" : "Create template"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TemplateSection({
+  icon,
+  title,
+  description,
+  templates,
+  canManage,
+  lockedHint,
+  onNew,
+  onEdit,
+  onDelete,
+  editingId,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  templates: EmailTemplate[];
+  canManage: boolean;
+  lockedHint?: React.ReactNode;
+  onNew: () => void;
+  onEdit: (t: EmailTemplate) => void;
+  onDelete: (t: EmailTemplate) => void;
+  editingId?: string;
+}) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
+            {icon}
+            {title}
+          </h3>
+          <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
+        </div>
+        {canManage ? (
+          <button
+            type="button"
+            onClick={onNew}
+            className="inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[image:var(--gradient-primary)] text-white shadow-sm hover:brightness-110 hover:shadow-md transition-all"
+          >
+            <Plus size={16} /> New
+          </button>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Lock size={12} /> View only
+          </span>
+        )}
+      </div>
+
+      {!canManage && lockedHint && (
+        <p className="text-xs text-muted-foreground">{lockedHint}</p>
+      )}
+
+      {templates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-card/50 p-8 text-center">
+          <Mail size={28} className="mx-auto text-muted-foreground mb-2" />
+          <p className="text-sm text-foreground font-medium">No templates yet</p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-border bg-card overflow-hidden">
+          <table className="w-full text-sm">
+            <tbody>
+              {templates.map((t) => (
+                <tr
+                  key={t.id}
+                  className={
+                    "border-t border-border first:border-t-0 hover:bg-muted/20 transition-colors" +
+                    (editingId === t.id ? " bg-muted/30" : "")
+                  }
+                >
+                  <td className="px-4 py-3">
+                    {canManage ? (
+                      <button
+                        type="button"
+                        onClick={() => onEdit(t)}
+                        className="font-medium text-foreground hover:text-[var(--brand-primary)] transition-colors text-left"
+                      >
+                        {t.name}
+                      </button>
+                    ) : (
+                      <span className="font-medium text-foreground">{t.name}</span>
+                    )}
+                  </td>
+                  <td className="w-10 px-2 py-3 text-right">
+                    {canManage && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger
+                          className="inline-flex items-center justify-center rounded-lg p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                          aria-label={`Actions for ${t.name}`}
+                        >
+                          <MoreHorizontal size={16} />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-36">
+                          <DropdownMenuItem onClick={() => onEdit(t)}>
+                            <Pencil size={14} /> Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem variant="destructive" onClick={() => onDelete(t)}>
+                            <Trash2 size={14} /> Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/email/authorize-template-mutation.test.ts
+++ b/src/lib/email/authorize-template-mutation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { authorizeTemplateMutation } from "./authorize-template-mutation";
+
+describe("authorizeTemplateMutation", () => {
+  it("denies an organization-wide mutation when the caller lacks manage_email_templates", () => {
+    expect(
+      authorizeTemplateMutation("organization", {
+        role: "crew_member",
+        grantedPermissions: [],
+      }),
+    ).toBe(false);
+  });
+
+  it("allows an organization-wide mutation when the caller holds manage_email_templates", () => {
+    expect(
+      authorizeTemplateMutation("organization", {
+        role: "crew_lead",
+        grantedPermissions: ["manage_email_templates"],
+      }),
+    ).toBe(true);
+  });
+
+  it("allows an organization-wide mutation for an admin without the key explicitly granted", () => {
+    expect(
+      authorizeTemplateMutation("organization", {
+        role: "admin",
+        grantedPermissions: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("allows a personal mutation regardless of role or granted permissions", () => {
+    expect(
+      authorizeTemplateMutation("personal", {
+        role: "crew_member",
+        grantedPermissions: [],
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/email/authorize-template-mutation.ts
+++ b/src/lib/email/authorize-template-mutation.ts
@@ -1,0 +1,23 @@
+import {
+  evaluatePermissionRule,
+  type PermissionFacts,
+} from "@/lib/request-context/evaluate-permission-rule";
+
+export type EmailTemplateScope = "organization" | "personal";
+
+// The app-layer permission gate for mutating an email template. RLS isolates
+// rows by organization and owner, but it cannot enforce Nookleus' granular
+// `manage_email_templates` permission (those grants live in our own tables,
+// not the JWT). So the rule lives here: an organization-wide template may only
+// be created/edited/deleted by a caller who holds `manage_email_templates`
+// (admins auto-pass), while a personal template is always the owner's to manage.
+export function authorizeTemplateMutation(
+  scope: EmailTemplateScope,
+  facts: PermissionFacts,
+): boolean {
+  if (scope === "personal") return true;
+  return evaluatePermissionRule(
+    { permission: "manage_email_templates" },
+    facts,
+  );
+}

--- a/src/lib/permissions/permission-keys.ts
+++ b/src/lib/permissions/permission-keys.ts
@@ -68,6 +68,7 @@ export const PERMISSION_CATALOG = [
 
   { key: "manage_templates", label: "Manage Estimate Templates", group: "Templates" },
   { key: "manage_contract_templates", label: "Manage Contract Templates", group: "Templates" },
+  { key: "manage_email_templates", label: "Manage Email Templates", group: "Templates" },
 
   { key: "manage_item_library", label: "Manage Item Library", group: "Catalogs" },
   { key: "manage_vendors", label: "Manage Vendors", group: "Catalogs" },

--- a/supabase/migration-572-email-templates.sql
+++ b/supabase/migration-572-email-templates.sql
@@ -1,0 +1,134 @@
+-- issue #639 (PRD #634) — email_templates table.
+--
+-- Purpose:   The store behind the email-templates feature: body-only
+--            rich-text (HTML) templates a user can drop into a compose
+--            window. Two scopes, decided by the nullable owner_user_id:
+--              owner_user_id IS NULL → Organization-wide (shared; every
+--                                      member of the org reads it; creating /
+--                                      editing / deleting requires the
+--                                      `manage_email_templates` permission,
+--                                      enforced in the app layer — see below)
+--              owner_user_id = X     → Personal (private to X; only X reads
+--                                      and manages it)
+--
+-- Defense-in-depth split:
+--            RLS here is the *data-isolation* backstop — it enforces the
+--            organization boundary and Personal-owner privacy, the things a
+--            row's columns can decide. It deliberately does NOT gate
+--            Organization-wide writes on a role, because the real gate is
+--            Nookleus' granular `manage_email_templates` permission, and
+--            those grants live in our own tables, not the JWT — RLS cannot
+--            see them. So at the SQL surface any member may write an
+--            Organization-wide row; the permission is enforced one layer up
+--            by `authorizeTemplateMutation` in the CRUD routes. This is the
+--            same reasoning as migration-140 (email_accounts), except those
+--            had no granular permission so migration-222 later tightened
+--            their Shared insert to admin-only; email_templates keeps the
+--            member-level RLS and leans on the app-layer permission instead.
+--
+-- Shape:     Mirrors the Shared/Personal split of email_accounts
+--            (migration-140) and phone_numbers (migration-307) — a single
+--            nullable owner column as the discriminator, no `kind` column.
+--            `created_by` records authorship for audit and is independent of
+--            ownership (an Organization-wide row has owner_user_id NULL but a
+--            non-NULL created_by). created_by is ON DELETE SET NULL so an
+--            Organization-wide template outlives the member who authored it;
+--            owner_user_id is ON DELETE CASCADE so a Personal template goes
+--            with its owner (matching migration-140's privacy-correct
+--            default).
+--
+-- RLS:       One `for all` policy, shaped like email_accounts'
+--            email_accounts_shared_or_personal: visibility == mutation rule
+--            at the SQL layer (the permission gate is app-layer, not RLS, so
+--            there is no per-command divergence to model). USING and WITH
+--            CHECK are identical:
+--              organization_id = active org
+--              AND ((owner_user_id IS NULL AND member of org)
+--                   OR owner_user_id = auth.uid())
+--
+-- Indexes:   idx_email_templates_org — org-scoped list query (Settings →
+--            Email → Templates, Organization section).
+--            idx_email_templates_owner — partial on owner_user_id for the
+--            Personal section, mirroring migration-140 / migration-307.
+--
+-- Depends on: schema.sql (organizations, user_organizations, the
+--            nookleus.active_organization_id() / nookleus.is_member_of()
+--            helpers, public.update_updated_at()), auth.users.
+--
+-- Smoke test: supabase/migration-572-smoke-test.sql exercises the SELECT
+--            visibility rule (the testable core) plus the INSERT isolation
+--            backstop, in the spirit of migration-307-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK -- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. The table.
+-- ---------------------------------------------------------------------------
+create table if not exists public.email_templates (
+  id                uuid primary key default gen_random_uuid(),
+  organization_id   uuid not null references public.organizations(id) on delete cascade,
+  -- NULL → Organization-wide; a uuid → Personal, owned by that user. ON
+  -- DELETE CASCADE so a deleted user's Personal templates go with them
+  -- rather than silently promoting to Organization-wide (SET NULL) or
+  -- blocking the delete (RESTRICT) — same rationale as migration-140.
+  owner_user_id     uuid references auth.users(id) on delete cascade,
+  name              text not null,
+  -- Body-only rich text. The compose window supplies subject / recipients;
+  -- a template is just the body, stored as sanitized HTML.
+  body_html         text not null default '',
+  -- Authorship audit, independent of ownership. SET NULL so an
+  -- Organization-wide template survives its author leaving the org.
+  created_by        uuid references auth.users(id) on delete set null,
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+create index if not exists idx_email_templates_org
+  on public.email_templates (organization_id);
+
+create index if not exists idx_email_templates_owner
+  on public.email_templates (owner_user_id)
+  where owner_user_id is not null;
+
+-- ---------------------------------------------------------------------------
+-- 2. updated_at trigger — the shared BEFORE UPDATE function schema.sql
+--    defines, same as the rest of the schema.
+-- ---------------------------------------------------------------------------
+drop trigger if exists trg_email_templates_updated_at on public.email_templates;
+create trigger trg_email_templates_updated_at
+  before update on public.email_templates
+  for each row execute function public.update_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- 3. RLS. ENABLE first, then the single Organization-or-Personal policy.
+--    The User-client policy is the data-isolation backstop; the CRUD routes
+--    additionally enforce `manage_email_templates` for Organization-wide
+--    mutations via authorizeTemplateMutation.
+-- ---------------------------------------------------------------------------
+alter table public.email_templates enable row level security;
+
+drop policy if exists email_templates_org_or_personal on public.email_templates;
+create policy email_templates_org_or_personal on public.email_templates
+  for all to authenticated
+  using (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (owner_user_id is null and nookleus.is_member_of(organization_id))
+      or owner_user_id = auth.uid()
+    )
+  )
+  with check (
+    organization_id = nookleus.active_organization_id()
+    and (
+      (owner_user_id is null and nookleus.is_member_of(organization_id))
+      or owner_user_id = auth.uid()
+    )
+  );
+
+-- ROLLBACK ---
+-- drop policy if exists email_templates_org_or_personal on public.email_templates;
+-- alter table public.email_templates disable row level security;
+-- drop trigger if exists trg_email_templates_updated_at on public.email_templates;
+-- drop index if exists public.idx_email_templates_owner;
+-- drop index if exists public.idx_email_templates_org;
+-- drop table if exists public.email_templates;

--- a/supabase/migration-572-smoke-test.sql
+++ b/supabase/migration-572-smoke-test.sql
@@ -1,0 +1,299 @@
+-- issue #639 (PRD #634) — email_templates RLS smoke test.
+--
+-- Purpose:   Verify that migration-572 produced the expected post-state and,
+--            above all, pins the testable core of the slice — the visibility
+--            rule: "a Request Context can read Organization-wide templates
+--            for its Active Organization plus its own Personal templates —
+--            never another user's Personal templates, never another
+--            Organization's templates."
+--
+-- Shape:     One transaction, rolled back at the end. Seeds 2 orgs + 3 users
+--            (admin org1, crew_lead org1, admin org2) under service-role
+--            bypass, asserts the column shape, then walks the RLS matrix
+--            under `role authenticated`:
+--              SELECT (the core) — each caller sees exactly Org-wide(own org)
+--                                  + own Personal; never another user's
+--                                  Personal, never another org's rows.
+--              INSERT (backstop) — Org-wide by a member allowed (incl. a
+--                                  non-admin: RLS does NOT gate the
+--                                  `manage_email_templates` permission — the
+--                                  app layer does); Personal-self allowed;
+--                                  Personal-other denied; cross-org denied.
+--
+-- Run:       Via Supabase MCP `execute_sql` against the target project. Once
+--            applied to prod, this script remains as the documented test of
+--            the policy. Not run by CI.
+--
+-- IDs:       Prefix `43` keeps these seeds distinct from migration-140 (`40`),
+--            migration-222 (`41`), and migration-307 (`42`).
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 0. Seed. Service-role bypass for orgs / users / memberships.
+--      Org 1: smoke-572-org-1   — User A (admin), User B (crew_lead)
+--      Org 2: smoke-572-org-2   — User C (admin)
+-- ---------------------------------------------------------------------------
+insert into public.organizations (id, name, slug)
+values
+  ('43000000-0000-0000-0000-000000000001', 'smoke-572-org-1', 'smoke-572-org-1'),
+  ('43000000-0000-0000-0000-000000000002', 'smoke-572-org-2', 'smoke-572-org-2');
+
+insert into auth.users (id, email, role, aud, instance_id)
+values
+  ('43000000-0000-0000-0000-000000000010', 'smoke-572-a@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('43000000-0000-0000-0000-000000000011', 'smoke-572-b@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000'),
+  ('43000000-0000-0000-0000-000000000012', 'smoke-572-c@example.invalid', 'authenticated', 'authenticated', '00000000-0000-0000-0000-000000000000');
+
+insert into public.user_organizations (user_id, organization_id, role)
+values
+  ('43000000-0000-0000-0000-000000000010', '43000000-0000-0000-0000-000000000001', 'admin'),
+  ('43000000-0000-0000-0000-000000000011', '43000000-0000-0000-0000-000000000001', 'crew_lead'),
+  ('43000000-0000-0000-0000-000000000012', '43000000-0000-0000-0000-000000000002', 'admin');
+
+-- ---------------------------------------------------------------------------
+-- 1. Column-shape assertions. Pin the discriminator: organization_id NOT
+--    NULL, owner_user_id nullable. A future schema drift that flips either
+--    breaks the Org-wide/Personal split and must fail loudly here.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_org_nullable text;
+  v_owner_nullable text;
+begin
+  select is_nullable into v_org_nullable
+    from information_schema.columns
+   where table_schema = 'public' and table_name = 'email_templates'
+     and column_name = 'organization_id';
+  select is_nullable into v_owner_nullable
+    from information_schema.columns
+   where table_schema = 'public' and table_name = 'email_templates'
+     and column_name = 'owner_user_id';
+
+  if v_org_nullable is distinct from 'NO' then
+    raise exception 'migration-572 smoke (shape): organization_id must be NOT NULL, got is_nullable=%', v_org_nullable;
+  end if;
+  if v_owner_nullable is distinct from 'YES' then
+    raise exception 'migration-572 smoke (shape): owner_user_id must be nullable, got is_nullable=%', v_owner_nullable;
+  end if;
+  raise notice 'migration-572 smoke (shape): organization_id NOT NULL + owner_user_id nullable confirmed';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Seed templates under service-role bypass (RLS exercised in §3-4):
+--      T1 — org1 Organization-wide   (owner NULL)
+--      T2 — org1 Personal-by-A
+--      T3 — org1 Personal-by-B
+--      T4 — org2 Organization-wide   (owner NULL)
+--      T5 — org2 Personal-by-C
+-- ---------------------------------------------------------------------------
+insert into public.email_templates
+  (id, organization_id, owner_user_id, name, body_html, created_by)
+values
+  ('43000000-0000-0000-0000-000000000101', '43000000-0000-0000-0000-000000000001', null,
+   'org1 shared', '<p>org1 shared</p>', '43000000-0000-0000-0000-000000000010'),
+  ('43000000-0000-0000-0000-000000000102', '43000000-0000-0000-0000-000000000001', '43000000-0000-0000-0000-000000000010',
+   'A personal', '<p>A personal</p>', '43000000-0000-0000-0000-000000000010'),
+  ('43000000-0000-0000-0000-000000000103', '43000000-0000-0000-0000-000000000001', '43000000-0000-0000-0000-000000000011',
+   'B personal', '<p>B personal</p>', '43000000-0000-0000-0000-000000000011'),
+  ('43000000-0000-0000-0000-000000000104', '43000000-0000-0000-0000-000000000002', null,
+   'org2 shared', '<p>org2 shared</p>', '43000000-0000-0000-0000-000000000012'),
+  ('43000000-0000-0000-0000-000000000105', '43000000-0000-0000-0000-000000000002', '43000000-0000-0000-0000-000000000012',
+   'C personal', '<p>C personal</p>', '43000000-0000-0000-0000-000000000012');
+
+-- ---------------------------------------------------------------------------
+-- 3. SELECT RLS — the testable core. Each caller sees exactly Org-wide(own
+--    org) + own Personal.
+-- ---------------------------------------------------------------------------
+
+-- 3a. As admin A (org1): sees T1 (org-wide org1) + T2 (own personal). Does
+--     NOT see T3 (B's personal), T4 / T5 (org2).
+do $$
+declare
+  v_count bigint;
+  v_ids uuid[];
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000010","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), array_agg(id order by id) into v_count, v_ids
+    from public.email_templates;
+
+  reset role;
+
+  if v_count <> 2 then
+    raise exception 'migration-572 smoke (3a): admin A expected 2 rows (org-wide + own personal), got % — ids=%', v_count, v_ids;
+  end if;
+  if not (v_ids @> array['43000000-0000-0000-0000-000000000101'::uuid, '43000000-0000-0000-0000-000000000102'::uuid]) then
+    raise exception 'migration-572 smoke (3a): admin A rows wrong — expected T1 (..101) + T2 (..102), got %', v_ids;
+  end if;
+  raise notice 'migration-572 smoke (3a): admin A correctly sees org-wide + own personal only';
+end $$;
+
+-- 3b. As crew_lead B (org1): sees T1 (org-wide) + T3 (own personal). Does
+--     NOT see T2 (A's personal) — another user's Personal is invisible even
+--     within the same org.
+do $$
+declare
+  v_count bigint;
+  v_ids uuid[];
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000011","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+  select count(*), array_agg(id order by id) into v_count, v_ids
+    from public.email_templates;
+
+  reset role;
+
+  if v_count <> 2 then
+    raise exception 'migration-572 smoke (3b): crew_lead B expected 2 rows (org-wide + own personal), got % — ids=%', v_count, v_ids;
+  end if;
+  if not (v_ids @> array['43000000-0000-0000-0000-000000000101'::uuid, '43000000-0000-0000-0000-000000000103'::uuid]) then
+    raise exception 'migration-572 smoke (3b): crew_lead B rows wrong — expected T1 (..101) + T3 (..103), got %', v_ids;
+  end if;
+  raise notice 'migration-572 smoke (3b): crew_lead B sees org-wide + own personal, not A''s personal';
+end $$;
+
+-- 3c. As admin C (org2): sees T4 (org-wide org2) + T5 (own personal). Org1
+--     is entirely invisible — never another Organization's rows.
+do $$
+declare
+  v_count bigint;
+  v_ids uuid[];
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000012","active_organization_id":"43000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+  select count(*), array_agg(id order by id) into v_count, v_ids
+    from public.email_templates;
+
+  reset role;
+
+  if v_count <> 2 then
+    raise exception 'migration-572 smoke (3c): admin C expected 2 rows (org2 org-wide + own personal), got % — ids=%', v_count, v_ids;
+  end if;
+  if not (v_ids @> array['43000000-0000-0000-0000-000000000104'::uuid, '43000000-0000-0000-0000-000000000105'::uuid]) then
+    raise exception 'migration-572 smoke (3c): admin C rows wrong — expected T4 (..104) + T5 (..105), got %', v_ids;
+  end if;
+  raise notice 'migration-572 smoke (3c): admin C sees only its own org';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. INSERT RLS — the data-isolation backstop. RLS allows any member to
+--    write Org-wide (the `manage_email_templates` permission is enforced in
+--    the app layer, NOT here), allows Personal-self, and denies
+--    Personal-other and cross-org.
+-- ---------------------------------------------------------------------------
+
+-- 4a. admin A inserts Org-wide in own org → allowed.
+do $$
+declare v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000010","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  begin
+    insert into public.email_templates (organization_id, owner_user_id, name, body_html)
+    values ('43000000-0000-0000-0000-000000000001', null, 'A org-wide insert', '<p>x</p>');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+  if v_blocked then
+    raise exception 'migration-572 smoke (4a): admin Org-wide INSERT should be allowed, but RLS blocked it';
+  end if;
+  raise notice 'migration-572 smoke (4a): admin Org-wide INSERT correctly allowed';
+end $$;
+
+-- 4b. crew_lead B (non-admin) inserts Org-wide in own org → allowed at RLS.
+--     This documents the defense-in-depth split: RLS does NOT gate the
+--     `manage_email_templates` permission — the app layer (the CRUD route's
+--     authorizeTemplateMutation) does. A non-admin without the permission is
+--     stopped one layer up, not here.
+do $$
+declare v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000011","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  begin
+    insert into public.email_templates (organization_id, owner_user_id, name, body_html)
+    values ('43000000-0000-0000-0000-000000000001', null, 'B org-wide insert', '<p>x</p>');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+  if v_blocked then
+    raise exception 'migration-572 smoke (4b): non-admin Org-wide INSERT should pass RLS (permission is app-layer), but RLS blocked it';
+  end if;
+  raise notice 'migration-572 smoke (4b): non-admin Org-wide INSERT correctly passes RLS (permission gate is app-layer)';
+end $$;
+
+-- 4c. crew_lead B inserts Personal owned by themselves → allowed.
+do $$
+declare v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000011","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  begin
+    insert into public.email_templates (organization_id, owner_user_id, name, body_html)
+    values ('43000000-0000-0000-0000-000000000001', '43000000-0000-0000-0000-000000000011', 'B personal insert', '<p>x</p>');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+  if v_blocked then
+    raise exception 'migration-572 smoke (4c): Personal-self INSERT should be allowed, but RLS blocked it';
+  end if;
+  raise notice 'migration-572 smoke (4c): Personal-self INSERT correctly allowed';
+end $$;
+
+-- 4d. crew_lead B inserts Personal owned by ANOTHER user (A) → denied.
+--     Neither WITH CHECK branch passes: owner_user_id is not NULL (Org-wide
+--     branch fails) and owner_user_id != auth.uid() (Personal branch fails).
+do $$
+declare v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000011","active_organization_id":"43000000-0000-0000-0000-000000000001","role":"authenticated"}';
+  begin
+    insert into public.email_templates (organization_id, owner_user_id, name, body_html)
+    values ('43000000-0000-0000-0000-000000000001', '43000000-0000-0000-0000-000000000010', 'B steals A', '<p>x</p>');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+  if not v_blocked then
+    raise exception 'migration-572 smoke (4d): Personal-owned-by-other INSERT should be denied, but it succeeded';
+  end if;
+  raise notice 'migration-572 smoke (4d): Personal-owned-by-other INSERT correctly denied';
+end $$;
+
+-- 4e. admin C (org2) inserts into org1 → denied (cross-org). WITH CHECK
+--     requires organization_id = active org, and C's active org is org2.
+do $$
+declare v_blocked boolean := false;
+begin
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"43000000-0000-0000-0000-000000000012","active_organization_id":"43000000-0000-0000-0000-000000000002","role":"authenticated"}';
+  begin
+    insert into public.email_templates (organization_id, owner_user_id, name, body_html)
+    values ('43000000-0000-0000-0000-000000000001', null, 'C cross-org', '<p>x</p>');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+  if not v_blocked then
+    raise exception 'migration-572 smoke (4e): cross-org INSERT should be denied, but it succeeded';
+  end if;
+  raise notice 'migration-572 smoke (4e): cross-org INSERT correctly denied';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. Done. Roll back so the seed leaves no residue. A clean run prints only
+--    the NOTICE lines above; a failure aborts earlier with a labeled
+--    exception.
+-- ---------------------------------------------------------------------------
+rollback;


### PR DESCRIPTION
## What this ships

The email-templates **store** behind PRD #634 (slice #639): body-only
rich-text (HTML) templates in two scopes.

- **Organization-wide** — shared with the whole org; viewable by every
  member, but creating/editing/deleting requires the new
  `manage_email_templates` permission (admins auto-pass).
- **Personal** — owner-private; only the owner can see or manage them.

Inserting a template into a compose window is a **separate slice (#644)** and
is intentionally out of scope here.

## The testable core: the visibility rule

> A Request Context can read Organization-wide templates for its Active
> Organization plus its own Personal templates — never another user's
> Personal templates, never another Organization's templates.

Enforced as **defense-in-depth**, with each layer tested where it lives:

| Layer | Responsibility | Test |
| --- | --- | --- |
| RLS (`migration-572`) | org boundary + owner privacy | `migration-572-smoke-test.sql` — SELECT visibility matrix (A/B/C across 2 orgs) + INSERT isolation |
| `authorizeTemplateMutation` (pure) | the `manage_email_templates` gate RLS can't see (granular grants aren't in the JWT) | `authorize-template-mutation.test.ts` — 4 behaviors |
| CRUD routes | wire the gate per scope; owner computed server-side | `route.test.ts` ×2 — 16 gate/scope cases |

RLS deliberately stays **member-level** for org-wide writes — the real
permission gate is the app layer, because Nookleus' granular grants never
reach Postgres. The smoke test documents this split explicitly (case 4b).

## Changes

- `supabase/migration-572-email-templates.sql` + companion smoke test
- `manage_email_templates` added to the Templates permission group
- `src/lib/email/authorize-template-mutation.ts` — the pure scope gate
- CRUD under `/api/email/templates` (GET list, POST create) and
  `/api/email/templates/[id]` (PUT, DELETE)
- Settings → Email → **Templates** tab (Organization + Personal sections)

## Verification

- 20 new unit/route tests pass (4 pure-module + 16 route).
- `tsc --noEmit` and `eslint` clean on all touched files (no new failures
  against the known-red baseline).
- Migration + smoke test were authored against proven prior art
  (migration-140 / migration-307); the smoke test runs at prod-apply time,
  per the established convention for these scripts.

Closes #639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
