### PR TITLE
feat(notifications): new-intake in-app bell — buzz builder, dispatcher, route, form wiring (#669)

### DIFF
--- a/src/app/api/intake/notify/route.test.ts
+++ b/src/app/api/intake/notify/route.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The wrapper authenticates against the User client and resolves the Active
+// Organization from the JWT claim; the route's org-scoping guard reads the
+// Job with the Service client. We mock both, plus the dispatcher itself — the
+// route's job is auth + tenant-scoping + delegation, and the dispatcher has
+// its own behavior tests.
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+vi.mock("@/lib/notifications/dispatch-new-intake", () => ({
+  dispatchNewIntakeNotifications: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { createServiceClient } from "@/lib/supabase-api";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import { dispatchNewIntakeNotifications } from "@/lib/notifications/dispatch-new-intake";
+import {
+  fakeUserClient,
+  fakeServiceClient,
+  memberTables,
+} from "../../__test-utils__/request-context-fakes";
+
+function postJson(body: unknown) {
+  return new Request("http://test/api/intake/notify", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+describe("POST /api/intake/notify", () => {
+  it("dispatches new-intake notifications for a Job in the caller's Active Organization", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        tables: { jobs: [{ id: "job-1", organization_id: "org-1" }] },
+      }) as never,
+    );
+
+    const res = await POST(postJson({ jobId: "job-1" }), { params: Promise.resolve({}) });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(dispatchNewIntakeNotifications).toHaveBeenCalledWith({
+      jobId: "job-1",
+      submitterUserId: "user-1",
+    });
+  });
+
+  it("returns 401 and does not dispatch when unauthenticated", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({ user: null }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(fakeServiceClient({}) as never);
+
+    const res = await POST(postJson({ jobId: "job-1" }), { params: Promise.resolve({}) });
+
+    expect(res.status).toBe(401);
+    expect(dispatchNewIntakeNotifications).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 and does not dispatch for a Job in another Organization", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({
+        // job-2 belongs to org-2; the caller's Active Organization is org-1.
+        tables: { jobs: [{ id: "job-2", organization_id: "org-2" }] },
+      }) as never,
+    );
+
+    const res = await POST(postJson({ jobId: "job-2" }), { params: Promise.resolve({}) });
+
+    expect(res.status).toBe(404);
+    expect(dispatchNewIntakeNotifications).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 and does not dispatch for a Job that does not exist", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(
+      fakeServiceClient({ tables: { jobs: [] } }) as never,
+    );
+
+    const res = await POST(postJson({ jobId: "job-missing" }), { params: Promise.resolve({}) });
+
+    expect(res.status).toBe(404);
+    expect(dispatchNewIntakeNotifications).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and does not dispatch when jobId is missing from the body", async () => {
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(
+      fakeUserClient({
+        user: { id: "user-1" },
+        tables: memberTables({ userId: "user-1", role: "member", grants: [] }),
+      }) as never,
+    );
+    vi.mocked(createServiceClient).mockReturnValue(fakeServiceClient({}) as never);
+
+    const res = await POST(postJson({}), { params: Promise.resolve({}) });
+
+    expect(res.status).toBe(400);
+    expect(dispatchNewIntakeNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/intake/notify/route.ts
+++ b/src/app/api/intake/notify/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { belongsToActiveOrganization } from "@/lib/request-context/belongs-to-active-organization";
+import { dispatchNewIntakeNotifications } from "@/lib/notifications/dispatch-new-intake";
+
+// POST /api/intake/notify — the client calls this best-effort right after an
+// Intake's Job is inserted, to fan out the in-app bell to the rest of the
+// Organization (see docs/adr/0016-new-intake-push-notifications.md).
+//
+// Logged-in only: any member who just logged an Intake may trigger its
+// notifications. The fan-out itself runs with the Service client (RLS
+// bypassed), so this route does the tenant-scoping the database would
+// otherwise do — a `jobId` from another Organization is 404, indistinguishable
+// from one that does not exist. The submitter is sourced from the session, not
+// the body, so a caller cannot spoof who triggered the Intake.
+export const POST = withRequestContext(
+  { serviceClient: true },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => ({}))) as { jobId?: unknown };
+    const jobId = typeof body.jobId === "string" ? body.jobId : "";
+    if (!jobId) {
+      return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+    }
+
+    const service = ctx.serviceClient!;
+    if (!(await belongsToActiveOrganization(service, { jobId }, ctx.orgId))) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    await dispatchNewIntakeNotifications({
+      jobId,
+      submitterUserId: ctx.userId,
+    });
+
+    return NextResponse.json({ ok: true });
+  },
+);

--- a/src/components/intake-form.test.tsx
+++ b/src/components/intake-form.test.tsx
@@ -447,6 +447,69 @@ describe("IntakeForm — referrer left blank (#302)", () => {
   });
 });
 
+// ─── New-intake notifications (#669) ────────────────────────────────────────
+// After a Job is created, the form fires a best-effort POST to
+// /api/intake/notify so the rest of the Organization gets an in-app bell. The
+// call must never block or break Intake submission (the Job is already saved).
+// See docs/adr/0016-new-intake-push-notifications.md.
+
+function notifyCalls() {
+  const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+  return fetchMock.mock.calls.filter(([url]) => url === "/api/intake/notify");
+}
+
+describe("IntakeForm — fires new-intake notifications after submit (#669)", () => {
+  it("POSTs the new Job's id to /api/intake/notify on a successful submit", async () => {
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(notifyCalls()).toHaveLength(1));
+    const [, init] = notifyCalls()[0];
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ jobId: "job-1" });
+  });
+
+  it("still navigates and shows success when the notify call fails (best-effort)", async () => {
+    const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "/api/intake/notify") return Promise.reject(new Error("network down"));
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ config: formConfigFixture }),
+      });
+    });
+
+    render(<IntakeForm />);
+
+    fireEvent.change(await screen.findByPlaceholderText("name-input"), {
+      target: { value: "Jane Doe" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("damage-input"), {
+      target: { value: "Water" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("address-input"), {
+      target: { value: "12 Oak St" },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /create job/i }));
+
+    await waitFor(() => expect(routerPush).toHaveBeenCalledWith("/jobs/job-1"));
+    expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/created successfully/i));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
 describe("IntakeForm — toggle off: referrer field absent (#302)", () => {
   it("does not render the picker and submits exactly as today when the field is omitted from the config", async () => {
     // Default `makeConfig()` is the today-shape (no referrer field).

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -315,6 +315,19 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
         });
       }
 
+      // Best-effort: fan out the in-app bell to the rest of the Organization.
+      // The Job is already saved, so a failed notify must never surface to the
+      // office user or block navigation. See ADR 0016 (#669).
+      try {
+        await fetch("/api/intake/notify", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jobId: job.id }),
+        });
+      } catch {
+        // Swallowed by contract — notifications are non-critical.
+      }
+
       toast.success(`Job ${job.job_number} created successfully!`);
       router.push(`/jobs/${job.id}`);
     } catch (err) {

--- a/src/lib/notifications/dispatch-new-intake.test.ts
+++ b/src/lib/notifications/dispatch-new-intake.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The dispatcher and writeNotification both build their Service client via
+// `createServiceClient`. We mock only that, so the test drives the REAL
+// fan-out logic (active members, submitter exclusion, org scoping) through a
+// single in-memory table fake.
+const { mockCreateServiceClient } = vi.hoisted(() => ({
+  mockCreateServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: mockCreateServiceClient,
+}));
+
+import { dispatchNewIntakeNotifications } from "./dispatch-new-intake";
+
+// ---------- minimal Supabase fake (finalize.test.ts idiom) ----------------
+type Row = Record<string, unknown>;
+interface FakeError {
+  message: string;
+}
+
+function makeFake() {
+  const tables: Record<string, Row[]> = {};
+  const inserts: Record<string, Row[]> = {};
+  const errors: Record<string, FakeError | null> = {};
+
+  const match = (row: Row, filters: Row) =>
+    Object.entries(filters).every(([k, v]) => row[k] === v);
+
+  function selectBuilder(table: string) {
+    const filters: Row = {};
+    const builder = {
+      eq(col: string, val: unknown) {
+        filters[col] = val;
+        return builder;
+      },
+      async maybeSingle() {
+        const err = errors[`${table}.select`];
+        if (err) return { data: null, error: err };
+        return {
+          data: (tables[table] ?? []).find((r) => match(r, filters)) ?? null,
+          error: null,
+        };
+      },
+      then(resolve: (v: { data: unknown; error: FakeError | null }) => unknown) {
+        const err = errors[`${table}.select`];
+        if (err) return resolve({ data: null, error: err });
+        return resolve({
+          data: (tables[table] ?? []).filter((r) => match(r, filters)),
+          error: null,
+        });
+      },
+    };
+    return builder;
+  }
+
+  const client = {
+    from(table: string) {
+      return {
+        select() {
+          return selectBuilder(table);
+        },
+        insert(payload: Row | Row[]) {
+          const rows = Array.isArray(payload) ? payload : [payload];
+          (inserts[table] ??= []).push(...rows);
+          return {
+            then(resolve: (v: { data: unknown; error: FakeError | null }) => unknown) {
+              return resolve({ data: null, error: errors[`${table}.insert`] ?? null });
+            },
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    client,
+    seed(table: string, rows: Row[]) {
+      (tables[table] ??= []).push(...rows);
+    },
+    setError(key: string, err: FakeError | null) {
+      errors[key] = err;
+    },
+    inserts,
+  };
+}
+
+type Fake = ReturnType<typeof makeFake>;
+
+/** Seed one Job + its Contact under org-1 (emergency by default). */
+function seedJob(fake: Fake, overrides: Partial<Row> = {}) {
+  fake.seed("jobs", [
+    {
+      id: "job-1",
+      organization_id: "org-1",
+      urgency: "emergency",
+      damage_type: "Water damage",
+      property_address: "123 Main St",
+      contact_id: "c-1",
+      ...overrides,
+    },
+  ]);
+  fake.seed("contacts", [{ id: "c-1", full_name: "John Smith" }]);
+}
+
+/** A membership row carrying the embedded is_active profile write.ts reads. */
+function member(userId: string, role: string, isActive: boolean, orgId = "org-1"): Row {
+  return {
+    user_id: userId,
+    organization_id: orgId,
+    role,
+    user_profiles: { is_active: isActive },
+  };
+}
+
+const notifs = (fake: Fake): Row[] => fake.inserts.notifications ?? [];
+
+let fake: Fake;
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The best-effort path logs to console.error; keep test output clean.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  fake = makeFake();
+  mockCreateServiceClient.mockReturnValue(fake.client);
+});
+
+describe("dispatchNewIntakeNotifications", () => {
+  it("writes a new_job bell row for every active member except the submitter", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("teammate-a", "crew_lead", true),
+      member("teammate-b", "crew_member", true),
+    ]);
+
+    await dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" });
+
+    const rows = notifs(fake);
+    expect(rows.map((r) => r.user_id).sort()).toEqual(["teammate-a", "teammate-b"]);
+    expect(rows.every((r) => r.type === "new_job")).toBe(true);
+    expect(rows[0]).toMatchObject({
+      organization_id: "org-1",
+      job_id: "job-1",
+      title: "🚨 EMERGENCY intake: John Smith",
+      body: "Water damage · 123 Main St",
+      href: "/jobs/job-1",
+    });
+  });
+
+  it("excludes inactive / deactivated members", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("active-teammate", "crew_member", true),
+      member("deactivated", "crew_member", false),
+    ]);
+
+    await dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" });
+
+    expect(notifs(fake).map((r) => r.user_id)).toEqual(["active-teammate"]);
+  });
+
+  it("stays within the Job's Organization (never notifies another org's members)", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("same-org", "crew_member", true, "org-1"),
+      member("other-org", "admin", true, "org-2"),
+    ]);
+
+    await dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" });
+
+    expect(notifs(fake).map((r) => r.user_id)).toEqual(["same-org"]);
+  });
+
+  it("reflects the Job's Urgency tier in the bell wording", async () => {
+    seedJob(fake, { urgency: "urgent", damage_type: "Mold", property_address: "5 Elm Rd" });
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("teammate", "crew_member", true),
+    ]);
+
+    await dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" });
+
+    expect(notifs(fake)[0]).toMatchObject({
+      title: "Urgent intake: John Smith",
+      body: "Mold · 5 Elm Rd",
+    });
+  });
+
+  it("writes nothing when the submitter is the only active member", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [member("submitter", "admin", true)]);
+
+    await dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" });
+
+    expect(notifs(fake)).toHaveLength(0);
+  });
+
+  describe("is best-effort — never throws when a downstream call errors", () => {
+    it("swallows a job-lookup error and writes nothing", async () => {
+      seedJob(fake);
+      fake.seed("user_organizations", [member("teammate", "crew_member", true)]);
+      fake.setError("jobs.select", { message: "db down" });
+
+      await expect(
+        dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" }),
+      ).resolves.toBeUndefined();
+      expect(notifs(fake)).toHaveLength(0);
+    });
+
+    it("swallows a member-lookup error and writes nothing", async () => {
+      seedJob(fake);
+      fake.seed("user_organizations", [member("teammate", "crew_member", true)]);
+      fake.setError("user_organizations.select", { message: "db down" });
+
+      await expect(
+        dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" }),
+      ).resolves.toBeUndefined();
+      expect(notifs(fake)).toHaveLength(0);
+    });
+
+    it("swallows a notifications-insert error", async () => {
+      seedJob(fake);
+      fake.seed("user_organizations", [member("teammate", "crew_member", true)]);
+      fake.setError("notifications.insert", { message: "write failed" });
+
+      await expect(
+        dispatchNewIntakeNotifications({ jobId: "job-1", submitterUserId: "submitter" }),
+      ).resolves.toBeUndefined();
+    });
+
+    it("does nothing (no throw) when the Job no longer exists", async () => {
+      // No jobs seeded.
+      fake.seed("user_organizations", [member("teammate", "crew_member", true)]);
+
+      await expect(
+        dispatchNewIntakeNotifications({ jobId: "missing", submitterUserId: "submitter" }),
+      ).resolves.toBeUndefined();
+      expect(notifs(fake)).toHaveLength(0);
+    });
+  });
+});

--- a/src/lib/notifications/dispatch-new-intake.ts
+++ b/src/lib/notifications/dispatch-new-intake.ts
@@ -1,0 +1,77 @@
+// New-intake dispatcher: the server-side reaction to a hand-logged Intake.
+// Given the freshly-inserted Job, it loads the Job + its Contact, builds the
+// per-Urgency buzz-wording, and fans out one `new_job` in-app bell row to every
+// active member of the Job's Organization except the submitter.
+//
+// Best-effort by contract: a failed notify must NEVER break Intake submission
+// (the Job is already saved). This function therefore swallows every error and
+// never throws. See docs/adr/0016-new-intake-push-notifications.md.
+
+import { createServiceClient } from "@/lib/supabase-api";
+
+import { buildIntakeBuzz, type IntakeUrgency } from "./intake-buzz";
+import { writeNotification } from "./write";
+
+export interface DispatchNewIntakeInput {
+  jobId: string;
+  // The member who submitted the Intake — excluded from the fan-out.
+  submitterUserId: string;
+}
+
+interface JobFacts {
+  id: string;
+  organization_id: string;
+  urgency: IntakeUrgency;
+  damage_type: string | null;
+  property_address: string | null;
+  contact_id: string | null;
+}
+
+export async function dispatchNewIntakeNotifications(
+  input: DispatchNewIntakeInput,
+): Promise<void> {
+  try {
+    const supabase = createServiceClient();
+
+    const { data: job, error: jobErr } = await supabase
+      .from("jobs")
+      .select("id, organization_id, urgency, damage_type, property_address, contact_id")
+      .eq("id", input.jobId)
+      .maybeSingle<JobFacts>();
+    if (jobErr) throw new Error(`job lookup: ${jobErr.message}`);
+    if (!job) return; // Nothing to notify about — best-effort, stay silent.
+
+    let customerName = "";
+    if (job.contact_id) {
+      const { data: contact, error: contactErr } = await supabase
+        .from("contacts")
+        .select("full_name")
+        .eq("id", job.contact_id)
+        .maybeSingle<{ full_name: string | null }>();
+      if (contactErr) throw new Error(`contact lookup: ${contactErr.message}`);
+      customerName = contact?.full_name ?? "";
+    }
+
+    const buzz = buildIntakeBuzz({
+      jobId: job.id,
+      customerName,
+      urgency: job.urgency,
+      damageType: job.damage_type,
+      propertyAddress: job.property_address,
+    });
+
+    await writeNotification({
+      type: "new_job",
+      title: buzz.title,
+      body: buzz.body,
+      href: buzz.href,
+      jobId: job.id,
+      organizationId: job.organization_id,
+      audience: "members",
+      excludeUserId: input.submitterUserId,
+    });
+  } catch (err) {
+    // Best-effort: never let a notify failure surface to the Intake flow.
+    console.error("[new-intake notify] dispatch failed:", err);
+  }
+}

--- a/src/lib/notifications/intake-buzz.test.ts
+++ b/src/lib/notifications/intake-buzz.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+
+import { buildIntakeBuzz } from "./intake-buzz";
+
+describe("buildIntakeBuzz", () => {
+  it("builds an emergency buzz: 🚨 title with the customer name, body, sound, and deep link", () => {
+    const buzz = buildIntakeBuzz({
+      jobId: "job-1",
+      customerName: "John Smith",
+      urgency: "emergency",
+      damageType: "Water damage",
+      propertyAddress: "123 Main St",
+    });
+
+    expect(buzz).toEqual({
+      title: "🚨 EMERGENCY intake: John Smith",
+      body: "Water damage · 123 Main St",
+      sound: "emergency.caf",
+      href: "/jobs/job-1",
+    });
+  });
+
+  describe("body degrades gracefully when damage type / address are missing", () => {
+    const base = {
+      jobId: "job-1",
+      customerName: "John Smith",
+      urgency: "scheduled" as const,
+    };
+
+    it("drops the missing address (no dangling separator)", () => {
+      expect(
+        buildIntakeBuzz({ ...base, damageType: "Water damage", propertyAddress: null }).body,
+      ).toBe("Water damage");
+    });
+
+    it("drops the missing damage type", () => {
+      expect(
+        buildIntakeBuzz({ ...base, damageType: null, propertyAddress: "123 Main St" }).body,
+      ).toBe("123 Main St");
+    });
+
+    it("treats blank/whitespace fields as missing", () => {
+      expect(
+        buildIntakeBuzz({ ...base, damageType: "   ", propertyAddress: "123 Main St" }).body,
+      ).toBe("123 Main St");
+    });
+
+    it("falls back to a generic body when both are missing", () => {
+      expect(
+        buildIntakeBuzz({ ...base, damageType: null, propertyAddress: null }).body,
+      ).toBe("New job");
+    });
+  });
+
+  it("builds an urgent buzz (no 🚨 prefix, own sound)", () => {
+    expect(
+      buildIntakeBuzz({
+        jobId: "job-2",
+        customerName: "Jane Doe",
+        urgency: "urgent",
+        damageType: "Mold",
+        propertyAddress: "5 Elm Rd",
+      }),
+    ).toEqual({
+      title: "Urgent intake: Jane Doe",
+      body: "Mold · 5 Elm Rd",
+      sound: "urgent.caf",
+      href: "/jobs/job-2",
+    });
+  });
+
+  it("builds a scheduled buzz (default tier wording, own sound)", () => {
+    expect(
+      buildIntakeBuzz({
+        jobId: "job-3",
+        customerName: "Sam Lee",
+        urgency: "scheduled",
+        damageType: "Roof leak",
+        propertyAddress: "12 Pine Ln",
+      }),
+    ).toEqual({
+      title: "New intake: Sam Lee",
+      body: "Roof leak · 12 Pine Ln",
+      sound: "scheduled.caf",
+      href: "/jobs/job-3",
+    });
+  });
+
+  it("drops the trailing colon when the customer name is blank", () => {
+    const buzz = buildIntakeBuzz({
+      jobId: "job-1",
+      customerName: "  ",
+      urgency: "emergency",
+      damageType: "Fire damage",
+      propertyAddress: "9 Oak Ave",
+    });
+    expect(buzz.title).toBe("🚨 EMERGENCY intake");
+  });
+});

--- a/src/lib/notifications/intake-buzz.ts
+++ b/src/lib/notifications/intake-buzz.ts
@@ -1,0 +1,49 @@
+// Buzz-wording for a new-intake notification: the pure mapping from a Job's
+// customer-facing facts to the title/body/sound/deep-link a bell row (and a
+// later push) carries. Title and sound vary by the Job's **Urgency** tier; an
+// 🚨 emergency leads the title. See docs/adr/0016-new-intake-push-notifications.md.
+
+export type IntakeUrgency = "emergency" | "urgent" | "scheduled";
+
+export interface IntakeBuzzInput {
+  jobId: string;
+  customerName: string;
+  urgency: IntakeUrgency;
+  damageType: string | null;
+  propertyAddress: string | null;
+}
+
+export interface IntakeBuzz {
+  title: string;
+  body: string;
+  sound: string;
+  href: string;
+}
+
+const TIERS: Record<IntakeUrgency, { titlePhrase: string; sound: string }> = {
+  emergency: { titlePhrase: "🚨 EMERGENCY intake", sound: "emergency.caf" },
+  urgent: { titlePhrase: "Urgent intake", sound: "urgent.caf" },
+  scheduled: { titlePhrase: "New intake", sound: "scheduled.caf" },
+};
+
+export function buildIntakeBuzz(input: IntakeBuzzInput): IntakeBuzz {
+  const tier = TIERS[input.urgency];
+  const customerName = input.customerName?.trim();
+  const title = customerName
+    ? `${tier.titlePhrase}: ${customerName}`
+    : tier.titlePhrase;
+
+  // Join the facts we have; drop blank/missing ones so the body never shows a
+  // dangling separator or a literal "null". Both missing → a generic fallback.
+  const parts = [input.damageType, input.propertyAddress]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+  const body = parts.length > 0 ? parts.join(" · ") : "New job";
+
+  return {
+    title,
+    body,
+    sound: tier.sound,
+    href: `/jobs/${input.jobId}`,
+  };
+}

--- a/src/lib/notifications/write.ts
+++ b/src/lib/notifications/write.ts
@@ -11,8 +11,15 @@ export interface WriteNotificationInput {
   priority?: "normal" | "high";
   jobId?: string | null;
   metadata?: Record<string, unknown>;
-  // If provided, notify only this user. Default: fan out to all active admins.
+  // If provided, notify only this user. Default: fan out per `audience`.
   userId?: string | null;
+  // Who the fan-out reaches (ignored when `userId` is set):
+  //   "admins"  — active admins only (default; preserves the original behavior)
+  //   "members" — every active member of the org, any role (e.g. new-intake)
+  audience?: "admins" | "members";
+  // When fanning out, omit this user — e.g. the submitter who triggered the
+  // event and need not be told of their own action. See ADR 0016.
+  excludeUserId?: string | null;
   // Org scope for the notification row(s). Required — writeNotification uses a
   // service client, so it cannot resolve the active org from a session JWT.
   // Callers in webhook context source this from the row they're reacting to
@@ -46,25 +53,30 @@ export async function writeNotification(
     return;
   }
 
-  // Fan out: one row per active admin of this org. Role lives on
+  // Fan out: one row per active member of this org. Role lives on
   // user_organizations; joined through user_profiles for the is_active filter.
-  const { data: admins, error: adminsErr } = await supabase
+  // "admins" keeps the role gate; "members" reaches every active member.
+  let query = supabase
     .from("user_organizations")
     .select("user_id, user_profiles:user_id(is_active)")
-    .eq("organization_id", orgId)
-    .eq("role", "admin");
-  if (adminsErr) throw new Error(`admin lookup: ${adminsErr.message}`);
+    .eq("organization_id", orgId);
+  if ((input.audience ?? "admins") === "admins") {
+    query = query.eq("role", "admin");
+  }
+  const { data: members, error: membersErr } = await query;
+  if (membersErr) throw new Error(`member lookup: ${membersErr.message}`);
 
-  const activeAdminIds = (admins ?? [])
-    .filter((a) => {
-      const profile = Array.isArray(a.user_profiles) ? a.user_profiles[0] : a.user_profiles;
+  const recipientIds = (members ?? [])
+    .filter((m) => {
+      const profile = Array.isArray(m.user_profiles) ? m.user_profiles[0] : m.user_profiles;
       return profile?.is_active === true;
     })
-    .map((a) => a.user_id);
+    .map((m) => m.user_id)
+    .filter((userId) => userId !== input.excludeUserId);
 
-  if (activeAdminIds.length === 0) return;
+  if (recipientIds.length === 0) return;
 
-  const rows = activeAdminIds.map((userId: string) => ({ ...row, user_id: userId }));
+  const rows = recipientIds.map((userId: string) => ({ ...row, user_id: userId }));
   const { error } = await supabase.from("notifications").insert(rows);
   if (error) throw new Error(`notifications bulk insert: ${error.message}`);
 }


### PR DESCRIPTION
Closes #669.

When a **New Customer Intake** form is submitted, fan out the existing `new_job` in-app notification — the bell entry **no code produced today** — to the rest of the team. Web-only and best-effort: no iPhone push / device tokens yet.

## What's in this slice

- **`intake-buzz.ts`** — pure buzz-wording builder: `{ customerName, urgency, damageType, propertyAddress } → { title, body, sound, href }`. Per-**Urgency**-tier title (🚨 EMERGENCY intake / Urgent intake / New intake) and sound; body (`damageType · propertyAddress`) degrades gracefully when fields are missing; `/jobs/{id}` deep link. `sound` is built but consumed later by the push slice.
- **`write.ts`** — generalize the active-member fan-out with `audience` (`"admins"` default | `"members"`) and `excludeUserId`. **Purely additive** — admin-default callers (the four Stripe webhook handlers) behave identically.
- **`dispatch-new-intake.ts`** — loads the Job + **Contact**, builds the buzz, and writes a `new_job` row for every active member of the Job's **Organization** except the submitter. **Best-effort — never throws** (ADR 0016).
- **`/api/intake/notify`** — logged-in POST that confirms the Job belongs to the caller's Active Organization (404 otherwise, indistinguishable from not-found) before dispatching. Submitter comes from the session, not the body, so it can't be spoofed.
- **`intake-form.tsx`** — best-effort `fetch` to the route after the Job insert succeeds; a failed notify never blocks navigation or surfaces an error.

## Acceptance criteria

- [x] Intake submit writes `new_job` for every active member of the Organization except the submitter
- [x] No notification for inactive/deactivated members, nor members of any other Organization
- [x] Title/body come from the buzz builder and reflect the Job's Urgency tier (🚨 for emergency)
- [x] Jobs created by paths other than the Intake form produce no notification (the producer is exclusively the form's post-insert call)
- [x] If notify fails or the dispatcher errors, Intake submission still succeeds and the Job is saved
- [x] Buzz builder unit tests (per-tier title/body/sound/href; 🚨 prefix; graceful degradation)
- [x] Dispatcher behavior tests in the spirit of `finalize.test.ts` (right active members, excludes submitter/inactive/cross-org, never throws on downstream errors)
- [x] `/api/intake/notify` happy-path + auth/Org-ownership coverage

## Tests & checks

Built TDD (red→green per slice). **33/33 tests pass** across the four files:

\`\`\`
intake-buzz.test.ts            8
dispatch-new-intake.test.ts    9
api/intake/notify/route.test.ts 5
intake-form.test.tsx           11  (9 pre-existing + 2 new)
\`\`\`

- ESLint clean on all 9 changed files
- `tsc --noEmit` clean on every file in this PR (pre-existing project type errors are all in unrelated email/mobile/pdf modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)