### PR TITLE
fix(email): harden body-HTML sanitizer vs invisible-char scheme smuggling + SVG data-URIs (#658)

### DIFF
--- a/src/lib/email/sanitize-email-html.test.ts
+++ b/src/lib/email/sanitize-email-html.test.ts
@@ -115,3 +115,66 @@ describe("sanitizeEmailHtmlForStorage", () => {
     expect(swapped).toContain("Hello");
   });
 });
+
+// Regressions from the #658 adversarial review: payloads that survived the
+// first cut of the allowlist (PR #665) and drove two follow-up hardenings —
+// invisible-character scheme smuggling, and SVG/non-raster data-URI images.
+describe("sanitizeEmailHtml — adversarial hardenings (#658 review)", () => {
+  it("drops a scheme hidden behind a leading BOM / zero-width char", () => {
+    // A leading U+FEFF (or a U+200B inside the scheme) defeats sanitize-html's
+    // scheme check, but a browser strips it on click — a parser-differential XSS.
+    const bom = sanitizeEmailHtmlForSend(
+      '<a href="\uFEFFjavascript:alert(1)">c</a>',
+    );
+    expect(bom).not.toMatch(/javascript:/i);
+    expect(bom).not.toContain("alert");
+    expect(bom).toContain("c");
+
+    const zwsp = sanitizeEmailHtmlForSend(
+      '<a href="java\u200Bscript:alert(1)">c</a>',
+    );
+    expect(zwsp).not.toMatch(/javascript:/i);
+
+    const vb = sanitizeEmailHtmlForSend(
+      '<a href="\uFEFFvbscript:msgbox(1)">c</a>',
+    );
+    expect(vb).not.toMatch(/vbscript:/i);
+  });
+
+  it("leaves a clean URL untouched (the noise-strip is lossless)", () => {
+    const ok = sanitizeEmailHtmlForSend(
+      '<a href="https://example.com/path?q=1">c</a>',
+    );
+    expect(ok).toContain('href="https://example.com/path?q=1"');
+  });
+
+  it("also hardens the storage path (shared buildOptions)", () => {
+    const out = sanitizeEmailHtmlForStorage(
+      '<a href="\uFEFFjavascript:alert(1)">c</a>',
+    );
+    expect(out).not.toMatch(/javascript:/i);
+  });
+
+  it("drops SVG and other non-raster data-URI images, keeps raster", () => {
+    // <img>-loaded SVG runs script-disabled in browsers and most mail clients
+    // block it, but SVG is the one markup/script-bearing image type, so the
+    // allowlist no longer admits it (the editor only ever emits raster images).
+    const svg = sanitizeEmailHtmlForSend(
+      '<img src="data:image/svg+xml;base64,PHN2Zz48c2NyaXB0PmFsZXJ0KDEpPC9zY3JpcHQ+PC9zdmc+"><p>after</p>',
+    );
+    expect(svg).not.toMatch(/svg\+xml/i);
+    expect(svg).not.toContain("<img");
+    expect(svg).toContain("<p>after</p>");
+
+    const texthtml = sanitizeEmailHtmlForSend(
+      '<img src="data:text/html;base64,PHNjcmlwdD4="><p>after</p>',
+    );
+    expect(texthtml).not.toContain("<img");
+    expect(texthtml).toContain("<p>after</p>");
+
+    const png = sanitizeEmailHtmlForSend(
+      '<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==">',
+    );
+    expect(png).toContain("data:image/png;base64,");
+  });
+});

--- a/src/lib/email/sanitize-email-html.ts
+++ b/src/lib/email/sanitize-email-html.ts
@@ -69,6 +69,34 @@ const ALLOWED_STYLES: sanitizeHtml.IOptions["allowedStyles"] = {
   },
 };
 
+// Characters a browser silently strips when it RESOLVES a clicked URL, but
+// which defeat sanitize-html's up-front scheme check: C0 controls + tab/CR/LF
+// (U+0000–U+001F), DEL (U+007F), NBSP (U+00A0), the zero-width / word-joiner /
+// bidi-control range (U+200B–U+200F, U+202A–U+202E, U+2060, U+2066–U+2069), and
+// the BOM (U+FEFF). Left in the value, a leading-BOM "U+FEFF javascript:" or a
+// zero-width "java U+200B script:" href has no recognized scheme, so
+// sanitize-html keeps it as if it were relative — then it re-forms into an
+// executable `javascript:` in the renderer. That is a classic
+// parser-differential XSS, and it survives the allowlist below until the noise
+// is removed. We strip these from href/src BEFORE the scheme allowlist runs
+// (issue #658 adversarial review). A real URL never contains them, so the strip
+// is lossless for legitimate content.
+const URL_NOISE =
+  /[\u0000-\u001F\u007F\u00A0\u200B-\u200F\u202A-\u202E\u2060\u2066-\u2069\uFEFF]/g;
+function cleanUrlAttr(value: string): string {
+  return value.replace(URL_NOISE, "").trim();
+}
+
+// `data:` is allowed for <img> src (pasted base64), but sanitize-html's scheme
+// check does not inspect the media type — so `data:image/svg+xml` (a
+// script/markup container) and `data:text/html` both pass it. The compose
+// editor only ever emits raster screenshots/photos, so an <img> data URI must
+// additionally be a genuine raster type; an http(s) URL is always fine. This
+// drops SVG — the one image type that can carry markup/active content — at no
+// legitimate-use cost (issue #658 adversarial review).
+const IMG_SRC_OK =
+  /^(?:https?:\/\/|data:image\/(?:png|jpe?g|gif|webp);base64,)/i;
+
 // Internal markers the compose editor round-trips: the signature region's
 // delimiter (#643) and the indent level (#642). They must SURVIVE storage so a
 // resumed draft can re-locate and swap its signature region, but must NOT ship
@@ -97,6 +125,30 @@ function buildOptions(preserveInternalMarkers: boolean): sanitizeHtml.IOptions {
     // Pasted images come through as base64 data URIs (editor allowBase64);
     // `data:` is only ever honored for <img> src, never for links.
     allowedSchemesByTag: { img: ["http", "https", "data"] },
+    // Strip URL-noise from href/src BEFORE sanitize-html evaluates the scheme,
+    // so invisible-character scheme smuggling collapses to the real scheme and
+    // is then rejected by the allowlist above (issue #658 adversarial review).
+    transformTags: {
+      a: (tagName, attribs) => {
+        if (typeof attribs.href === "string") {
+          attribs.href = cleanUrlAttr(attribs.href);
+        }
+        return { tagName, attribs };
+      },
+      img: (tagName, attribs) => {
+        if (typeof attribs.src === "string") {
+          attribs.src = cleanUrlAttr(attribs.src);
+        }
+        return { tagName, attribs };
+      },
+    },
+    // Reject any <img> whose src is not a remote URL or a genuine raster data
+    // URI — drops SVG / data:text/html images (see IMG_SRC_OK). Runs after the
+    // transformTags noise-strip above, so it tests the cleaned src.
+    exclusiveFilter: (frame) =>
+      frame.tag === "img" &&
+      typeof frame.attribs.src === "string" &&
+      !IMG_SRC_OK.test(frame.attribs.src.trim()),
   };
 }
 


### PR DESCRIPTION
## What

Follow-up hardening for the #658 server-side email-body sanitizer that shipped in #665. Two payloads an adversarial review confirmed survive #665's allowlist are now neutralized — both fixed in the shared `buildOptions`, so the storage (draft/template) and send paths are covered.

### 1. Invisible-character scheme smuggling (real XSS bypass)

A leading BOM (`U+FEFF`) or a zero-width char inside the scheme (`java<U+200B>script:`) leaves `sanitize-html` unable to recognize the scheme, so it keeps the `href` as if it were relative — then a browser strips the noise on click and executes `javascript:`. Verified against the installed `sanitize-html` with #665's exact config: `<a href="<BOM>javascript:alert(1)">` survives verbatim. This is exactly the "a direct API POST bypasses the Tiptap round-trip" threat the server-side sanitizer exists to stop.

**Fix:** strip URL-noise (C0 controls, DEL, NBSP, zero-width / bidi / word-joiner, BOM) from `href`/`src` via `transformTags` *before* the scheme allowlist runs, so a smuggled scheme collapses to its real form and is rejected. Lossless for legitimate URLs.

### 2. Non-raster data-URI images

`data:` is allowed for `<img>` with no media-type check, so `data:image/svg+xml` (a markup/script container) and `data:text/html` both pass.

**Fix:** an `exclusiveFilter` drops any `<img>` whose `src` isn't an http(s) URL or a genuine raster (png/jpeg/gif/webp) data URI. Lower severity — SVG is inert when loaded via `<img>` — but defense-in-depth at no legitimate-use cost (the editor only ever emits raster images).

## Testing

- New regression tests for both payload families (BOM / zero-width / vbscript hrefs; SVG / `data:text/html` / raster images; a clean URL preserved unchanged).
- Full email suite green: **238 tests**. `tsc --noEmit` and `eslint` clean on the touched files. No route/API changes.

## Notes

The #658 M4 authorization decision and L5 marker-stripping already shipped in #665 (including the `migration-658` RLS backstop); this PR closes the one residual gap left in #665's sanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
