### PR TITLE
feat(compose): inline From/To/Subject rows + contact picker + white canvas (#640)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -1,11 +1,9 @@
 "use client";
 
 import { useState, useEffect, useMemo, useRef, useReducer } from "react";
-import { Input } from "@/components/ui/input";
 import {
   Loader2,
   Send,
-  ChevronDown,
   ChevronUp,
   Paperclip,
   X,
@@ -14,10 +12,12 @@ import {
   Minus,
   Maximize2,
   Minimize2,
+  Users,
 } from "lucide-react";
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
+import ContactPicker from "@/components/email/contact-picker";
 import { htmlToText } from "@/lib/email/html-to-text";
 import {
   composeWindowReducer,
@@ -84,7 +84,9 @@ export default function ComposeEmailModal({
   const [toRecipients, setToRecipients] = useState<Recipient[]>([]);
   const [ccRecipients, setCcRecipients] = useState<Recipient[]>([]);
   const [bccRecipients, setBccRecipients] = useState<Recipient[]>([]);
-  const [showCcBcc, setShowCcBcc] = useState(false);
+  const [showCc, setShowCc] = useState(false);
+  const [showBcc, setShowBcc] = useState(false);
+  const [showContactPicker, setShowContactPicker] = useState(false);
   const [subject, setSubject] = useState(defaultSubject);
   const [bodyHtml, setBodyHtml] = useState("");
   const [sending, setSending] = useState(false);
@@ -154,23 +156,28 @@ export default function ComposeEmailModal({
         setToRecipients([]);
       }
 
-      // Set CC recipients (for Reply All)
+      setShowContactPicker(false);
+
+      // Set CC recipients (for Reply All) — reveal the Cc row only when there's
+      // something to show.
       if (defaultCc) {
         const ccEmails = defaultCc.split(",").map((e) => e.trim()).filter(Boolean);
         setCcRecipients(ccEmails.map((email) => ({ email, name: "" })));
-        setShowCcBcc(true);
+        setShowCc(true);
       } else {
         setCcRecipients([]);
-        setShowCcBcc(false);
+        setShowCc(false);
       }
 
-      // Set BCC recipients (for draft resume)
+      // Set BCC recipients (for draft resume) — reveal the Bcc row only when
+      // there's something to show.
       if (defaultBcc) {
         const bccEmails = defaultBcc.split(",").map((e) => e.trim()).filter(Boolean);
         setBccRecipients(bccEmails.map((email) => ({ email, name: "" })));
-        setShowCcBcc(true);
+        setShowBcc(true);
       } else {
         setBccRecipients([]);
+        setShowBcc(false);
       }
 
       // Fetch accounts and signatures
@@ -444,90 +451,136 @@ export default function ComposeEmailModal({
         onSubmit={handleSend}
         className={`flex-1 min-h-0 flex flex-col ${isMinimized ? "hidden" : ""}`}
       >
-        <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-3">
-          {/* From account */}
-          <div>
-            <label className="block text-sm font-medium text-[#333] mb-1">
-              From
-            </label>
-            {accounts.length === 0 ? (
-              <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
-                No email accounts configured.{" "}
-                <a href="/settings/email" className="underline font-medium">
-                  Add one in Settings.
-                </a>
-              </p>
-            ) : (
-              <select
-                value={selectedAccountId}
-                onChange={(e) => handleAccountChange(e.target.value)}
-                className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#2B5EA7]/30 focus:border-[#2B5EA7]"
-              >
-                {accounts.map((acc) => (
-                  <option key={acc.id} value={acc.id}>
-                    {acc.display_name || acc.label} &lt;{acc.email_address}&gt;
-                  </option>
-                ))}
-              </select>
+        <div className="flex-1 min-h-0 overflow-y-auto bg-white">
+          {/* Header fields — inline rows separated by hairlines, Outlook-style */}
+          <div className="px-4">
+            {/* From */}
+            <div className="flex items-center gap-3 border-b border-gray-200 py-2">
+              <span className="w-14 shrink-0 text-sm text-[#666]">From</span>
+              {accounts.length === 0 ? (
+                <p className="flex-1 text-sm text-red-600">
+                  No email accounts configured.{" "}
+                  <a href="/settings/email" className="underline font-medium">
+                    Add one in Settings.
+                  </a>
+                </p>
+              ) : (
+                <select
+                  aria-label="From account"
+                  value={selectedAccountId}
+                  onChange={(e) => handleAccountChange(e.target.value)}
+                  className="flex-1 min-w-0 bg-transparent text-sm text-[#333] outline-none cursor-pointer"
+                >
+                  {accounts.map((acc) => (
+                    <option key={acc.id} value={acc.id}>
+                      {acc.display_name || acc.label} &lt;{acc.email_address}&gt;
+                    </option>
+                  ))}
+                </select>
+              )}
+            </div>
+
+            {/* To — chips + type-ahead, with Cc/Bcc reveals and a contact picker */}
+            <div className="relative flex items-start gap-3 border-b border-gray-200 py-2">
+              <span className="w-14 shrink-0 pt-1 text-sm text-[#666]">To</span>
+              <EmailAddressInput
+                ref={toRef}
+                variant="inline"
+                label="To"
+                recipients={toRecipients}
+                onChange={setToRecipients}
+                placeholder="Type name or email..."
+              />
+              <div className="flex shrink-0 items-center gap-1 pt-0.5">
+                {!showCc && (
+                  <button
+                    type="button"
+                    onClick={() => setShowCc(true)}
+                    className="rounded px-1.5 py-0.5 text-xs font-medium text-[#666] hover:bg-gray-100 hover:text-[#2B5EA7]"
+                  >
+                    Cc
+                  </button>
+                )}
+                {!showBcc && (
+                  <button
+                    type="button"
+                    onClick={() => setShowBcc(true)}
+                    className="rounded px-1.5 py-0.5 text-xs font-medium text-[#666] hover:bg-gray-100 hover:text-[#2B5EA7]"
+                  >
+                    Bcc
+                  </button>
+                )}
+                <button
+                  type="button"
+                  aria-label="Browse contacts"
+                  onClick={() => setShowContactPicker((v) => !v)}
+                  className="rounded p-1 text-[#666] hover:bg-gray-100 hover:text-[#2B5EA7]"
+                >
+                  <Users size={16} />
+                </button>
+              </div>
+
+              {showContactPicker && (
+                <div className="absolute right-0 top-full z-50 mt-1 w-72 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                  <ContactPicker
+                    addedRecipients={toRecipients}
+                    onSelect={(r) => {
+                      setToRecipients([...toRecipients, r]);
+                      setShowContactPicker(false);
+                    }}
+                    onClose={() => setShowContactPicker(false)}
+                  />
+                </div>
+              )}
+            </div>
+
+            {/* Cc */}
+            {showCc && (
+              <div className="flex items-start gap-3 border-b border-gray-200 py-2">
+                <span className="w-14 shrink-0 pt-1 text-sm text-[#666]">Cc</span>
+                <EmailAddressInput
+                  ref={ccRef}
+                  variant="inline"
+                  label="Cc"
+                  recipients={ccRecipients}
+                  onChange={setCcRecipients}
+                  placeholder="Add Cc recipients..."
+                />
+              </div>
             )}
+
+            {/* Bcc */}
+            {showBcc && (
+              <div className="flex items-start gap-3 border-b border-gray-200 py-2">
+                <span className="w-14 shrink-0 pt-1 text-sm text-[#666]">Bcc</span>
+                <EmailAddressInput
+                  ref={bccRef}
+                  variant="inline"
+                  label="Bcc"
+                  recipients={bccRecipients}
+                  onChange={setBccRecipients}
+                  placeholder="Add Bcc recipients..."
+                />
+              </div>
+            )}
+
+            {/* Subject — borderless inline field, placeholder only */}
+            <div className="flex items-center gap-3 border-b border-gray-200 py-2">
+              <span className="w-14 shrink-0 text-sm text-[#666]">Subject</span>
+              <input
+                required
+                type="text"
+                aria-label="Subject"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Add a subject"
+                className="flex-1 min-w-0 bg-transparent text-sm text-[#333] outline-none placeholder:text-[#999]"
+              />
+            </div>
           </div>
 
-          {/* To */}
-          <EmailAddressInput
-            ref={toRef}
-            label="To"
-            recipients={toRecipients}
-            onChange={setToRecipients}
-            placeholder="Type name or email..."
-          />
-
-          {/* CC/BCC toggle */}
-          <button
-            type="button"
-            onClick={() => setShowCcBcc(!showCcBcc)}
-            className="flex items-center gap-1 text-xs text-[#2B5EA7] hover:underline"
-          >
-            {showCcBcc ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-            {showCcBcc ? "Hide CC/BCC" : "Add CC/BCC"}
-          </button>
-
-          {showCcBcc && (
-            <>
-              <EmailAddressInput
-                ref={ccRef}
-                label="CC"
-                recipients={ccRecipients}
-                onChange={setCcRecipients}
-                placeholder="Add CC recipients..."
-              />
-              <EmailAddressInput
-                ref={bccRef}
-                label="BCC"
-                recipients={bccRecipients}
-                onChange={setBccRecipients}
-                placeholder="Add BCC recipients..."
-              />
-            </>
-          )}
-
-          {/* Subject */}
-          <div>
-            <label className="block text-sm font-medium text-[#333] mb-1">
-              Subject
-            </label>
-            <Input
-              required
-              placeholder="Email subject"
-              value={subject}
-              onChange={(e) => setSubject(e.target.value)}
-            />
-          </div>
-
-          {/* Rich text body */}
-          <div>
-            <label className="block text-sm font-medium text-[#333] mb-1">
-              Message
-            </label>
+          {/* White message canvas */}
+          <div className="px-4 py-4">
             <TiptapEditor
               key={editorKey}
               content={bodyHtml}
@@ -537,7 +590,7 @@ export default function ComposeEmailModal({
           </div>
 
           {/* Attachments */}
-          <div>
+          <div className="px-4 pb-3">
             <input
               ref={fileInputRef}
               type="file"
@@ -568,15 +621,14 @@ export default function ComposeEmailModal({
                 ))}
               </div>
             )}
+
+            {/* Signature preview */}
+            {selectedAccount?.signature && (
+              <p className="text-xs text-[#999]">
+                Signature from &quot;{selectedAccount.label}&quot; will be included.
+              </p>
+            )}
           </div>
-
-          {/* Signature preview */}
-          {selectedAccount?.signature && (
-            <p className="text-xs text-[#999]">
-              Signature from &quot;{selectedAccount.label}&quot; will be included.
-            </p>
-          )}
-
         </div>
 
         {/* Footer action / send bar */}

--- a/src/components/email-address-input.tsx
+++ b/src/components/email-address-input.tsx
@@ -18,6 +18,13 @@ interface EmailAddressInputProps {
   recipients: EmailRecipient[];
   onChange: (recipients: EmailRecipient[]) => void;
   placeholder?: string;
+  /**
+   * "boxed" (default) draws the original bordered field with a stacked label.
+   * "inline" drops the border and stacked label so the field flows inside a
+   * hairline-separated compose row (PRD #634, issue #640); the parent row
+   * supplies the visible label and the input is aria-labelled instead.
+   */
+  variant?: "boxed" | "inline";
 }
 
 const EmailAddressInput = forwardRef<EmailAddressInputHandle, EmailAddressInputProps>(
@@ -27,6 +34,7 @@ const EmailAddressInput = forwardRef<EmailAddressInputHandle, EmailAddressInputP
     recipients,
     onChange,
     placeholder = "Type name or email...",
+    variant = "boxed",
   },
   ref
 ) {
@@ -131,13 +139,21 @@ const EmailAddressInput = forwardRef<EmailAddressInputHandle, EmailAddressInputP
     }
   }
 
+  const isInline = variant === "inline";
+
   return (
-    <div ref={containerRef} className="relative">
-      <label className="block text-sm font-medium text-[#333] mb-1">
-        {label}
-      </label>
+    <div ref={containerRef} className={isInline ? "relative flex-1 min-w-0" : "relative"}>
+      {!isInline && (
+        <label className="block text-sm font-medium text-[#333] mb-1">
+          {label}
+        </label>
+      )}
       <div
-        className="flex flex-wrap items-center gap-1.5 border border-gray-200 rounded-lg px-2 py-1.5 min-h-[38px] cursor-text focus-within:ring-2 focus-within:ring-[#2B5EA7]/30 focus-within:border-[#2B5EA7]"
+        className={
+          isInline
+            ? "flex flex-wrap items-center gap-1.5 min-h-[28px] cursor-text"
+            : "flex flex-wrap items-center gap-1.5 border border-gray-200 rounded-lg px-2 py-1.5 min-h-[38px] cursor-text focus-within:ring-2 focus-within:ring-[#2B5EA7]/30 focus-within:border-[#2B5EA7]"
+        }
         onClick={() => inputRef.current?.focus()}
       >
         {recipients.map((r, i) => (
@@ -161,6 +177,7 @@ const EmailAddressInput = forwardRef<EmailAddressInputHandle, EmailAddressInputP
         <input
           ref={inputRef}
           type="text"
+          aria-label={isInline ? label : undefined}
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/src/components/email/contact-picker.test.tsx
+++ b/src/components/email/contact-picker.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import ContactPicker from "./contact-picker";
+
+interface Contact {
+  email: string;
+  name: string;
+}
+
+// The picker reads its candidates from GET /api/email/contacts?q=… — the same
+// suggestion source the type-ahead uses. Each test seeds what that returns.
+function stubContacts(rows: Contact[]) {
+  const spy = vi.fn(
+    async () =>
+      new Response(JSON.stringify(rows), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ContactPicker — search", () => {
+  it("lists a matching contact as the user types", async () => {
+    stubContacts([{ email: "homer@aaa.com", name: "Homer Owner" }]);
+
+    render(<ContactPicker addedRecipients={[]} onSelect={() => {}} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search contacts/i), {
+      target: { value: "homer" },
+    });
+
+    expect(
+      await screen.findByRole("button", { name: /Homer Owner/i }),
+    ).toBeDefined();
+  });
+
+  it("fires onSelect with the chosen contact when one is clicked", async () => {
+    const chosen = { email: "marge@aaa.com", name: "Marge Owner" };
+    stubContacts([chosen]);
+    const onSelect = vi.fn();
+
+    render(<ContactPicker addedRecipients={[]} onSelect={onSelect} />);
+
+    fireEvent.change(screen.getByPlaceholderText(/search contacts/i), {
+      target: { value: "marge" },
+    });
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Marge Owner/i }),
+    );
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0]).toEqual(chosen);
+  });
+
+  it("excludes a contact already on the To field from the list", async () => {
+    stubContacts([
+      { email: "homer@aaa.com", name: "Homer Owner" },
+      { email: "marge@aaa.com", name: "Marge Owner" },
+    ]);
+
+    render(
+      <ContactPicker
+        addedRecipients={[{ email: "homer@aaa.com", name: "" }]}
+        onSelect={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/search contacts/i), {
+      target: { value: "owner" },
+    });
+
+    // Marge (not yet added) is offered; Homer (already on To) is not.
+    expect(
+      await screen.findByRole("button", { name: /Marge Owner/i }),
+    ).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: /Homer Owner/i }),
+    ).toBeNull();
+  });
+});

--- a/src/components/email/contact-picker.tsx
+++ b/src/components/email/contact-picker.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+
+import { selectableContacts } from "@/lib/email/contact-picker";
+
+interface Recipient {
+  email: string;
+  name: string;
+}
+
+interface ContactPickerProps {
+  /** Recipients already on the field — these are filtered out of the list. */
+  addedRecipients: Recipient[];
+  /** Fires with the chosen contact. */
+  onSelect: (recipient: Recipient) => void;
+  /** Optional dismiss affordance (e.g. the picker is shown in a popover). */
+  onClose?: () => void;
+}
+
+/**
+ * A search-driven picker for the To row (PRD #634, issue #640). It reuses the
+ * existing contacts suggestion source (`/api/email/contacts`) — the same one
+ * the type-ahead reads — so "browse and pick" and "type a recipient" stay in
+ * sync. Already-added recipients are excluded by the pure
+ * {@link selectableContacts} decision, so the picker never offers a duplicate.
+ */
+export default function ContactPicker({
+  addedRecipients,
+  onSelect,
+  onClose,
+}: ContactPickerProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Recipient[]>([]);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // setState only inside the debounce callback, never synchronously in the
+    // effect body — the react-hooks/set-state-in-effect avoidance used across
+    // the pickers (insurance-company-picker.tsx, job-cover-picker.tsx).
+    const timer = setTimeout(async () => {
+      const q = query.trim();
+      if (!q) {
+        setResults([]);
+        return;
+      }
+      try {
+        const res = await fetch(
+          `/api/email/contacts?q=${encodeURIComponent(q)}`,
+        );
+        const data = (await res.json()) as Recipient[];
+        setResults(Array.isArray(data) ? data : []);
+      } catch {
+        setResults([]);
+      }
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const pickable = selectableContacts(results, addedRecipients);
+
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2 border-b border-gray-200 px-3 py-2">
+        <Search size={14} className="text-[#999] shrink-0" />
+        <input
+          ref={inputRef}
+          autoFocus
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search contacts…"
+          className="flex-1 min-w-0 text-sm outline-none bg-transparent"
+        />
+        {onClose && (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close contact picker"
+            className="text-[#999] hover:text-[#333]"
+          >
+            <X size={14} />
+          </button>
+        )}
+      </div>
+
+      <div className="max-h-60 overflow-y-auto py-1">
+        {query.trim() && pickable.length === 0 ? (
+          <p className="px-3 py-4 text-center text-sm text-[#999]">
+            No matching contacts
+          </p>
+        ) : (
+          pickable.map((c) => (
+            <button
+              key={c.email}
+              type="button"
+              onClick={() => onSelect(c)}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-gray-50 transition-colors"
+            >
+              <div className="w-6 h-6 rounded-full bg-[#2B5EA7] text-white flex items-center justify-center text-[10px] font-bold shrink-0">
+                {(c.name || c.email).charAt(0).toUpperCase()}
+              </div>
+              <div className="min-w-0">
+                {c.name && (
+                  <div className="font-medium text-[#333] truncate">
+                    {c.name}
+                  </div>
+                )}
+                <div className="text-[#999] text-xs truncate">{c.email}</div>
+              </div>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/email/contact-picker.test.ts
+++ b/src/lib/email/contact-picker.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { selectableContacts } from "./contact-picker";
+
+describe("selectableContacts", () => {
+  it("excludes a contact already on the recipient list", () => {
+    const fetched = [
+      { email: "homer@aaa.com", name: "Homer" },
+      { email: "marge@aaa.com", name: "Marge" },
+    ];
+    const added = [{ email: "homer@aaa.com", name: "" }];
+
+    expect(selectableContacts(fetched, added)).toEqual([
+      { email: "marge@aaa.com", name: "Marge" },
+    ]);
+  });
+
+  it("matches an already-added recipient case-insensitively", () => {
+    const fetched = [{ email: "Homer@AAA.com", name: "Homer" }];
+    const added = [{ email: "homer@aaa.com", name: "" }];
+
+    expect(selectableContacts(fetched, added)).toEqual([]);
+  });
+});

--- a/src/lib/email/contact-picker.ts
+++ b/src/lib/email/contact-picker.ts
@@ -1,0 +1,23 @@
+// Pure logic behind the To-row contact picker (PRD #634, issue #640).
+//
+// One I/O-free helper, unit-tested in isolation exactly as the
+// insurance-company picker is (src/lib/insurance-picker.ts): given the
+// contacts the search source returned and the recipients already on the
+// field, it decides which contacts are still pickable. No fetch, no React —
+// just the decision.
+
+/**
+ * The contacts a user may still pick from a search result, given who is
+ * already on the recipient field. A contact whose email already appears in
+ * `alreadyAdded` is dropped, so the picker never offers to add a duplicate.
+ *
+ * Generic over the contact shape so the caller keeps its own extra fields
+ * (display name, etc.); only `email` is read.
+ */
+export function selectableContacts<T extends { email: string }>(
+  fetched: T[],
+  alreadyAdded: { email: string }[],
+): T[] {
+  const added = new Set(alreadyAdded.map((r) => r.email.toLowerCase()));
+  return fetched.filter((c) => !added.has(c.email.toLowerCase()));
+}


### PR DESCRIPTION
## What & why

Issue #640 (PRD #634 — Email drafting redesign). Reskins the compose
window's header into clean, hairline-separated **inline rows**
(Outlook-inspired), replacing today's boxed labeled inputs, and adds a
searchable **contact picker** on the To row.

## Changes

- **From row** — sender dropdown to switch the sending Email account
- **To row** — recipient chips + type-ahead, plus a contact-picker
  button (`Users` icon) that opens a searchable popover. The picker
  reuses `/api/email/contacts` as-is (no backend change) and excludes
  recipients already on To.
- **Subject** — borderless, placeholder-only inline field
- **CC/BCC** — revealed via inline `Cc`/`Bcc` toggles (drops the old
  "Add CC/BCC" disclosure link)
- **Body** — bright white message canvas
- `EmailAddressInput` gains an `inline` variant (no border / no stacked
  label) so the field flows inside a compose row; the `boxed` default is
  unchanged.

Behavior is preserved: sending, reply/forward defaults, and draft resume
still populate every field correctly.

## Design notes

The pick decision lives in a pure deep module, `selectableContacts`,
which excludes already-added recipients case-insensitively. The
`ContactPicker` shell debounces the search and renders the pickable
results; it only sets state inside the debounce callback (avoids the
`set-state-in-effect` rule).

## Tests

- `src/lib/email/contact-picker.test.ts` — pure logic (exclude
  already-added; case-insensitive match)
- `src/components/email/contact-picker.test.tsx` — picking adds a
  contact via `onSelect`; an already-added contact is excluded from the
  list; matches surface as the user types
- Re-ran the two consumer tests that mock the real compose modal
  (`job-email-row`, `email-inbox`) — still green.

`tsc` adds no new errors over the known-red baseline; the new files are
lint-clean.

Closes #640
