### PR TITLE
fix(export-pdf): open desktop export in a new tab; Share sheet in-app

### DIFF
--- a/src/components/documents/export-pdf-button.test.tsx
+++ b/src/components/documents/export-pdf-button.test.tsx
@@ -5,8 +5,14 @@
 // from the inline preview. The new button has no picker: it POSTs the pdf route
 // with NO preset_id, so the route falls back to the org default preset and
 // resolves the document's effective layout (ADR 0012) — byte-for-byte the look
-// the preview already shows. These tests pin that parity contract plus the
-// download / error / one-click-no-modal behavior.
+// the preview already shows. These tests pin that parity contract.
+//
+// Delivery: the pdf route returns a *cross-origin* Supabase signed URL, for
+// which browsers ignore <a download> and instead navigate the current tab —
+// ejecting the SPA. So on desktop we open the PDF in a new tab (pre-opened
+// synchronously inside the click so the popup blocker lets it through), and in
+// the installed iOS app we hand it to the native Share sheet. These tests pin
+// that split plus the parity / error / one-click-no-modal behavior.
 //
 // Mirrors the fetch-mock + sonner-stub pattern from live-layout-panel.test.tsx.
 
@@ -14,14 +20,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/share/share-or-download", () => ({
+  inStandaloneApp: vi.fn(() => false),
+  shareOrDownloadFile: vi.fn(() => Promise.resolve()),
+}));
 
 import { ExportPdfButton } from "./export-pdf-button";
 import { toast } from "sonner";
+import { inStandaloneApp, shareOrDownloadFile } from "@/lib/share/share-or-download";
 
 let fetchMock: ReturnType<typeof vi.fn>;
+let openMock: ReturnType<typeof vi.fn>;
+let fakeTab: { location: { href: string }; close: ReturnType<typeof vi.fn>; document: { write: ReturnType<typeof vi.fn> } };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(inStandaloneApp).mockReturnValue(false);
   fetchMock = vi.fn(() =>
     Promise.resolve({
       ok: true,
@@ -30,6 +44,9 @@ beforeEach(() => {
     } as Response),
   );
   vi.stubGlobal("fetch", fetchMock);
+  fakeTab = { location: { href: "" }, close: vi.fn(), document: { write: vi.fn() } };
+  openMock = vi.fn(() => fakeTab);
+  vi.stubGlobal("open", openMock);
 });
 
 afterEach(() => {
@@ -64,43 +81,50 @@ describe("ExportPdfButton (#487 one-click export)", () => {
     expect(body.preset_id).toBeUndefined();
   });
 
-  it("downloads the returned signed URL as <filenameHint>.pdf on success", async () => {
-    let downloadedHref = "";
-    let downloadName = "";
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(function (this: HTMLAnchorElement) {
-        downloadedHref = this.href;
-        downloadName = this.download;
-      });
-
+  it("on desktop, opens the signed URL in a new tab instead of navigating away", async () => {
     renderButton();
     fireEvent.click(screen.getByRole("button", { name: /export pdf/i }));
 
-    await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
-    expect(downloadedHref).toBe("https://signed.example/EST-001.pdf");
-    expect(downloadName).toBe("EST-001.pdf");
-    expect(toast.success).toHaveBeenCalled();
-    clickSpy.mockRestore();
+    // Tab is pre-opened synchronously (before the await) so the popup blocker
+    // lets it through, then pointed at the PDF once the route responds.
+    expect(openMock).toHaveBeenCalledWith("", "_blank");
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(fakeTab.location.href).toBe("https://signed.example/EST-001.pdf");
+    // Desktop never touches the native Share sheet.
+    expect(shareOrDownloadFile).not.toHaveBeenCalled();
   });
 
-  it("surfaces an error and triggers no download when the route fails", async () => {
+  it("closes the pre-opened tab and navigates nowhere when the route fails", async () => {
     fetchMock.mockResolvedValueOnce({
       ok: false,
       status: 400,
       json: async () => ({ error: "no default preset configured" }),
     } as Response);
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {});
 
     renderButton();
     fireEvent.click(screen.getByRole("button", { name: /export pdf/i }));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
-    expect(clickSpy).not.toHaveBeenCalled();
+    expect(fakeTab.close).toHaveBeenCalled();
+    expect(fakeTab.location.href).toBe(""); // never sent anywhere
     expect(toast.success).not.toHaveBeenCalled();
-    clickSpy.mockRestore();
+  });
+
+  it("in the installed app, hands the file to the Share sheet — no tab", async () => {
+    vi.mocked(inStandaloneApp).mockReturnValue(true);
+
+    renderButton();
+    fireEvent.click(screen.getByRole("button", { name: /export pdf/i }));
+
+    await waitFor(() => expect(shareOrDownloadFile).toHaveBeenCalled());
+    expect(shareOrDownloadFile).toHaveBeenCalledWith({
+      url: "https://signed.example/EST-001.pdf",
+      filename: "EST-001.pdf",
+      mode: "share",
+    });
+    // No tab is opened inside the WebView.
+    expect(openMock).not.toHaveBeenCalled();
+    expect(toast.success).toHaveBeenCalled();
   });
 
   it("targets the invoice pdf route for an invoice (still no preset_id)", async () => {

--- a/src/components/documents/export-pdf-button.tsx
+++ b/src/components/documents/export-pdf-button.tsx
@@ -5,6 +5,7 @@ import { FileDown } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import type { DocumentType } from "@/lib/types";
+import { inStandaloneApp, shareOrDownloadFile } from "@/lib/share/share-or-download";
 
 interface Props {
   documentType: DocumentType;
@@ -29,6 +30,30 @@ export function ExportPdfButton({
 
   async function handleExport() {
     if (exporting) return;
+
+    // The pdf route returns a *cross-origin* Supabase signed URL. Browsers
+    // ignore the <a download> attribute for cross-origin hrefs, so the old
+    // anchor click just navigated the current tab to the PDF — ejecting the
+    // SPA. On desktop we instead open the PDF in a new tab. The tab must be
+    // opened *synchronously*, inside this click gesture and before any await,
+    // or the popup blocker eats it (and post-await window.open is silently
+    // dropped by the iOS WebView). We point it at the PDF once it's rendered.
+    const app = inStandaloneApp();
+    const pdfTab = app ? null : window.open("", "_blank");
+    if (pdfTab) {
+      // A held-open blank tab reads as broken; show that work is in flight.
+      try {
+        pdfTab.document.write(
+          "<!doctype html><title>Preparing PDF…</title>" +
+            "<body style='margin:0;font:16px system-ui,sans-serif;" +
+            "display:flex;align-items:center;justify-content:center;" +
+            "height:100vh;color:#475569'>Preparing your PDF…",
+        );
+      } catch {
+        /* writing to the popup is best-effort polish, never load-bearing */
+      }
+    }
+
     setExporting(true);
     try {
       const base = documentType === "estimate" ? "estimates" : "invoices";
@@ -38,19 +63,29 @@ export function ExportPdfButton({
         body: "{}",
       });
       if (!res.ok) {
+        pdfTab?.close();
         const err = (await res.json().catch(() => ({}))) as { error?: string };
         toast.error(err.error || `Export failed (${res.status})`);
         return;
       }
       const { download_url } = (await res.json()) as { download_url: string };
-      const a = document.createElement("a");
-      a.href = download_url;
-      a.download = `${filenameHint}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
+      const filename = `${filenameHint}.pdf`;
+
+      if (app) {
+        // Installed iOS app / standalone shell: the in-app WebView can neither
+        // download nor open a usable tab, so hand the file to the native Share
+        // sheet (Save to Files, AirDrop, …) instead.
+        await shareOrDownloadFile({ url: download_url, filename, mode: "share" });
+      } else if (pdfTab) {
+        // Desktop: send the pre-opened tab to the freshly rendered PDF.
+        pdfTab.location.href = download_url;
+      } else {
+        // Pre-open was blocked — best effort rather than ejecting the SPA.
+        window.open(download_url, "_blank", "noopener,noreferrer");
+      }
       toast.success("PDF exported");
     } catch {
+      pdfTab?.close();
       toast.error("Export failed");
     } finally {
       setExporting(false);

--- a/src/lib/share/share-or-download.ts
+++ b/src/lib/share/share-or-download.ts
@@ -55,9 +55,11 @@ function canShareFile(file: File): boolean {
 /**
  * Whether we're running inside an installed shell — a standalone PWA, an iOS
  * Add-to-Home-Screen page, or a Capacitor WKWebView — where tapping a download
- * anchor navigates the SPA to the file instead of saving it.
+ * anchor (or opening a tab) navigates the SPA to the file instead of saving it.
+ * Exported because the Export PDF action needs the same branch (its third
+ * consumer, alongside DownloadPdfButton's inline copy).
  */
-function inStandaloneApp(): boolean {
+export function inStandaloneApp(): boolean {
   if (typeof window === "undefined") return false;
   const cap = (window as Window & {
     Capacitor?: { isNativePlatform?: () => boolean };


### PR DESCRIPTION
## Problem

"Export PDF" on estimates/invoices ejected you from the app. The `pdf`
route returns a **cross-origin Supabase signed URL**; the button then
clicked a hidden `<a download>`. Browsers **ignore `download` for
cross-origin hrefs**, so on desktop the click navigated the whole tab to
the PDF — kicking you out of the SPA.

## Fix

- **Desktop:** open the PDF in a **new tab**. The tab is pre-opened
  synchronously inside the click gesture (before any `await`, so the
  popup blocker lets it through), then pointed at the signed URL once
  rendered. The app stays put. Route errors close the blank tab + toast.
- **Installed iOS app / standalone:** hand the file to the native
  **Share sheet** via the existing `shareOrDownloadFile(mode: "share")`.
- Exported `inStandaloneApp()` from `share-or-download` (its third
  consumer) instead of copying the standalone/Capacitor detection again.

## Scope check

Verified the other PDF/download surfaces don't share the bug:
contracts download streams **same-origin** (`/api/contracts/[id]/pdf`)
and already uses the Share sheet in-app; accounting exports are
same-origin CSV/ZIP. The cross-origin-signed-URL eject was unique to the
estimate/invoice Export PDF.

## Tests

- `export-pdf-button.test.tsx` rewritten — desktop new-tab, in-app
  Share-sheet, and error-closes-the-tab branches. 6/6 pass.
- `share-or-download.test.ts` 7/7 pass; `tsc`/`eslint` clean on touched files.
- Desktop new-tab confirmed working by the reporter. iOS Share-sheet path
  is device-only — worth a TestFlight confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
