### PR TITLE
feat(financials): phone collection ring — core states (#717)

### DIFF
--- a/src/components/job-detail/collection-ring.tsx
+++ b/src/components/job-detail/collection-ring.tsx
@@ -1,0 +1,94 @@
+import type { CollectionRing as CollectionRingState } from "./financials-view-model";
+import type { RingGeometry } from "./ring-geometry";
+import { fmtCurrency } from "./format-currency";
+
+const NEUTRAL = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(255,255,255,0.08)",
+};
+
+// Presentational only — which state to show, the ring geometry, and the
+// numbers are all decided by the view-model deriver; this just lays them out.
+// The ring is a hand-rolled SVG arc, deliberately no charting dependency.
+export default function CollectionRing({ ring }: { ring: CollectionRingState }) {
+  // Nothing billed yet (deposits before billing) — no ring, just the total.
+  if (ring.kind === "not-invoiced-yet") {
+    return (
+      <div className="rounded-lg p-4" style={NEUTRAL}>
+        <span className="text-sm text-neutral-300">Collected {fmtCurrency(ring.collected)}</span>
+        <span className="ml-1 text-xs text-neutral-500">· not invoiced yet</span>
+      </div>
+    );
+  }
+
+  // collection-rate | clamped — both paint a ring; only collection-rate has a
+  // meaningful Outstanding (clamped/over-collected defers that to #718).
+  return (
+    <div className="flex items-center gap-4 rounded-lg p-4" style={NEUTRAL}>
+      <RingArc geometry={ring.geometry} />
+      <div>
+        <div className="text-xs uppercase tracking-wide text-neutral-400">Collected</div>
+        <div className="text-lg font-semibold text-neutral-100 tabular-nums">
+          {fmtCurrency(ring.collected)}
+        </div>
+        {ring.kind === "collection-rate" && (
+          <div className="mt-0.5 text-xs text-neutral-400">
+            <span>Outstanding</span>{" "}
+            <span className="tabular-nums">{fmtCurrency(ring.outstanding)}</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const STROKE = 8;
+
+function RingArc({ geometry }: { geometry: RingGeometry }) {
+  // The stroke straddles the radius, so the box must clear half a stroke on
+  // each side for the arc not to clip.
+  const size = (geometry.radius + STROKE / 2) * 2;
+  const c = size / 2;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={`${geometry.percent}% collected`}
+      className="shrink-0"
+    >
+      {/* unfilled track */}
+      <circle
+        cx={c}
+        cy={c}
+        r={geometry.radius}
+        fill="none"
+        stroke="rgba(255,255,255,0.10)"
+        strokeWidth={STROKE}
+      />
+      {/* progress arc — rotated to start at 12 o'clock and fill clockwise */}
+      <circle
+        cx={c}
+        cy={c}
+        r={geometry.radius}
+        fill="none"
+        stroke="#5DCAA5"
+        strokeWidth={STROKE}
+        strokeLinecap="round"
+        strokeDasharray={geometry.dashArray}
+        strokeDashoffset={geometry.dashOffset}
+        transform={`rotate(-90 ${c} ${c})`}
+      />
+      <text
+        x={c}
+        y={c}
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="fill-neutral-100 text-sm font-semibold"
+      >
+        {geometry.percent}%
+      </text>
+    </svg>
+  );
+}

--- a/src/components/job-detail/financials-tab.test.tsx
+++ b/src/components/job-detail/financials-tab.test.tsx
@@ -131,3 +131,44 @@ describe("FinancialsTab phone cash-flow waterfall", () => {
     expect(profitValue.style.color).toBe("rgb(240, 149, 149)"); // #F09595
   });
 });
+
+// #717 — above the waterfall (phone only), a collection ring shows how much of
+// what's been Invoiced has been Collected, with the two common states.
+describe("FinancialsTab phone collection ring", () => {
+  it("draws the ring (phone only) with Outstanding when Invoiced > 0", () => {
+    renderTab({ invoiced: 1000, collected: 600 });
+
+    const block = screen.getByTestId("collection-ring");
+    // same CSS-breakpoint split as the waterfall — phone only, no JS check
+    expect(block.className).toContain("lg:hidden");
+    // a hand-rolled SVG arc, not a charting dependency
+    expect(block.querySelector("svg")).not.toBeNull();
+
+    const ring = within(block);
+    expect(ring.getByText("Outstanding")).toBeTruthy();
+    expect(ring.getByText("$400")).toBeTruthy(); // Invoiced − Collected
+  });
+
+  it("draws no ring and reads 'Collected $X · not invoiced yet' when Invoiced is $0", () => {
+    renderTab({ invoiced: 0, collected: 500 }); // a deposit before billing
+
+    const block = screen.getByTestId("collection-ring");
+    expect(block.querySelector("svg")).toBeNull(); // no ring
+
+    const ring = within(block);
+    expect(ring.getByText("Collected $500")).toBeTruthy();
+    expect(ring.getByText(/not invoiced yet/)).toBeTruthy();
+  });
+
+  it("clamps an over-collected Job to a full ring with no negative Outstanding", () => {
+    renderTab({ invoiced: 1000, collected: 1200 }); // paid ahead
+
+    const block = screen.getByTestId("collection-ring");
+    expect(block.querySelector("svg")).not.toBeNull(); // a full ring, no error
+
+    // Outstanding would be negative here, so it is omitted (not "-$200")
+    const ring = within(block);
+    expect(ring.queryByText(/Outstanding/)).toBeNull();
+    expect(ring.queryByText(/-\$/)).toBeNull();
+  });
+});

--- a/src/components/job-detail/financials-tab.tsx
+++ b/src/components/job-detail/financials-tab.tsx
@@ -7,6 +7,7 @@ import { FinancialsInvoiceList, type FinancialsInvoice } from "./financials-invo
 import { profitFigure, type ProfitPalette } from "./profit-figure";
 import { financialsViewModel } from "./financials-view-model";
 import CashFlowWaterfall from "./cash-flow-waterfall";
+import CollectionRing from "./collection-ring";
 import { fmtCurrency } from "./format-currency";
 
 type Props = {
@@ -40,6 +41,11 @@ export default function FinancialsTab({
   const vm = financialsViewModel(summary);
   return (
     <div className="space-y-6">
+      {/* Phone (below lg): collection ring above the cash-flow waterfall. */}
+      <div data-testid="collection-ring" className="lg:hidden">
+        <CollectionRing ring={vm.collectionRing} />
+      </div>
+
       {/* Phone (below lg): cash-flow waterfall in place of the four-across. */}
       <div data-testid="cashflow-waterfall" className="lg:hidden">
         <CashFlowWaterfall rows={vm.waterfall} profit={vm.profit} />

--- a/src/components/job-detail/financials-view-model.test.ts
+++ b/src/components/job-detail/financials-view-model.test.ts
@@ -8,6 +8,7 @@ import { financialsViewModel } from "./financials-view-model";
 describe("financialsViewModel — cash-flow waterfall", () => {
   it("derives a Collected → Profit column whose subtotal reconciles", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 0,
       crew_labor: 0,
@@ -25,6 +26,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("shows Expenses as a clearly negative line that the subtotal reconciles", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 0,
@@ -41,6 +43,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("shows a negative Crew labor line marked '(est.)' when crew labor is non-zero", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 200,
@@ -58,6 +61,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("omits the Crew labor line when crew labor is $0, still reconciling", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 0,
@@ -73,6 +77,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("colours the Profit figure red when the reconciled subtotal is negative", () => {
     const vm = financialsViewModel({
+      invoiced: 500,
       collected: 500,
       expenses: 900,
       crew_labor: 400,
@@ -88,6 +93,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("colours the Profit figure green when the reconciled subtotal is non-negative", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 0,
@@ -100,6 +106,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("captions an in-progress Job '(in progress)', not its percent", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 0,
@@ -112,6 +119,7 @@ describe("financialsViewModel — cash-flow waterfall", () => {
 
   it("captions a completed Job with its profit percent", () => {
     const vm = financialsViewModel({
+      invoiced: 1000,
       collected: 1000,
       expenses: 300,
       crew_labor: 0,
@@ -120,5 +128,84 @@ describe("financialsViewModel — cash-flow waterfall", () => {
     });
 
     expect(vm.profit.caption).toBe("70.0% profit");
+  });
+});
+
+// #717 — the deriver also produces the phone collection ring's state: a
+// discriminated union (collection-rate / not-invoiced-yet / clamped) carrying
+// the ring geometry, so the component renders without any branch logic of its
+// own. Invoiced is billing context here, separate from the waterfall math.
+describe("financialsViewModel — collection ring", () => {
+  it("derives a collection-rate ring with Outstanding when Invoiced > 0", () => {
+    const vm = financialsViewModel({
+      invoiced: 1000,
+      collected: 600,
+      expenses: 0,
+      crew_labor: 0,
+      margin_pct: 60,
+      in_progress: false,
+    });
+
+    const ring = vm.collectionRing;
+    expect(ring.kind).toBe("collection-rate");
+    if (ring.kind === "collection-rate") {
+      expect(ring.rate).toBeCloseTo(0.6, 6); // 600 / 1000
+      expect(ring.outstanding).toBe(400); // Invoiced − Collected
+      expect(ring.geometry.percent).toBe(60);
+    }
+  });
+
+  it("reports not-invoiced-yet (no ring) when Invoiced is $0 but money has come in", () => {
+    const vm = financialsViewModel({
+      invoiced: 0,
+      collected: 500, // a deposit before any billing — the owner's early-job state
+      expenses: 0,
+      crew_labor: 0,
+      margin_pct: null,
+      in_progress: true,
+    });
+
+    const ring = vm.collectionRing;
+    expect(ring.kind).toBe("not-invoiced-yet");
+    if (ring.kind === "not-invoiced-yet") {
+      expect(ring.collected).toBe(500);
+    }
+  });
+
+  it("clamps an over-collected Job (Collected > Invoiced) to a full ring", () => {
+    const vm = financialsViewModel({
+      invoiced: 1000,
+      collected: 1200, // paid ahead — the dedicated annotation comes in #718
+      expenses: 0,
+      crew_labor: 0,
+      margin_pct: 120,
+      in_progress: false,
+    });
+
+    const ring = vm.collectionRing;
+    expect(ring.kind).toBe("clamped");
+    if (ring.kind === "clamped") {
+      // a full ring, not a 120%-overflowing one
+      expect(ring.geometry.percent).toBe(100);
+      expect(ring.geometry.fraction).toBe(1);
+    }
+  });
+
+  it("renders a brand-new Job with no activity as a zero not-invoiced-yet state, not a broken ring", () => {
+    const vm = financialsViewModel({
+      invoiced: 0,
+      collected: 0,
+      expenses: 0,
+      crew_labor: 0,
+      margin_pct: null,
+      in_progress: true,
+    });
+
+    const ring = vm.collectionRing;
+    // an intentional empty state — no division, no ring geometry to mis-paint
+    expect(ring.kind).toBe("not-invoiced-yet");
+    if (ring.kind === "not-invoiced-yet") {
+      expect(ring.collected).toBe(0);
+    }
   });
 });

--- a/src/components/job-detail/financials-view-model.ts
+++ b/src/components/job-detail/financials-view-model.ts
@@ -1,4 +1,5 @@
 import { profitFigure, type ProfitFigure } from "./profit-figure";
+import { ringGeometry, type RingGeometry } from "./ring-geometry";
 
 export type WaterfallRow = {
   label: string;
@@ -9,12 +10,68 @@ export type WaterfallRow = {
   note?: string;
 };
 
+// The phone collection ring's state. Invoiced is billing context — how much of
+// what's been billed has come in — and is deliberately separate from the
+// waterfall's profit math.
+export type CollectionRing =
+  | {
+      /** Invoiced > 0: the ring fills to Collected ÷ Invoiced. */
+      kind: "collection-rate";
+      rate: number;
+      collected: number;
+      invoiced: number;
+      /** Invoiced − Collected, the amount still owed */
+      outstanding: number;
+      geometry: RingGeometry;
+    }
+  | {
+      /** Invoiced is $0 — deposits before billing; no ring, just the collected total. */
+      kind: "not-invoiced-yet";
+      collected: number;
+    }
+  | {
+      /** Collected > Invoiced: a full ring this slice; "paid ahead" lands in #718. */
+      kind: "clamped";
+      collected: number;
+      invoiced: number;
+      geometry: RingGeometry;
+    };
+
 export type FinancialsViewModel = {
   profit: ProfitFigure;
   waterfall: WaterfallRow[];
+  collectionRing: CollectionRing;
 };
 
+function collectionRing(invoiced: number, collected: number): CollectionRing {
+  // Nothing billed yet — deposits routinely precede billing, so draw no ring
+  // and just report what's come in.
+  if (invoiced <= 0) {
+    return { kind: "not-invoiced-yet", collected };
+  }
+
+  const rate = collected / invoiced;
+  const geometry = ringGeometry(rate);
+
+  // Paid ahead: clamp to a full ring this slice. The "paid ahead" annotation
+  // (and a meaningful over-amount) arrives in #718; Outstanding would be
+  // negative here, so it is deliberately omitted.
+  if (collected > invoiced) {
+    return { kind: "clamped", collected, invoiced, geometry };
+  }
+
+  return {
+    kind: "collection-rate",
+    rate,
+    collected,
+    invoiced,
+    outstanding: invoiced - collected,
+    geometry,
+  };
+}
+
 export function financialsViewModel(summary: {
+  invoiced: number;
   collected: number;
   expenses: number;
   crew_labor: number;
@@ -53,5 +110,6 @@ export function financialsViewModel(summary: {
       in_progress: summary.in_progress,
     }),
     waterfall,
+    collectionRing: collectionRing(summary.invoiced, summary.collected),
   };
 }

--- a/src/components/job-detail/ring-geometry.test.ts
+++ b/src/components/job-detail/ring-geometry.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+
+import { ringGeometry } from "./ring-geometry";
+
+// #717 — the pure ring-geometry helper: a collection rate (0..1, possibly over
+// 1) maps to the SVG stroke-dash values for a hand-rolled arc. No charting dep.
+describe("ringGeometry", () => {
+  it("draws an empty ring at a 0% rate", () => {
+    const g = ringGeometry(0);
+
+    expect(g.percent).toBe(0);
+    expect(g.fraction).toBe(0);
+    // nothing revealed — the offset hides the entire circumference
+    expect(g.dashOffset).toBeCloseTo(g.circumference, 6);
+  });
+
+  it("reveals half the circle at a 50% rate", () => {
+    const g = ringGeometry(0.5);
+
+    expect(g.percent).toBe(50);
+    expect(g.fraction).toBe(0.5);
+    // dashArray is the whole circle; offset hides the unfilled remainder, so a
+    // half-filled ring offsets by half the circumference.
+    expect(g.dashOffset).toBeCloseTo(g.circumference / 2, 6);
+  });
+
+  it("fills the whole circle at a 100% rate", () => {
+    const g = ringGeometry(1);
+
+    expect(g.percent).toBe(100);
+    expect(g.fraction).toBe(1);
+    expect(g.dashOffset).toBeCloseTo(0, 6);
+  });
+
+  it("clamps an over-collected (>100%) rate to a full ring, never overflowing", () => {
+    const g = ringGeometry(1.5);
+
+    expect(g.percent).toBe(100);
+    expect(g.fraction).toBe(1); // not 1.5
+    expect(g.dashOffset).toBeCloseTo(0, 6); // a full ring, no negative offset
+  });
+});

--- a/src/components/job-detail/ring-geometry.ts
+++ b/src/components/job-detail/ring-geometry.ts
@@ -1,0 +1,31 @@
+// The collection ring is a hand-rolled SVG arc (no charting dependency). This
+// pure helper turns a collection rate into the stroke-dash values that reveal
+// that fraction of a circle, clamped so an over-collected Job can never paint
+// more than a full ring.
+export type RingGeometry = {
+  radius: number;
+  circumference: number;
+  /** the rate clamped into [0, 1] */
+  fraction: number;
+  /** the fraction as a rounded whole percent, for display/aria */
+  percent: number;
+  /** the full circumference — the progress stroke's dash length */
+  dashArray: number;
+  /** the offset that hides the unfilled remainder (0 = a full ring) */
+  dashOffset: number;
+};
+
+const DEFAULT_RADIUS = 36;
+
+export function ringGeometry(rate: number, radius: number = DEFAULT_RADIUS): RingGeometry {
+  const fraction = Math.max(0, Math.min(1, rate));
+  const circumference = 2 * Math.PI * radius;
+  return {
+    radius,
+    circumference,
+    fraction,
+    percent: Math.round(fraction * 100),
+    dashArray: circumference,
+    dashOffset: circumference * (1 - fraction),
+  };
+}


### PR DESCRIPTION
Closes #717. Second slice of the Job Financials epic (PRD #714), building on #716's phone cash-flow waterfall.

Adds the phone Financials **collection ring** above the waterfall — how much of what's been **Invoiced** has been **Collected** — with the two core states and a graceful over-collection clamp. Invoiced appears here as billing context; it is *not* part of the waterfall's profit math.

## States (acceptance criteria)
- **Invoiced > 0** → ring fills to Collected ÷ Invoiced; shows **Outstanding** (Invoiced − Collected). _(a)_
- **Invoiced = $0, Collected > 0** → no ring, reads "Collected $X · not invoiced yet" (deposits before billing). _(b)_
- **Collected > Invoiced** → ring clamps to a full circle, no overflow/error; Outstanding omitted (the "paid ahead" annotation lands in #718). _(c)_
- **No activity** → intentional zero `not-invoiced-yet` state, no broken ring. _(d)_

## Shape
- **`ring-geometry.ts`** — pure helper, rate → SVG `stroke-dasharray`/`dashoffset`, clamped to `[0,1]`. Hand-rolled arc, **no charting dependency**. _(e)_ Unit-tested at 0 / 50 / 100 / >100%-clamp. _(f)_
- **`financials-view-model.ts`** — deriver emits a `CollectionRing` discriminated union (`collection-rate` / `not-invoiced-yet` / `clamped`) carrying the geometry, so the component holds **no branch logic**. All three branches + zero state unit-tested. _(g)_
- **`collection-ring.tsx`** — presentational SVG arc, green progress ring starting at 12 o'clock with a centered % label.
- **`financials-tab.tsx`** — phone-only (`lg:hidden`) block above the waterfall, same CSS-breakpoint split as #716 — no JS/Capacitor check.

## Verification
- `npx vitest run src/components/job-detail/` → **67 passed (10 files)**.
- `npx tsc --noEmit` → only the 3 pre-existing `report-pdf-apple-jpeg.test.ts` baseline errors; none in touched files. _(h)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)