### PR TITLE
feat(compose): Cmd/Ctrl+Enter to send + iOS safe-area insets (#645)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -20,11 +20,13 @@ import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
 import ComposeFormattingToolbar from "@/components/email/compose-formatting-toolbar";
 import { composeRichExtensions } from "@/components/email/compose-editor-extensions";
+import { SendShortcutExtension } from "@/components/email/send-shortcut-extension";
 import {
   swapSignature,
   renderSignatureRegion,
 } from "@/lib/email/signature-swap";
 import { insertTemplateBody } from "@/lib/email/insert-template";
+import { isSendShortcut } from "@/lib/email/send-shortcut";
 import { type Editor } from "@tiptap/react";
 import EmailAddressInput, { EmailAddressInputHandle } from "@/components/email-address-input";
 import ContactPicker from "@/components/email/contact-picker";
@@ -133,9 +135,21 @@ export default function ComposeEmailModal({
   // body into the message above the signature, never clobbering typed content.
   const [showTemplatePicker, setShowTemplatePicker] = useState(false);
   const [templates, setTemplates] = useState<ComposeTemplate[] | null>(null);
+  // Cmd/Ctrl+Enter sends from anywhere in compose (issue #645). The in-editor
+  // chord is handled by SendShortcutExtension; this ref lets that extension —
+  // built once below — always reach the latest handleSend without rebuilding the
+  // editor. `sendingRef` dedupes so a held/repeated chord can't fire twice.
+  const handleSendRef = useRef<() => void>(() => {});
+  const sendingRef = useRef(false);
   // Opt-in rich-formatting extensions for the bottom toolbar. Stable across
   // renders so the shared editor isn't rebuilt; only compose loads these.
-  const richExtensions = useMemo(() => composeRichExtensions(), []);
+  const richExtensions = useMemo(
+    () => [
+      ...composeRichExtensions(),
+      SendShortcutExtension.configure({ onSend: () => handleSendRef.current() }),
+    ],
+    [],
+  );
   const [windowState, dispatchWindow] = useReducer(
     composeWindowReducer,
     initialComposeWindowState,
@@ -486,8 +500,12 @@ export default function ComposeEmailModal({
     applySignature(nextSig, nextSig ? accountId : null);
   }
 
-  async function handleSend(e: React.FormEvent) {
-    e.preventDefault();
+  // Accepts the form submit event, the Cmd/Ctrl+Enter keydown, or no event at
+  // all (the in-editor send chord). `sendingRef` makes a held/repeated chord or
+  // a double-click idempotent: a second call while a send is in flight no-ops.
+  async function handleSend(e?: { preventDefault?: () => void }) {
+    e?.preventDefault?.();
+    if (sendingRef.current) return;
     // Commit any typed-but-uncommitted email addresses
     toRef.current?.flush();
     ccRef.current?.flush();
@@ -510,6 +528,7 @@ export default function ComposeEmailModal({
       return;
     }
 
+    sendingRef.current = true;
     setSending(true);
     try {
       const res = await fetch("/api/email/send", {
@@ -535,7 +554,6 @@ export default function ComposeEmailModal({
         data = await res.json();
       } catch {
         toast.error(`Server error (${res.status}). Check email settings and try again.`);
-        setSending(false);
         return;
       }
 
@@ -553,9 +571,13 @@ export default function ComposeEmailModal({
       }
     } catch {
       toast.error("Network error sending email.");
+    } finally {
+      sendingRef.current = false;
+      setSending(false);
     }
-    setSending(false);
   }
+  // Keep the ref the SendShortcutExtension calls pointed at the latest closure.
+  handleSendRef.current = () => void handleSend();
 
   const title =
     mode === "reply" ? "Reply" : mode === "forward" ? "Forward" : "Compose Email";
@@ -581,8 +603,18 @@ export default function ComposeEmailModal({
       aria-label={title}
       className={panelClass}
     >
-      {/* Title bar — window chrome with minimize / maximize / close */}
-      <div className="flex items-center justify-between gap-2 px-4 py-2.5 bg-[#2B5EA7] text-white shrink-0 select-none">
+      {/* Title bar — window chrome with minimize / maximize / close. On the
+          full-screen mobile sheet the bar sits at the very top, so it takes the
+          iOS safe-area top inset to clear the status bar/notch (issue #645). The
+          minimized mini-sheet docks at the bottom and the desktop window is
+          inset, so both keep the normal 10px top padding. */}
+      <div
+        className={`flex items-center justify-between gap-2 px-4 pb-2.5 bg-[#2B5EA7] text-white shrink-0 select-none ${
+          isMinimized
+            ? "pt-2.5"
+            : "pt-[max(env(safe-area-inset-top),10px)] sm:pt-2.5"
+        }`}
+      >
         {isMinimized ? (
           <button
             type="button"
@@ -634,6 +666,16 @@ export default function ComposeEmailModal({
           in-progress draft — recipients, subject, body, attachments — survives. */}
       <form
         onSubmit={handleSend}
+        onKeyDown={(e) => {
+          // Cmd/Ctrl+Enter sends from the header fields (To/Cc/Bcc/Subject).
+          // The body has its own SendShortcutExtension, so skip keystrokes that
+          // originate inside the editor — otherwise the chord would fire twice.
+          if (editor?.view.dom.contains(e.target as Node)) return;
+          if (isSendShortcut(e)) {
+            e.preventDefault();
+            void handleSend(e);
+          }
+        }}
         className={`flex-1 min-h-0 flex flex-col ${isMinimized ? "hidden" : ""}`}
       >
         <div className="flex-1 min-h-0 overflow-y-auto bg-white">
@@ -826,8 +868,10 @@ export default function ComposeEmailModal({
           onToggleVisible={() => setToolbarVisible((v) => !v)}
         />
 
-        {/* Footer action / send bar */}
-        <div className="shrink-0 flex items-center gap-3 px-4 py-3 border-t border-gray-200 bg-white">
+        {/* Footer action / send bar. Bottom inset keeps the Send button clear of
+            the iOS home indicator on the full-screen sheet (issue #645); resolves
+            to the normal 12px on desktop where the safe area is 0. */}
+        <div className="shrink-0 flex items-center gap-3 px-4 pt-3 pb-[max(env(safe-area-inset-bottom),12px)] border-t border-gray-200 bg-white">
           <button
             type="submit"
             disabled={sending || uploading || accounts.length === 0}

--- a/src/components/email/send-shortcut-extension.ts
+++ b/src/components/email/send-shortcut-extension.ts
@@ -1,0 +1,37 @@
+import { Extension } from "@tiptap/core";
+
+export interface SendShortcutOptions {
+  /** Invoked when the user presses the send chord (Cmd/Ctrl+Enter) in the body. */
+  onSend: () => void;
+}
+
+/**
+ * Sends the compose email when Cmd/Ctrl+Enter is pressed inside the message body
+ * (issue #645 / PRD #634). StarterKit's HardBreak binds Mod-Enter to insert a
+ * line break; this extension's higher priority wins that chord so it triggers a
+ * send instead of dropping a stray <br> into the message. Header fields
+ * (To/Cc/Bcc/Subject) live outside the editor and route the same chord through
+ * the pure isSendShortcut module via a form-level handler, so the chord works
+ * from anywhere in compose.
+ *
+ * Opt-in: only the compose editor loads this via TiptapEditor's extraExtensions,
+ * so the shared editor's other consumers keep HardBreak's default Mod-Enter.
+ */
+export const SendShortcutExtension = Extension.create<SendShortcutOptions>({
+  name: "composeSendShortcut",
+  // Beat StarterKit's HardBreak (default priority 100) so Mod-Enter sends.
+  priority: 1000,
+
+  addOptions() {
+    return { onSend: () => {} };
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      "Mod-Enter": () => {
+        this.options.onSend();
+        return true;
+      },
+    };
+  },
+});

--- a/src/lib/email/send-shortcut.test.ts
+++ b/src/lib/email/send-shortcut.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { isSendShortcut } from "./send-shortcut";
+
+describe("isSendShortcut", () => {
+  it("fires on Cmd+Enter (macOS)", () => {
+    expect(isSendShortcut({ key: "Enter", metaKey: true, ctrlKey: false })).toBe(
+      true,
+    );
+  });
+
+  it("fires on Ctrl+Enter (Windows/Linux)", () => {
+    expect(isSendShortcut({ key: "Enter", metaKey: false, ctrlKey: true })).toBe(
+      true,
+    );
+  });
+
+  it("ignores a plain Enter so newlines are not hijacked", () => {
+    expect(
+      isSendShortcut({ key: "Enter", metaKey: false, ctrlKey: false }),
+    ).toBe(false);
+  });
+
+  it("ignores a modifier held with a non-Enter key", () => {
+    expect(isSendShortcut({ key: "a", metaKey: true, ctrlKey: false })).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/email/send-shortcut.ts
+++ b/src/lib/email/send-shortcut.ts
@@ -1,0 +1,20 @@
+// Keyboard-send detection for the compose editor (issue #645 / PRD #634).
+// Cmd/Ctrl+Enter sends the email from anywhere in compose. Kept pure and free of
+// React/Tiptap so the modifier logic can be unit-tested in isolation, mirroring
+// the sibling compose-indent module. The thin shells — a form-level onKeyDown for
+// the header fields and an opt-in Tiptap shortcut for the body — both defer the
+// "is this the send chord?" decision to this one function.
+
+/** The subset of a keyboard event this decision needs. */
+export interface SendShortcutEvent {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
+
+/** True when the event is the send chord: Enter held with Cmd (⌘, macOS) or
+ *  Ctrl (Windows/Linux). Plain Enter is left alone so it still inserts
+ *  newlines in the editor and submits nothing on its own. */
+export function isSendShortcut(e: SendShortcutEvent): boolean {
+  return e.key === "Enter" && (e.metaKey || e.ctrlKey);
+}


### PR DESCRIPTION
Closes #645. Final polish & QA slice of the compose redesign (PRD #634).

## What's in this PR

### Cmd/Ctrl+Enter to send (the test-driven part)
The "is this the send chord?" decision is a pure, unit-tested module
(`src/lib/email/send-shortcut.ts`) — built one RED→GREEN cycle at a time,
mirroring the existing `compose-indent` deep-module split:

- **In the body:** an opt-in `SendShortcutExtension` registered with higher
  priority than StarterKit's HardBreak, so `Mod-Enter` sends instead of
  inserting a `<br>`. Loaded **only** via compose's `extraExtensions`, so the
  shared editor's other consumers (contracts, estimates, signatures, …) keep
  HardBreak's default — covers the "no regressions" criterion by construction.
- **In the header fields** (To/Cc/Bcc/Subject): a form-level `onKeyDown` routes
  the same chord through `isSendShortcut`. It ignores keystrokes that originate
  inside the editor, so the chord never double-fires.
- `handleSend` gained a re-entrancy guard so a held/repeated chord or a
  double-click can't fire two sends.

### iOS safe-area insets
The full-screen mobile sheet now uses the repo's established
`env(safe-area-inset-*)` idiom: the title bar clears the status bar/notch and
the Send button clears the home indicator. Both resolve to the prior 10px/12px
on desktop (safe area = 0), and the minimized mini-sheet keeps its normal top
padding.

### Verification (inspection)
- **Call sites:** both the email inbox and job detail open the redesigned
  compose with job association + reply defaults (inbox also passes `draftId`
  for resume) and refresh after send (`loadEmails()`/`loadCounts()`;
  `fetchData()`).
- **No regressions:** 86 editor/compose tests green; the send extension is
  imported only by compose.

## Tests
- `src/lib/email/send-shortcut.test.ts` — 4 cases: ⌘+Enter, Ctrl+Enter,
  plain Enter (ignored), modifier + non-Enter key (ignored).
- Touched files add no new `tsc`/lint failures; full email/compose suites pass.

## Needs a real device / human eyes
- **iOS smoke test:** confirm the safe-area insets land correctly and the
  full-screen sheet, bottom toolbar, pickers, autosave, and send all behave in
  the Capacitor app. The in-editor `Mod-Enter` wiring is integration glue (not
  unit-testable) — worth a quick manual send-from-body check.
- **Design pass:** dark chrome vs. white canvas is already in place; finer
  spacing, header-field focus states, and toolbar/footer alignment are
  subjective and left for a design review rather than guessed at blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
