### PR TITLE
feat(jobs): relabel lifecycle to Lead→Active→Collections→Closed→Lost (display-only) (#720)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -490,11 +490,11 @@ export default function JobDetail({ jobId }: { jobId: string }) {
             onChange={(e) => updateStatus(e.target.value)}
             className="w-[180px] rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
           >
-            <option value="new">New</option>
-            <option value="in_progress">In Progress</option>
-            <option value="pending_invoice">Pending Invoice</option>
-            <option value="completed">Completed</option>
-            <option value="cancelled">Cancelled</option>
+            <option value="new">Lead</option>
+            <option value="in_progress">Active</option>
+            <option value="pending_invoice">Collections</option>
+            <option value="completed">Closed</option>
+            <option value="cancelled">Lost 😢</option>
           </select>
           {showJobDeleteAffordances && !job.deleted_at && (
             <button

--- a/src/lib/badge-colors.ts
+++ b/src/lib/badge-colors.ts
@@ -1,17 +1,23 @@
+// Job-status pipeline relabel (issue #720, ADR 0022): keys are frozen; only
+// the display changes — New→Lead, In Progress→Active, Pending Invoice→
+// Collections, Completed→Closed, Cancelled→Lost. Lost moves to a muted rose
+// so it no longer looks identical to grey Closed. The canonical source of
+// truth is src/lib/job-status-presentation.ts + the job_statuses rows; this
+// static map is the job-detail hold-out kept in sync until #722 migrates it.
 export const statusColors: Record<string, string> = {
   new: "bg-amber-100 text-amber-800 ring-1 ring-amber-200",
   in_progress: "bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200",
   pending_invoice: "bg-violet-100 text-violet-800 ring-1 ring-violet-200",
   completed: "bg-stone-100 text-stone-600 ring-1 ring-stone-200",
-  cancelled: "bg-stone-100 text-stone-500 ring-1 ring-stone-200",
+  cancelled: "bg-rose-100 text-rose-800 ring-1 ring-rose-200",
 };
 
 export const statusLabels: Record<string, string> = {
-  new: "New",
-  in_progress: "In Progress",
-  pending_invoice: "Pending Invoice",
-  completed: "Completed",
-  cancelled: "Cancelled",
+  new: "Lead",
+  in_progress: "Active",
+  pending_invoice: "Collections",
+  completed: "Closed",
+  cancelled: "Lost 😢",
 };
 
 export const urgencyColors: Record<string, string> = {

--- a/src/lib/config-context.tsx
+++ b/src/lib/config-context.tsx
@@ -3,23 +3,20 @@
 import { createContext, useContext, useEffect, useState, useCallback, type ReactNode } from "react";
 import { createClient } from "@/lib/supabase";
 import type { JobStatus, DamageType } from "@/lib/types";
+import { JOB_STATUS_PRESENTATION } from "@/lib/job-status-presentation";
 
-// Fallback defaults used before DB data loads
-const DEFAULT_STATUS_COLORS: Record<string, { bg: string; text: string }> = {
-  new: { bg: "#FAEEDA", text: "#633806" },
-  in_progress: { bg: "#E1F5EE", text: "#085041" },
-  pending_invoice: { bg: "#EEEDFE", text: "#3C3489" },
-  completed: { bg: "#F1EFE8", text: "#5F5E5A" },
-  cancelled: { bg: "#F1EFE8", text: "#5F5E5A" },
-};
+// Fallback defaults used before DB data loads. Derived from the single
+// code-side source of truth (issue #720) so the pre-load labels/colors —
+// Lead / Active / Collections / Closed / Lost — can never drift from the
+// presentation module or the relabel migration.
+const DEFAULT_STATUS_COLORS: Record<string, { bg: string; text: string }> =
+  Object.fromEntries(
+    Object.values(JOB_STATUS_PRESENTATION).map((p) => [p.key, p.badge]),
+  );
 
-const DEFAULT_STATUS_LABELS: Record<string, string> = {
-  new: "New",
-  in_progress: "In Progress",
-  pending_invoice: "Pending Invoice",
-  completed: "Completed",
-  cancelled: "Cancelled",
-};
+const DEFAULT_STATUS_LABELS: Record<string, string> = Object.fromEntries(
+  Object.values(JOB_STATUS_PRESENTATION).map((p) => [p.key, p.label]),
+);
 
 const DEFAULT_DAMAGE_COLORS: Record<string, { bg: string; text: string }> = {
   water: { bg: "#E6F1FB", text: "#0C447C" },

--- a/src/lib/job-status-presentation.test.ts
+++ b/src/lib/job-status-presentation.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getJobStatusPresentation,
+  isOpenJobStatus,
+  JOB_STATUS_PRESENTATION,
+} from "./job-status-presentation";
+
+// Issue #720 (PRD #719, ADR 0022) — the Job lifecycle relabels to the
+// pipeline Lead → Active → Collections → Closed → Lost as a DISPLAY-only
+// change. The snake_case keys stay frozen; this module is the code-side
+// source of truth for the facets job_statuses can't carry (icon, stripe
+// accent, pipeline rank, Open verdict) plus the default label/badge colors.
+
+describe("getJobStatusPresentation", () => {
+  it("relabels the `new` key to Lead — an open stage at pipeline rank 1", () => {
+    const lead = getJobStatusPresentation("new");
+    expect(lead.label).toBe("Lead");
+    expect(lead.isOpen).toBe(true);
+    expect(lead.sortRank).toBe(1);
+  });
+
+  // Display-only relabel of the five frozen keys (ADR 0022).
+  const labels: Array<[string, string]> = [
+    ["new", "Lead"],
+    ["in_progress", "Active"],
+    ["pending_invoice", "Collections"],
+    ["completed", "Closed"],
+    ["cancelled", "Lost 😢"],
+  ];
+  it.each(labels)("relabels %s to %s", (key, label) => {
+    expect(getJobStatusPresentation(key).label).toBe(label);
+  });
+});
+
+describe("isOpenJobStatus", () => {
+  // Open job = Lead / Active / Collections; Closed and Lost are dead stages.
+  const cases: Array<[string, boolean]> = [
+    ["new", true],
+    ["in_progress", true],
+    ["pending_invoice", true],
+    ["completed", false],
+    ["cancelled", false],
+  ];
+  it.each(cases)("treats %s as open=%s", (key, expected) => {
+    expect(isOpenJobStatus(key)).toBe(expected);
+    expect(getJobStatusPresentation(key).isOpen).toBe(expected);
+  });
+});
+
+describe("JOB_STATUS_PRESENTATION completeness", () => {
+  const KNOWN_KEYS = [
+    "new",
+    "in_progress",
+    "pending_invoice",
+    "completed",
+    "cancelled",
+  ] as const;
+
+  it("covers exactly the five frozen lifecycle keys", () => {
+    expect(Object.keys(JOB_STATUS_PRESENTATION).sort()).toEqual(
+      [...KNOWN_KEYS].sort(),
+    );
+  });
+
+  it.each(KNOWN_KEYS)(
+    "gives %s a non-empty label, icon, accent, and badge colors",
+    (key) => {
+      const p = JOB_STATUS_PRESENTATION[key];
+      expect(p.label.trim().length).toBeGreaterThan(0);
+      expect(p.icon.trim().length).toBeGreaterThan(0);
+      expect(p.accentColor.trim().length).toBeGreaterThan(0);
+      expect(p.badge.bg.trim().length).toBeGreaterThan(0);
+      expect(p.badge.text.trim().length).toBeGreaterThan(0);
+    },
+  );
+});
+
+describe("Lost is visually distinct from Closed", () => {
+  // The whole point of the relabel: Closed and Lost both render warm grey
+  // today; Lost (cancelled) must move to a muted rose so it no longer looks
+  // identical to grey Closed (completed).
+  it("gives Lost a different badge + accent than Closed", () => {
+    const closed = getJobStatusPresentation("completed");
+    const lost = getJobStatusPresentation("cancelled");
+    expect(lost.badge.bg).not.toBe(closed.badge.bg);
+    expect(lost.badge.text).not.toBe(closed.badge.text);
+    expect(lost.accentColor).not.toBe(closed.accentColor);
+  });
+});
+
+describe("pipeline sort order", () => {
+  it("ranks the stages Lead → Active → Collections → Closed → Lost", () => {
+    const ranks = [
+      "new",
+      "in_progress",
+      "pending_invoice",
+      "completed",
+      "cancelled",
+    ].map((k) => getJobStatusPresentation(k).sortRank);
+    expect(ranks).toEqual([1, 2, 3, 4, 5]);
+  });
+});
+
+describe("unknown status keys", () => {
+  it("falls back to the raw key, dead + sorted last, with usable defaults", () => {
+    const p = getJobStatusPresentation("some_custom_org_status");
+    expect(p.key).toBe("some_custom_org_status");
+    expect(p.label).toBe("some_custom_org_status");
+    expect(p.isOpen).toBe(false);
+    expect(p.sortRank).toBeGreaterThan(5); // sorts after the five known stages
+    expect(p.icon.trim().length).toBeGreaterThan(0);
+    expect(p.accentColor.trim().length).toBeGreaterThan(0);
+    expect(p.badge.bg.trim().length).toBeGreaterThan(0);
+    expect(p.badge.text.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/job-status-presentation.ts
+++ b/src/lib/job-status-presentation.ts
@@ -1,0 +1,103 @@
+// src/lib/job-status-presentation.ts
+//
+// Single source of truth for the CODE-SIDE facets of a Job status that the
+// org-scoped `job_statuses` table cannot carry: the stage icon, the card
+// left-stripe accent color, the pipeline sort rank, and the Open-vs-dead
+// verdict — plus the default label and badge colors used as the pre-load
+// fallback (and as the values the relabel migration seeds into the DB).
+//
+// The snake_case keys are FROZEN (ADR 0022). Only the DISPLAY changes: the
+// lifecycle relabels to the pipeline Lead → Active → Collections → Closed →
+// Lost. Any lifecycle logic must branch on the keys, never the labels.
+
+import type { Job } from "@/lib/types";
+
+export type JobStatusKey = Job["status"];
+
+export interface JobStatusPresentation {
+  /** Frozen snake_case status key (ADR 0022). */
+  key: string;
+  /** Default display label — the relabel migration seeds these into job_statuses.display_label. */
+  label: string;
+  /** lucide-react icon component name (same convention as damage_types.icon). */
+  icon: string;
+  /** Card left-stripe accent color (hex). */
+  accentColor: string;
+  /** Default badge colors — the pre-load fallback for getStatusColor and the migration source. */
+  badge: { bg: string; text: string };
+  /** Pipeline rank: Lead 1 → Active 2 → Collections 3 → Closed 4 → Lost 5. */
+  sortRank: number;
+  /** Open job stage? Lead/Active/Collections = true; Closed/Lost = false. */
+  isOpen: boolean;
+}
+
+export const JOB_STATUS_PRESENTATION: Record<string, JobStatusPresentation> = {
+  new: {
+    key: "new",
+    label: "Lead",
+    icon: "Sprout",
+    accentColor: "#C8841E",
+    badge: { bg: "#FAEEDA", text: "#633806" },
+    sortRank: 1,
+    isOpen: true,
+  },
+  in_progress: {
+    key: "in_progress",
+    label: "Active",
+    icon: "Hammer",
+    accentColor: "#0E9F6E",
+    badge: { bg: "#E1F5EE", text: "#085041" },
+    sortRank: 2,
+    isOpen: true,
+  },
+  pending_invoice: {
+    key: "pending_invoice",
+    label: "Collections",
+    icon: "Banknote",
+    accentColor: "#6E5BD6",
+    badge: { bg: "#EEEDFE", text: "#3C3489" },
+    sortRank: 3,
+    isOpen: true,
+  },
+  completed: {
+    key: "completed",
+    label: "Closed",
+    icon: "CheckCircle2",
+    accentColor: "#9A988F",
+    badge: { bg: "#F1EFE8", text: "#5F5E5A" },
+    sortRank: 4,
+    isOpen: false,
+  },
+  cancelled: {
+    key: "cancelled",
+    label: "Lost 😢",
+    icon: "Frown",
+    accentColor: "#E44B4A",
+    badge: { bg: "#FBEAEA", text: "#9B2C2C" },
+    sortRank: 5,
+    isOpen: false,
+  },
+};
+
+/** Presentation for an unknown key — renders the raw key, sorts last, counts as dead. */
+function unknownPresentation(key: string): JobStatusPresentation {
+  return {
+    key,
+    label: key,
+    icon: "Circle",
+    accentColor: "#9A988F",
+    badge: { bg: "#F1EFE8", text: "#5F5E5A" },
+    sortRank: 99,
+    isOpen: false,
+  };
+}
+
+/** Presentation facets for a status key, with a sensible fallback for unknown keys. */
+export function getJobStatusPresentation(key: string): JobStatusPresentation {
+  return JOB_STATUS_PRESENTATION[key] ?? unknownPresentation(key);
+}
+
+/** True when the status is an Open job stage (Lead / Active / Collections). */
+export function isOpenJobStatus(key: string): boolean {
+  return getJobStatusPresentation(key).isOpen;
+}

--- a/supabase/migration-659-relabel-job-statuses-pipeline.sql
+++ b/supabase/migration-659-relabel-job-statuses-pipeline.sql
@@ -1,0 +1,54 @@
+-- migration-659-relabel-job-statuses-pipeline.sql
+-- ===========================================================================
+-- Issue #720 (PRD #719, ADR 0022) — relabel the Job lifecycle to the pipeline
+-- Lead → Active → Collections → Closed → Lost as a DISPLAY-ONLY change.
+--
+-- The five snake_case status keys are FROZEN (ADR 0022): new / in_progress /
+-- pending_invoice / completed / cancelled stay exactly as they are. No
+-- jobs.status data is migrated; the ~12 key-based code sites (phone, Jarvis,
+-- margins, dashboard, the unread-threads RLS view) are untouched. Only the
+-- per-org job_statuses DISPLAY columns change:
+--   new             New             -> Lead
+--   in_progress     In Progress     -> Active
+--   pending_invoice Pending Invoice -> Collections
+--   completed       Completed       -> Closed
+--   cancelled       Cancelled       -> Lost 😢  (+ muted rose so it no longer
+--                                                looks identical to grey Closed)
+--
+-- Scope: ONLY the Nookleus-provided global defaults — the rows seeded in
+-- migration-build14c.sql with organization_id IS NULL (see migration-build44,
+-- Bucket D). An organization's own custom status rows (organization_id set)
+-- are never touched. Colors mirror src/lib/job-status-presentation.ts, the
+-- code-side source of truth; new/in_progress/pending_invoice/completed keep
+-- their existing palette, only cancelled (Lost) recolors to rose.
+--
+-- sort_order already runs 1..5 in pipeline order from the original seed; it is
+-- restated here so the migration is a complete statement of the desired end
+-- state. The Jobs-page stage GROUPING order (Active first) is a UI concern
+-- handled separately (issue #723), not this row ordering.
+--
+-- Depends on: migration-build14c (job_statuses + the 5 seeded defaults),
+--             migration-build43/44/45 (organization_id column, defaults LEFT NULL).
+-- Idempotent: re-running sets the same end state.
+-- ===========================================================================
+
+update public.job_statuses set display_label = 'Lead',        bg_color = '#FAEEDA', text_color = '#633806', sort_order = 1 where organization_id is null and name = 'new';
+update public.job_statuses set display_label = 'Active',       bg_color = '#E1F5EE', text_color = '#085041', sort_order = 2 where organization_id is null and name = 'in_progress';
+update public.job_statuses set display_label = 'Collections',  bg_color = '#EEEDFE', text_color = '#3C3489', sort_order = 3 where organization_id is null and name = 'pending_invoice';
+update public.job_statuses set display_label = 'Closed',       bg_color = '#F1EFE8', text_color = '#5F5E5A', sort_order = 4 where organization_id is null and name = 'completed';
+update public.job_statuses set display_label = 'Lost 😢',      bg_color = '#FBEAEA', text_color = '#9B2C2C', sort_order = 5 where organization_id is null and name = 'cancelled';
+
+-- VERIFY (run after applying) ---
+-- select name, display_label, bg_color, text_color, sort_order
+--   from public.job_statuses
+--  where organization_id is null
+--  order by sort_order;
+-- Expect: new=Lead, in_progress=Active, pending_invoice=Collections,
+--         completed=Closed (#F1EFE8/#5F5E5A), cancelled=Lost 😢 (#FBEAEA/#9B2C2C).
+
+-- ROLLBACK ---
+-- update public.job_statuses set display_label = 'New',             bg_color = '#FAEEDA', text_color = '#633806', sort_order = 1 where organization_id is null and name = 'new';
+-- update public.job_statuses set display_label = 'In Progress',     bg_color = '#E1F5EE', text_color = '#085041', sort_order = 2 where organization_id is null and name = 'in_progress';
+-- update public.job_statuses set display_label = 'Pending Invoice', bg_color = '#EEEDFE', text_color = '#3C3489', sort_order = 3 where organization_id is null and name = 'pending_invoice';
+-- update public.job_statuses set display_label = 'Completed',       bg_color = '#F1EFE8', text_color = '#5F5E5A', sort_order = 4 where organization_id is null and name = 'completed';
+-- update public.job_statuses set display_label = 'Cancelled',       bg_color = '#F1EFE8', text_color = '#5F5E5A', sort_order = 5 where organization_id is null and name = 'cancelled';


### PR DESCRIPTION
## Summary

First vertical slice of the job-status pipeline relabel (parent PRD #719, ADR 0022). Relabels the five Job lifecycle stages to **Lead → Active → Collections → Closed → Lost** as a **display-only** change — the snake_case keys (`new` / `in_progress` / `pending_invoice` / `completed` / `cancelled`) stay frozen, so no `jobs.status` data is migrated and every key-based code site (phone, Jarvis, margins, dashboard, the unread-threads RLS view) is untouched.

## What's in this slice

- **`src/lib/job-status-presentation.ts`** — the deep module and code-side source of truth for the facets `job_statuses` can't carry: `key → { label, icon, accentColor, badge, sortRank, isOpen }`, with `getJobStatusPresentation()` (sensible fallback for unknown keys) and `isOpenJobStatus()` (Lead/Active/Collections = open; Closed/Lost = dead). Icons are lucide names (the `damage_types.icon` convention) — verified to resolve against lucide-react 1.7.0.
- **`supabase/migration-659-relabel-job-statuses-pipeline.sql`** — `UPDATE`s the five `organization_id IS NULL` default rows to the new labels; **Lost** recolors to a muted rose (`#FBEAEA`/`#9B2C2C`) so it no longer looks identical to grey **Closed**. Scoped so org-custom rows and all `jobs.status` data are untouched.
- **`config-context.tsx`** — `DEFAULT_STATUS_*` fallbacks now *derive* from the module (one source of truth), so the three config-driven Job views + filter pills show the new labels/colors even before the DB row loads.
- **`badge-colors.ts` + `job-detail.tsx`** — relabeled the job-detail badge, toast, and dropdown option text. (Making the dropdown *config-driven* is #722; the card stripe is #724; the stage icon is #727.)

Dashboard new-jobs and the phone tab don't render a Job status badge, so there was nothing to change there.

## Test plan

- `npx vitest run src/lib/job-status-presentation.test.ts` → **20/20 passing** (tracer → all 5 labels → Open predicate → unknown-key fallback → completeness guard → Lost ≠ Closed → pipeline sort order).
- `tsc --noEmit` → no errors in any touched file.
- `eslint` → clean on touched lines (only the pre-existing repo-wide `react-hooks/set-state-in-effect` findings remain).

## Deploy note

`migration-659` ships here but only takes effect once applied to prod Supabase on deploy; the derived fallback maps mean the new labels render correctly even before that.

Parent: #719 · ADR: `docs/adr/0022-…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
