### PR TITLE
feat(financials): phone cash-flow waterfall + view-model deriver (#716)

### DIFF
--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -574,6 +574,7 @@ export default function JobDetail({ jobId }: { jobId: string }) {
               invoiced,
               collected,
               expenses: expensesTotal,
+              crew_labor: crewLabor,
               gross_margin,
               margin_pct,
               in_progress: job.status !== "completed",

--- a/src/components/job-detail/cash-flow-waterfall.tsx
+++ b/src/components/job-detail/cash-flow-waterfall.tsx
@@ -1,0 +1,56 @@
+import type { WaterfallRow } from "./financials-view-model";
+import type { ProfitFigure } from "./profit-figure";
+import { fmtCurrency } from "./format-currency";
+
+// Presentational only — the rows, sign colour, and caption are all decided by
+// the view-model deriver; this just lays them out as a right-aligned ledger.
+export default function CashFlowWaterfall({
+  rows,
+  profit,
+}: {
+  rows: WaterfallRow[];
+  profit: ProfitFigure;
+}) {
+  return (
+    <div
+      className="rounded-lg p-4"
+      style={{
+        background: "rgba(255,255,255,0.03)",
+        border: "1px solid rgba(255,255,255,0.08)",
+      }}
+    >
+      <dl className="space-y-2">
+        {rows.map((row) => (
+          <div
+            key={row.label}
+            className={
+              row.isSubtotal
+                ? "flex items-baseline justify-between border-t border-white/10 pt-2"
+                : "flex items-baseline justify-between"
+            }
+          >
+            <dt className="text-sm text-neutral-300">
+              {row.label}
+              {row.note && <span className="ml-1 text-xs text-neutral-500">{row.note}</span>}
+            </dt>
+            <dd
+              className={
+                row.isSubtotal
+                  ? "text-right tabular-nums text-lg font-semibold"
+                  : "text-right tabular-nums"
+              }
+              style={row.isSubtotal ? { color: profit.palette.text } : undefined}
+            >
+              {fmtCurrency(row.amount)}
+            </dd>
+          </div>
+        ))}
+      </dl>
+      {profit.caption && (
+        <div className="mt-1 text-right text-xs" style={{ color: profit.palette.caption }}>
+          {profit.caption}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/job-detail/financials-tab.test.tsx
+++ b/src/components/job-detail/financials-tab.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 
 import FinancialsTab from "./financials-tab";
 
@@ -12,6 +12,7 @@ type Summary = {
   invoiced: number;
   collected: number;
   expenses: number;
+  crew_labor: number;
   gross_margin: number;
   margin_pct: number | null;
   in_progress: boolean;
@@ -27,6 +28,7 @@ function renderTab(summary: Partial<Summary> = {}) {
         invoiced: 0,
         collected: 0,
         expenses: 0,
+        crew_labor: 0,
         gross_margin: 0,
         margin_pct: null,
         in_progress: false,
@@ -39,40 +41,93 @@ function renderTab(summary: Partial<Summary> = {}) {
 }
 
 // #715 — the headline figure is "Profit", coloured by sign on both the number
-// and the card tint, on the four-across summary row (phone + desktop).
-describe("FinancialsTab summary figure", () => {
+// and the card tint, on the four-across summary row (desktop). Scoped to the
+// desktop region since the same labels now also appear in the phone waterfall.
+describe("FinancialsTab desktop summary figure", () => {
   it("labels the headline figure 'Profit', not 'Gross margin'", () => {
     renderTab({ gross_margin: 1200, margin_pct: 34, in_progress: false });
 
-    expect(screen.getByText("Profit")).toBeTruthy();
-    expect(screen.queryByText("Gross margin")).toBeNull();
+    const cards = within(screen.getByTestId("summary-cards"));
+    expect(cards.getByText("Profit")).toBeTruthy();
+    expect(cards.queryByText("Gross margin")).toBeNull();
   });
 
   it("renders a negative Profit red — figure and card tint — not green", () => {
     renderTab({ gross_margin: -800, margin_pct: -20, in_progress: false });
 
-    const value = screen.getByText("-$800");
+    const cards = within(screen.getByTestId("summary-cards"));
+    const value = cards.getByText("-$800");
     expect(value.style.color).toBe("rgb(240, 149, 149)"); // #F09595
 
-    const card = screen.getByText("Profit").closest(".rounded-lg") as HTMLElement;
+    const card = cards.getByText("Profit").closest(".rounded-lg") as HTMLElement;
     expect(card.style.background).toContain("rgba(240, 149, 149"); // red tint
   });
 
   it("renders a positive Profit green with a profit-percent caption", () => {
     renderTab({ gross_margin: 3400, margin_pct: 34, in_progress: false });
 
-    const value = screen.getByText("$3,400");
+    const cards = within(screen.getByTestId("summary-cards"));
+    const value = cards.getByText("$3,400");
     expect(value.style.color).toBe("rgb(93, 202, 165)"); // #5DCAA5
 
-    const card = screen.getByText("Profit").closest(".rounded-lg") as HTMLElement;
+    const card = cards.getByText("Profit").closest(".rounded-lg") as HTMLElement;
     expect(card.style.background).toContain("rgba(29, 158, 117"); // green tint
-    expect(screen.getByText("34.0% profit")).toBeTruthy();
+    expect(cards.getByText("34.0% profit")).toBeTruthy();
   });
 
   it("captions an in-progress Job '(in progress)'", () => {
     renderTab({ gross_margin: 3400, margin_pct: 34, in_progress: true });
 
-    expect(screen.getByText("(in progress)")).toBeTruthy();
-    expect(screen.queryByText("34.0% profit")).toBeNull();
+    const cards = within(screen.getByTestId("summary-cards"));
+    expect(cards.getByText("(in progress)")).toBeTruthy();
+    expect(cards.queryByText("34.0% profit")).toBeNull();
+  });
+});
+
+// #716 — on the phone the four-across is replaced (via a CSS breakpoint) by a
+// cash-flow waterfall; the desktop four-across stays.
+describe("FinancialsTab phone cash-flow waterfall", () => {
+  it("renders the waterfall on phone (below lg) and keeps the four-across for desktop", () => {
+    renderTab({ collected: 1000, expenses: 300, crew_labor: 0, gross_margin: 700, margin_pct: 70 });
+
+    const waterfall = screen.getByTestId("cashflow-waterfall");
+    const cards = screen.getByTestId("summary-cards");
+
+    // layout switches on viewport width (CSS), not a JS platform/Capacitor check
+    expect(waterfall.className).toContain("lg:hidden");
+    expect(cards.className).toContain("hidden");
+    expect(cards.className).toContain("lg:grid");
+
+    const w = within(waterfall);
+    expect(w.getByText("Collected")).toBeTruthy();
+    expect(w.getByText("Expenses")).toBeTruthy();
+    expect(w.getByText("Profit")).toBeTruthy();
+  });
+
+  it("shows a '(est.)' Crew labor line and full seven-figure amounts, right-aligned", () => {
+    renderTab({
+      collected: 1_500_000,
+      expenses: 200_000,
+      crew_labor: 300_000,
+      gross_margin: 1_000_000,
+      margin_pct: 66.7,
+    });
+
+    const w = within(screen.getByTestId("cashflow-waterfall"));
+    expect(w.getByText("Crew labor")).toBeTruthy();
+    expect(w.getByText("(est.)")).toBeTruthy();
+
+    // full precision — never abbreviated to $1.5M / $1M — and right-aligned
+    const collectedValue = w.getByText("$1,500,000");
+    expect(collectedValue.className).toContain("text-right");
+    expect(w.getByText("$1,000,000")).toBeTruthy(); // Profit subtotal, in full
+  });
+
+  it("colours a negative Profit subtotal red in the waterfall", () => {
+    renderTab({ collected: 100, expenses: 900, crew_labor: 0, gross_margin: -800, margin_pct: -800 });
+
+    const w = within(screen.getByTestId("cashflow-waterfall"));
+    const profitValue = w.getByText("-$800");
+    expect(profitValue.style.color).toBe("rgb(240, 149, 149)"); // #F09595
   });
 });

--- a/src/components/job-detail/financials-tab.tsx
+++ b/src/components/job-detail/financials-tab.tsx
@@ -5,6 +5,9 @@ import BillingSection from "@/components/billing/billing-section";
 import ExpensesSection from "@/components/expenses/expenses-section";
 import { FinancialsInvoiceList, type FinancialsInvoice } from "./financials-invoice-list";
 import { profitFigure, type ProfitPalette } from "./profit-figure";
+import { financialsViewModel } from "./financials-view-model";
+import CashFlowWaterfall from "./cash-flow-waterfall";
+import { fmtCurrency } from "./format-currency";
 
 type Props = {
   jobId: string;
@@ -14,6 +17,7 @@ type Props = {
     invoiced: number;
     collected: number;
     expenses: number;
+    crew_labor: number;
     gross_margin: number;
     margin_pct: number | null;
     in_progress: boolean;
@@ -22,18 +26,6 @@ type Props = {
   onExpenseLogged: () => void;
   stripeConnected?: boolean;
 };
-
-function fmtCurrency(n: number): string {
-  // Show cents when the value has a non-zero fractional part (so small test
-  // invoices don't collapse to $0); otherwise keep the clean integer display.
-  const hasCents = Math.round(n * 100) % 100 !== 0;
-  return n.toLocaleString("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: hasCents ? 2 : 0,
-    maximumFractionDigits: hasCents ? 2 : 0,
-  });
-}
 
 export default function FinancialsTab({
   jobId,
@@ -45,10 +37,16 @@ export default function FinancialsTab({
   stripeConnected = false,
 }: Props) {
   const profit = profitFigure(summary);
+  const vm = financialsViewModel(summary);
   return (
     <div className="space-y-6">
-      {/* Summary metrics row — 4 pills */}
-      <div className="grid grid-cols-4 gap-3">
+      {/* Phone (below lg): cash-flow waterfall in place of the four-across. */}
+      <div data-testid="cashflow-waterfall" className="lg:hidden">
+        <CashFlowWaterfall rows={vm.waterfall} profit={vm.profit} />
+      </div>
+
+      {/* Desktop (lg and up): the existing four-across summary row. */}
+      <div data-testid="summary-cards" className="hidden grid-cols-4 gap-3 lg:grid">
         <SummaryPill label="Invoiced" value={fmtCurrency(summary.invoiced)} />
         <SummaryPill label="Collected" value={fmtCurrency(summary.collected)} />
         <SummaryPill label="Expenses" value={fmtCurrency(summary.expenses)} />

--- a/src/components/job-detail/financials-view-model.test.ts
+++ b/src/components/job-detail/financials-view-model.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+
+import { financialsViewModel } from "./financials-view-model";
+
+// #716 — the pure view-model deriver: figures in → cash-flow waterfall rows
+// (Collected − Expenses − Crew labor = Profit) plus the Profit sign/colour and
+// caption. Every branch is asserted here, with no React in sight.
+describe("financialsViewModel — cash-flow waterfall", () => {
+  it("derives a Collected → Profit column whose subtotal reconciles", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 0,
+      crew_labor: 0,
+      margin_pct: 100,
+      in_progress: false,
+    });
+
+    const collected = vm.waterfall.find((r) => r.label === "Collected");
+    const profit = vm.waterfall.find((r) => r.isSubtotal);
+
+    expect(collected?.amount).toBe(1000);
+    expect(profit?.label).toBe("Profit");
+    expect(profit?.amount).toBe(1000);
+  });
+
+  it("shows Expenses as a clearly negative line that the subtotal reconciles", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 0,
+      margin_pct: 70,
+      in_progress: false,
+    });
+
+    const expenses = vm.waterfall.find((r) => r.label === "Expenses");
+    const profit = vm.waterfall.find((r) => r.isSubtotal);
+
+    expect(expenses?.amount).toBe(-300);
+    expect(profit?.amount).toBe(700); // 1000 − 300
+  });
+
+  it("shows a negative Crew labor line marked '(est.)' when crew labor is non-zero", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 200,
+      margin_pct: 50,
+      in_progress: false,
+    });
+
+    const crew = vm.waterfall.find((r) => r.label === "Crew labor");
+    const profit = vm.waterfall.find((r) => r.isSubtotal);
+
+    expect(crew?.amount).toBe(-200);
+    expect(crew?.note).toBe("(est.)");
+    expect(profit?.amount).toBe(500); // 1000 − 300 − 200
+  });
+
+  it("omits the Crew labor line when crew labor is $0, still reconciling", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 0,
+      margin_pct: 70,
+      in_progress: false,
+    });
+
+    expect(vm.waterfall.find((r) => r.label === "Crew labor")).toBeUndefined();
+
+    const profit = vm.waterfall.find((r) => r.isSubtotal);
+    expect(profit?.amount).toBe(700); // Collected − Expenses = Profit
+  });
+
+  it("colours the Profit figure red when the reconciled subtotal is negative", () => {
+    const vm = financialsViewModel({
+      collected: 500,
+      expenses: 900,
+      crew_labor: 400,
+      margin_pct: -160,
+      in_progress: false,
+    });
+
+    // sign is taken from the reconciled subtotal (500 − 900 − 400 = −800)
+    expect(vm.waterfall.find((r) => r.isSubtotal)?.amount).toBe(-800);
+    expect(vm.profit.label).toBe("Profit");
+    expect(vm.profit.palette.text).toBe("#F09595"); // red
+  });
+
+  it("colours the Profit figure green when the reconciled subtotal is non-negative", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 0,
+      margin_pct: 70,
+      in_progress: false,
+    });
+
+    expect(vm.profit.palette.text).toBe("#5DCAA5"); // green
+  });
+
+  it("captions an in-progress Job '(in progress)', not its percent", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 0,
+      margin_pct: 70,
+      in_progress: true,
+    });
+
+    expect(vm.profit.caption).toBe("(in progress)");
+  });
+
+  it("captions a completed Job with its profit percent", () => {
+    const vm = financialsViewModel({
+      collected: 1000,
+      expenses: 300,
+      crew_labor: 0,
+      margin_pct: 70,
+      in_progress: false,
+    });
+
+    expect(vm.profit.caption).toBe("70.0% profit");
+  });
+});

--- a/src/components/job-detail/financials-view-model.ts
+++ b/src/components/job-detail/financials-view-model.ts
@@ -1,0 +1,57 @@
+import { profitFigure, type ProfitFigure } from "./profit-figure";
+
+export type WaterfallRow = {
+  label: string;
+  /** signed contribution: Collected positive, deductions negative, Profit = subtotal */
+  amount: number;
+  isSubtotal: boolean;
+  /** e.g. "(est.)" on the Crew labor line */
+  note?: string;
+};
+
+export type FinancialsViewModel = {
+  profit: ProfitFigure;
+  waterfall: WaterfallRow[];
+};
+
+export function financialsViewModel(summary: {
+  collected: number;
+  expenses: number;
+  crew_labor: number;
+  margin_pct: number | null;
+  in_progress: boolean;
+}): FinancialsViewModel {
+  // Derive the subtotal FROM the addends so the column always reconciles —
+  // Collected − Expenses − Crew labor = Profit — rather than trusting a
+  // separately-passed figure.
+  const profit = summary.collected - summary.expenses - summary.crew_labor;
+
+  const waterfall: WaterfallRow[] = [
+    { label: "Collected", amount: summary.collected, isSubtotal: false },
+    { label: "Expenses", amount: -summary.expenses, isSubtotal: false },
+  ];
+
+  // Crew labor is an estimate, so it only earns a line once the owner has
+  // entered one — a $0 line would just clutter the ledger.
+  if (summary.crew_labor !== 0) {
+    waterfall.push({
+      label: "Crew labor",
+      amount: -summary.crew_labor,
+      isSubtotal: false,
+      note: "(est.)",
+    });
+  }
+
+  waterfall.push({ label: "Profit", amount: profit, isSubtotal: true });
+
+  // The figure's sign/colour and caption come from the reconciled subtotal, so
+  // the headline can never disagree with the math in the column above it.
+  return {
+    profit: profitFigure({
+      gross_margin: profit,
+      margin_pct: summary.margin_pct,
+      in_progress: summary.in_progress,
+    }),
+    waterfall,
+  };
+}

--- a/src/components/job-detail/format-currency.ts
+++ b/src/components/job-detail/format-currency.ts
@@ -1,0 +1,12 @@
+export function fmtCurrency(n: number): string {
+  // Show cents when the value has a non-zero fractional part (so small test
+  // invoices don't collapse to $0); otherwise keep the clean integer display.
+  // Full precision always — seven-figure amounts render in full, never abbreviated.
+  const hasCents = Math.round(n * 100) % 100 !== 0;
+  return n.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: hasCents ? 2 : 0,
+    maximumFractionDigits: hasCents ? 2 : 0,
+  });
+}


### PR DESCRIPTION
Closes #716 — the phone slice of the Job Financials epic (parent #714).

## What

Below the **`lg` breakpoint** (≥1024px) the Financials-tab four-across summary row is replaced by a **cash-flow waterfall** (`Collected − Expenses − Crew labor = Profit`); at/above the breakpoint the four-across stays. The layout switches on **viewport width (CSS)**, not a JS/Capacitor platform check (ADR 0014 precedent).

## How

- **Pure view-model deriver** (`financials-view-model.ts`) — figures in → `{ profit, waterfall }` out, all branch logic isolated from React per the PRD's deep-module mandate. It derives the Profit subtotal **from its addends** so the column always reconciles, then composes `profitFigure` off that reconciled number — the headline's sign-colour/caption can never disagree with the math above it. Crew labor earns a line only when non-zero, tagged `(est.)`.
- **Presentational `CashFlowWaterfall`** — right-aligned, **full precision** (seven-figure fits, never abbreviated to `$1.5M`); the Profit subtotal carries the sign colour (green ≥0 `#5DCAA5` / red <0 `#F09595`) and the same caption rule as the pill (`(in progress)` while active, else `X% profit`).
- **Thread Crew labor** — `job-detail.tsx` now passes the already-computed `estimated_crew_labor_cost` into the tab summary so the waterfall can deduct it.
- **Extract `fmtCurrency`** into `format-currency.ts`, shared by the tab and the waterfall.

Invoiced is intentionally **not** a waterfall line.

## Tests

- **8** deriver unit tests: Collected/Expenses rows, Crew-labor present vs `$0` (line shown/omitted, both reconcile), negative→red, positive→green, in-progress vs completed caption.
- **3** render tests: breakpoint wiring (`lg:hidden` / `hidden lg:grid`), `(est.)` line + full-precision right-aligned amounts, negative-Profit red subtotal.
- The four **#715** desktop assertions are rescoped to the `summary-cards` region (the same labels now also appear in the phone waterfall under jsdom).

`54/54` `job-detail/` tests pass; tsc clean for all touched files; eslint clean for new/edited files (the pre-existing `set-state-in-effect` errors in `job-detail.tsx` are unchanged baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)