### PR TITLE
feat(push): Apple sender (APNs client module) (#672)

### DIFF
--- a/src/lib/push/apple-sender.test.ts
+++ b/src/lib/push/apple-sender.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { generateKeyPairSync, verify, type KeyObject } from "crypto";
+import {
+  send,
+  loadApnsConfigFromEnv,
+  type ApnsConfig,
+  type ApnsRequest,
+  type ApnsTransport,
+  type ApplePushPayload,
+} from "./apple-sender";
+
+// A throwaway EC P-256 keypair so the real signing path runs in tests
+// without needing the production .p8 secret. `.p8` files are PKCS#8 PEM,
+// which is exactly what `export({ type: "pkcs8", format: "pem" })` yields.
+function makeTestKeypair(): { config: ApnsConfig; publicKey: KeyObject } {
+  const { privateKey, publicKey } = generateKeyPairSync("ec", {
+    namedCurve: "P-256",
+  });
+  return {
+    config: {
+      keyId: "TESTKEY123",
+      teamId: "TEAMID9999",
+      bundleId: "com.example.app",
+      privateKey: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    },
+    publicKey,
+  };
+}
+
+function makeTestConfig(): ApnsConfig {
+  return makeTestKeypair().config;
+}
+
+function decodeSegment(seg: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+}
+
+const payload: ApplePushPayload = {
+  title: "New intake: Jane",
+  body: "Water damage · 123 Main St",
+  sound: "default.caf",
+  href: "/jobs/job-1",
+};
+
+describe("loadApnsConfigFromEnv — #670 secrets contract", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads the four APNS_* server secrets into a config", () => {
+    vi.stubEnv("APNS_KEY_ID", "NZK3A4PTWB");
+    vi.stubEnv("APNS_TEAM_ID", "QFTG9NJB7G");
+    vi.stubEnv("APNS_BUNDLE_ID", "com.aaacontracting.platform");
+    vi.stubEnv("APNS_PRIVATE_KEY", "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----");
+
+    expect(loadApnsConfigFromEnv()).toEqual({
+      keyId: "NZK3A4PTWB",
+      teamId: "QFTG9NJB7G",
+      bundleId: "com.aaacontracting.platform",
+      privateKey: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----",
+    });
+  });
+
+  it("throws naming the missing secret when one is absent", () => {
+    vi.stubEnv("APNS_KEY_ID", "NZK3A4PTWB");
+    vi.stubEnv("APNS_TEAM_ID", "QFTG9NJB7G");
+    vi.stubEnv("APNS_BUNDLE_ID", "com.aaacontracting.platform");
+    vi.stubEnv("APNS_PRIVATE_KEY", "");
+
+    expect(() => loadApnsConfigFromEnv()).toThrow(/APNS_PRIVATE_KEY/);
+  });
+});
+
+describe("send — successful delivery", () => {
+  it("reports a 200 response as a 'sent' outcome per token", async () => {
+    const transport: ApnsTransport = async () => ({ status: 200, apnsId: "apns-1" });
+
+    const result = await send(["tok-1"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 1, prunable: 0, failed: 0 });
+    expect(result.outcomes).toEqual([
+      { status: "sent", token: "tok-1", apnsId: "apns-1" },
+    ]);
+  });
+});
+
+describe("send — dead / unregistered address", () => {
+  it("surfaces a 410 Unregistered response as a 'prunable' outcome, not an error", async () => {
+    const transport: ApnsTransport = async () => ({
+      status: 410,
+      reason: "Unregistered",
+    });
+
+    const result = await send(["dead-tok"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 0, prunable: 1, failed: 0 });
+    expect(result.outcomes).toEqual([
+      { status: "prunable", token: "dead-tok", reason: "Unregistered" },
+    ]);
+  });
+});
+
+describe("send — contained transport error", () => {
+  it("reports a thrown transport error as 'failed' and never throws to the caller", async () => {
+    const transport: ApnsTransport = async () => {
+      throw new Error("ECONNRESET: connection to Apple dropped");
+    };
+
+    const result = await send(["tok-1"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 0, prunable: 0, failed: 1 });
+    expect(result.outcomes).toEqual([
+      {
+        status: "failed",
+        token: "tok-1",
+        error: expect.stringContaining("ECONNRESET"),
+      },
+    ]);
+  });
+});
+
+describe("send — signed request to Apple", () => {
+  it("signs each request with a valid ES256 provider token and the configured topic", async () => {
+    const { config, publicKey } = makeTestKeypair();
+
+    let captured: ApnsRequest | undefined;
+    const transport: ApnsTransport = async (req) => {
+      captured = req;
+      return { status: 200, apnsId: "apns-1" };
+    };
+
+    await send(["tok-1"], payload, { transport, config, now: 1_700_000_000 });
+
+    expect(captured).toBeDefined();
+    const req = captured!;
+
+    // The push topic is the configured bundle id.
+    expect(req.headers["apns-topic"]).toBe("com.example.app");
+    expect(req.headers["apns-push-type"]).toBe("alert");
+
+    // Authorization carries a bearer provider token (a JWS: header.claims.sig).
+    const auth = req.headers["authorization"];
+    expect(auth).toMatch(/^bearer .+\..+\..+$/);
+    const jwt = auth.slice("bearer ".length);
+    const [headerB64, claimsB64, sigB64] = jwt.split(".");
+
+    // The signature verifies against the auth key's public half (ES256 = raw r||s).
+    const signingInput = `${headerB64}.${claimsB64}`;
+    const valid = verify(
+      "sha256",
+      Buffer.from(signingInput),
+      { key: publicKey, dsaEncoding: "ieee-p1363" },
+      Buffer.from(sigB64, "base64url"),
+    );
+    expect(valid).toBe(true);
+
+    // Header identifies the key; claims identify the team + issue time.
+    expect(decodeSegment(headerB64)).toMatchObject({ alg: "ES256", kid: "TESTKEY123" });
+    expect(decodeSegment(claimsB64)).toMatchObject({
+      iss: "TEAMID9999",
+      iat: 1_700_000_000,
+    });
+
+    // The aps body carries the alert wording + sound and the deep-link data.
+    const body = JSON.parse(req.body);
+    expect(body.aps.alert).toEqual({ title: payload.title, body: payload.body });
+    expect(body.aps.sound).toBe("default.caf");
+    expect(body.href).toBe("/jobs/job-1");
+  });
+});
+
+describe("send — mixed batch", () => {
+  it("returns one outcome per token in order and tallies the summary across kinds", async () => {
+    const seen: ApnsRequest[] = [];
+    const transport: ApnsTransport = async (req) => {
+      seen.push(req);
+      if (req.token === "ok-tok") return { status: 200, apnsId: "apns-ok" };
+      if (req.token === "dead-tok") return { status: 410, reason: "Unregistered" };
+      throw new Error("ETIMEDOUT");
+    };
+
+    const result = await send(["ok-tok", "dead-tok", "boom-tok"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 1, prunable: 1, failed: 1 });
+    expect(result.outcomes.map((o) => [o.token, o.status])).toEqual([
+      ["ok-tok", "sent"],
+      ["dead-tok", "prunable"],
+      ["boom-tok", "failed"],
+    ]);
+
+    // One provider token is minted per send and reused for every device token.
+    const auths = new Set(seen.map((r) => r.headers["authorization"]));
+    expect(auths.size).toBe(1);
+  });
+});
+
+describe("send — non-dead error response", () => {
+  it("reports a 429/5xx APNs error response as 'failed' (every token gets an outcome)", async () => {
+    const transport: ApnsTransport = async () => ({
+      status: 429,
+      reason: "TooManyRequests",
+    });
+
+    const result = await send(["busy-tok"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 0, prunable: 0, failed: 1 });
+    expect(result.outcomes).toHaveLength(1);
+    const [outcome] = result.outcomes;
+    expect(outcome).toMatchObject({ status: "failed", token: "busy-tok" });
+    expect(outcome.status === "failed" && outcome.error).toEqual(
+      expect.stringContaining("429"),
+    );
+    expect(outcome.status === "failed" && outcome.error).toEqual(
+      expect.stringContaining("TooManyRequests"),
+    );
+  });
+});
+
+describe("send — bad device token", () => {
+  it("surfaces a 400 BadDeviceToken as 'prunable' (a dead address), not failed", async () => {
+    const transport: ApnsTransport = async () => ({
+      status: 400,
+      reason: "BadDeviceToken",
+    });
+
+    const result = await send(["garbage-tok"], payload, {
+      transport,
+      config: makeTestConfig(),
+    });
+
+    expect(result.summary).toEqual({ sent: 0, prunable: 1, failed: 0 });
+    expect(result.outcomes).toEqual([
+      { status: "prunable", token: "garbage-tok", reason: "BadDeviceToken" },
+    ]);
+  });
+});
+
+describe("send — no device tokens", () => {
+  it("returns an empty result without ever calling the transport", async () => {
+    let calls = 0;
+    const transport: ApnsTransport = async () => {
+      calls += 1;
+      return { status: 200, apnsId: "x" };
+    };
+
+    const result = await send([], payload, { transport, config: makeTestConfig() });
+
+    expect(calls).toBe(0);
+    expect(result.summary).toEqual({ sent: 0, prunable: 0, failed: 0 });
+    expect(result.outcomes).toEqual([]);
+  });
+});

--- a/src/lib/push/apple-sender.ts
+++ b/src/lib/push/apple-sender.ts
@@ -1,0 +1,256 @@
+import { createPrivateKey, sign } from "crypto";
+import { connect, constants } from "http2";
+
+// Self-contained Apple Push (APNs) sender.
+//
+// `send(deviceTokens, payload, deps)` delivers one alert payload to a set of
+// device tokens and returns a per-token outcome. It knows nothing about
+// intakes, Organizations, or notifications — it just signs a request with the
+// APNs auth key, hands each token to a transport, and reports what happened.
+//
+// The transport (the HTTP/2-to-Apple boundary) is dependency-injected so the
+// sender can be exercised against a faked Apple in tests; the real transport
+// (`createApnsTransport`) is verified end-to-end against a phone in the wiring
+// slice.
+
+export interface ApplePushPayload {
+  title: string;
+  body: string;
+  sound: string;
+  href: string;
+}
+
+export interface ApnsConfig {
+  keyId: string;
+  teamId: string;
+  bundleId: string;
+  privateKey: string;
+}
+
+export interface ApnsRequest {
+  token: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface ApnsResponse {
+  status: number;
+  reason?: string;
+  apnsId?: string;
+}
+
+export type ApnsTransport = (req: ApnsRequest) => Promise<ApnsResponse>;
+
+export type TokenOutcome =
+  | { status: "sent"; token: string; apnsId: string | null }
+  | { status: "prunable"; token: string; reason: string }
+  | { status: "failed"; token: string; error: string };
+
+// APNs reasons that mean the token is permanently dead and should be pruned
+// rather than retried. A 410 (Unregistered) is the canonical signal; a 400
+// BadDeviceToken means the address itself is invalid. (DeviceTokenNotForTopic
+// is deliberately NOT here — it usually signals a topic misconfiguration, so
+// pruning on it could wipe out otherwise-valid tokens.)
+const PRUNABLE_REASONS = new Set(["Unregistered", "BadDeviceToken"]);
+
+function isPrunable(res: ApnsResponse): boolean {
+  return res.status === 410 || (!!res.reason && PRUNABLE_REASONS.has(res.reason));
+}
+
+export interface SendResult {
+  summary: { sent: number; prunable: number; failed: number };
+  outcomes: TokenOutcome[];
+}
+
+export interface SendDeps {
+  // The Apple transport. Defaults to a real HTTP/2 client (`createApnsTransport`);
+  // tests inject a fake.
+  transport?: ApnsTransport;
+  // APNs credentials. Defaults to `loadApnsConfigFromEnv()`.
+  config?: ApnsConfig;
+  // Unix seconds for the provider token's `iat` (injected for test determinism).
+  now?: number;
+}
+
+// Apple's two APNs front doors. Production serves tokens from App Store / signed
+// production builds; sandbox serves tokens from development / TestFlight builds.
+// The .p8 auth key works for both — only the host distinguishes them.
+export const APNS_HOSTS = {
+  production: "api.push.apple.com",
+  sandbox: "api.sandbox.push.apple.com",
+} as const;
+
+export interface ApnsTransportOptions {
+  host?: string; // defaults to APNS_HOST env or the production host
+  timeoutMs?: number; // per-request timeout; a hung connection becomes a failed outcome
+}
+
+// The real HTTP/2-to-Apple boundary. Receives a fully-formed (already-signed)
+// request and ships it. Non-2xx responses are normal APNs outcomes and resolve
+// (with the `reason` from the JSON body); only genuine transport failures
+// reject — `send` contains those as `failed` outcomes. Not unit-tested here:
+// it is exercised end-to-end against a real phone in the final wiring slice.
+export function createApnsTransport(opts: ApnsTransportOptions = {}): ApnsTransport {
+  const host = opts.host ?? process.env.APNS_HOST ?? APNS_HOSTS.production;
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+
+  return (req) =>
+    new Promise<ApnsResponse>((resolve, reject) => {
+      const session = connect(`https://${host}`);
+      const fail = (err: Error) => {
+        session.destroy();
+        reject(err);
+      };
+      session.on("error", fail);
+
+      const stream = session.request({
+        [constants.HTTP2_HEADER_METHOD]: "POST",
+        [constants.HTTP2_HEADER_PATH]: `/3/device/${req.token}`,
+        ...req.headers,
+      });
+      stream.setTimeout(timeoutMs, () =>
+        fail(new Error(`APNs request timed out after ${timeoutMs}ms`)),
+      );
+
+      let status = 0;
+      let apnsId: string | undefined;
+      const chunks: Buffer[] = [];
+      stream.on("response", (headers) => {
+        status = Number(headers[constants.HTTP2_HEADER_STATUS] ?? 0);
+        const id = headers["apns-id"];
+        apnsId = Array.isArray(id) ? id[0] : (id as string | undefined);
+      });
+      stream.on("data", (c: Buffer) => chunks.push(Buffer.from(c)));
+      stream.on("end", () => {
+        let reason: string | undefined;
+        if (chunks.length) {
+          try {
+            reason = JSON.parse(Buffer.concat(chunks).toString()).reason;
+          } catch {
+            /* a 200 carries no body */
+          }
+        }
+        session.close();
+        resolve({ status, reason, apnsId });
+      });
+      stream.on("error", fail);
+      stream.end(req.body);
+    });
+}
+
+function base64url(input: string | Buffer): string {
+  return Buffer.from(input).toString("base64url");
+}
+
+// APNs authenticates each request with a short-lived JWT ("provider token")
+// signed ES256 with the .p8 auth key. One token is minted per `send` and
+// reused across all device tokens (Apple recommends reusing, not re-signing
+// per request).
+function buildProviderToken(config: ApnsConfig, nowSeconds: number): string {
+  const header = base64url(JSON.stringify({ alg: "ES256", kid: config.keyId }));
+  const claims = base64url(JSON.stringify({ iss: config.teamId, iat: nowSeconds }));
+  const signingInput = `${header}.${claims}`;
+  const signature = sign("sha256", Buffer.from(signingInput), {
+    key: createPrivateKey(config.privateKey),
+    dsaEncoding: "ieee-p1363", // JWS ES256 needs raw r||s, not DER
+  });
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+function buildRequest(
+  token: string,
+  payload: ApplePushPayload,
+  providerToken: string,
+  config: ApnsConfig,
+): ApnsRequest {
+  return {
+    token,
+    headers: {
+      authorization: `bearer ${providerToken}`,
+      "apns-topic": config.bundleId,
+      "apns-push-type": "alert",
+      "apns-priority": "10",
+    },
+    body: JSON.stringify({
+      aps: {
+        alert: { title: payload.title, body: payload.body },
+        sound: payload.sound,
+      },
+      href: payload.href,
+    }),
+  };
+}
+
+// Reads the APNs provider credentials from the server secrets configured in
+// slice #670. Throws if any are missing — a deploy-time misconfiguration.
+export function loadApnsConfigFromEnv(): ApnsConfig {
+  const keyId = process.env.APNS_KEY_ID;
+  const teamId = process.env.APNS_TEAM_ID;
+  const bundleId = process.env.APNS_BUNDLE_ID;
+  const privateKey = process.env.APNS_PRIVATE_KEY;
+  if (!keyId || !teamId || !bundleId || !privateKey) {
+    throw new Error(
+      "APNs config is incomplete: set APNS_KEY_ID, APNS_TEAM_ID, APNS_BUNDLE_ID, APNS_PRIVATE_KEY",
+    );
+  }
+  return { keyId, teamId, bundleId, privateKey };
+}
+
+function summarize(outcomes: TokenOutcome[]): SendResult["summary"] {
+  return outcomes.reduce(
+    (acc, o) => {
+      if (o.status === "sent") acc.sent += 1;
+      else if (o.status === "prunable") acc.prunable += 1;
+      else acc.failed += 1;
+      return acc;
+    },
+    { sent: 0, prunable: 0, failed: 0 },
+  );
+}
+
+export async function send(
+  deviceTokens: string[],
+  payload: ApplePushPayload,
+  deps: SendDeps,
+): Promise<SendResult> {
+  // Nothing to send: don't sign or load config when there are no recipients.
+  if (deviceTokens.length === 0) {
+    return { summary: summarize([]), outcomes: [] };
+  }
+
+  const config = deps.config ?? loadApnsConfigFromEnv();
+  const transport = deps.transport ?? createApnsTransport();
+  const nowSeconds = deps.now ?? Math.floor(Date.now() / 1000);
+  const providerToken = buildProviderToken(config, nowSeconds);
+
+  const outcomes: TokenOutcome[] = [];
+
+  for (const token of deviceTokens) {
+    try {
+      const res = await transport(
+        buildRequest(token, payload, providerToken, config),
+      );
+      if (res.status === 200) {
+        outcomes.push({ status: "sent", token, apnsId: res.apnsId ?? null });
+      } else if (isPrunable(res)) {
+        outcomes.push({ status: "prunable", token, reason: res.reason ?? "Unregistered" });
+      } else {
+        // Any other non-OK response (429, 5xx, …): a real but non-fatal error.
+        // Report it as failed so the token still gets exactly one outcome.
+        outcomes.push({
+          status: "failed",
+          token,
+          error: `APNs ${res.status}${res.reason ? `: ${res.reason}` : ""}`,
+        });
+      }
+    } catch (e) {
+      outcomes.push({
+        status: "failed",
+        token,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  return { summary: summarize(outcomes), outcomes };
+}


### PR DESCRIPTION
## What this is

A self-contained **Apple Push (APNs) sender** — slice of the new-intake push-notifications epic (#667, design in [ADR 0016](docs/adr/0016-new-intake-push-notifications.md)).

`send(deviceTokens, payload, deps) -> { summary, outcomes }` signs one short-lived ES256 provider token with the `.p8` auth key, ships each token's request over HTTP/2 to Apple, and returns exactly one outcome per token. It knows nothing about intakes or Organizations — it just delivers a payload and reports what happened. The global best-effort wrap lives in the dispatcher slice (#673).

## Acceptance criteria

- [x] `send` accepts device tokens + a payload (title, body, sound, deep-link `href`) and returns a per-token outcome.
- [x] Requests are signed with the APNs auth key from the configured server secrets (`loadApnsConfigFromEnv()` reads the four `APNS_*` secrets from #670).
- [x] A successful send reports `sent` per token (with the returned `apns-id`).
- [x] A dead / unregistered response is surfaced as a **`prunable`** outcome, not an error — `410 Unregistered` **and** `400 BadDeviceToken`.
- [x] A transport-level error is contained and reported as `failed`, **never thrown** to the caller.
- [x] Tests against a **faked Apple transport** cover: success, dead-address-prunable, and contained transport error.

## Design notes

- **Injectable transport.** The HTTP/2-to-Apple boundary (`createApnsTransport`) is dependency-injected, so tests run the real signing path against a fake Apple. The real transport is the humble object — exercised end-to-end against a phone in the wiring slice, not unit-tested here.
- **Signing is verified for real.** One test captures the signed request from the fake transport and cryptographically verifies the ES256 provider token against a throwaway EC P-256 public key (`dsaEncoding: "ieee-p1363"` — JWS needs raw r‖s, not DER), plus the `apns-topic`/push-type headers and the `aps` body.
- **Prunable vs failed.** `DeviceTokenNotForTopic` is deliberately **not** prunable (it usually signals a topic misconfig, so pruning on it could wipe valid tokens). Every non-OK, non-prunable response (429/5xx) becomes a `failed` outcome — every token always gets exactly one outcome.
- **Loud where it should be loud.** Transport and error-response failures are contained per-token; a *missing* config throws (a deploy-time misconfiguration, not a runtime delivery failure).
- **No new dependencies** — Node built-in `crypto` + `http2` only.

## Outcome shape

```ts
type TokenOutcome =
  | { status: "sent";     token: string; apnsId: string | null }
  | { status: "prunable"; token: string; reason: string }
  | { status: "failed";   token: string; error: string };
// + summary: { sent, prunable, failed }
```

## Tests

10 tests, all green (`vitest`): config-from-secrets (present + missing), success, 410 Unregistered → prunable, 400 BadDeviceToken → prunable, thrown transport error → failed, 429 → failed, real ES256 signature verification, mixed batch (one provider token reused across tokens), and empty-token-set short-circuit (transport never called). Lint and type-check clean.

Built with TDD — two silent-drop bugs (BadDeviceToken and 429/5xx producing no outcome) were caught and fixed red→green.

Closes #672. Parent #667. Blocked by #670 (secrets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)