### PR TITLE
fix(estimate-builder): confirm dialog owns Escape/focus; harden delete coverage (#628)

### DIFF
--- a/src/components/contracts/confirm-dialog.test.tsx
+++ b/src/components/contracts/confirm-dialog.test.tsx
@@ -1,0 +1,125 @@
+// Tests for the shared destructive-confirm modal (contracts/confirm-dialog).
+// #631 wired this dialog in front of the Estimate Builder's line-item delete,
+// layered above a touch editor that runs its OWN window-level Escape handler.
+// A bare modal let Escape fall through and close the whole editor; these pin the
+// dialog's keyboard + focus contract so it owns its own dismissal: Escape
+// cancels (and is captured so it never reaches a surrounding handler), focus
+// moves into the dialog on open and is restored on close, and Tab stays trapped.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { ComponentProps } from "react";
+
+import ConfirmDialog from "./confirm-dialog";
+
+function renderDialog(
+  overrides: Partial<ComponentProps<typeof ConfirmDialog>> = {},
+) {
+  const props: ComponentProps<typeof ConfirmDialog> = {
+    open: true,
+    ariaLabel: "Delete thing",
+    title: "Delete thing?",
+    body: "This can't be undone.",
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+    ...overrides,
+  };
+  render(<ConfirmDialog {...props} />);
+  return props;
+}
+
+describe("ConfirmDialog", () => {
+  it("cancels when Escape is pressed", () => {
+    const { onCancel, onConfirm } = renderDialog();
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onCancel on Escape when it is closed", () => {
+    const onCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        open={false}
+        ariaLabel="x"
+        title="x"
+        body="x"
+        onCancel={onCancel}
+        onConfirm={vi.fn()}
+      />,
+    );
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("swallows Escape so a surrounding window handler never sees it", () => {
+    // The editor panel listens for Escape on the window (bubble phase) to close
+    // itself. The dialog must capture + stop the event so cancelling the confirm
+    // doesn't also tear down the surface behind it.
+    const outer = vi.fn();
+    window.addEventListener("keydown", outer);
+    try {
+      renderDialog();
+      fireEvent.keyDown(document.body, { key: "Escape" });
+      expect(outer).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener("keydown", outer);
+    }
+  });
+
+  it("moves focus onto the Cancel action on open", () => {
+    renderDialog();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /cancel/i }),
+    );
+  });
+
+  it("restores focus to the opener when it closes", () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const { rerender } = render(
+      <ConfirmDialog
+        open
+        ariaLabel="x"
+        title="x"
+        body="x"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    // Focus moved into the dialog…
+    expect(document.activeElement).not.toBe(opener);
+
+    rerender(
+      <ConfirmDialog
+        open={false}
+        ariaLabel="x"
+        title="x"
+        body="x"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+      />,
+    );
+    // …and is handed back to the opener on close.
+    expect(document.activeElement).toBe(opener);
+
+    opener.remove();
+  });
+
+  it("traps Tab within the dialog's two actions", () => {
+    renderDialog();
+    const cancel = screen.getByRole("button", { name: /cancel/i });
+    const confirm = screen.getByRole("button", { name: /^delete$/i });
+
+    confirm.focus();
+    fireEvent.keyDown(confirm, { key: "Tab" });
+    expect(document.activeElement).toBe(cancel);
+
+    cancel.focus();
+    fireEvent.keyDown(cancel, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(confirm);
+  });
+});

--- a/src/components/contracts/confirm-dialog.tsx
+++ b/src/components/contracts/confirm-dialog.tsx
@@ -1,13 +1,23 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from "react";
 
-// Shared destructive-confirm modal used by DeleteDraftDialog (#61) and
-// PermanentlyDeleteDialog (#63). VoidContractDialog deliberately stays on
-// its own chrome — it carries a reason textarea, not a binary confirm.
+// Shared destructive-confirm modal used by DeleteDraftDialog (#61),
+// PermanentlyDeleteDialog (#63), and the Estimate Builder's line-item delete
+// guard (#631). VoidContractDialog deliberately stays on its own chrome — it
+// carries a reason textarea, not a binary confirm.
 //
 // The dialog is fully controlled: pass `open` to render, supply `onCancel`
 // and `onConfirm`. Backdrop click and Cancel both invoke onCancel.
+//
+// Keyboard + focus contract (#631): when this was layered in front of the touch
+// editor — which runs its own window-level Escape-to-close handler — a bare
+// modal let Escape fall through and tear down the whole editor instead of just
+// the confirm. So the dialog now owns its keyboard: Escape cancels via a
+// CAPTURE-phase window listener that stops the event before any surrounding
+// handler sees it, focus moves onto Cancel on open and is restored to the opener
+// on close, and Tab is trapped between the two actions (aria-modal kept honest).
 
 interface Props {
   open: boolean;
@@ -30,14 +40,69 @@ export default function ConfirmDialog({
   onCancel,
   onConfirm,
 }: Props) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Read onCancel through a ref so the capture listener binds once per open
+  // rather than re-binding on every parent re-render.
+  const onCancelRef = useRef(onCancel);
+  useEffect(() => {
+    onCancelRef.current = onCancel;
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    // Remember the opener so focus can return to it when the dialog closes.
+    const opener = document.activeElement as HTMLElement | null;
+    // Park focus on the non-destructive action — safest default for a
+    // destructive confirm, and it seats focus inside the dialog subtree.
+    cancelRef.current?.focus();
+
+    // Escape cancels. Capture-phase + stopPropagation so the event never reaches
+    // a surrounding window listener (e.g. the editor panel's own Escape-to-close),
+    // which would otherwise close the surface behind us.
+    function onEscapeCapture(e: KeyboardEvent) {
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        e.preventDefault();
+        e.stopPropagation();
+        onCancelRef.current();
+      }
+    }
+    window.addEventListener("keydown", onEscapeCapture, true);
+    return () => {
+      window.removeEventListener("keydown", onEscapeCapture, true);
+      opener?.focus?.();
+    };
+  }, [open]);
+
   if (!open) return null;
+
+  // Keep Tab within the two actions so focus can't wander to the fields behind
+  // the aria-modal dialog.
+  function onKeyDownTrap(e: ReactKeyboardEvent) {
+    if (e.key !== "Tab") return;
+    const buttons = overlayRef.current?.querySelectorAll<HTMLElement>("button");
+    if (!buttons || buttons.length === 0) return;
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
   return (
     <div
+      ref={overlayRef}
       role="dialog"
       aria-modal="true"
       aria-label={ariaLabel}
       className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
       onClick={onCancel}
+      onKeyDown={onKeyDownTrap}
     >
       <div
         className="w-full max-w-sm rounded-xl border border-border bg-card p-5 shadow-2xl"
@@ -47,18 +112,22 @@ export default function ConfirmDialog({
           {title}
         </h2>
         <div className="mt-2 text-sm text-muted-foreground">{body}</div>
+        {/* min-h-[44px]: finger-friendly tap targets for the touch surfaces this
+            now backs (the iPad estimate builder), where a destructive mis-tap
+            matters most (AC 3). */}
         <div className="mt-5 flex items-center justify-end gap-2">
           <button
+            ref={cancelRef}
             type="button"
             onClick={onCancel}
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 border border-border text-foreground hover:bg-accent transition-colors"
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 min-h-[44px] border border-border text-foreground hover:bg-accent transition-colors"
           >
             {cancelLabel}
           </button>
           <button
             type="button"
             onClick={onConfirm}
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 bg-red-500/90 text-white hover:bg-red-500 transition-colors"
+            className="inline-flex items-center justify-center rounded-md text-sm font-medium px-3 py-1.5 min-h-[44px] bg-red-500/90 text-white hover:bg-red-500 transition-colors"
           >
             {confirmLabel}
           </button>

--- a/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.integration.test.tsx
@@ -11,7 +11,8 @@
 // the panel must show up on the inline row, and vice-versa.
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, screen, within, fireEvent } from "@testing-library/react";
+import { render, screen, within, fireEvent, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
 
 import type {
   BuilderEntity,
@@ -799,5 +800,105 @@ describe("EstimateBuilder × editor delete button (#630)", () => {
     expect(
       within(panel).queryByRole("button", { name: /delete line item/i }),
     ).toBeNull();
+  });
+
+  it("keeps the editor open (cancels only the confirm) when Escape is pressed with the confirm up", () => {
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    selectRowByName("Tear-off");
+    fireEvent.click(panelDeleteButton());
+    // The #631 guard is up.
+    within(screen.getByTestId("builder-editor-panel")).getByRole("dialog", {
+      name: /delete line item/i,
+    });
+
+    // Before the keyboard fix, this window-level Escape closed the WHOLE editor
+    // out from under the open confirm. It must now cancel the confirm only.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    const panel = screen.getByTestId("builder-editor-panel");
+    expect(
+      within(panel).queryByRole("dialog", { name: /delete line item/i }),
+    ).toBeNull();
+    // Editor still open, line still present.
+    expect(
+      within(screen.getByTestId("builder-document")).queryByText("Tear-off"),
+    ).not.toBeNull();
+  });
+
+  it("recomputes the totals and shows a success toast after a successful delete (AC 12, AC 18)", async () => {
+    vi.mocked(toast.success).mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => ({}) })),
+    );
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    const totals = screen.getByTestId("builder-totals-bar");
+    expect(within(totals).getAllByText("$150.00").length).toBeGreaterThan(0);
+
+    // Delete Tear-off ($100 of the $150 subtotal).
+    selectRowByName("Tear-off");
+    fireEvent.click(panelDeleteButton());
+    confirmPanelDelete();
+
+    // AC 12: totals recompute optimistically ($150 → $50); the editor auto-closes
+    // so the full breakdown is shown again.
+    expect(within(totals).queryByText("$150.00")).toBeNull();
+    expect(within(totals).getAllByText("$50.00").length).toBeGreaterThan(0);
+
+    // AC 18: a success toast confirms the removal once the DELETE resolves.
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Line item deleted"),
+    );
+
+    vi.unstubAllGlobals();
+  });
+
+  it("restores the line and shows an error toast when the delete request fails (AC 19)", async () => {
+    vi.mocked(toast.error).mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false, json: async () => ({ error: "nope" }) })),
+    );
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    selectRowByName("Tear-off");
+    fireEvent.click(panelDeleteButton());
+    confirmPanelDelete();
+
+    // Optimistically removed first, then the failed DELETE rolls the line back in.
+    const doc = screen.getByTestId("builder-document");
+    await waitFor(() => {
+      expect(within(doc).queryByText("Tear-off")).not.toBeNull();
+    });
+    expect(toast.error).toHaveBeenCalledWith("nope");
+
+    vi.unstubAllGlobals();
+  });
+
+  it("restores the line and shows a network error toast when the delete request throws (AC 19)", async () => {
+    vi.mocked(toast.error).mockClear();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        throw new Error("offline");
+      }),
+    );
+    render(<EstimateBuilder entity={makeEstimateEntity()} />);
+
+    selectRowByName("Tear-off");
+    fireEvent.click(panelDeleteButton());
+    confirmPanelDelete();
+
+    const doc = screen.getByTestId("builder-document");
+    await waitFor(() => {
+      expect(within(doc).queryByText("Tear-off")).not.toBeNull();
+    });
+    expect(toast.error).toHaveBeenCalledWith(
+      "Network error — could not delete line item",
+    );
+
+    vi.unstubAllGlobals();
   });
 });

--- a/src/components/estimate-builder/line-item-editor-panel.test.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.test.tsx
@@ -322,6 +322,19 @@ describe("LineItemEditorPanel", () => {
     expect(screen.queryByTestId("editor-scrim")).toBeNull();
   });
 
+  it("docks with sticky positioning so it can follow scroll (#629)", () => {
+    render(
+      <LineItemEditorPanel item={makeItem()} onChange={vi.fn()} onClose={vi.fn()} />,
+    );
+
+    const panel = screen.getByTestId("line-item-editor-panel");
+    expect(panel.getAttribute("data-variant")).toBe("desktop");
+    // The scroll-follow fix (#629) hinges on the dock keeping `sticky top-6`;
+    // jsdom can't observe real pinning, so guard the class against regression.
+    expect(panel.className).toContain("sticky");
+    expect(panel.className).toContain("top-6");
+  });
+
   it("renders as a slide-up sheet with a dismiss scrim on phone", () => {
     setMatchMedia(false); // phone viewport
     const onClose = vi.fn();
@@ -469,6 +482,22 @@ describe("LineItemEditorPanel — delete affordance (#630)", () => {
     ).toBeNull();
   });
 
+  it("gives the delete button a finger-friendly tap target (AC 3)", () => {
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    // jsdom can't measure layout; guard the 44px min-height class (iOS minimum).
+    expect(
+      screen.getByRole("button", { name: /delete line item/i }).className,
+    ).toContain("min-h-[44px]");
+  });
+
   it("shows the delete button in the phone slide-up sheet too", () => {
     setMatchMedia(false); // phone viewport
     render(
@@ -605,5 +634,34 @@ describe("LineItemEditorPanel — delete confirmation (#631)", () => {
 
     fireEvent.click(within(dialog).getByRole("button", { name: /^delete$/i }));
     expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the confirmation, not the editor, when Escape is pressed while it is open", () => {
+    const onClose = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <LineItemEditorPanel
+        item={makeItem()}
+        onChange={vi.fn()}
+        onClose={onClose}
+        onDelete={onDelete}
+      />,
+    );
+
+    fireEvent.click(deleteButton());
+    expect(
+      screen.getByRole("dialog", { name: /delete line item/i }),
+    ).toBeDefined();
+
+    // Escape must dismiss the confirm only. The panel's own window-level
+    // Escape-to-close must NOT fire and tear the editor down underneath the
+    // open confirm (the #631 layering bug). The confirm owns Escape now.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+
+    expect(
+      screen.queryByRole("dialog", { name: /delete line item/i }),
+    ).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/src/components/estimate-builder/line-item-editor-panel.tsx
+++ b/src/components/estimate-builder/line-item-editor-panel.tsx
@@ -363,7 +363,7 @@ export function LineItemEditorPanel({
             <button
               type="button"
               onClick={() => setConfirmOpen(true)}
-              className="flex w-full items-center justify-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/20"
+              className="flex w-full min-h-[44px] items-center justify-center gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2.5 text-sm font-medium text-destructive transition-colors hover:bg-destructive/20"
             >
               <Trash2 size={16} />
               Delete line item


### PR DESCRIPTION
## Summary

Follow-up to **PRD #628** (iPad Estimate Builder), from a full review of the three
merged slices (#629/#630/#631). The review found the feature is fully implemented
and working, with one genuine interaction bug plus some a11y/coverage gaps. This
PR fixes them.

### The bug

The line-item delete **confirmation** (#631) renders above the editor, which runs
its **own window-level Escape-to-close** handler. The shared `ConfirmDialog` never
took focus or handled Escape, so pressing **Escape while the confirm was open
closed the entire editor** (selection cleared → panel unmounted) instead of just
cancelling the confirm. No data loss, but it's the opposite of what Escape should
do — and it hits keyboard / iPad-with-keyboard users.

### Fix — `ConfirmDialog` now owns its keyboard + focus

- **Escape cancels** via a **capture-phase** window listener with `stopPropagation`,
  so the event never reaches a surrounding handler (the editor's Escape-to-close).
- **Initial focus** moves onto Cancel on open; **focus is restored** to the opener
  on close.
- **Tab is trapped** between the two actions — focus can't wander to the fields
  behind the `aria-modal` dialog (closes the a11y finding).
- **44px minimum tap targets** on the confirm buttons and the panel's delete
  trigger (AC 3 — touch-first surface).

These are additive for the dialog's only other consumer (`contracts-section`'s
Delete-draft / Permanently-delete confirms) — its tests are unchanged and green.

### Tests (closing review-identified coverage gaps)

- **`confirm-dialog.test.tsx`** (new): Escape cancels + is swallowed from an outer
  window handler, closed no-op, initial focus, focus restoration, Tab trap.
- **Panel unit:** Escape cancels the confirm (not the editor); `#629` sticky-class
  regression guard; 44px trigger guard.
- **Integration:** Escape keeps the editor open with the confirm up (the real-world
  bug); **AC-19** failed-delete rollback (HTTP-error + network-throw — line
  restored + error toast); **AC-12/18** totals recompute + success toast on delete.

## Verification

- **76/76** tests pass across the affected files (incl. `contracts-section`).
- `tsc --noEmit` and ESLint clean on the touched files.
- Verified in an isolated worktree off the current `main`.

## Out of scope (flagged in the review, intentionally not changed here)

- The per-row hover trash deletes without a confirm — but it's desktop-hover-only
  and explicitly out of PRD #628's scope (touch users delete via the editor).
- Possible totals-pill / editor-footer overlap on a tall editor — needs a real
  iPad-landscape browser smoke; jsdom can't observe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
