### PR TITLE
feat(financials): rename Job summary figure to "Profit" + color by sign (#715)

### DIFF
--- a/src/components/job-detail/financials-tab.test.tsx
+++ b/src/components/job-detail/financials-tab.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import FinancialsTab from "./financials-tab";
+
+// The Billing and Expenses sections fetch live data / need auth context; this
+// slice only touches the summary row, so stub them out to keep the render pure.
+vi.mock("@/components/billing/billing-section", () => ({ default: () => null }));
+vi.mock("@/components/expenses/expenses-section", () => ({ default: () => null }));
+
+type Summary = {
+  invoiced: number;
+  collected: number;
+  expenses: number;
+  gross_margin: number;
+  margin_pct: number | null;
+  in_progress: boolean;
+};
+
+function renderTab(summary: Partial<Summary> = {}) {
+  return render(
+    <FinancialsTab
+      jobId="job-1"
+      payments={[]}
+      invoices={[]}
+      summary={{
+        invoiced: 0,
+        collected: 0,
+        expenses: 0,
+        gross_margin: 0,
+        margin_pct: null,
+        in_progress: false,
+        ...summary,
+      }}
+      onPaymentRecorded={() => {}}
+      onExpenseLogged={() => {}}
+    />,
+  );
+}
+
+// #715 — the headline figure is "Profit", coloured by sign on both the number
+// and the card tint, on the four-across summary row (phone + desktop).
+describe("FinancialsTab summary figure", () => {
+  it("labels the headline figure 'Profit', not 'Gross margin'", () => {
+    renderTab({ gross_margin: 1200, margin_pct: 34, in_progress: false });
+
+    expect(screen.getByText("Profit")).toBeTruthy();
+    expect(screen.queryByText("Gross margin")).toBeNull();
+  });
+
+  it("renders a negative Profit red — figure and card tint — not green", () => {
+    renderTab({ gross_margin: -800, margin_pct: -20, in_progress: false });
+
+    const value = screen.getByText("-$800");
+    expect(value.style.color).toBe("rgb(240, 149, 149)"); // #F09595
+
+    const card = screen.getByText("Profit").closest(".rounded-lg") as HTMLElement;
+    expect(card.style.background).toContain("rgba(240, 149, 149"); // red tint
+  });
+
+  it("renders a positive Profit green with a profit-percent caption", () => {
+    renderTab({ gross_margin: 3400, margin_pct: 34, in_progress: false });
+
+    const value = screen.getByText("$3,400");
+    expect(value.style.color).toBe("rgb(93, 202, 165)"); // #5DCAA5
+
+    const card = screen.getByText("Profit").closest(".rounded-lg") as HTMLElement;
+    expect(card.style.background).toContain("rgba(29, 158, 117"); // green tint
+    expect(screen.getByText("34.0% profit")).toBeTruthy();
+  });
+
+  it("captions an in-progress Job '(in progress)'", () => {
+    renderTab({ gross_margin: 3400, margin_pct: 34, in_progress: true });
+
+    expect(screen.getByText("(in progress)")).toBeTruthy();
+    expect(screen.queryByText("34.0% profit")).toBeNull();
+  });
+});

--- a/src/components/job-detail/financials-tab.tsx
+++ b/src/components/job-detail/financials-tab.tsx
@@ -4,6 +4,7 @@ import type { Payment } from "@/lib/types";
 import BillingSection from "@/components/billing/billing-section";
 import ExpensesSection from "@/components/expenses/expenses-section";
 import { FinancialsInvoiceList, type FinancialsInvoice } from "./financials-invoice-list";
+import { profitFigure, type ProfitPalette } from "./profit-figure";
 
 type Props = {
   jobId: string;
@@ -43,6 +44,7 @@ export default function FinancialsTab({
   onExpenseLogged,
   stripeConnected = false,
 }: Props) {
+  const profit = profitFigure(summary);
   return (
     <div className="space-y-6">
       {/* Summary metrics row — 4 pills */}
@@ -51,16 +53,10 @@ export default function FinancialsTab({
         <SummaryPill label="Collected" value={fmtCurrency(summary.collected)} />
         <SummaryPill label="Expenses" value={fmtCurrency(summary.expenses)} />
         <SummaryPill
-          label="Gross margin"
+          label={profit.label}
           value={fmtCurrency(summary.gross_margin)}
-          highlight
-          caption={
-            summary.in_progress
-              ? "(in progress)"
-              : summary.margin_pct !== null
-              ? `${summary.margin_pct.toFixed(1)}% margin`
-              : undefined
-          }
+          palette={profit.palette}
+          caption={profit.caption}
         />
       </div>
 
@@ -81,42 +77,38 @@ export default function FinancialsTab({
 function SummaryPill({
   label,
   value,
-  highlight,
+  palette,
   caption,
 }: {
   label: string;
   value: string;
-  highlight?: boolean;
+  /** when set, the pill is the highlighted figure tinted by sign (green/red) */
+  palette?: ProfitPalette;
   caption?: string;
 }) {
-  const hl = highlight
-    ? {
-        background: "rgba(29, 158, 117, 0.12)",
-        border: "1px solid rgba(29, 158, 117, 0.35)",
-        color: "#5DCAA5",
-      }
-    : undefined;
   return (
     <div
       className="rounded-lg p-4"
       style={
-        hl ?? {
-          background: "rgba(255,255,255,0.03)",
-          border: "1px solid rgba(255,255,255,0.08)",
-        }
+        palette
+          ? { background: palette.background, border: `1px solid ${palette.border}` }
+          : {
+              background: "rgba(255,255,255,0.03)",
+              border: "1px solid rgba(255,255,255,0.08)",
+            }
       }
     >
       <div className="text-xs uppercase tracking-wide text-neutral-400">{label}</div>
       <div
         className="mt-1 text-2xl font-semibold"
-        style={hl ? { color: "#5DCAA5" } : undefined}
+        style={palette ? { color: palette.text } : undefined}
       >
         {value}
       </div>
       {caption && (
         <div
           className="mt-1 text-xs"
-          style={{ color: highlight ? "#9FE1CB" : "#a3a3a3" }}
+          style={{ color: palette ? palette.caption : "#a3a3a3" }}
         >
           {caption}
         </div>

--- a/src/components/job-detail/profit-figure.test.ts
+++ b/src/components/job-detail/profit-figure.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+
+import { profitFigure } from "./profit-figure";
+
+// #715 — the Job Financials headline figure is "Profit" (a Job's running cash
+// position, Collected − Expenses − Crew labor), coloured by sign: green ≥ 0,
+// red < 0. This pure deriver owns that figure→display logic so every state is
+// unit-testable without rendering React.
+describe("profitFigure", () => {
+  it("labels the figure 'Profit' and tints it green when profit is positive", () => {
+    const figure = profitFigure({ gross_margin: 1200, margin_pct: 34, in_progress: false });
+
+    expect(figure.label).toBe("Profit");
+    expect(figure.palette.text).toBe("#5DCAA5");
+  });
+
+  it("tints a negative profit red (fixing the prior always-green bug)", () => {
+    const figure = profitFigure({ gross_margin: -800, margin_pct: -20, in_progress: false });
+
+    expect(figure.palette.text).toBe("#F09595");
+  });
+
+  it("treats exactly-zero profit as the non-negative (green) boundary", () => {
+    const figure = profitFigure({ gross_margin: 0, margin_pct: 0, in_progress: false });
+
+    expect(figure.palette.text).toBe("#5DCAA5");
+  });
+
+  it("carries a green card tint (background + border) for a positive profit", () => {
+    const { palette } = profitFigure({ gross_margin: 500, margin_pct: 10, in_progress: false });
+
+    expect(palette.background).toBe("rgba(29, 158, 117, 0.12)");
+    expect(palette.border).toBe("rgba(29, 158, 117, 0.35)");
+  });
+
+  it("carries a red card tint (background + border) for a negative profit", () => {
+    const { palette } = profitFigure({ gross_margin: -500, margin_pct: -10, in_progress: false });
+
+    expect(palette.background).toBe("rgba(240, 149, 149, 0.12)");
+    expect(palette.border).toBe("rgba(240, 149, 149, 0.35)");
+  });
+
+  it("captions a completed Job's percent in profit terms, not margin", () => {
+    const figure = profitFigure({ gross_margin: 3400, margin_pct: 34, in_progress: false });
+
+    expect(figure.caption).toBe("34.0% profit");
+  });
+
+  it("captions an in-progress Job '(in progress)', not a percent", () => {
+    const figure = profitFigure({ gross_margin: 3400, margin_pct: 34, in_progress: true });
+
+    expect(figure.caption).toBe("(in progress)");
+  });
+
+  it("omits the caption on a completed Job with no percent (nothing collected)", () => {
+    const figure = profitFigure({ gross_margin: -200, margin_pct: null, in_progress: false });
+
+    expect(figure.caption).toBeUndefined();
+  });
+
+  it("gives the caption a sign-matched colour so it never contradicts the figure", () => {
+    const profit = profitFigure({ gross_margin: 3400, margin_pct: 34, in_progress: false });
+    const loss = profitFigure({ gross_margin: -3400, margin_pct: -34, in_progress: false });
+
+    expect(profit.palette.caption).toBe("#9FE1CB");
+    expect(loss.palette.caption).toBe("#F09595");
+  });
+});

--- a/src/components/job-detail/profit-figure.ts
+++ b/src/components/job-detail/profit-figure.ts
@@ -1,0 +1,51 @@
+export type ProfitPalette = {
+  /** the headline number's text colour */
+  text: string;
+  /** the card's background tint */
+  background: string;
+  /** the card's border tint */
+  border: string;
+  /** the caption's text colour — a lighter shade of the figure colour */
+  caption: string;
+};
+
+export type ProfitFigure = {
+  label: "Profit";
+  palette: ProfitPalette;
+  /** sub-label under the figure; omitted when there's nothing to say */
+  caption?: string;
+};
+
+// Green keeps the figure's existing money-palette tint verbatim so a positive
+// Profit is visually unchanged; red is the same #F09595 named in the palette,
+// derived to a matching low-alpha background/border for the loss case.
+const GREEN: ProfitPalette = {
+  text: "#5DCAA5",
+  background: "rgba(29, 158, 117, 0.12)",
+  border: "rgba(29, 158, 117, 0.35)",
+  caption: "#9FE1CB",
+};
+
+const RED: ProfitPalette = {
+  text: "#F09595",
+  background: "rgba(240, 149, 149, 0.12)",
+  border: "rgba(240, 149, 149, 0.35)",
+  caption: "#F09595",
+};
+
+// `gross_margin`/`margin_pct` keep the existing summary field names; the value
+// is the Job's Profit (Collected − Expenses − Crew labor) — renaming the data
+// shape is a separate concern (see #714's view-model deriver).
+export function profitFigure(summary: {
+  gross_margin: number;
+  margin_pct: number | null;
+  in_progress: boolean;
+}): ProfitFigure {
+  const palette = summary.gross_margin >= 0 ? GREEN : RED;
+  const caption = summary.in_progress
+    ? "(in progress)"
+    : summary.margin_pct !== null
+      ? `${summary.margin_pct.toFixed(1)}% profit`
+      : undefined;
+  return { label: "Profit", palette, caption };
+}


### PR DESCRIPTION
Closes #715. Parent: #714.

## What

On the Job **Financials** tab, the headline figure was labelled **"Gross margin"** and hard-coded green regardless of value — so a Job with a negative result showed green. This slice:

- Renames the figure to **"Profit"** (a Job's running cash position, Collected − Expenses − Crew labor — per CONTEXT.md / ADR 0021).
- Colours **both the number and the card tint by sign**: green `#5DCAA5` when ≥ 0, red `#F09595` when < 0 — fixing the always-green bug.
- Updates the completed-Job caption to read in profit terms (e.g. `34.0% profit`); the in-progress caption still reads `(in progress)`.
- **No layout change** — the existing four-across summary row is untouched on every width; the positive case is pixel-identical.

## How

The figure→display logic moves into a new **pure, client-safe deriver** — `src/components/job-detail/profit-figure.ts` — so every state (sign → colour, caption wording) is unit-testable without rendering React. This is the deep module the parent PRD (#714) calls for; later #714 slices can build the phone layout on top of it.

`SummaryPill`'s hard-coded green `highlight` boolean becomes an optional sign-aware `palette`; the other three pills stay neutral.

## Tests (TDD, red→green per behavior)

- `profit-figure.test.ts` — 9 cases: label; positive→green; negative→red (the bug fix); zero boundary; green/red tints; completed `X% profit` caption; in-progress override; sign-matched caption colour.
- `financials-tab.test.tsx` — 4 render cases on the real component: "Profit" shows / "Gross margin" gone; negative renders a red number + tint; positive green + `34.0% profit`; in-progress caption.

All 13 pass. Touched files are `tsc --noEmit` clean and `eslint` clean (pre-existing baseline errors live only in unrelated files — email tiptap, `sanitize-html`, camera, `jay-peg`, `tests/integration/*.pg` — from optional deps not installed since the recent pull).

## Acceptance criteria

- [x] Figure reads **"Profit"** on phone + desktop
- [x] Profit ≥ 0 → green number + tint; Profit < 0 → red
- [x] Negative Profit no longer renders green
- [x] Completed caption in profit terms; in-progress reads `(in progress)`
- [x] No layout change to the four-across row
- [x] No new type-check / lint / test failures beyond baseline

## Note for review

The completed caption renders **`34.0% profit`** — I kept the existing `.toFixed(1)` precision and only swapped the noun (margin → profit). The AC's "e.g. 34% profit" reads as illustrative; if you'd prefer an integer percent, it's a one-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)