### PR TITLE
fix(compose-email): signature region correctness — dedup, accurate matcher, honest hint (#656)

### DIFF
--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -24,6 +24,7 @@ import { SendShortcutExtension } from "@/components/email/send-shortcut-extensio
 import {
   swapSignature,
   renderSignatureRegion,
+  hasSignatureRegion,
 } from "@/lib/email/signature-swap";
 import { insertTemplateBody } from "@/lib/email/insert-template";
 import { isSendShortcut } from "@/lib/email/send-shortcut";
@@ -207,11 +208,6 @@ export default function ComposeEmailModal({
     [selectedAccountId, toRecipients, ccRecipients, bccRecipients, subject, bodyHtml, jobId, replyToMessageId],
   );
 
-  const selectedAccount = useMemo(
-    () => accounts.find((a) => a.id === selectedAccountId),
-    [accounts, selectedAccountId]
-  );
-
   // Signature data from email_signatures table
   const [signaturesMap, setSignaturesMap] = useState<Record<string, { signature_html: string; auto_insert: boolean }>>({});
 
@@ -238,11 +234,15 @@ export default function ComposeEmailModal({
 
   // Build initial body with signature, wrapped in the delimited region so it can
   // later be located and swapped without touching the user's typed content.
+  // A resumed draft already carries its own signature region, so it is treated
+  // as authoritative: we never prepend a second region (issue #656). Otherwise a
+  // resume → edit → autosave cycle would accumulate a fresh duplicate every time.
   function buildInitialBody(account: EmailAccountData | undefined, quotedHtml: string, sigs?: typeof signaturesMap) {
-    let html = quotedHtml || "";
+    const html = quotedHtml || "";
+    if (hasSignatureRegion(html)) return html;
     const rendered = resolveSignatureHtml(account, true, sigs);
     if (rendered) {
-      html = `<p></p><br>${renderSignatureRegion(rendered)}${html ? `<br>${html}` : ""}`;
+      return `<p></p><br>${renderSignatureRegion(rendered)}${html ? `<br>${html}` : ""}`;
     }
     return html;
   }
@@ -261,6 +261,25 @@ export default function ComposeEmailModal({
     }
     return opts;
   }, [accounts, signaturesMap]);
+
+  // Label of the signature currently in the body, or null when none is active
+  // ("No signature"). Drives the preview hint from the live selection instead of
+  // the From account's legacy column, so the hint stays truthful after the user
+  // picks "No signature" or a non-default signature (issue #656). Falls back to
+  // the account's own label for a legacy-column signature not in the picker.
+  const activeSignatureLabel = useMemo(() => {
+    if (activeSignatureId === null) return null;
+    const opt = signatureOptions.find((o) => o.id === activeSignatureId);
+    if (opt) return opt.label;
+    const acc = accounts.find((a) => a.id === activeSignatureId);
+    return acc?.label || acc?.email_address || null;
+  }, [activeSignatureId, signatureOptions, accounts]);
+
+  // Whether the body actually still holds a signature region right now. Gating
+  // the preview hint on this keeps it from claiming a signature the body no
+  // longer has — e.g. after the user deletes the signature block directly in the
+  // editor rather than via the "No signature" picker option (issue #656).
+  const bodyHasSignature = useMemo(() => hasSignatureRegion(bodyHtml), [bodyHtml]);
 
   // Swap (or remove, when null) the signature region in place, preserving the
   // user's typed message (issue #643). Pushes into the live editor so the change
@@ -392,10 +411,12 @@ export default function ComposeEmailModal({
         if (defaultAcc) {
           const initialBody = buildInitialBody(defaultAcc, defaultBody, sigs);
           setSelectedAccountId(defaultAcc.id);
-          // The initial body carries defaultAcc's signature iff one resolved
-          // (respecting its auto_insert default), so seed the picker to match.
+          // Seed the picker from whether the opened body actually has a
+          // signature region — true for a fresh auto-insert AND for a resumed
+          // draft that already carried one — so the preview hint never claims a
+          // signature that isn't there, or omits one that is (issue #656).
           setActiveSignatureId(
-            resolveSignatureHtml(defaultAcc, true, sigs) ? defaultAcc.id : null,
+            hasSignatureRegion(initialBody) ? defaultAcc.id : null,
           );
           setBodyHtml(initialBody);
           setEditorKey((k) => k + 1);
@@ -853,10 +874,14 @@ export default function ComposeEmailModal({
               </div>
             )}
 
-            {/* Signature preview */}
-            {selectedAccount?.signature && (
+            {/* Signature preview — reflects the active signature selection
+                (issue #656), not the From account's legacy column, and only when
+                the body actually still holds a region, so it stays truthful
+                after the user picks "No signature" or deletes the signature
+                block in the editor. */}
+            {activeSignatureLabel && bodyHasSignature && (
               <p className="text-xs text-[#999]">
-                Signature from &quot;{selectedAccount.label}&quot; will be included.
+                Signature from &quot;{activeSignatureLabel}&quot; will be included.
               </p>
             )}
           </div>

--- a/src/lib/email/insert-template.test.ts
+++ b/src/lib/email/insert-template.test.ts
@@ -31,6 +31,20 @@ describe("insertTemplateBody", () => {
     );
   });
 
+  it("does not treat the marker substring as the region when inserting a template", () => {
+    // Pasted/quoted email HTML whose class merely CONTAINS the marker substring
+    // is not the real region. With no real region present, the template must
+    // append after the existing content — never split the pasted block by being
+    // spliced "above" a phantom region.
+    const pasted =
+      '<div class="data-signature-block-quote"><p>Pasted thread</p></div>';
+    const result = insertTemplateBody(pasted, "<p>Template body</p>");
+    expect(result).toContain("Pasted thread");
+    expect(result.indexOf("Pasted thread")).toBeLessThan(
+      result.indexOf("Template body"),
+    );
+  });
+
   it("inserts above the signature even with nested signature markup and a quoted reply below", () => {
     // The realistic forward/reply shape: a logo signature (nested <div>s) with a
     // quoted thread below it. The template must land above the whole signature

--- a/src/lib/email/insert-template.ts
+++ b/src/lib/email/insert-template.ts
@@ -4,27 +4,26 @@
 // Kept pure and free of React/Tiptap so the splice logic can be unit-tested in
 // isolation, mirroring the sibling signature-swap module.
 
-import { SIGNATURE_BLOCK_ATTR } from "./signature-swap";
-
-// Matches the opening tag of the delimited signature region (see signature-swap).
-// We only need where the region BEGINS — the template is spliced in just above
-// it, so the whole signature block stays intact at the bottom of the message.
-const REGION_OPEN_RE = new RegExp(
-  `<div\\b[^>]*\\b${SIGNATURE_BLOCK_ATTR}\\b[^>]*>`,
-  "i",
-);
+import { findSignatureRegion } from "./signature-swap";
 
 /** Return `bodyHtml` with `templateHtml` inserted into the message region:
  *  just above the signature region when one exists (so the signature stays at
  *  the bottom), otherwise appended after the existing content. The user's typed
- *  content and the entire signature region are preserved. */
+ *  content and the entire signature region are preserved.
+ *
+ *  Region detection is shared with the signature-swap path (issue #656): both
+ *  rely on the single `findSignatureRegion` matcher, so neither can be fooled by
+ *  pasted email HTML that merely contains the marker substring. We only need
+ *  where the region BEGINS — the template is spliced just above it. */
 export function insertTemplateBody(
   bodyHtml: string,
   templateHtml: string,
 ): string {
-  const open = REGION_OPEN_RE.exec(bodyHtml);
-  if (open) {
-    return bodyHtml.slice(0, open.index) + templateHtml + bodyHtml.slice(open.index);
+  const region = findSignatureRegion(bodyHtml);
+  if (region) {
+    return (
+      bodyHtml.slice(0, region.start) + templateHtml + bodyHtml.slice(region.start)
+    );
   }
   return bodyHtml + templateHtml;
 }

--- a/src/lib/email/signature-swap.test.ts
+++ b/src/lib/email/signature-swap.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from "vitest";
-import { swapSignature, SIGNATURE_BLOCK_ATTR } from "./signature-swap";
+import {
+  swapSignature,
+  renderSignatureRegion,
+  hasSignatureRegion,
+  SIGNATURE_BLOCK_ATTR,
+} from "./signature-swap";
+
+/** Count rendered signature regions by their emitted marker attribute. */
+function countRegions(html: string): number {
+  return (html.match(new RegExp(`${SIGNATURE_BLOCK_ATTR}="true"`, "g")) || [])
+    .length;
+}
 
 describe("swapSignature", () => {
   it("applies a signature to an empty body", () => {
@@ -27,6 +38,77 @@ describe("swapSignature", () => {
   it("leaves a body with no signature unchanged when none is provided", () => {
     const body = "<p>Just a message</p>";
     expect(swapSignature(body, null)).toBe(body);
+  });
+
+  it("does not mistake HTML that merely contains the marker substring for the region", () => {
+    // Pasted/quoted email HTML whose class CONTAINS the `data-signature-block`
+    // substring (here as a hyphenated suffix), but is NOT the real
+    // `data-signature-block="true"` attribute. A swap must leave it intact and
+    // append the new signature, not destroy the pasted content.
+    const pasted =
+      '<div class="data-signature-block-wrapper"><p>Quoted thread content</p></div>';
+    const result = swapSignature(pasted, "<p>My signature</p>");
+    expect(result).toContain("Quoted thread content");
+    expect(result).toContain("My signature");
+  });
+
+  it("ignores the marker substring in an id or another attribute's value", () => {
+    // No REAL region: the substring lives in an id and inside a class value. A
+    // swap must leave both decoys intact and append exactly one new region.
+    const decoys =
+      '<div id="data-signature-block"><p>Decoy A</p></div>' +
+      '<div class="x data-signature-block y"><p>Decoy B</p></div>';
+    const result = swapSignature(decoys, "<p>Real sig</p>");
+    expect(result).toContain("Decoy A");
+    expect(result).toContain("Decoy B");
+    expect(countRegions(result)).toBe(1);
+  });
+
+  it("collapses to a single region when the body already has duplicates", () => {
+    // A legacy double-inserted draft (the resume bug) or an orphaned region can
+    // leave two marker regions. A swap replaces ONE and strips the rest, so
+    // exactly one signature ever survives — it is never shipped twice.
+    const twoRegions =
+      "<p>Body</p>" +
+      renderSignatureRegion("<p>Old A</p>") +
+      renderSignatureRegion("<p>Old B</p>");
+    const result = swapSignature(twoRegions, "<p>New sig</p>");
+    expect(countRegions(result)).toBe(1);
+    expect(result).toContain("Body");
+    expect(result).toContain("New sig");
+    expect(result).not.toContain("Old A");
+    expect(result).not.toContain("Old B");
+  });
+
+  it("removes every region when clearing the signature, even duplicates", () => {
+    const twoRegions =
+      renderSignatureRegion("<p>Old A</p>") +
+      "<p>Body</p>" +
+      renderSignatureRegion("<p>Old B</p>");
+    const result = swapSignature(twoRegions, null);
+    expect(countRegions(result)).toBe(0);
+    expect(result).toContain("Body");
+  });
+
+  it("replaces a single existing region in place rather than appending", () => {
+    // A plain in-place swap of one well-formed region stays at one region.
+    // (The orphaned/duplicate-region case is guarded by the "collapses to a
+    // single region" test above, which constructs two real regions.)
+    const withSig = swapSignature("<p>Message</p>", "<p>First</p>");
+    const swapped = swapSignature(withSig, "<p>Second</p>");
+    expect(countRegions(swapped)).toBe(1);
+    expect(swapped).toContain("Second");
+    expect(swapped).not.toContain("First");
+  });
+});
+
+describe("hasSignatureRegion", () => {
+  it("is true only for the real marker, not a substring decoy", () => {
+    expect(hasSignatureRegion(renderSignatureRegion("<p>Sig</p>"))).toBe(true);
+    expect(hasSignatureRegion("<p>Just a message</p>")).toBe(false);
+    expect(
+      hasSignatureRegion('<div class="data-signature-block-x"><p>Q</p></div>'),
+    ).toBe(false);
   });
 
   it("locates the region correctly when the signature contains nested markup", () => {

--- a/src/lib/email/signature-swap.ts
+++ b/src/lib/email/signature-swap.ts
@@ -20,23 +20,58 @@ export function renderSignatureRegion(signatureHtml: string): string {
   return `<div ${SIGNATURE_BLOCK_ATTR}="true" style="${SIGNATURE_BLOCK_STYLE}">${signatureHtml}</div>`;
 }
 
-const REGION_OPEN_RE = new RegExp(
-  `<div\\b[^>]*\\b${SIGNATURE_BLOCK_ATTR}\\b[^>]*>`,
-  "i",
-);
-
+// Match a single `<div …>` opening tag and capture its raw attribute list.
+const DIV_OPEN_RE = /<div\b([^>]*)>/gi;
 const DIV_TAG_RE = /<\/?div\b[^>]*>/gi;
+
+// Walk the attribute LIST of one tag, capturing each attribute name (group 1)
+// while consuming any quoted/unquoted value so a marker substring buried inside
+// a value is never mistaken for an attribute name. `[^\s=/>]+` requires at
+// least one char, so the global scan always advances and never loops.
+const ATTR_RE = /([^\s=/>]+)(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+))?/g;
+
+/** True when the tag's attribute list contains the `data-signature-block`
+ *  marker as an attribute NAME — not as a substring inside another attribute's
+ *  value, and not as a hyphenated suffix like `data-signature-block-foo`. HTML
+ *  attribute names are case-insensitive; the marker we emit is lowercase. */
+function attrsHaveMarker(attrs: string): boolean {
+  ATTR_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = ATTR_RE.exec(attrs)) !== null) {
+    if (m[1].toLowerCase() === SIGNATURE_BLOCK_ATTR) return true;
+  }
+  return false;
+}
+
+/** Locate the opening `<div …>` tag of the signature region: the first div
+ *  whose attributes include the real marker. Keying on the marker as an
+ *  attribute name (not a loose substring) is what keeps pasted/quoted email
+ *  HTML that merely contains the substring from being treated as the region. */
+function findRegionOpen(
+  bodyHtml: string,
+): { index: number; length: number } | null {
+  DIV_OPEN_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = DIV_OPEN_RE.exec(bodyHtml)) !== null) {
+    if (attrsHaveMarker(m[1])) return { index: m.index, length: m[0].length };
+  }
+  return null;
+}
 
 /** Locate the signature region in `bodyHtml`. Returns the char range of the
  *  whole `<div data-signature-block …>…</div>`, or null when there is none.
  *  Depth-aware so nested `<div>`s inside the signature (e.g. a logo block) do
- *  not end the region early, and a quoted reply below it is never consumed. */
-function findRegion(bodyHtml: string): { start: number; end: number } | null {
-  const open = REGION_OPEN_RE.exec(bodyHtml);
+ *  not end the region early, and a quoted reply below it is never consumed.
+ *  Shared by the signature-swap and template-insert paths so a single matcher
+ *  decides where the region is (issue #656). */
+export function findSignatureRegion(
+  bodyHtml: string,
+): { start: number; end: number } | null {
+  const open = findRegionOpen(bodyHtml);
   if (!open) return null;
   const start = open.index;
   let depth = 1;
-  DIV_TAG_RE.lastIndex = start + open[0].length;
+  DIV_TAG_RE.lastIndex = start + open.length;
   let tag: RegExpExecArray | null;
   while ((tag = DIV_TAG_RE.exec(bodyHtml)) !== null) {
     depth += tag[0].startsWith("</") ? -1 : 1;
@@ -45,18 +80,41 @@ function findRegion(bodyHtml: string): { start: number; end: number } | null {
   return null;
 }
 
+/** True when `bodyHtml` already contains a signature region. Lets the compose
+ *  shell treat a resumed draft as authoritative instead of prepending a second
+ *  region (issue #656). */
+export function hasSignatureRegion(bodyHtml: string): boolean {
+  return findSignatureRegion(bodyHtml) !== null;
+}
+
+/** Remove every signature region from `html`, leaving all other content. */
+function stripRegions(html: string): string {
+  let out = html;
+  let region = findSignatureRegion(out);
+  while (region) {
+    out = out.slice(0, region.start) + out.slice(region.end);
+    region = findSignatureRegion(out);
+  }
+  return out;
+}
+
 /** Return body HTML with its signature region replaced by `nextSignatureHtml`
- *  (or removed when null/empty), preserving all other content. */
+ *  (or removed when null/empty), preserving all other content. Always yields AT
+ *  MOST ONE region: the first region is replaced and any further regions are
+ *  stripped, so an orphaned or duplicated region (e.g. from a deleted node or a
+ *  legacy double-inserted draft) can never accumulate or ship (issue #656). */
 export function swapSignature(
   bodyHtml: string,
   nextSignatureHtml: string | null,
 ): string {
   const hasSig = nextSignatureHtml != null && nextSignatureHtml.trim() !== "";
-  const region = findRegion(bodyHtml);
+  const region = findSignatureRegion(bodyHtml);
   if (region) {
     const before = bodyHtml.slice(0, region.start);
-    const after = bodyHtml.slice(region.end);
-    return hasSig ? before + renderSignatureRegion(nextSignatureHtml!) + after : before + after;
+    const after = stripRegions(bodyHtml.slice(region.end));
+    return hasSig
+      ? before + renderSignatureRegion(nextSignatureHtml!) + after
+      : before + after;
   }
   return hasSig ? bodyHtml + renderSignatureRegion(nextSignatureHtml!) : bodyHtml;
 }


### PR DESCRIPTION
## What

Fixes the compose signature region's whole lifecycle (issue #656, PRD #634): duplicate signature on draft resume, an over-broad region matcher that destroyed pasted email HTML, orphaned/duplicate regions, and a preview hint that lied about the active signature.

## Why

- **Duplicate-on-resume (High):** `buildInitialBody` unconditionally prepended a fresh signature region even when resuming a draft that already had one. Only the first region was ever swapped, so the duplicate shipped to the recipient and re-persisted — compounding on every resume → edit → autosave cycle.
- **Over-broad matcher:** the matcher keyed on the `data-signature-block` substring via `\b…\b` word boundaries, so it matched the marker buried in any `class`/`id`/attribute value or a hyphenated suffix (`data-signature-block-foo`). Pasted or quoted email HTML containing that substring had its content destroyed on the next swap. The loose regex was duplicated in the template-insert path.
- **Orphaned region:** deleting the signature node could leave the body in a state where the next swap appended a duplicate instead of replacing.
- **Stale hint:** the preview read the legacy account column, so it lied after the user picked "No signature" or a non-default signature.

## How

- **Single, attribute-accurate matcher** in `signature-swap.ts`: `findSignatureRegion` parses each `<div>`'s attribute list and consumes quoted/unquoted values, so the marker is only matched as a real **attribute name** — never a substring in a value or a hyphenated suffix. `insert-template.ts` now imports it, so both paths share one matcher (no duplicated regex).
- **At-most-one-region invariant:** `swapSignature` replaces the first region and strips any extras, so an orphaned or legacy double-inserted region can never accumulate or ship — exactly one signature survives.
- **Resume authoritative:** `buildInitialBody` consults `hasSignatureRegion` and uses a resumed draft as-is, never prepending a second region.
- **Honest hint:** the preview reflects the active signature selection and only renders when the body still actually holds a region (so it stays truthful after "No signature" or an in-editor deletion).

## Verification

- New pure unit tests assert observable HTML behavior: substring decoys (class/id/hyphenated) left untouched by both swap and template-insert; duplicates collapsed to one; content preserved; clearing removes every region. 16/16 pure tests pass; full email suite 123/123; `tsc` adds no new errors in touched files.
- Reviewed adversarially (20-agent fan-out across matcher / invariant / integration / regression lenses); no High/Medium real defects found in the shipped logic.

## Known limitation

The signature region carries no owning-account id, so a draft saved with one account's signature but resumed under a different From account (or whose original account was later deactivated) shows a best-effort account *label* in the hint. The correct signature still **ships** (send uses the body HTML, not the label), and the hint never claims a signature the body doesn't contain. Recovering the exact label would require persisting the signature's account id in the region — out of scope here.

Closes #656. Refs #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
