### PR TITLE
docs(adr): new-intake push notifications design (ADR 0016) + glossary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -135,6 +135,26 @@ two-party-consent jurisdictions. The initiating party hears it before the dial;
 the answering party hears the same line via a per-leg whisper.
 _Avoid_: disclaimer, warning, disclosure
 
+**Intake**:
+The hand-logging of a new customer lead: a member fills out the **New Customer
+Intake** form (`/intake`, `intake-form.tsx`) when a lead comes in, and a single
+submit creates the **Job** along with its **Contact**, any adjuster link, custom
+fields, and a first "Intake notes" activity. "An intake" means both the act and
+the Job it produces — the moment a Job is born by hand, distinct from Jobs created
+as a side effect elsewhere (e.g. from a payment or a Referral Partner's job list).
+Submitting an intake is the event that buzzes the rest of the team — see
+[ADR 0016](docs/adr/0016-new-intake-push-notifications.md).
+_Avoid_: lead, prospect, enquiry, ticket; "new job" (that names the resulting record, not the act)
+
+**Urgency**:
+A Job's response-time tier — one of three fixed values, `emergency`, `urgent`, or
+`scheduled` (the default) — chosen on the **Intake** form and shown thereafter as a
+colored badge (shared `urgencyLabels`/`urgencyColors`). It says how fast the team
+must move, not where the Job sits in its lifecycle (that is its **status**): the
+Jobs page floats emergencies to the top, and the new-intake notification speaks the
+tier — an 🚨 emergency leads the title, and each tier carries its own sound.
+_Avoid_: priority, severity, importance (fine in UI copy)
+
 **Active job**:
 A job that is still alive — its status is neither `completed` nor `cancelled`,
 and it has not been trashed (`deleted_at IS NULL`). A cancelled job is dead,
@@ -354,6 +374,7 @@ _Avoid_: site integration, WP hookup, website sync
 - A **Job tag** ties one text or call event to exactly zero or one **Job**. A single Conversation may contain events with several different Job tags (or none).
 - A **Call recording** belongs to exactly one answered voice call (one recording per call); deleting the call cascades the recording, and deleting the recording also hard-deletes it on Twilio. Whether a call records is governed per **Organization** by `recording_enabled_default`, overridable per call on the outbound bridge — see [ADR 0006](docs/adr/0006-twilio-as-telephony-backbone.md).
 - A row on the Referral Partners call list belongs to one **Organization** and is called either a **Target** or a **Referral Partner** depending on its **Lifecycle status** — same row, different name.
+- An **Intake** produces exactly one **Job** (and the **Contact** it belongs to) in a single submit; that submission is what notifies the rest of the team of the new Job, carrying its **Urgency** tier — see [ADR 0016](docs/adr/0016-new-intake-push-notifications.md).
 - A **Job** has zero or one referring **Referral Partner** (the Partner who sent the job our way). Only Active rows are eligible — see [ADR 0002](docs/adr/0002-only-active-partners-attach-to-jobs.md).
 - A **Job** has zero or more **Estimates**; each Estimate converts into at most one **Invoice**, and every Invoice is born from exactly one Estimate — conversion is the only way to create one. A deposit or staged payment is a partial payment on that single Invoice, not an additional Invoice. See [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md).
 - An **Estimate** or **Invoice** has zero or one **PDF layout** of its own; with none it renders using its Organization's **default preset**. A document's own layout always wins over the default, resolved by a pure precedence rule, and is locked once the document is frozen (Estimate converted, Invoice paid or voided). A **PDF preset** belongs to one **Organization** and seeds a document's layout; applying one copies its preferences in, it is not a binding link.

--- a/docs/adr/0016-new-intake-push-notifications.md
+++ b/docs/adr/0016-new-intake-push-notifications.md
@@ -1,0 +1,46 @@
+# New-intake push notifications: client-triggered send, direct to APNs
+
+**Status:** accepted (2026-06-15)
+
+When a member submits the **New Customer Intake** form, the rest of the team is
+notified on their iPhones that a new Job came in. Two shape decisions are worth
+recording because a future reader would otherwise assume the opposite.
+
+## Decision
+
+- The notification is **fired from the client.** After the intake form's existing
+  client-side Job insert succeeds, it calls a server route that fans out the in-app
+  **notification** rows and sends the push. We did *not* put a database trigger on
+  `jobs` insert.
+- Push is sent **directly to Apple (APNs)** from our own server using one APNs auth
+  key — no Firebase/OneSignal middleman, no edge function.
+- Audience is every active member of the **Organization** except the submitter.
+  Delivery rides Capacitor's push plugin on the iOS app only: web/desktop sessions
+  and devices that never enrolled get the in-app bell, not a buzz. The buzz's title
+  and sound vary by the Job's **Urgency** (`emergency` / `urgent` / `scheduled`).
+
+## Considered options
+
+- **Database trigger → edge function** (guaranteed, server-authoritative). Rejected
+  for v1: it needs a new `created_via` discriminator on `jobs` (there is none — a raw
+  insert trigger can't tell an intake from any other Job insert), the repo's
+  first-ever Supabase edge function, `pg_net`, and APNs creds in the edge runtime.
+  Too much new machinery for the first slice.
+- **Move Job creation server-side** (transactional notify). Rejected for v1: it means
+  rebuilding a working multi-insert client form for no user-visible gain yet.
+- **Firebase / OneSignal** (helper service). Rejected: the team is iPhone-only and
+  internal, so the dashboards and easy-Android reach a service buys aren't worth a
+  third party in the data path and an extra SDK in the app.
+
+## Consequences
+
+- The send is **best-effort.** If the submitter's client dies between the Job insert
+  and the server call, that Job is still saved (and visible in the jobs list) but no
+  buzz or bell is emitted for it. Acceptable while intakes are low-volume and
+  internal; revisit with the DB-trigger option if a missed buzz ever costs a lead.
+- We now hold an APNs auth key as a server secret and a `device_tokens` table (one
+  row per member per device) that must be refreshed and pruned as Apple invalidates
+  tokens.
+- "Critical Alerts" (break-through-silent-mode), per-person opt-out, and a per-person
+  sound picker are deliberately **out of v1** — see the feature's PRD. Sounds still
+  differ by Urgency tier.


### PR DESCRIPTION
Records the outcome of the `/grill-with-docs` session for #667.

## What's here
- **`docs/adr/0016-new-intake-push-notifications.md`** — captures the two non-obvious architecture choices: client-triggered send (the intake form taps a server route after its existing client-side Job insert; best-effort, not a DB trigger) and direct-to-APNs with one auth key (no Firebase/OneSignal). Plus rejected alternatives (DB-trigger→edge fn, server-side Job creation) and the best-effort consequence.
- **`CONTEXT.md`** — two new domain terms surfaced during the grill: **Intake** (the hand-logging act and the Job it produces) and **Urgency** (the emergency/urgent/scheduled response tier driving the buzz), plus a relationships bullet tying an Intake to the single Job/Contact it creates and the team notification it fires.

Docs-only; no code changes. The implementation is broken out into #669–#673 under parent #667.

🤖 Generated with [Claude Code](https://claude.com/claude-code)