### PR TITLE
feat(job-detail): config-driven status dropdown (#722)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -33,6 +33,7 @@ import { JobEmailRow } from "@/components/email/job-email-row";
 import { buildQuotedReply } from "@/components/email/build-quoted-reply";
 import { JobMessagesSection } from "@/components/job-detail/job-messages-section";
 import { JobCallsSection } from "@/components/job-detail/job-calls-section";
+import { JobStatusSelect } from "@/components/job-detail/job-status-select";
 import { buildJobTextContacts } from "@/components/job-detail/job-text-contacts";
 import JarvisJobPanel from "@/components/jarvis/JarvisJobPanel";
 import JobFiles from "@/components/job-files";
@@ -65,13 +66,12 @@ import {
 } from "lucide-react";
 import { canDeleteJobs } from "@/lib/jobs/auth";
 import {
-  statusColors,
-  statusLabels,
   urgencyColors,
   urgencyLabels,
   damageTypeColors,
   damageTypeLabels,
 } from "@/lib/badge-colors";
+import { useConfig } from "@/lib/config-context";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { toast } from "sonner";
@@ -97,6 +97,7 @@ const SCREENFUL_PRELOAD = 12;
 
 export default function JobDetail({ jobId }: { jobId: string }) {
   const { hasPermission, profile } = useAuth();
+  const { getStatusColor, getStatusLabel } = useConfig();
   const showJobDeleteAffordances = canDeleteJobs(profile?.role);
   const [job, setJob] = useState<Job | null>(null);
   const [activities, setActivities] = useState<JobActivity[]>([]);
@@ -303,7 +304,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
     if (error) {
       toast.error("Failed to update status.");
     } else {
-      toast.success(`Status updated to ${statusLabels[newStatus]}.`);
+      toast.success(`Status updated to ${getStatusLabel(newStatus)}.`);
       fetchData();
     }
   }
@@ -448,10 +449,10 @@ export default function JobDetail({ jobId }: { jobId: string }) {
             <Badge
               className={cn(
                 "text-xs font-medium px-2 py-0.5 rounded-md",
-                statusColors[job.status]
+                getStatusColor(job.status)
               )}
             >
-              {statusLabels[job.status]}
+              {getStatusLabel(job.status)}
             </Badge>
             {job.has_signed_contract ? (
               <Badge
@@ -485,17 +486,11 @@ export default function JobDetail({ jobId }: { jobId: string }) {
               damageType: job.damage_type,
             }}
           />
-          <select
+          <JobStatusSelect
             value={job.status}
-            onChange={(e) => updateStatus(e.target.value)}
+            onChange={updateStatus}
             className="w-[180px] rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
-          >
-            <option value="new">Lead</option>
-            <option value="in_progress">Active</option>
-            <option value="pending_invoice">Collections</option>
-            <option value="completed">Closed</option>
-            <option value="cancelled">Lost 😢</option>
-          </select>
+          />
           {showJobDeleteAffordances && !job.deleted_at && (
             <button
               type="button"

--- a/src/components/job-detail/job-status-select.test.tsx
+++ b/src/components/job-detail/job-status-select.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+// Issue #722 (PRD #719) — the Job-detail status picker reads its five options
+// from config (via getJobStatusOptions) instead of a hardcoded <option> list,
+// so it shows the pipeline labels and reflects per-org renames without a code
+// change. JobStatusSelect pulls the org's job_statuses off the config context;
+// stub the context so the picker renders without a live ConfigProvider.
+//
+// The stubbed rows are deliberately in a NON-pipeline order and rename Lead to
+// "Prospect" — proving the picker takes its ORDER from the presentation module
+// and its LABELS from config.
+vi.mock("@/lib/config-context", () => ({
+  useConfig: () => ({
+    statuses: [
+      { name: "cancelled", display_label: "Lost 😢" },
+      { name: "new", display_label: "Prospect" },
+      { name: "completed", display_label: "Closed" },
+      { name: "in_progress", display_label: "Active" },
+      { name: "pending_invoice", display_label: "Collections" },
+    ],
+  }),
+}));
+
+import { JobStatusSelect } from "./job-status-select";
+
+describe("JobStatusSelect (#722)", () => {
+  it("renders the five stages from config, pipeline-ordered with org labels", () => {
+    render(<JobStatusSelect value="new" onChange={vi.fn()} />);
+
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(5);
+    expect(options.map((o) => o.textContent)).toEqual([
+      "Prospect", // org renamed Lead → Prospect (label from config)
+      "Active",
+      "Collections",
+      "Closed",
+      "Lost 😢",
+    ]);
+    expect(options.map((o) => (o as HTMLOptionElement).value)).toEqual([
+      "new",
+      "in_progress",
+      "pending_invoice",
+      "completed",
+      "cancelled",
+    ]);
+  });
+
+  it("reflects the current status and emits the new key when a stage is picked", () => {
+    const onChange = vi.fn();
+    render(<JobStatusSelect value="new" onChange={onChange} />);
+
+    const select = screen.getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("new");
+
+    fireEvent.change(select, { target: { value: "completed" } });
+    expect(onChange).toHaveBeenCalledWith("completed");
+  });
+});

--- a/src/components/job-detail/job-status-select.tsx
+++ b/src/components/job-detail/job-status-select.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useConfig } from "@/lib/config-context";
+import { getJobStatusOptions } from "@/lib/job-status-presentation";
+
+interface JobStatusSelectProps {
+  /** The Job's current status key (frozen snake_case). */
+  value: string;
+  /** Called with the newly-selected status key. */
+  onChange: (next: string) => void;
+  className?: string;
+}
+
+/**
+ * Job-detail status picker (#722).
+ *
+ * Reads the five lifecycle stages from config — getJobStatusOptions overlays
+ * the org's per-status display_label onto the canonical pipeline order — so the
+ * picker shows Lead / Active / Collections / Closed / Lost, reflects a per-org
+ * rename with no code change, and never drifts from the badges shown elsewhere.
+ * Selecting a stage calls onChange with the frozen status key.
+ */
+export function JobStatusSelect({
+  value,
+  onChange,
+  className,
+}: JobStatusSelectProps) {
+  const { statuses } = useConfig();
+  const options = getJobStatusOptions(statuses);
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={className}
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/lib/badge-colors.ts
+++ b/src/lib/badge-colors.ts
@@ -1,25 +1,7 @@
-// Job-status pipeline relabel (issue #720, ADR 0022): keys are frozen; only
-// the display changes — New→Lead, In Progress→Active, Pending Invoice→
-// Collections, Completed→Closed, Cancelled→Lost. Lost moves to a muted rose
-// so it no longer looks identical to grey Closed. The canonical source of
-// truth is src/lib/job-status-presentation.ts + the job_statuses rows; this
-// static map is the job-detail hold-out kept in sync until #722 migrates it.
-export const statusColors: Record<string, string> = {
-  new: "bg-amber-100 text-amber-800 ring-1 ring-amber-200",
-  in_progress: "bg-emerald-100 text-emerald-800 ring-1 ring-emerald-200",
-  pending_invoice: "bg-violet-100 text-violet-800 ring-1 ring-violet-200",
-  completed: "bg-stone-100 text-stone-600 ring-1 ring-stone-200",
-  cancelled: "bg-rose-100 text-rose-800 ring-1 ring-rose-200",
-};
-
-export const statusLabels: Record<string, string> = {
-  new: "Lead",
-  in_progress: "Active",
-  pending_invoice: "Collections",
-  completed: "Closed",
-  cancelled: "Lost 😢",
-};
-
+// Static badge palettes for job urgency and damage type. (Job-status colors and
+// labels now come from useConfig() + src/lib/job-status-presentation.ts — the
+// single source of truth per ADR 0022; #722 migrated the job-detail view off the
+// old static status maps, so they no longer live here.)
 export const urgencyColors: Record<string, string> = {
   emergency: "bg-red-100 text-red-800 ring-1 ring-red-300 font-semibold",
   urgent: "bg-amber-100 text-amber-800 ring-1 ring-amber-300",

--- a/src/lib/job-status-presentation.test.ts
+++ b/src/lib/job-status-presentation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  getJobStatusOptions,
   getJobStatusPresentation,
   isOpenJobStatus,
   JOB_STATUS_PRESENTATION,
@@ -113,5 +114,78 @@ describe("unknown status keys", () => {
     expect(p.accentColor.trim().length).toBeGreaterThan(0);
     expect(p.badge.bg.trim().length).toBeGreaterThan(0);
     expect(p.badge.text.trim().length).toBeGreaterThan(0);
+  });
+});
+
+// Issue #722 (PRD #719) — the Job-detail status picker reads its five options
+// from config instead of a hardcoded <option> list. getJobStatusOptions builds
+// that list: the five frozen stages in pipeline order, each labelled by the
+// org's display_label when present, else the canonical label. One source of
+// truth, so the picker never drifts from the badges shown elsewhere.
+describe("getJobStatusOptions", () => {
+  it("returns the five stages in pipeline order", () => {
+    const options = getJobStatusOptions();
+    expect(options.map((o) => o.value)).toEqual([
+      "new",
+      "in_progress",
+      "pending_invoice",
+      "completed",
+      "cancelled",
+    ]);
+  });
+
+  it("labels the stages with the canonical pipeline labels when given no config", () => {
+    expect(getJobStatusOptions().map((o) => o.label)).toEqual([
+      "Lead",
+      "Active",
+      "Collections",
+      "Closed",
+      "Lost 😢",
+    ]);
+  });
+
+  it("uses an org's display_label override for a stage when config provides it", () => {
+    const options = getJobStatusOptions([
+      { name: "new", display_label: "Prospect" },
+    ]);
+    const lead = options.find((o) => o.value === "new");
+    expect(lead?.label).toBe("Prospect");
+    // Stages without an override keep their canonical label.
+    expect(options.find((o) => o.value === "in_progress")?.label).toBe("Active");
+  });
+
+  it("ignores config rows for keys outside the five frozen stages", () => {
+    const options = getJobStatusOptions([
+      { name: "archived", display_label: "Archived" },
+      { name: "on_hold", display_label: "On Hold" },
+    ]);
+    expect(options).toHaveLength(5);
+    expect(options.map((o) => o.value)).not.toContain("archived");
+    expect(options.map((o) => o.value)).not.toContain("on_hold");
+  });
+
+  it("falls back to the canonical label for stages a partial config omits", () => {
+    // Config carries only Collections — the other four keep canonical labels.
+    const options = getJobStatusOptions([
+      { name: "pending_invoice", display_label: "Awaiting Payment" },
+    ]);
+    expect(options.map((o) => o.label)).toEqual([
+      "Lead",
+      "Active",
+      "Awaiting Payment",
+      "Closed",
+      "Lost 😢",
+    ]);
+  });
+
+  it("falls back to the canonical label when a config override is blank or whitespace-only", () => {
+    // A blank/whitespace display_label must never erase a stage's visible label
+    // — the picker always shows the five stages, so an empty override is ignored.
+    const options = getJobStatusOptions([
+      { name: "new", display_label: "" },
+      { name: "in_progress", display_label: "   " },
+    ]);
+    expect(options.find((o) => o.value === "new")?.label).toBe("Lead");
+    expect(options.find((o) => o.value === "in_progress")?.label).toBe("Active");
   });
 });

--- a/src/lib/job-status-presentation.ts
+++ b/src/lib/job-status-presentation.ts
@@ -101,3 +101,37 @@ export function getJobStatusPresentation(key: string): JobStatusPresentation {
 export function isOpenJobStatus(key: string): boolean {
   return getJobStatusPresentation(key).isOpen;
 }
+
+/** One selectable option for the Job-detail status picker (#722). */
+export interface JobStatusOption {
+  /** Frozen snake_case status key — the value persisted on the Job. */
+  value: string;
+  /** Display label shown in the picker. */
+  label: string;
+}
+
+/**
+ * The five frozen lifecycle stages, in pipeline order, as picker options (#722).
+ *
+ * Drives the Job-detail status dropdown from one source of truth so it never
+ * drifts from the badges shown elsewhere. Always returns exactly the five
+ * canonical stages (ordered by sortRank), so extra/unknown org rows can't leak
+ * into the picker and a missing row can't drop a stage. When `configStatuses`
+ * (the org's job_statuses rows) provides a non-blank `display_label` for a
+ * stage, that label wins — so a per-org rename shows in the picker with no code
+ * change. A blank/whitespace-only override is ignored (it must never erase a
+ * stage's visible label), falling back to the canonical label.
+ */
+export function getJobStatusOptions(
+  configStatuses?: ReadonlyArray<{ name: string; display_label: string }>,
+): JobStatusOption[] {
+  const overrides = new Map(
+    (configStatuses ?? []).map((s) => [s.name, s.display_label]),
+  );
+  return Object.values(JOB_STATUS_PRESENTATION)
+    .sort((a, b) => a.sortRank - b.sortRank)
+    .map((p) => {
+      const override = overrides.get(p.key);
+      return { value: p.key, label: override?.trim() ? override : p.label };
+    });
+}


### PR DESCRIPTION
## What & why

Issue #722 (PRD #719, ADR 0022): the Job-detail status picker now reads its
five options from config instead of a hardcoded `<option>` list, and the
view's status badge + toast read their label/colors from the same
config-aware source the Jobs-page cards/rows already use.

This closes the last gap in ADR 0022's single source of truth — job-detail
was the only remaining importer of the static `statusColors`/`statusLabels`
maps. With it migrated onto `useConfig()`, those maps are dead and removed.

The DB snake_case keys stay frozen (ADR 0022); this is a display-only wiring
change. The five stages relabel to the pipeline **Lead → Active →
Collections → Closed → Lost 😢**.

## Changes

- **`JobStatusSelect`** (new) — a thin, testable seam that renders the five
  frozen lifecycle stages in pipeline order, labelled by the org's
  `display_label` when present, else the canonical label. Replaces the
  inline `<select>` in job-detail and fires `onChange` with the frozen
  snake_case key.
- **`getJobStatusOptions`** — builds that option list from
  `JOB_STATUS_PRESENTATION` (sorted by `sortRank`) overlaid with the org's
  `job_statuses` rows. Hardened so a blank/whitespace `display_label`
  override falls back to the canonical label (an empty config row must never
  erase a stage's visible label).
- **job-detail badge + toast** — migrated off the static
  `statusColors`/`statusLabels` onto `useConfig()`'s `getStatusColor` /
  `getStatusLabel`.
- **`lib/badge-colors.ts`** — dropped the now-dead `statusColors` /
  `statusLabels`; the urgency and damage-type palettes are unchanged.

## Tests

- `getJobStatusOptions`: pipeline order, canonical labels with no config,
  per-org `display_label` override, ignores keys outside the five frozen
  stages, partial-config fallback, and blank/whitespace-override fallback.
- `JobStatusSelect`: renders the five stages and fires `onChange` with the
  frozen snake_case key on selection.
- `npx vitest run` on the two touched test files: **28 passing**.
- `tsc --noEmit` clean on touched files; eslint clean on the new/lib files
  (job-detail.tsx's pre-existing `react-hooks/set-state-in-effect` baseline
  is untouched).

Closes #722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
