### PR TITLE
docs(adr): job-status pipeline relabel — ADR 0022 + glossary (#719)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,7 +107,7 @@ _Avoid_: chat, thread (in code — fine in UI copy), message log
 **Job tag**:
 The link from a single text/call event to a Job. Set automatically when
 the event has no ambiguity (outbound started from a Job page; inbound
-from a Contact with exactly one Active job) and prompted-for otherwise.
+from a Contact with exactly one Open job) and prompted-for otherwise.
 Untagged events live only in the Phone tab; tagged events also surface on
 the Job's card. Visibility follows the tag: a Job-tagged event on a
 Personal phone number is team-visible (because Job content is company
@@ -144,7 +144,9 @@ the Job it produces — the moment a Job is born by hand, distinct from Jobs cre
 as a side effect elsewhere (e.g. from a payment or a Referral Partner's job list).
 Submitting an intake is the event that buzzes the rest of the team — see
 [ADR 0018](docs/adr/0018-new-intake-push-notifications.md).
-_Avoid_: lead, prospect, enquiry, ticket; "new job" (that names the resulting record, not the act)
+_Avoid_: prospect, enquiry, ticket; "a lead" for the act (the intake is the act of
+logging the job; **Lead** is the **Job status** the resulting Job is born into — so
+"lead" names the Job's stage, never the act); "new job" (that names the resulting record, not the act)
 
 **Urgency**:
 A Job's response-time tier — one of three fixed values, `emergency`, `urgent`, or
@@ -155,12 +157,31 @@ Jobs page floats emergencies to the top, and the new-intake notification speaks 
 tier — an 🚨 emergency leads the title, and each tier carries its own sound.
 _Avoid_: priority, severity, importance (fine in UI copy)
 
-**Active job**:
-A job that is still alive — its status is neither `completed` nor `cancelled`,
-and it has not been trashed (`deleted_at IS NULL`). A cancelled job is dead,
-not active. The dashboard's "Jobs to advance" and "People to respond to"
-sections both filter to Active jobs only.
-_Avoid_: open job, current job, running job, in-progress job (that one is a specific status, not the whole alive set)
+**Job status**:
+The lifecycle stage a Job sits in — one of five, in pipeline order: **Lead**
+(a new job just logged; the sale not yet won), **Active** (a contract is
+signed and the work is live), **Collections** (the work is billed and payment
+is being chased), **Closed** (finished and settled), and **Lost** (the job
+fell through — the renamed "dead" state). A Job is born a **Lead** at
+**Intake**. Signing a contract is the one automatic move: it advances a
+**Lead** — or revives a **Lost** job — to **Active**, and never drags a job
+already further along backward; every other move is a deliberate user choice.
+Says where a Job is in its lifecycle, distinct from its **Urgency** (how fast
+to respond) and from a Referral Partner's **Lifecycle status** (a different
+four-state concept on a different list).
+_Avoid_: stage, phase, pipeline status, label (in code — "label" is fine in
+UI copy); "Active" for the whole alive set (that is an **Open job**)
+
+**Open job**:
+A Job that is still alive — its **Job status** is **Lead**, **Active**, or
+**Collections** (i.e. not **Closed** and not **Lost**), and it has not been
+trashed (`deleted_at IS NULL`). A **Lost** job is dormant, not open; a
+**Closed** job is done. The dashboard's "Jobs to advance" and "People to
+respond to" sections, and the Jobs page's headline count (shown as "Open
+jobs"), all filter to Open jobs only. Renamed from the earlier "Active job"
+once **Active** became a single **Job status** and the two would have collided.
+_Avoid_: active job (collides with the **Active** status), current job,
+running job, in-progress job (that one is a specific status, not the whole alive set)
 
 **Photo**:
 A single image — or short video — captured on a Job and shown in the Job's
@@ -283,6 +304,55 @@ never authored on its own. Unlike an Estimate it carries a due date, a payment
 state, and QuickBooks sync; a deposit or staged payment is a partial payment on
 the single Invoice, never a second Invoice.
 _Avoid_: bill (fine in UI copy), receipt
+
+**Invoiced** (Financials figure):
+The sum of a Job's sent-or-later Invoices — `sent`, `partial`, or `paid`;
+drafts and voided are excluded (see [ADR 0007](docs/adr/0007-estimates-are-the-single-billing-entry-point.md)).
+The "what you've billed on this Job so far" figure on the Financials tab.
+_Avoid_: billed, total invoices (drafts and voided do not count)
+
+**Collected**:
+The sum of a Job's received payments. A payment can land before any Invoice
+exists — a deposit is routinely taken before an Estimate is even written — so
+Collected may be positive while Invoiced is still $0, and may even run past
+Invoiced (the Job is then "paid ahead"). Billing and collecting are
+independent: Collected is not a slice of Invoiced.
+_Avoid_: paid, revenue, income
+
+**Outstanding**:
+Invoiced − Collected: the Job's unpaid receivable. Meaningful only once an
+Invoice exists; when Collected has run past Invoiced the Job is **paid ahead**,
+not outstanding.
+_Avoid_: balance, amount due, owed
+
+**Collection rate**:
+Collected ÷ Invoiced — the share of what's been billed that has actually been
+paid, drawn as the collection ring on the Financials tab (see [ADR 0021](docs/adr/0021-financials-tab-job-profit-and-collection-ring.md)).
+Undefined until an Invoice exists: the tab shows "not invoiced yet" in place of a
+ring, which is the common early-Job state because deposits precede billing.
+_Avoid_: paid percentage, collection ratio
+
+**Crew labor**:
+A Job's estimated crew-labor cost (`estimated_crew_labor_cost`) — a single,
+hand-entered figure the owner sets per Job. It is the **one cost basis the app
+keeps**: a deliberate, narrow exception to the rule that Nookleus stores no
+contractor cost (see Estimate line item), narrow because it is always an
+*estimate*, never a captured or actual labor cost (Job timesheets record hours,
+not dollars). It feeds **Job profit**, and the Financials tab labels it "(est.)"
+so it is never read as a billed or actual figure.
+_Avoid_: labor cost, actual labor, payroll
+
+**Job profit**:
+A Job's running cash position on the Financials tab: Collected − Expenses −
+Crew labor (the Job's estimated crew-labor cost). It is **not** an accounting
+margin — it blends actual cash (Collected, Expenses) with an estimate (Crew
+labor), swings over a Job's life, and is marked "(in progress)" until the Job
+is completed. The rule that the app computes no cost-basis margin (see Estimate
+line item) is about **Estimate pricing**; Job profit is cash-in minus cash-out
+minus estimated crew labor — a different thing, deliberately kept apart from an
+Estimate's **Markup** / **Overhead & Profit** (see [ADR 0021](docs/adr/0021-financials-tab-job-profit-and-collection-ring.md)).
+_Avoid_: gross margin (the former UI label and the `gross_margin` code field —
+a misnomer: it is not a cost-basis margin), margin, profit margin, net
 
 **PDF preset**:
 A saved, reusable set of look-preferences for the customer-facing PDF of an
@@ -487,8 +557,10 @@ _Avoid_: local time, device time, user timezone
 ## Flagged ambiguities
 
 - "auth gate" was used for four near-identical route helpers (`requirePermission`, `requireAdmin`, `requireViewAccounting`, and an inline `requireLogExpenses`) — resolved: these collapse into the one **Request Context** wrapper.
-- "active" was being used for two unrelated concepts in `src/lib/accounting/margins.ts`: (a) a job with financial activity in a reporting period, and (b) a non-completed job (the user-facing filter pill on the Job Profitability page, which also folds cancelled jobs in with active ones). Neither matches the canonical **Active job** definition above. The dashboard rebuild adopts the canonical meaning; the accounting page is left as-is for now but is a cleanup candidate.
+- "active" was being used for two unrelated concepts in `src/lib/accounting/margins.ts`: (a) a job with financial activity in a reporting period, and (b) a non-completed job (the user-facing filter pill on the Job Profitability page, which also folds cancelled jobs in with active ones). Neither matches the canonical **Open job** definition above. The dashboard rebuild adopts the canonical meaning; the accounting page is left as-is for now but is a cleanup candidate.
+- "active" gained a _third_ sense when Job statuses were relabeled (Lead / Active / Collections / Closed / Lost): **Active** is now a single **Job status** — a signed, live job (formerly the `in_progress` status). Resolved: the alive-set concept is renamed **Open job** (UI stat "Open jobs"), and "Active" is reserved for the one status. The code's internal `ACTIVE_STATUSES` list and `active` filters keep their names but denote the Open-job set; the relabel is glossary/UI-level — the underlying status keys (`new`, `in_progress`, `pending_invoice`, `completed`, `cancelled`) are unchanged, only their display labels move (Lead, Active, Collections, Closed, Lost).
 - "section" is used for two unrelated concepts: an **Estimate** Section (a group of priced line items) and a **Photo Report** Section (a heading + one-page write-up + photos). Resolved: both keep the word but are always qualified by their document ("Estimate section" vs "Photo Report section"); they share no table, type, or component.
 - "template" is likewise overloaded: an **Estimate** template (see [ADR 0004](docs/adr/0004-template-line-items-snapshot.md)) and a **Photo Report** template. Resolved: always qualify by document. Note the older Photo-Report builder UI also called these "presets" — the canonical term is **Photo Report template**; "preset" is an alias to retire _there_.
 - "preset" and "layout" are overloaded across domains. On the **Photo Report** side both are words to avoid (canonical term: **Photo Report template**). On the **billing-PDF** side they are first-class and canonical — a **PDF preset** (reusable saved look) and a **PDF layout** (the look stuck to one Estimate/Invoice). Resolved the same way as "section"/"template": always qualify by document, so bare "preset"/"layout" never appear unqualified. The billing-PDF preset has lived in the code (`pdf_presets`) since before this was written; ADR 0007 explicitly left that system out of its scope.
 - "subcontractor" is overloaded. In the existing code it is a **`vendor` type** (`VendorType`, `src/lib/types.ts`) — an outside *company* whose bills the Organization records as job expenses. The new time-tracking feature also has outside help — an individual hired for a day whose *hours* go on a **Job timesheet** — but that is a different thing entirely (a person's labor, not a company's invoice). Resolved: the timesheet person is an **Off-app worker**; "subcontractor" stays reserved for the vendor sense, and the two never share a table or term.
+- "margin" / "gross margin" was overloaded. The Financials tab's bottom-line figure was labelled **Gross margin** and the code field is `gross_margin` (`src/lib/accounting/margins.ts`), yet the glossary says the app computes no cost-basis margin. Resolved: the figure is renamed **Job profit** (a job cash position, not an accounting margin); "margin" is reserved for the Estimate-pricing discussion (**Markup** / **Overhead & Profit**), where the no-cost-basis rule genuinely holds. The `gross_margin`/`margin_pct` code fields are a rename cleanup candidate, mirroring the `margins.ts` "active" note above.

--- a/docs/adr/0022-job-status-labels-display-only-and-signed-contract-auto-advance.md
+++ b/docs/adr/0022-job-status-labels-display-only-and-signed-contract-auto-advance.md
@@ -1,0 +1,103 @@
+# Job-status labels are display-only; signing a contract auto-advances Lead or Lost to Active
+
+**Status:** Accepted
+**Date:** 2026-06-19 (grilling session for the job-status relabel — `/grill-with-docs`)
+
+The five **Job status** stages (**Lead → Active → Collections → Closed →
+Lost**) are a pure **relabel** of the existing vocabulary: only the
+org-scoped `job_statuses` display labels (and colors/icons/order) change,
+while the underlying snake_case keys — `new`, `in_progress`,
+`pending_invoice`, `completed`, `cancelled` — stay exactly as they are.
+Separately, signing a contract becomes the one automatic status move: it
+advances a **Lead** (or revives a **Lost** job) to **Active**, and never
+drags a job that is already further along backward.
+
+## Context
+
+A Job's lifecycle stage is free-text `jobs.status` (no CHECK constraint, no
+FK). The human-facing vocabulary lives in the per-Organization
+`job_statuses` table (`name` key / `display_label` / `bg_color` /
+`text_color` / `sort_order` / `is_default`), seeded with five rows whose keys
+are `new` / `in_progress` / `pending_invoice` / `completed` / `cancelled`.
+Those keys are also hardcoded as string literals across ~12 code sites — the
+phone-tab `ACTIVE_STATUSES` sets, Jarvis tools, accounting margins, the
+dashboard `new`-count, and an RLS view that filters
+`status not in ('completed','cancelled')` — so the keys are a de-facto API
+that a rename would have to chase everywhere, plus a data migration over every
+existing job row.
+
+The owner asked for a "1-to-1 rename with some automations," not new stages.
+Because labels already render through `job_statuses` + `config-context.tsx`,
+the rename is achievable entirely at the display layer with **zero** churn to
+the keys, the ~12 call sites, the RLS view, or existing data.
+
+Today the only writer of `jobs.status` is a person (the job-detail dropdown).
+The owner wants signing a contract to move the job forward on its own — but
+only forward, and only from the two states where "we just won the work" is
+true: a fresh **Lead**, or a **Lost** deal that came back to life.
+
+## Decision
+
+1. **Relabel by editing `job_statuses` display columns only; never the
+   `name` keys.** `new` displays as **Lead**, `in_progress` as **Active**,
+   `pending_invoice` as **Collections**, `completed` as **Closed**, and
+   `cancelled` as **Lost 😢**. The keys, the ~12 hardcoded key sites, the
+   unread-threads RLS view, and all existing `jobs.status` data are
+   untouched. `config-context.tsx` (`getStatusLabel` / `getStatusColor`) plus
+   the `job_statuses` rows remain the single source of truth for how a key
+   renders; the hardcoded status dropdown in `job-detail.tsx` must be made
+   config-driven so it reads these five labels instead of carrying its own
+   copy.
+
+2. **Signing a contract is the one automatic status move, and it only moves
+   forward.** When a contract is marked signed, if the Job's status is `new`
+   (**Lead**) **or** `cancelled` (**Lost**), set it to `in_progress`
+   (**Active**). If the Job is already `in_progress`, `pending_invoice`, or
+   `completed`, signing leaves the status untouched — it never moves a job
+   backward. Every other transition (into Collections, Closed, Lost, or any
+   manual correction) stays a deliberate user choice; no money event auto-moves
+   status.
+
+## Consequences
+
+- **A future reader will see `jobs.status = 'cancelled'` rendering as
+  "Lost 😢" and `pending_invoice` rendering as "Collections," and must not
+  "fix" it.** The key↔label divergence is deliberate, recorded here, and
+  centralized in `job_statuses` + `config-context.tsx`. Any new lifecycle
+  logic must branch on the snake_case **keys**, never on the display labels.
+- **The auto-advance adds a second writer of `jobs.status`** (previously
+  user-only). It must fire at the single signing choke point and be
+  idempotent, because a contract can be finalized through more than one path
+  (the `mark_contract_signed` RPC in `migration-build33-contracts.sql` and the
+  `src/lib/contracts/finalize.ts` write path). Re-running a sign must not
+  re-advance or otherwise change a status that has since moved on.
+- **Reviving a Lost job on signing is intentional**: a deal marked Lost that
+  later signs re-enters the live pipeline at Active rather than being stranded
+  as dead. This is the only path that moves a job *out of* a terminal-looking
+  state automatically.
+- **Sort order, default visibility (hiding Closed/Lost), the per-stage
+  filter, and the visual treatment are UI concerns, not recorded here** —
+  they are easily reversible and live in the PRD, not this ADR.
+
+## Considered options
+
+- **Rename the database keys to `lead`/`active`/`collections`/`closed`/`lost`.**
+  Rejected: it buys nothing a user can see (labels already come from
+  `job_statuses`) while forcing a data migration over every Job row plus a
+  rewrite of ~12 hardcoded `status === '…'` sites and an RLS view — real risk
+  on a live system for cosmetic key-tidiness. Keeping the keys is the safe,
+  reversible choice; the labels can be re-tuned freely without ever touching
+  data or code.
+- **Lock the vocabulary with a CHECK constraint or FK to `job_statuses`.**
+  Rejected (out of scope): the vocabulary is intentionally org-editable and
+  dynamic; constraining it is a separate decision with its own trade-offs.
+- **Let signing advance *any* status to Active.** Rejected: it would drag a
+  billed (Collections) or finished (Closed) job backward into Active, which is
+  wrong — signing is only meaningful as the Lead→Active gate (plus the
+  Lost-revival case).
+- **Advance only Lead→Active; leave Lost alone.** Rejected: the owner
+  explicitly wanted a resurrected deal to climb back into the pipeline
+  ("Lead OR Lost moves up").
+- **Auto-move further down the pipeline on money events (payment →
+  Collections, paid → Closed).** Rejected: the owner chose to keep every
+  money-related transition manual; only the signing gate is automated.


### PR DESCRIPTION
## What

Docs-only: capture the job-status pipeline design agreed via `/grill-with-docs`.

- **ADR 0022** — two hard-to-reverse decisions:
  1. The five-stage relabel (**Lead → Active → Collections → Closed → Lost**) is **display-only** — the `job_statuses` labels/colors change but the snake_case keys (`new` / `in_progress` / `pending_invoice` / `completed` / `cancelled`) stay, so the key-based code sites (phone, Jarvis, margins, dashboard) and the email-thread RLS view don't break.
  2. Signing a contract **auto-advances a Lead or Lost job to Active**, never backward; all other moves stay manual.
- **CONTEXT.md** — new **Job status** glossary term; **Active job → Open job** rename (headline stat "Open jobs") to resolve the "Active" collision; Intake "lead" wording reconciled.

## Why

These are the documentation deliverables of the grilling session; the implementation is tracked separately.

## Related

- PRD: #719
- Implementation slices: #720–#728

🤖 Generated with [Claude Code](https://claude.com/claude-code)
