### PR TITLE
feat(compose): automatic draft autosave (scheduler module + Saving/Saved status) (#641)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useMemo, useRef, useReducer } from "react";
+import { useState, useEffect, useMemo, useRef, useReducer, useCallback } from "react";
 import {
   Loader2,
   Send,
@@ -8,7 +8,7 @@ import {
   Paperclip,
   X,
   FileIcon,
-  Save,
+  Check,
   Minus,
   Maximize2,
   Minimize2,
@@ -19,6 +19,12 @@ import TiptapEditor from "@/components/tiptap-editor";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
 import ContactPicker from "@/components/email/contact-picker";
 import { htmlToText } from "@/lib/email/html-to-text";
+import {
+  createDraftAutosaveScheduler,
+  type DraftAutosaveScheduler,
+  type DraftSnapshot,
+  type DraftSaveStatus,
+} from "@/lib/email/draft-autosave";
 import {
   composeWindowReducer,
   initialComposeWindowState,
@@ -90,7 +96,7 @@ export default function ComposeEmailModal({
   const [subject, setSubject] = useState(defaultSubject);
   const [bodyHtml, setBodyHtml] = useState("");
   const [sending, setSending] = useState(false);
-  const [savingDraft, setSavingDraft] = useState(false);
+  const [autosaveStatus, setAutosaveStatus] = useState<DraftSaveStatus>("idle");
   const [draftId, setDraftId] = useState<string | null>(initialDraftId || null);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
   const [uploading, setUploading] = useState(false);
@@ -111,6 +117,46 @@ export default function ComposeEmailModal({
   ccRecipientsRef.current = ccRecipients;
   const bccRecipientsRef = useRef(bccRecipients);
   bccRecipientsRef.current = bccRecipients;
+
+  // Automatic draft autosave (issue #641). The decision logic lives in the pure
+  // scheduler; this component is the thin shell that baselines on open, feeds
+  // edits, flushes on close, cancels on send, and renders the status. The
+  // scheduler instance is created once and reused across opens (reset() re-
+  // baselines each open). `armedRef` gates edits until the opened content has
+  // settled, so opening (incl. an auto-inserted signature) never autosaves.
+  const armedRef = useRef(false);
+  const schedulerRef = useRef<DraftAutosaveScheduler | null>(null);
+  if (schedulerRef.current === null) {
+    schedulerRef.current = createDraftAutosaveScheduler({
+      onStatusChange: setAutosaveStatus,
+      save: async (payload) => {
+        const res = await fetch("/api/email/drafts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!res.ok) throw new Error("Draft autosave failed");
+        const data = await res.json();
+        setDraftId(data.id);
+        return { id: data.id };
+      },
+    });
+  }
+
+  const buildSnapshot = useCallback(
+    (): DraftSnapshot => ({
+      accountId: selectedAccountId,
+      to: toRecipients.map((r) => r.email).join(", "),
+      cc: ccRecipients.length > 0 ? ccRecipients.map((r) => r.email).join(", ") : undefined,
+      bcc: bccRecipients.length > 0 ? bccRecipients.map((r) => r.email).join(", ") : undefined,
+      subject,
+      bodyText: htmlToText(bodyHtml),
+      bodyHtml,
+      jobId: jobId || undefined,
+      replyToMessageId,
+    }),
+    [selectedAccountId, toRecipients, ccRecipients, bccRecipients, subject, bodyHtml, jobId, replyToMessageId],
+  );
 
   const selectedAccount = useMemo(
     () => accounts.find((a) => a.id === selectedAccountId),
@@ -144,41 +190,37 @@ export default function ComposeEmailModal({
     if (open) {
       // Each fresh open starts as the corner-docked panel.
       dispatchWindow({ type: "reset" });
+      // Disarm autosave until the opened content has settled (see the baseline
+      // reset in the fetch below).
+      armedRef.current = false;
       setSubject(defaultSubject);
       setUploadedFiles(defaultAttachments);
       setDraftId(initialDraftId || null);
 
+      const parseRecipients = (raw: string): Recipient[] =>
+        raw
+          .split(",")
+          .map((e) => e.trim())
+          .filter(Boolean)
+          .map((email) => ({ email, name: "" }));
+
       // Set To recipients
-      if (defaultTo) {
-        const toEmails = defaultTo.split(",").map((e) => e.trim()).filter(Boolean);
-        setToRecipients(toEmails.map((email) => ({ email, name: "" })));
-      } else {
-        setToRecipients([]);
-      }
+      const toList = defaultTo ? parseRecipients(defaultTo) : [];
+      setToRecipients(toList);
 
       setShowContactPicker(false);
 
       // Set CC recipients (for Reply All) — reveal the Cc row only when there's
       // something to show.
-      if (defaultCc) {
-        const ccEmails = defaultCc.split(",").map((e) => e.trim()).filter(Boolean);
-        setCcRecipients(ccEmails.map((email) => ({ email, name: "" })));
-        setShowCc(true);
-      } else {
-        setCcRecipients([]);
-        setShowCc(false);
-      }
+      const ccList = defaultCc ? parseRecipients(defaultCc) : [];
+      setCcRecipients(ccList);
+      setShowCc(!!defaultCc);
 
       // Set BCC recipients (for draft resume) — reveal the Bcc row only when
       // there's something to show.
-      if (defaultBcc) {
-        const bccEmails = defaultBcc.split(",").map((e) => e.trim()).filter(Boolean);
-        setBccRecipients(bccEmails.map((email) => ({ email, name: "" })));
-        setShowBcc(true);
-      } else {
-        setBccRecipients([]);
-        setShowBcc(false);
-      }
+      const bccList = defaultBcc ? parseRecipients(defaultBcc) : [];
+      setBccRecipients(bccList);
+      setShowBcc(!!defaultBcc);
 
       // Fetch accounts and signatures
       Promise.all([
@@ -205,14 +247,63 @@ export default function ComposeEmailModal({
           || active.find((a: EmailAccountData) => a.is_default)
           || active[0];
         if (defaultAcc) {
+          const initialBody = buildInitialBody(defaultAcc, defaultBody, sigs);
           setSelectedAccountId(defaultAcc.id);
-          setBodyHtml(buildInitialBody(defaultAcc, defaultBody, sigs));
+          setBodyHtml(initialBody);
           setEditorKey((k) => k + 1);
+
+          // Baseline the autosave scheduler to the just-opened content so the
+          // opened state (including any auto-inserted signature, and a resumed
+          // draft's id) is never treated as a user edit. Only edits past this
+          // baseline mark the draft dirty and schedule a save.
+          schedulerRef.current?.reset(
+            {
+              accountId: defaultAcc.id,
+              to: toList.map((r) => r.email).join(", "),
+              cc: ccList.length > 0 ? ccList.map((r) => r.email).join(", ") : undefined,
+              bcc: bccList.length > 0 ? bccList.map((r) => r.email).join(", ") : undefined,
+              subject: defaultSubject,
+              bodyText: htmlToText(initialBody),
+              bodyHtml: initialBody,
+              jobId: jobId || undefined,
+              replyToMessageId,
+            },
+            initialDraftId || null,
+          );
+          armedRef.current = true;
         }
       });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, defaultTo, defaultCc, defaultBcc, defaultSubject, defaultBody, defaultAccountId, initialDraftId]);
+
+  // Feed every settled compose snapshot into the scheduler. Inert until the
+  // baseline is armed (above), then each edit schedules a debounced save.
+  useEffect(() => {
+    if (!open || !armedRef.current) return;
+    schedulerRef.current?.notifyChange(buildSnapshot());
+  }, [open, buildSnapshot]);
+
+  // On close, flush any pending edit so the last change is kept as a draft
+  // (issue #641: closing the compose window keeps the draft). Send takes a
+  // different path — it cancels first (below) so this never recreates a draft
+  // for an already-sent message.
+  useEffect(() => {
+    if (open) return;
+    if (armedRef.current) {
+      void schedulerRef.current?.flush();
+      armedRef.current = false;
+    }
+  }, [open]);
+
+  // Belt-and-suspenders: if the component unmounts while still armed (parent
+  // tears it down without toggling `open`), flush the pending edit too.
+  useEffect(() => {
+    const scheduler = schedulerRef.current;
+    return () => {
+      if (armedRef.current) void scheduler?.flush();
+    };
+  }, []);
 
   // Handle file upload
   async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
@@ -248,54 +339,6 @@ export default function ComposeEmailModal({
 
   function removeFile(index: number) {
     setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
-  }
-
-  // Save draft
-  async function handleSaveDraft() {
-    if (!selectedAccountId) {
-      toast.error("No email account selected.");
-      return;
-    }
-    toRef.current?.flush();
-    ccRef.current?.flush();
-    bccRef.current?.flush();
-    const currentTo = toRecipientsRef.current;
-    const currentCc = ccRecipientsRef.current;
-    const currentBcc = bccRecipientsRef.current;
-
-    const bodyText = htmlToText(bodyHtml);
-
-    setSavingDraft(true);
-    try {
-      const res = await fetch("/api/email/drafts", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          draftId: draftId || undefined,
-          accountId: selectedAccountId,
-          to: currentTo.map((r) => r.email).join(", "),
-          cc: currentCc.length > 0 ? currentCc.map((r) => r.email).join(", ") : undefined,
-          bcc: currentBcc.length > 0 ? currentBcc.map((r) => r.email).join(", ") : undefined,
-          subject,
-          bodyText,
-          bodyHtml,
-          jobId: jobId || undefined,
-          replyToMessageId,
-        }),
-      });
-      const data = await res.json();
-      if (res.ok) {
-        setDraftId(data.id);
-        toast.success("Draft saved.");
-        onOpenChange(false);
-        onSent?.();
-      } else {
-        toast.error(data.error || "Failed to save draft.");
-      }
-    } catch {
-      toast.error("Failed to save draft.");
-    }
-    setSavingDraft(false);
   }
 
   // Update signature when account changes
@@ -360,6 +403,11 @@ export default function ComposeEmailModal({
       }
 
       if (res.ok) {
+        // The message was sent and the server deletes the backing draft (it was
+        // passed `draftId`). Cancel and disarm so the close handler below does
+        // NOT flush a pending edit back into a new draft for a sent message.
+        schedulerRef.current?.cancel();
+        armedRef.current = false;
         toast.success("Email sent successfully.");
         onOpenChange(false);
         onSent?.();
@@ -660,24 +708,31 @@ export default function ComposeEmailModal({
           </button>
           <button
             type="button"
-            onClick={handleSaveDraft}
-            disabled={savingDraft || accounts.length === 0}
-            className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5 disabled:opacity-50"
-          >
-            {savingDraft ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : (
-              <Save size={14} />
-            )}
-            Save Draft
-          </button>
-          <button
-            type="button"
             onClick={() => onOpenChange(false)}
             className="px-5 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50"
           >
             Cancel
           </button>
+
+          {/* Autosave status — drafts now save automatically (issue #641); the
+              manual "Save Draft" button is gone. */}
+          <div
+            className="ml-auto flex items-center gap-1.5 text-xs text-[#999]"
+            aria-live="polite"
+          >
+            {autosaveStatus === "saving" && (
+              <>
+                <Loader2 size={12} className="animate-spin" />
+                <span>Saving…</span>
+              </>
+            )}
+            {autosaveStatus === "saved" && (
+              <>
+                <Check size={12} className="text-green-600" />
+                <span>Saved</span>
+              </>
+            )}
+          </div>
         </div>
       </form>
     </div>

--- a/src/lib/email/draft-autosave.test.ts
+++ b/src/lib/email/draft-autosave.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  createDraftAutosaveScheduler,
+  type DraftSnapshot,
+  type DraftSavePayload,
+  type DraftSaveResult,
+} from "./draft-autosave";
+
+const DEBOUNCE = 2000;
+
+function snap(overrides: Partial<DraftSnapshot> = {}): DraftSnapshot {
+  return {
+    accountId: "acc-1",
+    to: "",
+    subject: "",
+    bodyText: "",
+    bodyHtml: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("createDraftAutosaveScheduler", () => {
+  it("coalesces rapid edits into a single debounced save of the latest snapshot", async () => {
+    const save = vi.fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>(
+      async () => ({ id: "draft-1" }),
+    );
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+
+    scheduler.reset(snap()); // opened with an empty baseline
+
+    scheduler.notifyChange(snap({ subject: "Hel" }));
+    scheduler.notifyChange(snap({ subject: "Hello" }));
+    scheduler.notifyChange(snap({ subject: "Hello there" }));
+
+    // Nothing saved before the debounce window elapses.
+    expect(save).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0]).toMatchObject({
+      accountId: "acc-1",
+      subject: "Hello there",
+    });
+    // First save creates — no draftId yet.
+    expect(save.mock.calls[0][0].draftId).toBeUndefined();
+  });
+
+  it("never saves while clean, and a reverted edit cancels a pending save", async () => {
+    const save = vi.fn(async () => ({ id: "draft-1" }));
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+
+    scheduler.reset(snap({ subject: "Hello" }));
+
+    // A snapshot identical to the baseline must not schedule anything.
+    scheduler.notifyChange(snap({ subject: "Hello" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).not.toHaveBeenCalled();
+
+    // Edit, then revert back to the baseline within the debounce window.
+    scheduler.notifyChange(snap({ subject: "Hello!" }));
+    scheduler.notifyChange(snap({ subject: "Hello" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("creates on first save, then reuses the returned id — no duplicate drafts even if an edit lands mid-flight", async () => {
+    let resolveFirst!: (r: { id: string }) => void;
+    const firstSave = new Promise<{ id: string }>((r) => {
+      resolveFirst = r;
+    });
+    const save = vi
+      .fn<(p: { draftId?: string }) => Promise<{ id: string }>>()
+      .mockReturnValueOnce(firstSave) // first create hangs until we resolve it
+      .mockResolvedValue({ id: "draft-99" }); // any later save
+
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    // First edit → first (create) save fires and stays in flight.
+    scheduler.notifyChange(snap({ subject: "A" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0].draftId).toBeUndefined();
+
+    // Edit again while the create is still in flight — a second save must NOT
+    // start yet (it would create a duplicate, the id isn't known).
+    scheduler.notifyChange(snap({ subject: "AB" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(1);
+
+    // The create returns its id; the queued edit now saves as an UPDATE.
+    resolveFirst({ id: "draft-99" });
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save.mock.calls[1][0].draftId).toBe("draft-99");
+    expect(scheduler.getDraftId()).toBe("draft-99");
+  });
+
+  it("flush() persists a pending edit immediately, then is a no-op when clean (close)", async () => {
+    const save = vi.fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>(
+      async () => ({ id: "draft-1" }),
+    );
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "Closing now" }));
+    // No timer advance — flush must not wait for the debounce window.
+    await scheduler.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0]).toMatchObject({ subject: "Closing now" });
+
+    // Nothing pending anymore — a second flush saves nothing.
+    await scheduler.flush();
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel() drops a pending edit so no save fires (send)", async () => {
+    const save = vi.fn(async () => ({ id: "draft-1" }));
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "Discard me" }));
+    scheduler.cancel();
+
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("keeps the edit pending and does not mark saved when a save fails", async () => {
+    const save = vi
+      .fn<() => Promise<{ id: string }>>()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue({ id: "draft-1" });
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "Retry me" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(scheduler.getStatus()).toBe("idle"); // never "saved" on failure
+    expect(scheduler.getDraftId()).toBeNull();
+
+    // The edit isn't lost — flushing on close retries it and succeeds.
+    await scheduler.flush();
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(scheduler.getStatus()).toBe("saved");
+    expect(scheduler.getDraftId()).toBe("draft-1");
+  });
+});

--- a/src/lib/email/draft-autosave.ts
+++ b/src/lib/email/draft-autosave.ts
@@ -1,0 +1,209 @@
+// Draft autosave scheduler (deep module B, issue #641 / PRD #634).
+//
+// Owns the autosave DECISION and the draft-id lifecycle for the compose window,
+// kept entirely free of React so it can be unit-tested with fake timers and a
+// mocked save call. The React layer is a thin shell that:
+//   • establishes a baseline on open/resume via reset(),
+//   • feeds every compose snapshot into notifyChange() as the user edits,
+//   • flush()es on close and cancel()s on send,
+//   • renders getStatus() ("Saving…/Saved") and reads getDraftId().
+//
+// Responsibilities (mirrors the estimate-builder autosave split, where the pure
+// planUnmountFlush owns the decision and the hook is transport):
+//   • debounce edits into a single save (coalescing),
+//   • track a dirty flag relative to the last-saved/opened baseline so an
+//     untouched (or reverted) compose never autosaves — "no save when clean",
+//   • manage the create-then-update transition: the first save sends no draftId,
+//     captures the returned id, and every later save reuses it (no duplicate
+//     drafts) — including when edits arrive while a create is still in flight.
+
+const DEFAULT_DEBOUNCE_MS = 2000;
+
+export type DraftSaveStatus = "idle" | "saving" | "saved";
+
+/** The compose fields the scheduler watches and serializes into a save. */
+export interface DraftSnapshot {
+  accountId: string;
+  to: string;
+  cc?: string;
+  bcc?: string;
+  subject: string;
+  bodyText: string;
+  bodyHtml: string;
+  jobId?: string;
+  replyToMessageId?: string;
+}
+
+/** Body POSTed to /api/email/drafts; draftId present only on update. */
+export interface DraftSavePayload extends DraftSnapshot {
+  draftId?: string;
+}
+
+export interface DraftSaveResult {
+  id: string;
+}
+
+export interface DraftAutosaveOptions {
+  /** Performs the actual network save; resolves with the persisted draft id. */
+  save: (payload: DraftSavePayload) => Promise<DraftSaveResult>;
+  /** Debounce window in ms (default 2000, matching the estimate autosave). */
+  debounceMs?: number;
+  /** Notified on every status transition so a React shell can render it. */
+  onStatusChange?: (status: DraftSaveStatus) => void;
+  /** Resumed-draft id, so the first autosave updates rather than creates. */
+  initialDraftId?: string | null;
+}
+
+export interface DraftAutosaveScheduler {
+  /** (Re)baseline to an opened/resumed snapshot; edits past this go dirty. */
+  reset(baseline: DraftSnapshot, draftId?: string | null): void;
+  /** Feed the latest compose snapshot; schedules a debounced save if dirty. */
+  notifyChange(snapshot: DraftSnapshot): void;
+  /** Persist any pending change immediately (used on close). */
+  flush(): Promise<void>;
+  /** Drop any pending change without saving (used on send). */
+  cancel(): void;
+  getStatus(): DraftSaveStatus;
+  getDraftId(): string | null;
+}
+
+/** Stable string key of the savable fields, for dirty comparison. */
+function serialize(s: DraftSnapshot): string {
+  return JSON.stringify([
+    s.accountId,
+    s.to,
+    s.cc ?? "",
+    s.bcc ?? "",
+    s.subject,
+    s.bodyText,
+    s.bodyHtml,
+    s.jobId ?? "",
+    s.replyToMessageId ?? "",
+  ]);
+}
+
+export function createDraftAutosaveScheduler(
+  opts: DraftAutosaveOptions,
+): DraftAutosaveScheduler {
+  const debounceMs = opts.debounceMs ?? DEFAULT_DEBOUNCE_MS;
+
+  // Last successfully-saved (or opened/resumed) snapshot. A snapshot equal to
+  // this is "clean" and never triggers a save.
+  let baseline: DraftSnapshot | null = null;
+  let baselineKey = "";
+  // Latest dirty snapshot awaiting a save, or null when clean.
+  let pending: DraftSnapshot | null = null;
+  let draftId: string | null = opts.initialDraftId ?? null;
+  let status: DraftSaveStatus = "idle";
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  // Guards the create-then-update transition: while a save is awaiting we must
+  // not start a second one, or two concurrent creates would each insert a draft
+  // (the first hasn't returned its id yet) — duplicate drafts.
+  let inFlight = false;
+
+  function setStatus(next: DraftSaveStatus) {
+    if (status === next) return;
+    status = next;
+    opts.onStatusChange?.(next);
+  }
+
+  function clearTimer() {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  }
+
+  function schedule() {
+    clearTimer();
+    timer = setTimeout(() => {
+      timer = null;
+      void runSave();
+    }, debounceMs);
+  }
+
+  async function runSave(): Promise<void> {
+    if (pending === null) return;
+    // A save is already in flight — leave `pending` set; the in-flight save's
+    // finally block reschedules once it has the draft id.
+    if (inFlight) return;
+
+    const snapshot = pending;
+    pending = null;
+    inFlight = true;
+    setStatus("saving");
+    let failed = false;
+    try {
+      const payload: DraftSavePayload = {
+        ...snapshot,
+        draftId: draftId ?? undefined,
+      };
+      const result = await opts.save(payload);
+      draftId = result.id;
+      baseline = snapshot;
+      baselineKey = serialize(snapshot);
+      setStatus("saved");
+    } catch {
+      // A failed save must not surface as "Saved" or escape as an unhandled
+      // rejection. Preserve the unsaved snapshot so a later edit or the
+      // flush-on-close retries it, and return to idle. We deliberately do NOT
+      // auto-reschedule here — that would spin every debounce on a persistent
+      // failure (e.g. a 400). The next edit/flush is the retry trigger.
+      failed = true;
+      if (pending === null) pending = snapshot;
+      setStatus("idle");
+    } finally {
+      inFlight = false;
+      // A genuinely newer edit arrived mid-save — debounce and save it (now
+      // with the draft id). Skipped on the failure path to avoid a retry spin.
+      if (!failed && pending !== null) schedule();
+    }
+  }
+
+  return {
+    reset(newBaseline, newDraftId) {
+      clearTimer();
+      pending = null;
+      baseline = newBaseline;
+      baselineKey = serialize(newBaseline);
+      if (newDraftId !== undefined) draftId = newDraftId;
+      setStatus("idle");
+    },
+
+    notifyChange(snapshot) {
+      // Before a baseline is established, the first snapshot simply becomes the
+      // baseline (programmatic open-fill is never treated as a user edit).
+      if (baseline === null) {
+        baseline = snapshot;
+        baselineKey = serialize(snapshot);
+        return;
+      }
+      if (serialize(snapshot) === baselineKey) {
+        // Back to clean (e.g. an edit was reverted) — drop the pending save.
+        pending = null;
+        clearTimer();
+        return;
+      }
+      pending = snapshot;
+      schedule();
+    },
+
+    async flush() {
+      clearTimer();
+      await runSave();
+    },
+
+    cancel() {
+      clearTimer();
+      pending = null;
+    },
+
+    getStatus() {
+      return status;
+    },
+
+    getDraftId() {
+      return draftId;
+    },
+  };
+}


### PR DESCRIPTION
## What & why

Implements #641 (part of PRD #634, email-drafting redesign). Replaces the
manual **Save Draft** button with **automatic draft autosave**, surfaced as a
**"Saving… / Saved"** status in the compose footer.

## Design — deep module + thin shell

The autosave **decision** and the **draft-id lifecycle** are extracted into a
pure, framework-free module, `createDraftAutosaveScheduler` (`src/lib/email/draft-autosave.ts`):

- **Debounce coalescing** — rapid edits collapse into a single save of the latest snapshot (2s window, matching the estimate-builder autosave).
- **No save when clean** — a dirty flag tracked against the opened/last-saved *baseline*; an untouched or reverted compose never autosaves.
- **Create-then-update** — the first save creates (no `draftId`); the returned id is captured and every later save reuses it. An `inFlight` guard means an edit landing while a create is still in flight can't spawn a duplicate draft — it saves as an update once the id is known.
- **flush / cancel** — `flush()` persists immediately (close); `cancel()` drops a pending edit (send).
- **Failure resilient** — a failed save keeps the edit pending, never shows "Saved", and doesn't spin; the next edit/flush retries.

`compose-email.tsx` becomes the thin shell: baselines the scheduler on open
(so an auto-inserted signature is never treated as a user edit, and a resumed
draft *updates* rather than creates), feeds each settled snapshot via
`notifyChange`, **flushes on close** (closing keeps the draft), and **cancels
on send** (the send route already deletes the backing draft, so a sent message
doesn't linger in Drafts). Reuses the existing `POST /api/email/drafts`
contract unchanged.

## Tests

Per the acceptance criteria, the pure scheduler is unit-tested with fake timers
and a mocked save call (`src/lib/email/draft-autosave.test.ts`, 6 tests):
debounce coalescing, no-save-when-clean (incl. revert), create-then-update id
reuse with a mid-flight edit, flush/cancel on close/send, and save-failure
resilience.

## Verification

- `vitest run` — scheduler **6/6** green; compose consumer suites (`job-email-row`, `email-inbox`) still pass.
- `eslint` on touched files — clean.
- `tsc --noEmit` — **no new errors** in touched files.

Closes #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
