### PR TITLE
fix(photo-viewer): open on the selected Photo, not the last one viewed (#636)

### DIFF
--- a/src/components/photo-viewer.test.tsx
+++ b/src/components/photo-viewer.test.tsx
@@ -860,6 +860,69 @@ describe("PhotoViewer — navigation across the Job's Photos", () => {
   });
 });
 
+// Issue #636 — "the photo I selected isn't the one that gets pulled up". The
+// viewer is always mounted (the parent toggles `open`), so its internal index
+// survives across opens. The position must be seeded for the opened Photo on the
+// first render, never inherited from where the previous open was left.
+describe("PhotoViewer — opens on the selected Photo (#636)", () => {
+  const a = makePhoto({ id: "a", storage_path: "job-1/a.jpg", created_at: "2026-05-03T10:00:00Z" });
+  const b = makePhoto({ id: "b", storage_path: "job-1/b.jpg", created_at: "2026-05-02T10:00:00Z" });
+  const c = makePhoto({ id: "c", storage_path: "job-1/c.jpg", created_at: "2026-05-01T10:00:00Z" });
+  const trio = [a, b, c];
+
+  const src = () => (screen.getByRole("img") as HTMLImageElement).getAttribute("src");
+
+  // The always-mounted props, minus the two that the parent flips per open.
+  const stableProps = {
+    onOpenChange: vi.fn(),
+    onUpdated: vi.fn(),
+    onAnnotate: vi.fn(),
+    photos: trio,
+    allTags: [],
+    supabaseUrl: SUPABASE_URL,
+    coverPhotoId: null,
+  };
+
+  it("shows the newly opened Photo, not the one left from the previous open", async () => {
+    // Open on the oldest Photo.
+    const { rerender } = render(
+      <PhotoViewer open initialPhotoIndex={2} {...stableProps} />,
+    );
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(c, SUPABASE_URL, "full"));
+
+    // Close (the instance stays mounted, keeping its internal index)…
+    rerender(<PhotoViewer open={false} initialPhotoIndex={2} {...stableProps} />);
+    await act(async () => {});
+
+    // …then reopen on the newest. It must be the Photo on screen, not the
+    // oldest left over from last time.
+    rerender(<PhotoViewer open initialPhotoIndex={0} {...stableProps} />);
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(a, SUPABASE_URL, "full"));
+  });
+
+  it("re-seeds when reopening on the same Photo after paging away", async () => {
+    // Open on the newest, then page to the next (older) Photo.
+    const { rerender } = render(
+      <PhotoViewer open initialPhotoIndex={0} {...stableProps} />,
+    );
+    await act(async () => {});
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /next/i }));
+    });
+    expect(src()).toBe(photoUrl(b, SUPABASE_URL, "full"));
+
+    // Close, then reopen on the newest again — the same Photo it first opened
+    // on. Reopening must return to it, not stay where paging left off.
+    rerender(<PhotoViewer open={false} initialPhotoIndex={0} {...stableProps} />);
+    await act(async () => {});
+    rerender(<PhotoViewer open initialPhotoIndex={0} {...stableProps} />);
+    await act(async () => {});
+    expect(src()).toBe(photoUrl(a, SUPABASE_URL, "full"));
+  });
+});
+
 describe("PhotoViewer — zoom", () => {
   // jsdom gives every element a 0×0 rect; the zoom math needs a real viewport.
   // Stub a 1000×800 surface (origin 0,0) so focal points equal clientX/clientY,

--- a/src/components/photo-viewer.tsx
+++ b/src/components/photo-viewer.tsx
@@ -146,16 +146,25 @@ export default function PhotoViewer({
 
   const initialId = photos[initialPhotoIndex]?.id ?? null;
   const [currentIndex, setCurrentIndex] = useState(0);
-  // Seed the position when the viewer opens on a Photo. Keyed on the opened
-  // Photo (not the `photos` array) so a background refetch doesn't yank the
-  // user back to where they started.
-  useEffect(() => {
-    if (!open) return;
+  // Seed the position when the viewer opens on a Photo — DURING render, not in a
+  // post-paint effect (#636). The viewer instance is always mounted (the parent
+  // just toggles `open`), so `currentIndex` survives across opens; seeding it in
+  // an effect let the first frame paint the Photo left over from the previous
+  // open before the effect corrected it — on a slow connection the wrong photo
+  // visibly "pulled up". Correcting during render (the picker viewer does the
+  // same for its zoom) makes the first paint the opened Photo. Keyed on the
+  // opened Photo's id, not the `photos` array, so a background refetch doesn't
+  // yank the user back to where they started; reset on close so the next open
+  // re-seeds even onto the same Photo.
+  const [seededFor, setSeededFor] = useState<string | null>(null);
+  if (open && seededFor !== initialId) {
+    setSeededFor(initialId);
     setRemovedIds(new Set());
     const idx = ordered.findIndex((p) => p.id === initialId);
     setCurrentIndex(idx >= 0 ? idx : 0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialId]);
+  } else if (!open && seededFor !== null) {
+    setSeededFor(null);
+  }
 
   const safeIndex = Math.min(currentIndex, visiblePhotos.length - 1);
   const currentPhoto = visiblePhotos[safeIndex];


### PR DESCRIPTION
## What

Fixes #636 — "sometimes the photo I select isn't the one that gets pulled up."

## Root cause

The full-screen `PhotoViewer` is **always mounted** — the parent (`job-detail.tsx`) only toggles its `open` prop — so its internal `currentIndex` state **survives across opens**. The index was seeded in a **post-paint `useEffect`**, so on reopen the first frame painted the photo left over from the *previous* open before the effect corrected it. Because the `<img>` shows its last pixels until a new `src` finishes loading, on a slow/field connection the wrong photo visibly lingered — exactly the intermittent "wrong photo pulled up" symptom.

It's intermittent because it only shows when the new photo's position differs from where the previous open was left **and** the wrong-position photo is cached while the right one is still loading.

This is *not* a list-ordering bug: the viewer resolves the opened photo by **id**, not position, so reordering can't change which photo opens.

## Fix

Seed the position **during render** instead of in an effect — mirroring the pattern the sibling picker viewer already uses for its zoom (`photo-report-picker-viewer.tsx`). React re-renders before committing, so the first painted frame is the selected photo. Since the viewer's subtree unmounts when closed, the freshly mounted `<img>` then gets the correct `src` on its first paint, closing the window where stale pixels could show.

The seed is keyed on the opened photo's id and **reset on close**, so reopening the same photo after paging away still re-seeds.

```js
const [seededFor, setSeededFor] = useState<string | null>(null);
if (open && seededFor !== initialId) {
  setSeededFor(initialId);
  setRemovedIds(new Set());
  const idx = ordered.findIndex((p) => p.id === initialId);
  setCurrentIndex(idx >= 0 ? idx : 0);
} else if (!open && seededFor !== null) {
  setSeededFor(null);
}
```

## Tests

Adds two regression tests under `"opens on the selected Photo (#636)"`:
- reopening on a **different** photo shows the newly opened one, not the leftover;
- reopening on the **same** photo after paging away re-seeds back to it.

`npx vitest run src/components/photo-viewer.test.tsx` → **80 passed**.

## Note for the reviewer

The underlying defect is a sub-frame paint-timing issue, which jsdom/RTL can't directly observe (effects flush inside `act`), so the unit tests guard the contract ("opens on the right photo") rather than the timing itself. Worth a quick manual check on a throttled connection to confirm the flash is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
