### PR TITLE
fix(compose-email): draft autosave lifecycle — races, lost edits, reopen-discard, attachments, failure UX (#657)

### DIFF
--- a/src/app/api/email/drafts/route.ts
+++ b/src/app/api/email/drafts/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { withRequestContext } from "@/lib/request-context/with-request-context";
 
 // POST /api/email/drafts — save or update a draft
-// Body: { draftId?, accountId, to, cc, bcc, subject, bodyText, bodyHtml, jobId?, replyToMessageId? }
+// Body: { draftId?, accountId, to, cc, bcc, subject, bodyText, bodyHtml, jobId?, replyToMessageId?, attachments? }
 // Requires `send_email` (#105, PRD #95) — tightened from the logged-in-only
 // gate the #85 Request-Context conversion gave this previously-ungated route.
 export const POST = withRequestContext({ permission: "send_email" }, async (request, ctx) => {
@@ -17,6 +17,7 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
     bodyHtml,
     jobId,
     replyToMessageId,
+    attachments,
   } = await request.json();
 
   if (!accountId) {
@@ -63,7 +64,11 @@ export const POST = withRequestContext({ permission: "send_email" }, async (requ
     snippet: snippet || null,
     is_read: true,
     is_starred: false,
-    has_attachments: false,
+    // Report attachments honestly so the Drafts list shows the paperclip and
+    // doesn't claim "no attachments" for a draft that has them (issue #657 L1).
+    // NOTE: this only records the FLAG; persisting the email_attachments rows so
+    // a resumed draft re-hydrates its files is tracked as a follow-up.
+    has_attachments: Array.isArray(attachments) && attachments.length > 0,
     matched_by: jobId ? ("job_id" as const) : null,
     received_at: new Date().toISOString(),
   };

--- a/src/components/compose-email.tsx
+++ b/src/components/compose-email.tsx
@@ -15,6 +15,7 @@ import {
   Users,
   PenLine,
   FileText,
+  AlertCircle,
 } from "lucide-react";
 import { toast } from "sonner";
 import TiptapEditor from "@/components/tiptap-editor";
@@ -175,6 +176,11 @@ export default function ComposeEmailModal({
   // baselines each open). `armedRef` gates edits until the opened content has
   // settled, so opening (incl. an auto-inserted signature) never autosaves.
   const armedRef = useRef(false);
+  // Guards full re-initialization to the open transition only. A parent
+  // re-rendering with changed default props while the window is already open
+  // must NOT re-run the reset — that blew away the user's in-progress content,
+  // the draft id, and any pending autosave (issue #657 M5).
+  const initializedRef = useRef(false);
   const schedulerRef = useRef<DraftAutosaveScheduler | null>(null);
   if (schedulerRef.current === null) {
     schedulerRef.current = createDraftAutosaveScheduler({
@@ -204,9 +210,18 @@ export default function ComposeEmailModal({
       bodyHtml,
       jobId: jobId || undefined,
       replyToMessageId,
+      // Carry uploaded attachments so attaching one marks the draft dirty and
+      // the saved draft reports its attachments honestly (issue #657 L1).
+      attachments: uploadedFiles.length > 0 ? uploadedFiles : undefined,
     }),
-    [selectedAccountId, toRecipients, ccRecipients, bccRecipients, subject, bodyHtml, jobId, replyToMessageId],
+    [selectedAccountId, toRecipients, ccRecipients, bccRecipients, subject, bodyHtml, jobId, replyToMessageId, uploadedFiles],
   );
+  // Always-current snapshot builder for imperative callers (handleSend's failure
+  // paths), so resuming autosave after a failed send persists the LATEST content
+  // — including edits typed while the send was in flight — rather than the
+  // snapshot captured when handleSend's closure was created (issue #657 review).
+  const buildSnapshotRef = useRef(buildSnapshot);
+  buildSnapshotRef.current = buildSnapshot;
 
   // Signature data from email_signatures table
   const [signaturesMap, setSignaturesMap] = useState<Record<string, { signature_html: string; auto_insert: boolean }>>({});
@@ -348,7 +363,11 @@ export default function ComposeEmailModal({
   }
 
   useEffect(() => {
-    if (open) {
+    // Initialize ONLY on the open transition. Prop changes while the window is
+    // already open must not re-initialize and discard in-progress edits (#657
+    // M5); the close effect below re-arms this for the next open.
+    if (open && !initializedRef.current) {
+      initializedRef.current = true;
       // Each fresh open starts as the corner-docked panel.
       dispatchWindow({ type: "reset" });
       // Disarm autosave until the opened content has settled (see the baseline
@@ -436,6 +455,8 @@ export default function ComposeEmailModal({
               bodyHtml: initialBody,
               jobId: jobId || undefined,
               replyToMessageId,
+              attachments:
+                defaultAttachments.length > 0 ? defaultAttachments : undefined,
             },
             initialDraftId || null,
           );
@@ -463,6 +484,8 @@ export default function ComposeEmailModal({
       void schedulerRef.current?.flush();
       armedRef.current = false;
     }
+    // Allow a full re-initialization on the next open (issue #657 M5).
+    initializedRef.current = false;
   }, [open]);
 
   // Belt-and-suspenders: if the component unmounts while still armed (parent
@@ -551,6 +574,16 @@ export default function ComposeEmailModal({
 
     sendingRef.current = true;
     setSending(true);
+    // Settle autosave BEFORE sending: cancel() drops the pending edit (we're
+    // sending, not drafting), waits for any in-flight create to resolve, and
+    // returns the persisted draft id. This closes the race where sending during
+    // the first create-autosave read a null draftId (deleting nothing) while the
+    // in-flight create then inserted an orphan draft (issue #657 M1). Disarm so
+    // no autosave fires during the send; re-armed below only if the send fails.
+    const settledDraftId = (await schedulerRef.current?.cancel()) ?? null;
+    armedRef.current = false;
+    if (settledDraftId) setDraftId(settledDraftId);
+    const draftIdToDelete = settledDraftId ?? draftId ?? undefined;
     try {
       const res = await fetch("/api/email/send", {
         method: "POST",
@@ -566,7 +599,7 @@ export default function ComposeEmailModal({
           bodyHtml,
           replyToMessageId,
           attachments: uploadedFiles.length > 0 ? uploadedFiles : undefined,
-          draftId: draftId || undefined,
+          draftId: draftIdToDelete,
         }),
       });
 
@@ -575,23 +608,29 @@ export default function ComposeEmailModal({
         data = await res.json();
       } catch {
         toast.error(`Server error (${res.status}). Check email settings and try again.`);
+        // Resume autosave so the in-progress draft keeps saving after the error.
+        armedRef.current = true;
+        schedulerRef.current?.notifyChange(buildSnapshotRef.current());
         return;
       }
 
       if (res.ok) {
-        // The message was sent and the server deletes the backing draft (it was
-        // passed `draftId`). Cancel and disarm so the close handler below does
-        // NOT flush a pending edit back into a new draft for a sent message.
-        schedulerRef.current?.cancel();
-        armedRef.current = false;
+        // Sent — the server deleted the backing draft (passed `draftIdToDelete`).
+        // Autosave is already cancelled/disarmed above, so the close handler
+        // won't flush a pending edit back into a new draft for a sent message.
         toast.success("Email sent successfully.");
         onOpenChange(false);
         onSent?.();
       } else {
         toast.error(data.error || "Failed to send email.");
+        // The user stays in compose — resume autosave so further edits persist.
+        armedRef.current = true;
+        schedulerRef.current?.notifyChange(buildSnapshotRef.current());
       }
     } catch {
       toast.error("Network error sending email.");
+      armedRef.current = true;
+      schedulerRef.current?.notifyChange(buildSnapshotRef.current());
     } finally {
       sendingRef.current = false;
       setSending(false);
@@ -1079,6 +1118,14 @@ export default function ComposeEmailModal({
                 <Check size={12} className="text-green-600" />
                 <span>Saved</span>
               </>
+            )}
+            {autosaveStatus === "error" && (
+              // A failed autosave must read as a distinct, visible "not saved"
+              // state — never silently fall back to idle (issue #657 L2).
+              <span className="flex items-center gap-1.5 text-red-600">
+                <AlertCircle size={12} />
+                <span>Not saved — will retry</span>
+              </span>
             )}
           </div>
         </div>

--- a/src/lib/email/draft-autosave.test.ts
+++ b/src/lib/email/draft-autosave.test.ts
@@ -125,19 +125,144 @@ describe("createDraftAutosaveScheduler", () => {
     expect(save).toHaveBeenCalledTimes(1);
   });
 
-  it("cancel() drops a pending edit so no save fires (send)", async () => {
+  it("flush() waits for an in-flight save, then persists the newest pending edit (no lost last edit on close)", async () => {
+    // Close while a create is still in flight AND a newer edit is pending. The
+    // old flush resolved instantly (the in-flight save blocked runSave), so the
+    // newest edit was never saved and the in-flight save then re-armed a timer
+    // that fired after the window closed (issue #657 M2).
+    let resolveCreate!: (r: { id: string }) => void;
+    const createPromise = new Promise<{ id: string }>((r) => {
+      resolveCreate = r;
+    });
+    const save = vi
+      .fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>()
+      .mockReturnValueOnce(createPromise)
+      .mockResolvedValue({ id: "draft-3" });
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "First" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE); // create fires, stays in flight
+    expect(save).toHaveBeenCalledTimes(1);
+
+    // A newer edit arrives while the create is still in flight.
+    scheduler.notifyChange(snap({ subject: "Newest" }));
+
+    // Close: flush must persist the newest edit — not resolve instantly.
+    const flushing = scheduler.flush();
+    resolveCreate({ id: "draft-3" });
+    await flushing;
+
+    expect(save).toHaveBeenCalledTimes(2);
+    expect(save.mock.calls[1][0]).toMatchObject({
+      subject: "Newest",
+      draftId: "draft-3", // the newest edit updates the just-created draft
+    });
+
+    // No autosave fires after the window has closed.
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancel() drops a pending edit so no save fires, and resolves null when no draft was ever created (send)", async () => {
     const save = vi.fn(async () => ({ id: "draft-1" }));
     const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
     scheduler.reset(snap());
 
     scheduler.notifyChange(snap({ subject: "Discard me" }));
-    scheduler.cancel();
+    // The common no-in-flight branch must resolve null (no backing draft to
+    // delete), not float an unawaited promise or return garbage.
+    const settledId = await scheduler.cancel();
+    expect(settledId).toBeNull();
 
     await vi.advanceTimersByTimeAsync(DEBOUNCE);
     expect(save).not.toHaveBeenCalled();
   });
 
-  it("keeps the edit pending and does not mark saved when a save fails", async () => {
+  it("cancel() awaits an in-flight create and resolves the real draft id (no sent-draft orphan)", async () => {
+    // Sending while the FIRST create-autosave is still in flight: the send must
+    // learn the real draft id so it can delete the backing draft, and no second
+    // save may fire afterward to insert an orphan (issue #657 M1).
+    let resolveCreate!: (r: { id: string }) => void;
+    const createPromise = new Promise<{ id: string }>((r) => {
+      resolveCreate = r;
+    });
+    const save = vi
+      .fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>()
+      .mockReturnValueOnce(createPromise)
+      .mockResolvedValue({ id: "draft-7" });
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "A" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE); // create fires, stays in flight
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(scheduler.getDraftId()).toBeNull(); // id not known yet
+
+    // User hits send while the create is still in flight.
+    const settled = scheduler.cancel();
+    resolveCreate({ id: "draft-7" });
+    const settledId = await settled;
+
+    // The send now knows the real draft id to delete.
+    expect(settledId).toBe("draft-7");
+    expect(scheduler.getDraftId()).toBe("draft-7");
+
+    // No further autosave fires after cancel — nothing to orphan.
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats attaching a file as a dirty edit and carries the attachments in the saved payload", async () => {
+    // The draft snapshot must include uploaded attachments so attaching one
+    // marks the draft dirty (autosaves) and the persisted draft can report its
+    // attachments honestly rather than hardcoding "none" (issue #657 L1).
+    const save = vi.fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>(
+      async () => ({ id: "draft-1" }),
+    );
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap()); // opened with no attachments
+
+    const file = {
+      filename: "quote.pdf",
+      content_type: "application/pdf",
+      file_size: 1234,
+      storage_path: "drafts/1-quote.pdf",
+    };
+    scheduler.notifyChange(snap({ attachments: [file] }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0].attachments).toEqual([file]);
+  });
+
+  it("reset() rescues a still-pending edit by saving it before re-baselining (reopen never drops edits)", async () => {
+    // A debounced edit is waiting when the window re-baselines (reopen, or a
+    // parent re-render with changed default props). The old reset dropped that
+    // pending edit with no save; it must be persisted first (issue #657 M5).
+    const save = vi.fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>(
+      async () => ({ id: "draft-1" }),
+    );
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap()); // opened
+    scheduler.notifyChange(snap({ subject: "Half-typed" })); // armed, not yet fired
+    expect(save).not.toHaveBeenCalled();
+
+    // Re-baseline before the debounce window elapses.
+    scheduler.reset(snap({ subject: "Reopened content" }), "draft-1");
+    await vi.advanceTimersByTimeAsync(0); // let the rescue save run
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save.mock.calls[0][0]).toMatchObject({ subject: "Half-typed" });
+
+    // The new baseline is adopted: a snapshot equal to it stays clean (the
+    // rescue's late save must not have clobbered the freshly-set baseline).
+    scheduler.notifyChange(snap({ subject: "Reopened content" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a visible 'error' state when a save fails, never 'saved', and keeps the edit", async () => {
     const save = vi
       .fn<() => Promise<{ id: string }>>()
       .mockRejectedValueOnce(new Error("network"))
@@ -148,7 +273,9 @@ describe("createDraftAutosaveScheduler", () => {
     scheduler.notifyChange(snap({ subject: "Retry me" }));
     await vi.advanceTimersByTimeAsync(DEBOUNCE);
     expect(save).toHaveBeenCalledTimes(1);
-    expect(scheduler.getStatus()).toBe("idle"); // never "saved" on failure
+    // A failed save must not read as "saved"; it surfaces a distinct, visible
+    // "not saved" state so the user is not misled (issue #657 L2).
+    expect(scheduler.getStatus()).toBe("error");
     expect(scheduler.getDraftId()).toBeNull();
 
     // The edit isn't lost — flushing on close retries it and succeeds.
@@ -156,5 +283,57 @@ describe("createDraftAutosaveScheduler", () => {
     expect(save).toHaveBeenCalledTimes(2);
     expect(scheduler.getStatus()).toBe("saved");
     expect(scheduler.getDraftId()).toBe("draft-1");
+  });
+
+  it("clears the stale 'error' state when a failed edit is reverted back to clean (no lingering 'Not saved')", async () => {
+    // A save fails (status 'error', the edit held as pending). The user then
+    // deletes the edit, returning to the saved baseline. There is now nothing to
+    // persist, so the 'Not saved — will retry' badge must clear rather than stick
+    // forever on a draft that has no pending change (issue #657 review).
+    const save = vi
+      .fn<() => Promise<{ id: string }>>()
+      .mockRejectedValue(new Error("offline"));
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap());
+
+    scheduler.notifyChange(snap({ subject: "Oops" }));
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(scheduler.getStatus()).toBe("error");
+
+    // Revert all the way back to the (empty) baseline.
+    scheduler.notifyChange(snap());
+    await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    expect(scheduler.getStatus()).not.toBe("error");
+    // Nothing pending → no retry spin.
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failed reset-rescue stays isolated: it never re-targets the freshly-adopted draft nor leaks its status into the new session", async () => {
+    // A reused scheduler re-baselines across compose sessions. When reset()
+    // rescues a pending edit from the OLD draft and that rescue save FAILS, it
+    // must not (a) resurface as the NEW session's 'error' status, nor (b) be
+    // re-saved against the new draft id, clobbering it with stale content
+    // (issue #657 review: cross-draft clobber + status leak).
+    const save = vi
+      .fn<(p: DraftSavePayload) => Promise<DraftSaveResult>>()
+      .mockRejectedValueOnce(new Error("rescue failed")) // the rescue save fails
+      .mockResolvedValue({ id: "draft-new" });
+    const scheduler = createDraftAutosaveScheduler({ save, debounceMs: DEBOUNCE });
+    scheduler.reset(snap({ subject: "Base0" }), "draft-old");
+
+    scheduler.notifyChange(snap({ subject: "OldStale" })); // pending vs draft-old
+    // Re-baseline to a DIFFERENT draft before the debounce fires.
+    scheduler.reset(snap({ subject: "Reopened" }), "draft-new");
+    await vi.advanceTimersByTimeAsync(0); // let the failing rescue settle
+
+    // The fresh session is not showing the old draft's failure.
+    expect(scheduler.getStatus()).not.toBe("error");
+
+    // A close-flush must not write the stale "OldStale" content onto draft-new.
+    await scheduler.flush();
+    const wroteStaleToNew = save.mock.calls.some(
+      ([p]) => p.subject === "OldStale" && p.draftId === "draft-new",
+    );
+    expect(wroteStaleToNew).toBe(false);
   });
 });

--- a/src/lib/email/draft-autosave.ts
+++ b/src/lib/email/draft-autosave.ts
@@ -19,7 +19,20 @@
 
 const DEFAULT_DEBOUNCE_MS = 2000;
 
-export type DraftSaveStatus = "idle" | "saving" | "saved";
+// "error" surfaces a failed autosave as a visible "not saved" state, distinct
+// from saving/saved, so the user is never misled into believing a draft saved
+// (issue #657 L2).
+export type DraftSaveStatus = "idle" | "saving" | "saved" | "error";
+
+/** A draft attachment already uploaded to storage (the /attachments/upload
+ *  response shape). Carried in the snapshot so attaching marks the draft dirty
+ *  and the saved draft can report its attachments honestly (issue #657 L1). */
+export interface DraftAttachment {
+  filename: string;
+  content_type: string;
+  file_size: number;
+  storage_path: string;
+}
 
 /** The compose fields the scheduler watches and serializes into a save. */
 export interface DraftSnapshot {
@@ -32,6 +45,7 @@ export interface DraftSnapshot {
   bodyHtml: string;
   jobId?: string;
   replyToMessageId?: string;
+  attachments?: DraftAttachment[];
 }
 
 /** Body POSTed to /api/email/drafts; draftId present only on update. */
@@ -61,8 +75,10 @@ export interface DraftAutosaveScheduler {
   notifyChange(snapshot: DraftSnapshot): void;
   /** Persist any pending change immediately (used on close). */
   flush(): Promise<void>;
-  /** Drop any pending change without saving (used on send). */
-  cancel(): void;
+  /** Drop any pending change without saving, wait for any in-flight save to
+   *  settle, and resolve the persisted draft id (used on send, so the caller
+   *  can delete the right draft and no in-flight create orphans one). */
+  cancel(): Promise<string | null>;
   getStatus(): DraftSaveStatus;
   getDraftId(): string | null;
 }
@@ -79,6 +95,9 @@ function serialize(s: DraftSnapshot): string {
     s.bodyHtml,
     s.jobId ?? "",
     s.replyToMessageId ?? "",
+    // Identity by storage path: attaching/removing a file is a dirty edit, but
+    // re-uploading the same set is not.
+    (s.attachments ?? []).map((a) => a.storage_path),
   ]);
 }
 
@@ -100,6 +119,10 @@ export function createDraftAutosaveScheduler(
   // not start a second one, or two concurrent creates would each insert a draft
   // (the first hasn't returned its id yet) — duplicate drafts.
   let inFlight = false;
+  // The promise of the save currently in flight, so close (flush) and send
+  // (cancel) can await it — learning the created draft id and never racing a
+  // second save past it (issue #657).
+  let inFlightDone: Promise<void> | null = null;
 
   function setStatus(next: DraftSaveStatus) {
     if (status === next) return;
@@ -122,51 +145,98 @@ export function createDraftAutosaveScheduler(
     }, debounceMs);
   }
 
-  async function runSave(): Promise<void> {
-    if (pending === null) return;
-    // A save is already in flight — leave `pending` set; the in-flight save's
-    // finally block reschedules once it has the draft id.
-    if (inFlight) return;
-
-    const snapshot = pending;
-    pending = null;
+  // Persist one snapshot on the normal autosave path: on success it adopts the
+  // returned draft id and advances the saved baseline (so the saved content is
+  // now "clean"). The reset rescue does NOT go through here — it uses the
+  // isolated rescueSave below precisely so it can't advance this baseline or
+  // status (issue #657 review).
+  function doSave(snapshot: DraftSnapshot): Promise<void> {
     inFlight = true;
     setStatus("saving");
-    let failed = false;
-    try {
-      const payload: DraftSavePayload = {
-        ...snapshot,
-        draftId: draftId ?? undefined,
-      };
-      const result = await opts.save(payload);
-      draftId = result.id;
-      baseline = snapshot;
-      baselineKey = serialize(snapshot);
-      setStatus("saved");
-    } catch {
-      // A failed save must not surface as "Saved" or escape as an unhandled
-      // rejection. Preserve the unsaved snapshot so a later edit or the
-      // flush-on-close retries it, and return to idle. We deliberately do NOT
-      // auto-reschedule here — that would spin every debounce on a persistent
-      // failure (e.g. a 400). The next edit/flush is the retry trigger.
-      failed = true;
-      if (pending === null) pending = snapshot;
-      setStatus("idle");
-    } finally {
-      inFlight = false;
-      // A genuinely newer edit arrived mid-save — debounce and save it (now
-      // with the draft id). Skipped on the failure path to avoid a retry spin.
-      if (!failed && pending !== null) schedule();
-    }
+    const run = async () => {
+      let failed = false;
+      try {
+        const payload: DraftSavePayload = {
+          ...snapshot,
+          draftId: draftId ?? undefined,
+        };
+        const result = await opts.save(payload);
+        draftId = result.id;
+        baseline = snapshot;
+        baselineKey = serialize(snapshot);
+        setStatus("saved");
+      } catch {
+        // A failed save must not surface as "Saved" or escape as an unhandled
+        // rejection. Preserve the unsaved snapshot so a later edit or the
+        // flush-on-close retries it, and surface a visible "not saved" state
+        // (issue #657 L2). We deliberately do NOT auto-reschedule here — that
+        // would spin every debounce on a persistent failure (e.g. a 400). The
+        // next edit/flush is the retry trigger.
+        failed = true;
+        if (pending === null) pending = snapshot;
+        setStatus("error");
+      } finally {
+        inFlight = false;
+        // A genuinely newer edit arrived mid-save — debounce and save it (now
+        // with the draft id). Skipped on the failure path to avoid a retry spin.
+        if (!failed && pending !== null) schedule();
+      }
+    };
+    inFlightDone = run();
+    return inFlightDone;
+  }
+
+  // Fire-and-forget rescue of a pending edit when reset() re-baselines (reopen /
+  // changed props). It persists the edit against the CURRENT (old) draft id,
+  // best-effort, WITHOUT touching the new session's shared status, in-flight
+  // tracking, or `pending`. That isolation is deliberate: a single scheduler
+  // instance is reused across compose sessions (the modal stays mounted, only
+  // `open` toggles), so the rescue's own success/failure must never leak into
+  // the freshly-adopted draft's status, nor — on failure — be re-stashed and
+  // later re-saved against the NEW draft id, clobbering it with stale content
+  // (issue #657 review: cross-draft clobber + status leak across a reused
+  // instance). Captured `rescueDraftId` is read synchronously, before reset()
+  // adopts the new id, so the rescue always targets the draft the edit belongs to.
+  function rescueSave(snapshot: DraftSnapshot): void {
+    const rescueDraftId = draftId;
+    void (async () => {
+      try {
+        await opts.save({ ...snapshot, draftId: rescueDraftId ?? undefined });
+      } catch {
+        /* best-effort; never re-stash or surface — see above */
+      }
+    })();
+  }
+
+  // Save the current pending edit (the normal debounced/flush path). A no-op
+  // when clean; when a save is already in flight, returns that save's promise
+  // so callers can await it without starting a second create.
+  function runSave(): Promise<void> {
+    if (pending === null) return Promise.resolve();
+    // A save is already in flight — leave `pending` set; the in-flight save's
+    // finally block reschedules once it has the draft id.
+    if (inFlight) return inFlightDone ?? Promise.resolve();
+    const snapshot = pending;
+    pending = null;
+    return doSave(snapshot);
   }
 
   return {
     reset(newBaseline, newDraftId) {
       clearTimer();
+      // Rescue a still-pending (debounced) edit before the reopened content
+      // takes over, so a reopen never silently drops the user's latest change
+      // (issue #657 M5). The rescue is isolated (see rescueSave): it targets the
+      // OLD draft and can neither leak its status into the new session nor clobber
+      // the freshly-adopted baseline. A save already in flight owns its own
+      // snapshot, so we don't start a nested save under it here.
+      if (pending !== null && !inFlight) rescueSave(pending);
       pending = null;
       baseline = newBaseline;
       baselineKey = serialize(newBaseline);
       if (newDraftId !== undefined) draftId = newDraftId;
+      // A (re)open is a fresh session: reset the visible status to idle. The
+      // rescue (if any) runs silently and never drives this indicator.
       setStatus("idle");
     },
 
@@ -182,6 +252,14 @@ export function createDraftAutosaveScheduler(
         // Back to clean (e.g. an edit was reverted) — drop the pending save.
         pending = null;
         clearTimer();
+        // If the last save FAILED, reverting all the way back to the saved
+        // baseline leaves nothing to persist — clear the stale "error" so the
+        // "Not saved — will retry" badge doesn't stick forever on a draft that
+        // has no pending change and will never retry (issue #657 review). A
+        // genuine in-flight save owns its own status, so don't disturb it.
+        if (status === "error" && !inFlight) {
+          setStatus(draftId !== null ? "saved" : "idle");
+        }
         return;
       }
       pending = snapshot;
@@ -190,12 +268,43 @@ export function createDraftAutosaveScheduler(
 
     async flush() {
       clearTimer();
+      // If a save is already running, wait for it to settle first (so we don't
+      // start a duplicate create), THEN persist whatever is still pending — the
+      // newest edit at close time, which the in-flight save did not include
+      // (issue #657 M2). Without the await, flush resolved instantly and the
+      // last edit was lost while the in-flight save re-armed a post-close timer.
+      if (inFlight && inFlightDone) {
+        try {
+          await inFlightDone;
+        } catch {
+          /* doSave swallows its own errors; never rejects */
+        }
+      }
+      // The settled save may have re-armed the debounce for the pending edit;
+      // cancel it and persist synchronously so nothing fires after close.
+      clearTimer();
       await runSave();
     },
 
-    cancel() {
+    async cancel() {
+      clearTimer();
+      // Drop the pending edit — send discards the draft, it must not be saved.
+      pending = null;
+      // Wait for any in-flight save to settle so its created draft id is known
+      // (the send needs it to delete the draft) and no second save inserts an
+      // orphan after the message is sent (issue #657 M1).
+      if (inFlight && inFlightDone) {
+        try {
+          await inFlightDone;
+        } catch {
+          /* doSave swallows its own errors; never rejects */
+        }
+      }
+      // The in-flight save's finally may have re-armed a timer if a new edit
+      // slipped in; clear it and re-drop so nothing autosaves post-send.
       clearTimer();
       pending = null;
+      return draftId;
     },
 
     getStatus() {


### PR DESCRIPTION
## Closes #657

Fixes five compounding draft-autosave defects in the floating compose window (PRD #634), all rooted in how the pure scheduler handles the create / save / close / send races.

## The five defects

| | Defect | Fix |
|---|---|---|
| **M1** | Sending during the first "create draft" autosave deleted nothing (send read a still-null draft id) and the in-flight create then orphaned a draft. | `cancel()` awaits the in-flight create and resolves the real draft id; `handleSend` deletes that id. Sending mid-create now leaves **zero** leftover draft rows. |
| **M2** | The close-time flush resolved instantly when a save was already in flight, so the newest edit was never persisted and the in-flight save re-armed a post-close timer. | `flush()` awaits the in-flight save, then persists whatever is still pending, cancelling any re-armed timer. |
| **M5** | Reopening — or a parent re-render with changed default props while open — re-ran `reset()` and dropped the debounced edit. | `reset()` rescues a pending edit before re-baselining, **and** the shell gates full re-init to the open transition (`initializedRef`) so a prop change while open no longer wipes content/draft id. |
| **L1** | The snapshot omitted attachments and the drafts route hardcoded `has_attachments: false`. | The snapshot carries uploaded attachments (keyed by storage path, so attaching is a dirty edit) and the route reports `has_attachments` honestly. |
| **L2** | A failed autosave silently returned to idle. | A distinct `"error"` status renders a visible red "Not saved — will retry". |

## Confirm-don't-change item

The issue asked to confirm the send-route draft delete is still RLS-authorized. **Confirmed, unchanged:** the delete runs on the user-scoped (RLS-enforced) `ctx.supabase` client — `serviceClient: true` only *adds* `ctx.serviceClient`, used elsewhere for cross-org account resolution. The `emails_track_parent_account` policy (`FOR ALL`) authorizes the delete iff the caller can see the draft's parent account, which the handler already proved by selecting that account on the same client. No code change.

## L1 scope / follow-up

This slice does the **honest minimal** fix per the acceptance criterion: it stops misreporting "no attachments". Full draft-attachment **persistence + resume restore** (writing `email_attachments` rows, joining on the drafts list, re-hydrating on resume) is a larger schema/lifecycle decision tracked in **#663**. A resumed draft does not yet re-attach its files.

## Behavior change worth calling out

M5 adds `initializedRef` so the open effect only fully initializes on the `open` false→true transition. Previously it re-ran whenever any `default*` prop changed while the window was open, which reset the draft id to null (causing duplicate-draft creation) and blew away typed content. Prop changes while open are now ignored until the next open.

## Adversarial review hardening

After the functional fixes, a multi-agent review surfaced three reachable edge cases, now fixed (each TDD):

1. **Stuck "error" badge** — reverting a failed edit back to the baseline left "Not saved — will retry" lingering forever with nothing pending. The clean-revert path now clears it.
2. **Rescue leak/clobber on the reused scheduler instance** — the modal stays mounted and one scheduler is reused across sessions; a failed reset-rescue could re-stash stale content that later clobbered a *different* draft, and leaked status into a fresh session. The rescue is now an isolated `rescueSave` that targets the old draft best-effort and never touches shared status/pending.
3. **Send-failure stale snapshot** — resuming autosave after a failed send fed the render-time snapshot, dropping edits typed during the in-flight send. It now feeds the latest snapshot via a ref.

A focused re-verification of these three fixes found no new races, lost edits, or orphans, and confirmed the M1/M2/normal save paths are unchanged.

## Tests / verification

- Pure scheduler unit tests: **12/12** (M1, M2, M5, L1, L2, plus revert-to-clean, rescue-isolation, and the `cancel()`-returns-null assertion).
- Email lib + API suite: **31 files / 222 tests** pass.
- `tsc --noEmit`: no errors in any touched file.
- ESLint: clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
