### PR TITLE
feat(compose): insert email template into the message body (#644)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -14,6 +14,7 @@ import {
   Minimize2,
   Users,
   PenLine,
+  FileText,
 } from "lucide-react";
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
@@ -23,6 +24,7 @@ import {
   swapSignature,
   renderSignatureRegion,
 } from "@/lib/email/signature-swap";
+import { insertTemplateBody } from "@/lib/email/insert-template";
 import { type Editor } from "@tiptap/react";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
 import ContactPicker from "@/components/email/contact-picker";
@@ -51,6 +53,17 @@ interface EmailAccountData {
 interface Recipient {
   email: string;
   name: string;
+}
+
+// An email template the user may drop into the message body (issue #644). The
+// list comes from /api/email/templates, which already returns only what this
+// caller may see — Organization-wide templates plus their own Personal ones
+// (owner_user_id distinguishes the two: null = organization, set = personal).
+interface ComposeTemplate {
+  id: string;
+  name: string;
+  body_html: string;
+  owner_user_id: string | null;
 }
 
 interface UploadedFile {
@@ -115,6 +128,11 @@ export default function ComposeEmailModal({
   // signature is currently in the body, or null for "No signature".
   const [showSignaturePicker, setShowSignaturePicker] = useState(false);
   const [activeSignatureId, setActiveSignatureId] = useState<string | null>(null);
+  // Template picker (issue #644). Templates load lazily the first time the
+  // picker opens; null means "not fetched yet". Inserting a template drops its
+  // body into the message above the signature, never clobbering typed content.
+  const [showTemplatePicker, setShowTemplatePicker] = useState(false);
+  const [templates, setTemplates] = useState<ComposeTemplate[] | null>(null);
   // Opt-in rich-formatting extensions for the bottom toolbar. Stable across
   // renders so the shared editor isn't rebuilt; only compose loads these.
   const richExtensions = useMemo(() => composeRichExtensions(), []);
@@ -261,6 +279,41 @@ export default function ComposeEmailModal({
     applySignature(resolveSignatureHtml(account, false), id);
   }
 
+  // Insert a template's body into the message above the signature region,
+  // preserving the user's typed content (issue #644). Pushes into the live
+  // editor so the change survives without a remount; falls back to state when
+  // the editor isn't ready (mirrors applySignature).
+  function applyTemplate(templateHtml: string) {
+    if (!editor) {
+      setBodyHtml((prev) => insertTemplateBody(prev, templateHtml));
+      return;
+    }
+    const next = insertTemplateBody(editor.getHTML(), templateHtml);
+    editor.commands.setContent(next, { emitUpdate: false });
+    setBodyHtml(editor.getHTML());
+  }
+
+  function handlePickTemplate(t: ComposeTemplate) {
+    setShowTemplatePicker(false);
+    applyTemplate(t.body_html);
+  }
+
+  // Toggle the picker, lazily fetching the visible templates the first time it
+  // opens. The server returns only Organization-wide + the caller's own
+  // Personal templates, so whatever comes back is safe to render as-is.
+  async function toggleTemplatePicker() {
+    const next = !showTemplatePicker;
+    setShowTemplatePicker(next);
+    if (next && templates === null) {
+      try {
+        const res = await fetch("/api/email/templates");
+        setTemplates(res.ok ? await res.json() : []);
+      } catch {
+        setTemplates([]);
+      }
+    }
+  }
+
   useEffect(() => {
     if (open) {
       // Each fresh open starts as the corner-docked panel.
@@ -284,6 +337,7 @@ export default function ComposeEmailModal({
       setToRecipients(toList);
 
       setShowContactPicker(false);
+      setShowTemplatePicker(false);
 
       // Set CC recipients (for Reply All) — reveal the Cc row only when there's
       // something to show.
@@ -852,6 +906,87 @@ export default function ComposeEmailModal({
                       <span className="truncate">{opt.label}</span>
                     </button>
                   ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Template picker (issue #644) — drop an Organization or Personal
+              template body into the message, above the signature, without
+              clobbering what's already typed. */}
+          <div className="relative">
+            <button
+              type="button"
+              aria-label="Insert template"
+              aria-haspopup="menu"
+              aria-expanded={showTemplatePicker}
+              onClick={toggleTemplatePicker}
+              className="px-4 py-2.5 border border-gray-200 rounded-lg text-sm font-medium text-[#666666] hover:bg-gray-50 flex items-center gap-1.5"
+            >
+              <FileText size={14} />
+              Template
+            </button>
+            {showTemplatePicker && (
+              <>
+                {/* Click-away backdrop */}
+                <div
+                  className="fixed inset-0 z-40"
+                  onClick={() => setShowTemplatePicker(false)}
+                />
+                <div
+                  role="menu"
+                  className="absolute bottom-full left-0 z-50 mb-1 max-h-72 w-64 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg"
+                >
+                  {templates === null ? (
+                    <div className="px-3 py-2 text-sm text-[#999]">Loading…</div>
+                  ) : templates.length === 0 ? (
+                    <div className="px-3 py-2 text-sm text-[#999]">
+                      No templates yet.
+                    </div>
+                  ) : (
+                    <>
+                      {templates.some((t) => t.owner_user_id === null) && (
+                        <>
+                          <div className="px-3 pt-1.5 pb-0.5 text-xs font-semibold uppercase tracking-wide text-[#999]">
+                            Organization
+                          </div>
+                          {templates
+                            .filter((t) => t.owner_user_id === null)
+                            .map((t) => (
+                              <button
+                                key={t.id}
+                                type="button"
+                                role="menuitem"
+                                onClick={() => handlePickTemplate(t)}
+                                className="block w-full truncate px-3 py-2 text-left text-sm text-[#333] hover:bg-gray-50"
+                              >
+                                {t.name}
+                              </button>
+                            ))}
+                        </>
+                      )}
+                      {templates.some((t) => t.owner_user_id !== null) && (
+                        <>
+                          <div className="px-3 pt-1.5 pb-0.5 text-xs font-semibold uppercase tracking-wide text-[#999]">
+                            Personal
+                          </div>
+                          {templates
+                            .filter((t) => t.owner_user_id !== null)
+                            .map((t) => (
+                              <button
+                                key={t.id}
+                                type="button"
+                                role="menuitem"
+                                onClick={() => handlePickTemplate(t)}
+                                className="block w-full truncate px-3 py-2 text-left text-sm text-[#333] hover:bg-gray-50"
+                              >
+                                {t.name}
+                              </button>
+                            ))}
+                        </>
+                      )}
+                    </>
+                  )}
                 </div>
               </>
             )}

--- a/src/lib/email/insert-template.test.ts
+++ b/src/lib/email/insert-template.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { insertTemplateBody } from "./insert-template";
+import { renderSignatureRegion } from "./signature-swap";
+
+describe("insertTemplateBody", () => {
+  it("inserts the template into an empty message body", () => {
+    const result = insertTemplateBody("", "<p>Thanks for reaching out!</p>");
+    expect(result).toContain("Thanks for reaching out!");
+  });
+
+  it("inserts above the signature, preserving typed content and the signature", () => {
+    const body = "<p>Hi there</p>" + renderSignatureRegion("<p>Best, Jane</p>");
+    const result = insertTemplateBody(body, "<p>Template body</p>");
+    expect(result).toContain("Hi there");
+    expect(result).toContain("Best, Jane");
+    // The template lands between the typed message and the signature.
+    expect(result.indexOf("Template body")).toBeGreaterThan(
+      result.indexOf("Hi there"),
+    );
+    expect(result.indexOf("Template body")).toBeLessThan(
+      result.indexOf("Best, Jane"),
+    );
+  });
+
+  it("appends the template after typed content when there is no signature", () => {
+    const body = "<p>My message</p>";
+    const result = insertTemplateBody(body, "<p>Template body</p>");
+    expect(result).toContain("My message");
+    expect(result.indexOf("My message")).toBeLessThan(
+      result.indexOf("Template body"),
+    );
+  });
+
+  it("inserts above the signature even with nested signature markup and a quoted reply below", () => {
+    // The realistic forward/reply shape: a logo signature (nested <div>s) with a
+    // quoted thread below it. The template must land above the whole signature
+    // block — never inside it and never inside the quoted reply.
+    const logoSig =
+      '<div class="logo"><img src="x"><span>Jane</span></div><p>Acme Inc</p>';
+    const body =
+      "<p>Top message</p>" +
+      renderSignatureRegion(logoSig) +
+      "<p>Quoted reply</p>";
+    const result = insertTemplateBody(body, "<p>Template body</p>");
+    expect(result).toContain("Top message");
+    expect(result).toContain("Acme Inc");
+    expect(result).toContain("Quoted reply");
+    expect(result.indexOf("Template body")).toBeGreaterThan(
+      result.indexOf("Top message"),
+    );
+    expect(result.indexOf("Template body")).toBeLessThan(
+      result.indexOf("Jane"),
+    );
+    expect(result.indexOf("Template body")).toBeLessThan(
+      result.indexOf("Acme Inc"),
+    );
+  });
+});

--- a/src/lib/email/insert-template.ts
+++ b/src/lib/email/insert-template.ts
@@ -1,0 +1,30 @@
+// Template-insertion math for the compose editor (issue #644 / PRD #634).
+// Picking an email template drops its body HTML into the message — without
+// clobbering what the user already typed or the signature region below it.
+// Kept pure and free of React/Tiptap so the splice logic can be unit-tested in
+// isolation, mirroring the sibling signature-swap module.
+
+import { SIGNATURE_BLOCK_ATTR } from "./signature-swap";
+
+// Matches the opening tag of the delimited signature region (see signature-swap).
+// We only need where the region BEGINS — the template is spliced in just above
+// it, so the whole signature block stays intact at the bottom of the message.
+const REGION_OPEN_RE = new RegExp(
+  `<div\\b[^>]*\\b${SIGNATURE_BLOCK_ATTR}\\b[^>]*>`,
+  "i",
+);
+
+/** Return `bodyHtml` with `templateHtml` inserted into the message region:
+ *  just above the signature region when one exists (so the signature stays at
+ *  the bottom), otherwise appended after the existing content. The user's typed
+ *  content and the entire signature region are preserved. */
+export function insertTemplateBody(
+  bodyHtml: string,
+  templateHtml: string,
+): string {
+  const open = REGION_OPEN_RE.exec(bodyHtml);
+  if (open) {
+    return bodyHtml.slice(0, open.index) + templateHtml + bodyHtml.slice(open.index);
+  }
+  return bodyHtml + templateHtml;
+}


### PR DESCRIPTION
## What & why

Implements **#644** (a slice of PRD #634 — Email drafting redesign): Compose can now
insert an email template into the message body.

- Adds an **"Insert template"** picker in the compose footer, grouped into
  **Organization** and **Personal** sections. The list comes from
  `GET /api/email/templates`, which is RLS-gated, so only templates the user is
  allowed to see (org-wide + their own personal) ever reach the client.
- Picking a template splices its body HTML **just above the signature region**, so it
  never clobbers already-typed content or the signature block, and the **subject is
  untouched** (templates are body-only).

## How

- **`src/lib/email/insert-template.ts`** — a pure, framework-free deep module
  (`insertTemplateBody`) holding the splice math, mirroring the sibling
  `signature-swap` module. It finds the signature region's opening delimiter and
  inserts the template immediately before it (or appends when there's no signature).
- **`src/components/compose-email.tsx`** — thin Tiptap shell: computes the next HTML
  from the live editor via the pure module, pushes it with
  `setContent({ emitUpdate: false })`, and mirrors the result back to `bodyHtml` so the
  autosave snapshot and the sent body stay consistent (same pattern as the signature picker).

## Acceptance criteria

- [x] Compose exposes an "Insert template" picker listing Org-wide + the user's Personal templates
- [x] Selecting a template inserts its body HTML into the message editor
- [x] Inserting does not clobber typed content or the signature region
- [x] Only templates the user is allowed to see appear (enforced server-side via RLS)
- [x] Subject is unaffected (templates are body-only)

## Testing

Built with `/tdd` — one vertical slice per cycle. `insert-template.test.ts` covers:
empty body, insertion above a signature (typed content + signature preserved), append
when no signature, and nested signature markup with a quoted reply below.

- `npx vitest run src/lib/email/insert-template.test.ts` → **4/4 pass**
- `npx eslint` on the touched files → clean
- `npx tsc --noEmit` → no new errors in the touched files (suite is known-red on main)

Closes #644.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
