### PR TITLE
fix(compose-email): readable body & recipient text on the white canvas in dark mode

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -814,6 +814,7 @@ export default function ComposeEmailModal({
               onChange={setBodyHtml}
               placeholder="Type your message..."
               hideToolbar
+              lightSurface
               extraExtensions={richExtensions}
               onReady={setEditor}
             />

--- a/src/components/email-address-input.tsx
+++ b/src/components/email-address-input.tsx
@@ -183,7 +183,7 @@ const EmailAddressInput = forwardRef<EmailAddressInputHandle, EmailAddressInputP
           onKeyDown={handleKeyDown}
           onFocus={() => input.length >= 1 && setShowSuggestions(true)}
           placeholder={recipients.length === 0 ? placeholder : ""}
-          className="flex-1 min-w-[120px] text-sm outline-none bg-transparent py-0.5"
+          className="flex-1 min-w-[120px] text-sm text-[#333] outline-none bg-transparent py-0.5 placeholder:text-[#999]"
         />
       </div>
 

--- a/src/components/tiptap-editor.tsx
+++ b/src/components/tiptap-editor.tsx
@@ -28,6 +28,15 @@ interface TiptapEditorProps {
    * existing consumer keeps the top toolbar unchanged.
    */
   hideToolbar?: boolean;
+  /**
+   * Render content for a fixed light surface instead of following the app
+   * theme. Opt-in for consumers (e.g. the compose window) that draw their own
+   * always-white canvas: in dark mode the themed `text-foreground` +
+   * `dark:prose-invert` would paint light text onto that white canvas, leaving
+   * it unreadable. Defaults to false so every existing consumer keeps the
+   * theme-aware colors unchanged.
+   */
+  lightSurface?: boolean;
 }
 
 export default function TiptapEditor({
@@ -37,6 +46,7 @@ export default function TiptapEditor({
   extraExtensions,
   onReady,
   hideToolbar = false,
+  lightSurface = false,
 }: TiptapEditorProps) {
   const editor = useEditor({
     extensions: [
@@ -53,8 +63,14 @@ export default function TiptapEditor({
     },
     editorProps: {
       attributes: {
-        class:
-          "prose prose-sm dark:prose-invert max-w-none min-h-[160px] px-3 py-2 focus:outline-none text-foreground [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1",
+        class: [
+          "prose prose-sm max-w-none min-h-[160px] px-3 py-2 focus:outline-none [&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1",
+          // A fixed light surface keeps the light-mode prose palette (dark text)
+          // and pins an explicit dark color; otherwise follow the app theme.
+          lightSurface
+            ? "text-[#333]"
+            : "dark:prose-invert text-foreground",
+        ].join(" "),
       },
     },
   });


### PR DESCRIPTION
## What

Fixes the dark-mode readability bug in the compose window: the body message and the To/Cc/Bcc recipient text rendered in a washed-out light gray, near-unreadable, against the compose window's white canvas.

## Why

The compose window draws an **always-white** canvas (`bg-white`), but its text colors still came from the **app theme**. In dark mode:

- the body editor styled content with `text-foreground` **+ `dark:prose-invert`** — both resolve to a *light* color in dark mode, painted onto white;
- the recipient `<input>` set **no explicit text color**, so it inherited the same light dark-mode foreground (the adjacent Subject field already pinned `text-[#333]`, which is why it slipped through).

This is dark-mode-only, which is why the static PRD #634 review didn't catch it — it lands in the "needs a real browser" residual risk.

## How

- `TiptapEditor` gains an opt-in **`lightSurface`** prop. When set, it keeps the light-mode prose palette (dark text) and pins an explicit dark color instead of `dark:prose-invert` + `text-foreground`. The compose window passes it; the **7 other editor consumers** (contracts, estimates, signatures, templates, photo/report builders) don't, so they remain fully theme-aware and visually unchanged.
- The recipient input now sets an explicit dark text color + muted placeholder, matching the Subject field. `EmailAddressInput` is used only in compose (always a light surface).

## Verification

- `tsc --noEmit` adds no new errors in the touched files (full suite is known-red on main).
- Presentational change — contrast is visual, so jsdom can't assert it; please eyeball the Vercel preview in dark mode (typed body text + To/Cc/Bcc should be near-black on the white canvas, other editors unchanged).

Addresses the lead item of #660 (PRD #634).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
