### PR TITLE
feat(compose): signature picker + pure signature-swap module (#643)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -13,11 +13,16 @@ import {
   Maximize2,
   Minimize2,
   Users,
+  PenLine,
 } from "lucide-react";
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
 import ComposeFormattingToolbar from "@/components/email/compose-formatting-toolbar";
 import { composeRichExtensions } from "@/components/email/compose-editor-extensions";
+import {
+  swapSignature,
+  renderSignatureRegion,
+} from "@/lib/email/signature-swap";
 import { type Editor } from "@tiptap/react";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
 import ContactPicker from "@/components/email/contact-picker";
@@ -106,6 +111,10 @@ export default function ComposeEmailModal({
   const [editorKey, setEditorKey] = useState(0);
   const [editor, setEditor] = useState<Editor | null>(null);
   const [toolbarVisible, setToolbarVisible] = useState(true);
+  // Signature picker (issue #643). `activeSignatureId` is the account id whose
+  // signature is currently in the body, or null for "No signature".
+  const [showSignaturePicker, setShowSignaturePicker] = useState(false);
+  const [activeSignatureId, setActiveSignatureId] = useState<string | null>(null);
   // Opt-in rich-formatting extensions for the bottom toolbar. Stable across
   // renders so the shared editor isn't rebuilt; only compose loads these.
   const richExtensions = useMemo(() => composeRichExtensions(), []);
@@ -174,24 +183,82 @@ export default function ComposeEmailModal({
   // Signature data from email_signatures table
   const [signaturesMap, setSignaturesMap] = useState<Record<string, { signature_html: string; auto_insert: boolean }>>({});
 
-  // Build initial body with signature
-  function buildInitialBody(account: EmailAccountData | undefined, quotedHtml: string, sigs?: typeof signaturesMap) {
-    let html = "";
-    if (quotedHtml) {
-      html = quotedHtml;
-    }
+  // Resolve the signature HTML to drop into the body for an account, or null if
+  // it has none. When `respectAutoInsert` (account switch / initial insert) an
+  // auto_insert=false signature is skipped; an explicit picker choice passes
+  // false to force the signature in regardless of its default.
+  function resolveSignatureHtml(
+    account: EmailAccountData | undefined,
+    respectAutoInsert: boolean,
+    sigs?: typeof signaturesMap,
+  ): string | null {
     const sigData = (sigs || signaturesMap)[account?.id || ""];
-    const sigHtml = sigData?.auto_insert !== false ? sigData?.signature_html : null;
-    const fallbackSig = account?.signature;
-    const effectiveSig = sigHtml || fallbackSig;
+    const sigHtml =
+      !respectAutoInsert || sigData?.auto_insert !== false
+        ? sigData?.signature_html
+        : null;
+    const effectiveSig = sigHtml || account?.signature;
+    if (!effectiveSig) return null;
+    return effectiveSig.includes("<")
+      ? effectiveSig
+      : `<p>${effectiveSig.replace(/\n/g, "<br>")}</p>`;
+  }
 
-    if (effectiveSig) {
-      const rendered = effectiveSig.includes("<")
-        ? effectiveSig
-        : `<p>${effectiveSig.replace(/\n/g, "<br>")}</p>`;
-      html = `<p></p><br><div style="border-top: 1px solid #ccc; padding-top: 8px; margin-top: 16px; color: #666;">${rendered}</div>${html ? `<br>${html}` : ""}`;
+  // Build initial body with signature, wrapped in the delimited region so it can
+  // later be located and swapped without touching the user's typed content.
+  function buildInitialBody(account: EmailAccountData | undefined, quotedHtml: string, sigs?: typeof signaturesMap) {
+    let html = quotedHtml || "";
+    const rendered = resolveSignatureHtml(account, true, sigs);
+    if (rendered) {
+      html = `<p></p><br>${renderSignatureRegion(rendered)}${html ? `<br>${html}` : ""}`;
     }
     return html;
+  }
+
+  // Options for the signature picker: every account that has a saved signature,
+  // plus "No signature" — so any signature can be dropped in regardless of the
+  // From account (issue #643).
+  const signatureOptions = useMemo(() => {
+    const opts: { id: string | null; label: string }[] = [
+      { id: null, label: "No signature" },
+    ];
+    for (const acc of accounts) {
+      if (signaturesMap[acc.id]?.signature_html) {
+        opts.push({ id: acc.id, label: acc.label || acc.email_address });
+      }
+    }
+    return opts;
+  }, [accounts, signaturesMap]);
+
+  // Swap (or remove, when null) the signature region in place, preserving the
+  // user's typed message (issue #643). Pushes into the live editor so the change
+  // survives without a remount; falls back to state when the editor isn't ready.
+  function applySignature(
+    nextSignatureHtml: string | null,
+    signatureId: string | null,
+  ) {
+    setActiveSignatureId(signatureId);
+    if (!editor) {
+      setBodyHtml((prev) => swapSignature(prev, nextSignatureHtml));
+      return;
+    }
+    const next = swapSignature(editor.getHTML(), nextSignatureHtml);
+    editor.commands.setContent(next, { emitUpdate: false });
+    // Mirror the editor's reserialized HTML into state so bodyHtml, the autosave
+    // snapshot, and the sent body all see exactly what the editor holds.
+    setBodyHtml(editor.getHTML());
+  }
+
+  // Explicit picker choice — force the chosen signature in (ignoring its
+  // auto_insert default), or clear it when "No signature".
+  function handlePickSignature(id: string | null) {
+    setShowSignaturePicker(false);
+    if (id === null) {
+      applySignature(null, null);
+      return;
+    }
+    const account = accounts.find((a) => a.id === id);
+    applySignature(resolveSignatureHtml(account, false), id);
   }
 
   useEffect(() => {
@@ -257,6 +324,11 @@ export default function ComposeEmailModal({
         if (defaultAcc) {
           const initialBody = buildInitialBody(defaultAcc, defaultBody, sigs);
           setSelectedAccountId(defaultAcc.id);
+          // The initial body carries defaultAcc's signature iff one resolved
+          // (respecting its auto_insert default), so seed the picker to match.
+          setActiveSignatureId(
+            resolveSignatureHtml(defaultAcc, true, sigs) ? defaultAcc.id : null,
+          );
           setBodyHtml(initialBody);
           setEditorKey((k) => k + 1);
 
@@ -349,12 +421,15 @@ export default function ComposeEmailModal({
     setUploadedFiles((prev) => prev.filter((_, i) => i !== index));
   }
 
-  // Update signature when account changes
+  // Switch the From account. Swap ONLY the signature block for the new account's
+  // signature (honoring its auto_insert default), leaving the user's typed
+  // message intact — previously this rebuilt the whole body and discarded any
+  // typed content (issue #643).
   function handleAccountChange(accountId: string) {
     setSelectedAccountId(accountId);
     const account = accounts.find((a) => a.id === accountId);
-    // Reset body with new signature (preserve user content before sig)
-    setBodyHtml(buildInitialBody(account, defaultBody));
+    const nextSig = resolveSignatureHtml(account, true);
+    applySignature(nextSig, nextSig ? accountId : null);
   }
 
   async function handleSend(e: React.FormEvent) {
@@ -731,6 +806,56 @@ export default function ComposeEmailModal({
           >
             Cancel
           </button>
+
+          {/* Signature picker (issue #643) — choose which signature to drop in;
+              swaps the block in place, never clobbering the typed message. */}
+          <div className="relative">
+            <button
+              type="button"
+              aria-label="Choose signature"
+              aria-haspopup="menu"
+              aria-expanded={showSignaturePicker}
+              onClick={() => setShowSignaturePicker((v) => !v)}
+              className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5"
+            >
+              <PenLine size={14} />
+              Signature
+            </button>
+            {showSignaturePicker && (
+              <>
+                {/* Click-away backdrop */}
+                <div
+                  className="fixed inset-0 z-40"
+                  onClick={() => setShowSignaturePicker(false)}
+                />
+                <div
+                  role="menu"
+                  className="absolute bottom-full left-0 z-50 mb-1 w-56 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+                >
+                  {signatureOptions.map((opt) => (
+                    <button
+                      key={opt.id ?? "__none__"}
+                      type="button"
+                      role="menuitemradio"
+                      aria-checked={activeSignatureId === opt.id}
+                      onClick={() => handlePickSignature(opt.id)}
+                      className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-[#333] hover:bg-gray-50"
+                    >
+                      <Check
+                        size={14}
+                        className={
+                          activeSignatureId === opt.id
+                            ? "text-[#2B5EA7]"
+                            : "invisible"
+                        }
+                      />
+                      <span className="truncate">{opt.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
 
           {/* Autosave status — drafts now save automatically (issue #641); the
               manual "Save Draft" button is gone. */}

--- a/src/components/email/compose-editor-extensions.ts
+++ b/src/components/email/compose-editor-extensions.ts
@@ -2,6 +2,7 @@ import { TextStyle, FontSize, Color } from "@tiptap/extension-text-style";
 import Highlight from "@tiptap/extension-highlight";
 import Image from "@tiptap/extension-image";
 import { IndentExtension } from "./compose-indent-extension";
+import { SignatureBlockExtension } from "./signature-block-extension";
 
 /**
  * The opt-in rich-formatting extensions for the compose editor's bottom toolbar
@@ -16,6 +17,10 @@ import { IndentExtension } from "./compose-indent-extension";
  *
  * FontSize and Color both decorate the `textStyle` mark, so TextStyle must be
  * present for them to attach.
+ *
+ * SignatureBlockExtension (issue #643) preserves the delimited signature
+ * region's marker across editor round-trips so the signature can be located and
+ * swapped without clobbering the user's typed message.
  */
 export function composeRichExtensions() {
   return [
@@ -25,5 +30,6 @@ export function composeRichExtensions() {
     Highlight.configure({ multicolor: true }),
     Image.configure({ allowBase64: true }),
     IndentExtension,
+    SignatureBlockExtension,
   ];
 }

--- a/src/components/email/signature-block-extension.ts
+++ b/src/components/email/signature-block-extension.ts
@@ -1,0 +1,45 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import {
+  SIGNATURE_BLOCK_ATTR,
+  SIGNATURE_BLOCK_STYLE,
+} from "@/lib/email/signature-swap";
+
+/**
+ * A block node that wraps the compose signature in a delimited, marked region
+ * (issue #643 / PRD #634). Its only job is to make the `data-signature-block`
+ * marker survive Tiptap round-trips: StarterKit has no generic `div` node, so an
+ * unmarked wrapper `<div>` (and its attributes) is dropped on parse — which would
+ * lose the marker the moment the user edits, leaving the signature impossible to
+ * locate and swap. Registering the marked div as a real node preserves it through
+ * getHTML(), so the pure signature-swap module can always find the block.
+ *
+ * Opt-in: only the compose editor loads this via TiptapEditor's extraExtensions
+ * (composeRichExtensions), so the shared editor's other consumers are untouched.
+ * All locate-and-replace logic lives in the pure, unit-tested signature-swap
+ * module; this node is the thin Tiptap shell that guarantees the marker round-
+ * trips, mirroring the IndentExtension split.
+ */
+export const SignatureBlockExtension = Node.create({
+  name: "signatureBlock",
+  group: "block",
+  // Holds the signature's own block content (paragraphs, images, lists, …).
+  content: "block+",
+  // Keep the signature contained as a unit so edits to the message above don't
+  // bleed into or merge with the block.
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: `div[${SIGNATURE_BLOCK_ATTR}]` }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "div",
+      mergeAttributes(HTMLAttributes, {
+        [SIGNATURE_BLOCK_ATTR]: "true",
+        style: SIGNATURE_BLOCK_STYLE,
+      }),
+      0,
+    ];
+  },
+});

--- a/src/lib/email/signature-swap.test.ts
+++ b/src/lib/email/signature-swap.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { swapSignature, SIGNATURE_BLOCK_ATTR } from "./signature-swap";
+
+describe("swapSignature", () => {
+  it("applies a signature to an empty body", () => {
+    const result = swapSignature("", "<p>Jane Doe</p>");
+    expect(result).toContain("Jane Doe");
+    expect(result).toContain(SIGNATURE_BLOCK_ATTR);
+  });
+
+  it("swaps one signature for another while preserving typed content", () => {
+    const initial = swapSignature("<p>Hello there</p>", "<p>Sig A</p>");
+    const swapped = swapSignature(initial, "<p>Sig B</p>");
+    expect(swapped).toContain("Hello there");
+    expect(swapped).toContain("Sig B");
+    expect(swapped).not.toContain("Sig A");
+  });
+
+  it("removes the signature region when the next signature is null", () => {
+    const withSig = swapSignature("<p>Hello there</p>", "<p>Sig A</p>");
+    const removed = swapSignature(withSig, null);
+    expect(removed).toContain("Hello there");
+    expect(removed).not.toContain("Sig A");
+    expect(removed).not.toContain(SIGNATURE_BLOCK_ATTR);
+  });
+
+  it("leaves a body with no signature unchanged when none is provided", () => {
+    const body = "<p>Just a message</p>";
+    expect(swapSignature(body, null)).toBe(body);
+  });
+
+  it("locates the region correctly when the signature contains nested markup", () => {
+    // A logo signature with nested <div>s, and a quoted reply BELOW the
+    // signature (compose inserts the signature above the quoted thread).
+    const logoSig =
+      '<div class="logo"><img src="x"><span>Jane</span></div><p>Acme Inc</p>';
+    const body =
+      swapSignature("<p>Message body</p>", logoSig) + "<p>Quoted reply</p>";
+    const swapped = swapSignature(body, "<p>New sig</p>");
+    expect(swapped).toContain("Message body");
+    expect(swapped).toContain("Quoted reply");
+    expect(swapped).toContain("New sig");
+    expect(swapped).not.toContain("Acme Inc");
+    expect(swapped).not.toContain("Jane");
+  });
+});

--- a/src/lib/email/signature-swap.ts
+++ b/src/lib/email/signature-swap.ts
@@ -1,0 +1,62 @@
+// Signature-swap math for the compose editor (issue #643 / PRD #634). Switching
+// the From account — or picking a different signature — must replace ONLY the
+// signature block and leave the user's typed message intact. Kept pure and free
+// of React/Tiptap so the locate-and-replace logic can be unit-tested in
+// isolation. The Tiptap SignatureBlock node is the thin shell: it preserves the
+// delimited region's marker across editor round-trips so this module can always
+// find the block to swap.
+
+/** Attribute that marks the delimited signature region in the body HTML. */
+export const SIGNATURE_BLOCK_ATTR = "data-signature-block";
+
+/** Inline styling for the signature region. Inlined as a style so the visual
+ *  separator survives into the sent email's HTML, not just the editor view. */
+export const SIGNATURE_BLOCK_STYLE =
+  "border-top: 1px solid #ccc; padding-top: 8px; margin-top: 16px; color: #666;";
+
+/** Wrap raw signature HTML in the delimited region the compose body uses, so it
+ *  can be located and swapped without touching the user's typed content. */
+export function renderSignatureRegion(signatureHtml: string): string {
+  return `<div ${SIGNATURE_BLOCK_ATTR}="true" style="${SIGNATURE_BLOCK_STYLE}">${signatureHtml}</div>`;
+}
+
+const REGION_OPEN_RE = new RegExp(
+  `<div\\b[^>]*\\b${SIGNATURE_BLOCK_ATTR}\\b[^>]*>`,
+  "i",
+);
+
+const DIV_TAG_RE = /<\/?div\b[^>]*>/gi;
+
+/** Locate the signature region in `bodyHtml`. Returns the char range of the
+ *  whole `<div data-signature-block …>…</div>`, or null when there is none.
+ *  Depth-aware so nested `<div>`s inside the signature (e.g. a logo block) do
+ *  not end the region early, and a quoted reply below it is never consumed. */
+function findRegion(bodyHtml: string): { start: number; end: number } | null {
+  const open = REGION_OPEN_RE.exec(bodyHtml);
+  if (!open) return null;
+  const start = open.index;
+  let depth = 1;
+  DIV_TAG_RE.lastIndex = start + open[0].length;
+  let tag: RegExpExecArray | null;
+  while ((tag = DIV_TAG_RE.exec(bodyHtml)) !== null) {
+    depth += tag[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) return { start, end: tag.index + tag[0].length };
+  }
+  return null;
+}
+
+/** Return body HTML with its signature region replaced by `nextSignatureHtml`
+ *  (or removed when null/empty), preserving all other content. */
+export function swapSignature(
+  bodyHtml: string,
+  nextSignatureHtml: string | null,
+): string {
+  const hasSig = nextSignatureHtml != null && nextSignatureHtml.trim() !== "";
+  const region = findRegion(bodyHtml);
+  if (region) {
+    const before = bodyHtml.slice(0, region.start);
+    const after = bodyHtml.slice(region.end);
+    return hasSig ? before + renderSignatureRegion(nextSignatureHtml!) + after : before + after;
+  }
+  return hasSig ? bodyHtml + renderSignatureRegion(nextSignatureHtml!) : bodyHtml;
+}


### PR DESCRIPTION
## What & why

Closes #643 (slice of PRD #634, Email drafting redesign).

Switching the **From** account in the compose window used to rebuild the entire
body and **discard the user's typed message**. This PR fixes that and adds a
signature picker — both now swap **only** the delimited signature block and
leave typed content intact.

## How

**Deep module (pure, unit-tested):** `src/lib/email/signature-swap.ts`
- `swapSignature(bodyHtml, nextSignatureHtml | null)` locates the signature
  region by a `data-signature-block` marker and replaces it (or removes it when
  `null`/empty), preserving everything else.
- Locator is **depth-aware**: nested `<div>`s inside a logo signature don't end
  the region early, and a quoted reply below the signature is never consumed.
- `renderSignatureRegion()` wraps raw signature HTML in the delimited region.

**Thin Tiptap shell:** `src/components/email/signature-block-extension.ts`
- A `signatureBlock` node whose only job is to make the marker survive editor
  round-trips. StarterKit has no generic `div` node, so an unmarked wrapper
  `<div>` (and its attributes) is dropped on parse — which would lose the marker
  the moment the user edits. Registered in `composeRichExtensions()` (opt-in, so
  every other shared-editor consumer is untouched), mirroring the #642
  IndentExtension split.

**Wiring:** `src/components/compose-email.tsx`
- `handleAccountChange` swaps the signature in the **live editor** via
  `swapSignature` instead of rebuilding the body — typed content preserved.
- Footer **signature picker** (pen icon, opens upward): lists every account's
  saved signature plus **No signature**, so any can be dropped in regardless of
  the From account.
- Initial insert and account switches **respect the `auto_insert` default**; an
  explicit picker choice forces the selected signature in regardless.

## Acceptance criteria

- [x] Switching the From account preserves the typed message
- [x] Picker lets the user choose among available signatures
- [x] Choosing a different signature replaces the prior region in place, typed
      content intact
- [x] Initial signature respects the `auto_insert` default
- [x] Signature-swap module is a pure function with unit tests (apply-to-empty,
      swap-preserving-typed, remove, no-signature) + a nested-markup robustness test

## Verification

- `vitest run src/lib/email/signature-swap.test.ts` → **5/5 pass**
- `tsc --noEmit` → **0 errors** in any touched file (the only remaining errors
  are the pre-existing `jay-peg`/PDF-test types, unrelated to this change)
- `eslint` on all 5 touched files → **clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
