### PR TITLE
docs(timesheets): glossary + ADRs 0019/0020 for per-Job timesheets (#699)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -362,6 +362,98 @@ connection or an Email account: per-Organization, opt-in, never a shared
 admin login. An Organization without one simply has no site publishing.
 _Avoid_: site integration, WP hookup, website sync
 
+**Job timesheet**:
+A document an Organization generates from a Job's recorded labor — per-worker
+totals plus a chronological list of sessions over a chosen date range — and
+exports as a PDF to send alongside an **Invoice**, built to stand up to a harsh
+insurance review. Belongs to exactly one Job. Records **hours only**: it carries
+no billing rates and no location stamp — its weight comes from auditable time and
+an owner/lead **certification**, not GPS (see [ADR 0019](docs/adr/0019-timesheets-record-defensible-hours-not-location.md)).
+Generated, certified, and listed on the Job like a numbered **Photo Report**;
+once signed its PDF is frozen and never regenerated (the signed-contract rule —
+[ADR 0011](docs/adr/0011-signed-contract-pdfs-are-immutable.md)).
+_Avoid_: timecard, time report, labor report, payroll (it is explicitly not payroll)
+
+**Certification** (of a Job timesheet):
+The owner's or lead's sign-off that closes a **Job timesheet** — a printed
+attestation that the recorded hours are accurate, stamped with their drawn or
+saved signature at generation time. It is what gives the sheet its evidentiary
+weight for an insurer, in place of GPS (see [ADR 0019](docs/adr/0019-timesheets-record-defensible-hours-not-location.md)),
+and signing it **freezes** the PDF (the signed-contract rule —
+[ADR 0011](docs/adr/0011-signed-contract-pdfs-are-immutable.md)). v1 is a single
+owner/lead Certification, not a per-worker signature.
+_Avoid_: sign-off, approval, e-signature (that names the mechanism, not the act)
+
+**Time session**:
+The atomic unit of recorded labor: one worker, on one Job, from a **Clock in** to
+a **Clock out** — the hours are the span between. The worker is either an app
+**User** or an **Off-app worker**, never both. A person has at most one **Open
+session** at a time; clocking into a different Job closes the previous one. The
+hours of a session split into **Regular** and **Premium** (see [ADR 0020](docs/adr/0020-labor-hour-classification-and-org-timezone.md)).
+_Avoid_: shift (implies a scheduled workday), punch, time entry, clock event
+
+**Open session**:
+A **Time session** that has a clock-in but no clock-out yet — someone currently
+working. A person has at most one across all Jobs. The presence surfaces ("On the
+clock", "On site now") are built from the set of Open sessions.
+_Avoid_: active session, current clock, open punch
+
+**Clock in / Clock out**:
+The acts of starting and ending one's own **Time session** by tapping in the app
+on site. **Crew members can only live-clock themselves** in and out — they can
+never type or edit a time; changing a recorded time is a **Correction**
+(leads/admins only).
+_Avoid_: punch in/out, check in/out, sign in (that is authentication)
+
+**Regular hours**:
+Labor hours at the base rate: worked Monday–Friday between 7am and 5pm, up to 8
+hours in a calendar day. Everything outside that window is **Premium hours**.
+Bucketed in the **Organization timezone**, not the device's. See [ADR 0020](docs/adr/0020-labor-hour-classification-and-org-timezone.md).
+_Avoid_: standard hours, straight time, normal time
+
+**Premium hours**:
+Labor hours above the base rate — a single tier covering both overtime and
+after-hours, because the Organization bills them at one rate. Premium = before
+7am or after 5pm on a weekday, all hours on Saturdays, Sundays, and US federal
+holidays, or any hours past 8 in a calendar day. Each premium stretch is labelled
+with its reason (overtime / evening / weekend / holiday), but the reason never
+changes the rate — premiums do **not** stack. See [ADR 0020](docs/adr/0020-labor-hour-classification-and-org-timezone.md).
+_Avoid_: overtime (that is one reason for Premium, not the whole tier), OT,
+after-hours (likewise), time-and-a-half
+
+**Off-app worker**:
+A person whose hours appear on a **Job timesheet** but who is not an app
+**User** — e.g. day labor or a sub helping for a day. Entered by name by a lead,
+carries hand-entered hours only, and never self-clocks or shows on a live
+presence board. Distinct from a **vendor subcontractor** (an outside *company*
+whose bills the Organization records as expenses — a `vendor` type); the two are
+unrelated despite both meaning "outside help" — see Flagged ambiguities.
+_Avoid_: subcontractor (collides with the vendor sense), sub, guest, contractor
+
+**Correction** (of a Time session):
+A lead's or admin's edit to a session's times — or a session created entirely by
+hand — used when someone forgot to clock in or out, a phone died, or an **Off-app
+worker**'s day must be recorded. Times are **never auto-fabricated**; every
+Correction is audit-logged (who, when, old → new) and the session is marked
+hand-entered so it is visibly distinguishable on the **Job timesheet** from a live
+clock.
+_Avoid_: edit, adjustment, override, manual entry (use "hand-entered")
+
+**On the clock**:
+The set of people with an **Open session** right now. Surfaced two ways: per-Job
+("On site now", visible to anyone who can view the Job) and company-wide ("On the
+clock now" on the owner's dashboard, a leads/admins view). **Off-app workers**
+never appear here — only on the printed **Job timesheet**.
+_Avoid_: online, present, active, checked in
+
+**Organization timezone**:
+The single timezone an Organization's labor hours are bucketed and classified
+against — defaulted from its business address, set in Settings. It is
+authoritative: **Regular**/**Premium** classification is computed server-side
+against this zone, never an individual device's clock, so the same session yields
+the same hours no matter whose phone recorded it. See [ADR 0020](docs/adr/0020-labor-hour-classification-and-org-timezone.md).
+_Avoid_: local time, device time, user timezone
+
 ## Relationships
 
 - A **User** belongs to one or more **Organizations**; each membership carries a role.
@@ -382,6 +474,10 @@ _Avoid_: site integration, WP hookup, website sync
 - A **Photo Report template** belongs to one **Organization** and seeds a new Photo Report's **Sections**; applying one is a starting point, not a binding link.
 - A **Job** has zero or one **Showcase**; a Showcase belongs to exactly one Job and gathers that Job's **Photos** plus a write-up for public marketing.
 - An **Organization** has one **Report layout default**; it seeds every new Photo Report's **Report Settings** at creation and is not a binding link (the report keeps its own copy). Distinct from a **Photo Report template**, which seeds Sections rather than look.
+- A **Time session** belongs to one **Organization** and one **Job** and names exactly one worker — either an app **User** or an **Off-app worker**, never both. A person has at most one **Open session** across all Jobs; clocking into another Job closes the prior session. An **Off-app worker** has no record of its own — it is just the typed name carried on its sessions.
+- A **Job** has zero or more **Time sessions** and zero or more **Job timesheets**; each Job timesheet is generated from that Job's sessions over a chosen date range, numbered per Job (like a **Photo Report**), and frozen once certified-and-signed (see [ADR 0011](docs/adr/0011-signed-contract-pdfs-are-immutable.md), [ADR 0019](docs/adr/0019-timesheets-record-defensible-hours-not-location.md)).
+- A **Time session**'s hours split into **Regular** and **Premium**, classified against the **Organization timezone** (see [ADR 0020](docs/adr/0020-labor-hour-classification-and-org-timezone.md)); a session crossing midnight is split at the calendar-day boundary.
+- An **Organization** has exactly one **Organization timezone**, defaulted from its business address.
 
 ## Example dialogue
 
@@ -395,3 +491,4 @@ _Avoid_: site integration, WP hookup, website sync
 - "section" is used for two unrelated concepts: an **Estimate** Section (a group of priced line items) and a **Photo Report** Section (a heading + one-page write-up + photos). Resolved: both keep the word but are always qualified by their document ("Estimate section" vs "Photo Report section"); they share no table, type, or component.
 - "template" is likewise overloaded: an **Estimate** template (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)) and a **Photo Report** template. Resolved: always qualify by document. Note the older Photo-Report builder UI also called these "presets" — the canonical term is **Photo Report template**; "preset" is an alias to retire _there_.
 - "preset" and "layout" are overloaded across domains. On the **Photo Report** side both are words to avoid (canonical term: **Photo Report template**). On the **billing-PDF** side they are first-class and canonical — a **PDF preset** (reusable saved look) and a **PDF layout** (the look stuck to one Estimate/Invoice). Resolved the same way as "section"/"template": always qualify by document, so bare "preset"/"layout" never appear unqualified. The billing-PDF preset has lived in the code (`pdf_presets`) since before this was written; ADR 0007 explicitly left that system out of its scope.
+- "subcontractor" is overloaded. In the existing code it is a **`vendor` type** (`VendorType`, `src/lib/types.ts`) — an outside *company* whose bills the Organization records as job expenses. The new time-tracking feature also has outside help — an individual hired for a day whose *hours* go on a **Job timesheet** — but that is a different thing entirely (a person's labor, not a company's invoice). Resolved: the timesheet person is an **Off-app worker**; "subcontractor" stays reserved for the vendor sense, and the two never share a table or term.

--- a/docs/adr/0019-timesheets-record-defensible-hours-not-location.md
+++ b/docs/adr/0019-timesheets-record-defensible-hours-not-location.md
@@ -1,0 +1,71 @@
+# Job timesheets prove hours worked, not location
+
+**Status:** Accepted
+**Date:** 2026-06-17 (grilling session for the per-Job timesheet PRD — issue #699)
+
+Nookleus is adding per-Job timesheets so an Organization can send an insurance
+reviewer a defensible record of the labor hours behind an Invoice (see the new
+glossary terms **Job timesheet** and **Time session**). The obvious instinct for
+an "insurance-grade" record is to GPS-stamp every clock-in to prove a worker was
+physically on site. We are deliberately **not** doing that.
+
+## Context
+
+The app already takes a deliberate no-location stance: **Photos carry no GPS**
+(a Photo Report records "location captured" as the Job's property address, not
+coordinates), and the product stores no other position data. An insurance
+timesheet is the one surface where a reviewer might *expect* a location stamp, so
+its absence will read as an oversight to a future engineer unless it is recorded
+as a choice.
+
+## Decision
+
+1. **A Job timesheet substantiates hours, not presence.** Its evidentiary weight
+   comes from defensible, auditable time records — who, which Job, clock-in and
+   clock-out, how each **Time session** was captured (live clock vs hand-entered),
+   a full edit audit trail, and an owner/lead **certification** with signature —
+   not from any geographic proof that a person stood at a coordinate. No
+   latitude/longitude is captured, stored, or printed.
+2. **Times are never fabricated, and that is the integrity story.** Crew members
+   can only live-clock *themselves* in and out; a missing or wrong time is fixed
+   only by a lead/admin **Correction**, which is audit-logged (who, when, old →
+   new) and visibly marked as hand-entered on the sheet. Every hour being
+   traceable to a live tap or a named human's hand-entry is what survives a harsh
+   review — in place of GPS.
+3. **Location is reserved strictly for a future clock-in *assist*, never as
+   evidence.** A planned fast-follow may use the device's foreground location to
+   *suggest* the nearest Job when a worker taps "Clock in" (so crews stop clocking
+   into the wrong Job). That is a convenience hint computed on-device; it is not
+   recorded on the session and never appears on the timesheet. Background "you
+   left the site" geofencing is deferred further still.
+
+## Consequences
+
+- The timesheet's defensibility rests entirely on **audit quality**:
+  immutable-once-signed PDFs (the same rule as signed contracts —
+  [ADR 0011](0011-signed-contract-pdfs-are-immutable.md)), the capture-method
+  marker on every session, and the edit audit log. Those must be solid because
+  there is no GPS fallback to lean on.
+- We avoid the privacy, battery, and iOS always-on-location-permission costs of
+  tracking worker positions — and the liability of holding employee location
+  histories.
+- If an insurer ever specifically demands geo-proof, this is the decision to
+  revisit — and it would be a genuinely new posture (location as a stored
+  evidentiary fact), not a small toggle, which is exactly why it is recorded here.
+
+## Considered options
+
+- **GPS-stamp each clock-in as on-site proof.** Rejected: it breaks the app's
+  standing no-location stance for marginal evidentiary gain (a coordinate proves a
+  phone's position, not who worked or for how long), and it imposes always-on
+  location permission, battery drain, and the liability of storing staff location
+  trails.
+- **Geofence the Job site and auto-clock in/out on arrival/departure.** Rejected
+  for v1: it needs always-on background location and push, and it still does not
+  make the *hours* more honest — it just relocates where the unverified edge cases
+  live. Deferred.
+- **No location code at all, ever.** Rejected as too absolute: the foreground
+  "nearest Job" clock-in *assist* is a real usability win the owner asked for, and
+  it can be done without recording position. The line is drawn at "location may
+  *assist* the act of clocking in, but is never recorded as evidence," not "no
+  location code exists."

--- a/docs/adr/0020-labor-hour-classification-and-org-timezone.md
+++ b/docs/adr/0020-labor-hour-classification-and-org-timezone.md
@@ -1,0 +1,77 @@
+# Labor hours classify into Regular and one Premium tier, in one Organization timezone
+
+**Status:** Accepted
+**Date:** 2026-06-17 (grilling session for the per-Job timesheet PRD — issue #699)
+
+A **Job timesheet** splits each worker's hours into billing tiers. Two
+non-obvious choices are worth recording: there is exactly **one** premium tier
+(overtime and after-hours do not stack), and all classification is computed
+against a **single Organization timezone**, never the recording device's clock.
+
+## Context
+
+Most payroll and time systems model overtime and night/weekend premiums as
+separate, stackable multipliers (e.g. 1.5× overtime, 2× Sunday, compounding to
+3×), and they classify against wherever the clock physically is. This
+Organization bills differently and operates differently, so the feature deviates
+from both norms — and an engineer porting payroll intuition would "fix" this into
+stacking multipliers and device-local time unless the deviation is recorded. This
+is a billing-practice rule, not a legal one (it is explicitly **not** payroll).
+
+## Decision
+
+1. **Two tiers only: Regular and Premium.** Regular = Monday–Friday, 7am–5pm, up
+   to 8 hours in a calendar day. Premium = everything else: before 7am or after
+   5pm on a weekday, *all* hours on Saturdays, Sundays, and the 11 US federal
+   holidays (observed dates), or any hours past 8 in a calendar day.
+2. **Premium is a single rate; reasons label but never stack.** The Organization
+   bills overtime and after-hours at the same rate, so a premium stretch carries a
+   human-readable reason (overtime / evening / weekend / holiday) for the
+   reviewer, but an hour is Premium *once* — a Saturday hour past the 8th is not
+   "double premium." This is also why business hours start at **7am**: an early
+   start must not be penalised into a higher tier, because there is no higher tier
+   and the owner will not charge a homeowner premium merely for starting early.
+3. **Classified server-side against one authoritative Organization timezone.** A
+   new per-Organization timezone setting (defaulted from the business address) is
+   the single zone hours are bucketed in. The 7am/5pm boundaries, the day-of-week,
+   the >8h/day cap, and the holiday calendar are all evaluated against that zone —
+   never the recording device's clock — so the same session yields identical hours
+   regardless of whose phone captured it or where they were. Sessions are summed
+   per calendar day for the daily cap; a session crossing midnight is split at the
+   day boundary; overtime is daily-only (no weekly accumulator).
+
+## Consequences
+
+- A **new authoritative Organization setting** (timezone) is introduced and must
+  be defaulted sensibly from the business address; classification depends on it
+  and must never silently fall back to device-local `new Date()`. The codebase
+  already has a documented UTC-vs-local "previous calendar day" trap
+  (`src/lib/date-field.ts`), so the boundary math must be written against the
+  Organization zone explicitly rather than the host's.
+- A maintained **US federal-holiday calendar** (observed dates) becomes part of
+  the billing logic — a small data dependency that has to be kept current.
+- Because there is no stacking, the model cannot express a customer or
+  jurisdiction that genuinely pays, say, 2× on Sundays *on top of* overtime. That
+  is a deliberate simplification matching how this Organization bills; revisit only
+  if a multi-rate premium is ever actually billed.
+- The thresholds (7am–5pm, 8h/day, the federal-holiday set) are business rules,
+  not law, and live in one place so they can be tuned to the owner's billing
+  practice.
+
+## Considered options
+
+- **Stacking multipliers (separate overtime, evening, weekend, holiday rates).**
+  Rejected: the Organization bills all premium time at one rate, so multiple tiers
+  would be machinery with no billing meaning — and a future source of disputes
+  ("why is this hour billed 3×?").
+- **Classify in each device's local timezone.** Rejected: a crew member
+  travelling, a misconfigured phone, or plain UTC drift would silently mis-bucket
+  hours and make two people's records of the same day disagree. One Organization
+  zone is the only way the math is reproducible and defensible.
+- **Weekly overtime (>40h/week) in addition to daily.** Rejected for v1: the owner
+  bills daily (>8h/day); a weekly accumulator adds state and reconciliation with no
+  stated need. Left as a future option.
+- **A 9am start or no business-hours floor.** Rejected: the owner specifically
+  does not want to charge a homeowner premium for an early-morning start, which a
+  9am floor — or an after-5pm-only rule with no morning boundary — would get
+  wrong in opposite directions. 7am–5pm matches the actual billing intent.


### PR DESCRIPTION
Docs output from the `/grill-with-docs` session on the per-Job timesheet PRD (**#699**).

- **CONTEXT.md** — new glossary terms: Job timesheet, Certification, Time session, Open session, Clock in/out, Regular/Premium hours, Off-app worker, plus a "subcontractor" overload note (vendor company vs. timesheet person). 97 insertions, additive only.
- **ADR 0019** — timesheets prove hours worked, not location: no GPS; the owner/lead Certification carries the evidentiary weight for insurers.
- **ADR 0020** — labor hours classify into Regular + a single Premium tier (overtime and after-hours don't stack), bucketed in the Organization timezone, not the device's.

Docs only — no code. ADR 0017 (contract-email frame, #687) was intentionally left out as unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
