### PR TITLE
feat(push): new-intake end-to-end buzz — wire push into the dispatcher (#673)

### DIFF
--- a/src/lib/notifications/dispatch-new-intake.test.ts
+++ b/src/lib/notifications/dispatch-new-intake.test.ts
@@ -11,6 +11,15 @@ vi.mock("@/lib/supabase-api", () => ({
   createServiceClient: mockCreateServiceClient,
 }));
 
+import { generateKeyPairSync } from "crypto";
+import type {
+  ApnsConfig,
+  ApnsRequest,
+  ApnsResponse,
+  ApnsTransport,
+  SendDeps,
+} from "@/lib/push/apple-sender";
+
 import { dispatchNewIntakeNotifications } from "./dispatch-new-intake";
 
 // ---------- minimal Supabase fake (finalize.test.ts idiom) ----------------
@@ -29,16 +38,24 @@ function makeFake() {
 
   function selectBuilder(table: string) {
     const filters: Row = {};
+    const inFilters: Record<string, unknown[]> = {};
+    const matches = (r: Row) =>
+      match(r, filters) &&
+      Object.entries(inFilters).every(([col, vals]) => vals.includes(r[col]));
     const builder = {
       eq(col: string, val: unknown) {
         filters[col] = val;
+        return builder;
+      },
+      in(col: string, vals: unknown[]) {
+        inFilters[col] = vals;
         return builder;
       },
       async maybeSingle() {
         const err = errors[`${table}.select`];
         if (err) return { data: null, error: err };
         return {
-          data: (tables[table] ?? []).find((r) => match(r, filters)) ?? null,
+          data: (tables[table] ?? []).find(matches) ?? null,
           error: null,
         };
       },
@@ -46,9 +63,30 @@ function makeFake() {
         const err = errors[`${table}.select`];
         if (err) return resolve({ data: null, error: err });
         return resolve({
-          data: (tables[table] ?? []).filter((r) => match(r, filters)),
+          data: (tables[table] ?? []).filter(matches),
           error: null,
         });
+      },
+    };
+    return builder;
+  }
+
+  // `.delete().in(col, vals)` — removes the matching rows and resolves like a
+  // PostgREST delete. Used by the registry's dead-token prune.
+  function deleteBuilder(table: string) {
+    const inFilters: Record<string, unknown[]> = {};
+    const builder = {
+      in(col: string, vals: unknown[]) {
+        inFilters[col] = vals;
+        return builder;
+      },
+      then(resolve: (v: { data: unknown; error: FakeError | null }) => unknown) {
+        const err = errors[`${table}.delete`];
+        if (err) return resolve({ data: null, error: err });
+        tables[table] = (tables[table] ?? []).filter(
+          (r) => !Object.entries(inFilters).every(([col, vals]) => vals.includes(r[col])),
+        );
+        return resolve({ data: null, error: null });
       },
     };
     return builder;
@@ -59,6 +97,9 @@ function makeFake() {
       return {
         select() {
           return selectBuilder(table);
+        },
+        delete() {
+          return deleteBuilder(table);
         },
         insert(payload: Row | Row[]) {
           const rows = Array.isArray(payload) ? payload : [payload];
@@ -82,6 +123,8 @@ function makeFake() {
       errors[key] = err;
     },
     inserts,
+    // Current contents of a table (post-prune, etc.).
+    tableRows: (table: string) => tables[table] ?? [],
   };
 }
 
@@ -114,6 +157,37 @@ function member(userId: string, role: string, isActive: boolean, orgId = "org-1"
 }
 
 const notifs = (fake: Fake): Row[] => fake.inserts.notifications ?? [];
+
+// ---------- push (APNs) test deps ------------------------------------------
+// A throwaway EC P-256 key so the dispatcher drives the REAL Apple sender /
+// signing path without the production .p8 secret (same idiom as
+// apple-sender.test.ts). Only the host distinguishes prod from sandbox.
+function testPushConfig(): ApnsConfig {
+  const { privateKey } = generateKeyPairSync("ec", { namedCurve: "P-256" });
+  return {
+    keyId: "TESTKEY123",
+    teamId: "TEAMID9999",
+    bundleId: "com.example.app",
+    privateKey: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  };
+}
+
+/**
+ * SendDeps whose transport records every device token it is handed, so a test
+ * can assert exactly which devices were buzzed. `respond` maps a token to its
+ * APNs reply (default 200 OK) — override it to simulate dead/erroring tokens.
+ */
+function recordingPush(
+  respond: (token: string) => ApnsResponse = () => ({ status: 200, apnsId: "ok" }),
+) {
+  const requests: ApnsRequest[] = [];
+  const transport: ApnsTransport = async (req) => {
+    requests.push(req);
+    return respond(req.token);
+  };
+  const deps: SendDeps = { transport, config: testPushConfig(), now: 1_700_000_000 };
+  return { deps, requests, tokens: () => requests.map((r) => r.token) };
+}
 
 let fake: Fake;
 beforeEach(() => {
@@ -238,6 +312,168 @@ describe("dispatchNewIntakeNotifications", () => {
         dispatchNewIntakeNotifications({ jobId: "missing", submitterUserId: "submitter" }),
       ).resolves.toBeUndefined();
       expect(notifs(fake)).toHaveLength(0);
+    });
+  });
+});
+
+// ===========================================================================
+// #673 — wire push into the dispatcher: after the in-app bell write, buzz the
+// targeted members' enrolled iOS devices. The bell write stays primary; the
+// push is a best-effort enhancement layered on top.
+// ===========================================================================
+describe("dispatchNewIntakeNotifications — push fan-out (#673)", () => {
+  it("buzzes exactly the targeted members' devices — not the submitter's, not another org's — with the per-tier payload", async () => {
+    seedJob(fake); // emergency · John Smith · Water damage · 123 Main St
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("teammate-a", "crew_lead", true),
+      member("teammate-b", "crew_member", true),
+      member("other-org", "admin", true, "org-2"),
+    ]);
+    fake.seed("device_tokens", [
+      { id: "d0", user_id: "submitter", organization_id: "org-1", token: "tok-submitter" },
+      { id: "d1", user_id: "teammate-a", organization_id: "org-1", token: "tok-a" },
+      { id: "d2", user_id: "teammate-b", organization_id: "org-1", token: "tok-b" },
+      { id: "d3", user_id: "other-org", organization_id: "org-2", token: "tok-other" },
+    ]);
+    const push = recordingPush();
+
+    await dispatchNewIntakeNotifications(
+      { jobId: "job-1", submitterUserId: "submitter" },
+      push.deps,
+    );
+
+    // The in-app bell still fans out to the two active teammates.
+    expect(notifs(fake).map((r) => r.user_id).sort()).toEqual(["teammate-a", "teammate-b"]);
+    // The push reaches exactly their devices — never the submitter's own
+    // device, never a member of another Organization.
+    expect(push.tokens().sort()).toEqual(["tok-a", "tok-b"]);
+    // The payload carries the emergency-tier wording, sound, and deep link.
+    const body = JSON.parse(push.requests[0].body);
+    expect(body.aps.alert).toEqual({
+      title: "🚨 EMERGENCY intake: John Smith",
+      body: "Water damage · 123 Main St",
+    });
+    expect(body.aps.sound).toBe("emergency.caf");
+    expect(body.href).toBe("/jobs/job-1");
+  });
+
+  it("a targeted member with no enrolled device still gets the bell — push only reaches enrolled devices", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("has-device", "crew_member", true),
+      member("web-only", "crew_member", true),
+    ]);
+    fake.seed("device_tokens", [
+      { id: "d1", user_id: "has-device", organization_id: "org-1", token: "tok-has" },
+    ]);
+    const push = recordingPush();
+
+    await dispatchNewIntakeNotifications(
+      { jobId: "job-1", submitterUserId: "submitter" },
+      push.deps,
+    );
+
+    // The bell reaches both active teammates regardless of enrollment.
+    expect(notifs(fake).map((r) => r.user_id).sort()).toEqual(["has-device", "web-only"]);
+    // Only the enrolled device is buzzed; the web-only member gets the bell only.
+    expect(push.tokens()).toEqual(["tok-has"]);
+  });
+
+  it("when no targeted member is enrolled, writes the bell and never calls the transport", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("web-only", "crew_member", true),
+    ]);
+    // No device_tokens seeded at all.
+    const push = recordingPush();
+
+    await dispatchNewIntakeNotifications(
+      { jobId: "job-1", submitterUserId: "submitter" },
+      push.deps,
+    );
+
+    expect(notifs(fake).map((r) => r.user_id)).toEqual(["web-only"]);
+    expect(push.requests).toHaveLength(0);
+  });
+
+  it("prunes the addresses the Apple sender reports dead, leaving the live ones", async () => {
+    seedJob(fake);
+    fake.seed("user_organizations", [
+      member("submitter", "admin", true),
+      member("live", "crew_member", true),
+      member("dead", "crew_member", true),
+    ]);
+    fake.seed("device_tokens", [
+      { id: "d1", user_id: "live", organization_id: "org-1", token: "tok-live" },
+      { id: "d2", user_id: "dead", organization_id: "org-1", token: "tok-dead" },
+    ]);
+    const push = recordingPush((token) =>
+      token === "tok-dead"
+        ? { status: 410, reason: "Unregistered" }
+        : { status: 200, apnsId: "ok" },
+    );
+
+    await dispatchNewIntakeNotifications(
+      { jobId: "job-1", submitterUserId: "submitter" },
+      push.deps,
+    );
+
+    // The dead address is dropped from the registry; the live one survives.
+    expect(fake.tableRows("device_tokens").map((r) => r.token)).toEqual(["tok-live"]);
+  });
+
+  describe("push is best-effort — a buzz failure never undoes the bell", () => {
+    it("never throws when the Apple sender errors; the bell is still written and nothing is pruned", async () => {
+      seedJob(fake);
+      fake.seed("user_organizations", [
+        member("submitter", "admin", true),
+        member("teammate", "crew_member", true),
+      ]);
+      fake.seed("device_tokens", [
+        { id: "d1", user_id: "teammate", organization_id: "org-1", token: "tok-1" },
+      ]);
+      const push = recordingPush(() => {
+        throw new Error("ECONNRESET: connection to Apple dropped");
+      });
+
+      await expect(
+        dispatchNewIntakeNotifications(
+          { jobId: "job-1", submitterUserId: "submitter" },
+          push.deps,
+        ),
+      ).resolves.toBeUndefined();
+
+      // The in-app bell — the durable record — is written regardless.
+      expect(notifs(fake).map((r) => r.user_id)).toEqual(["teammate"]);
+      // A transport error is not a dead address, so nothing is pruned.
+      expect(fake.tableRows("device_tokens").map((r) => r.token)).toEqual(["tok-1"]);
+    });
+
+    it("contains a push-path failure (registry/token-lookup error) without blocking the bell write", async () => {
+      seedJob(fake);
+      fake.seed("user_organizations", [
+        member("submitter", "admin", true),
+        member("teammate", "crew_member", true),
+      ]);
+      fake.seed("device_tokens", [
+        { id: "d1", user_id: "teammate", organization_id: "org-1", token: "tok-1" },
+      ]);
+      // The device-address lookup itself fails — a push-infra error that throws.
+      fake.setError("device_tokens.select", { message: "registry unavailable" });
+      const push = recordingPush();
+
+      await expect(
+        dispatchNewIntakeNotifications(
+          { jobId: "job-1", submitterUserId: "submitter" },
+          push.deps,
+        ),
+      ).resolves.toBeUndefined();
+
+      // The bell write precedes the push attempt, so it survives the failure.
+      expect(notifs(fake).map((r) => r.user_id)).toEqual(["teammate"]);
     });
   });
 });

--- a/src/lib/notifications/dispatch-new-intake.ts
+++ b/src/lib/notifications/dispatch-new-intake.ts
@@ -1,15 +1,21 @@
 // New-intake dispatcher: the server-side reaction to a hand-logged Intake.
 // Given the freshly-inserted Job, it loads the Job + its Contact, builds the
-// per-Urgency buzz-wording, and fans out one `new_job` in-app bell row to every
-// active member of the Job's Organization except the submitter.
+// per-Urgency buzz-wording, fans out one `new_job` in-app bell row to every
+// active member of the Job's Organization except the submitter, and then buzzes
+// those members' enrolled iOS devices via APNs (#673).
 //
 // Best-effort by contract: a failed notify must NEVER break Intake submission
 // (the Job is already saved). This function therefore swallows every error and
-// never throws. See docs/adr/0016-new-intake-push-notifications.md.
+// never throws. The in-app bell write is the primary, durable outcome; the push
+// is a best-effort enhancement layered on top and is isolated so a push failure
+// can never undo the bell write. See docs/adr/0018-new-intake-push-notifications.md.
 
 import { createServiceClient } from "@/lib/supabase-api";
+import { send, type ApplePushPayload, type SendDeps } from "@/lib/push/apple-sender";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-import { buildIntakeBuzz, type IntakeUrgency } from "./intake-buzz";
+import { buildIntakeBuzz, type IntakeBuzz, type IntakeUrgency } from "./intake-buzz";
+import { listDeviceTokensForUsers, pruneDeviceTokens } from "./device-tokens";
 import { writeNotification } from "./write";
 
 export interface DispatchNewIntakeInput {
@@ -29,6 +35,10 @@ interface JobFacts {
 
 export async function dispatchNewIntakeNotifications(
   input: DispatchNewIntakeInput,
+  // APNs send dependencies (transport/config/now). Defaults to `{}` so the real
+  // Apple transport + env credentials are used in production; tests inject a
+  // fake transport. See src/lib/push/apple-sender.ts.
+  push: SendDeps = {},
 ): Promise<void> {
   try {
     const supabase = createServiceClient();
@@ -60,7 +70,9 @@ export async function dispatchNewIntakeNotifications(
       propertyAddress: job.property_address,
     });
 
-    await writeNotification({
+    // The in-app bell is the primary outcome; its recipient list is the single
+    // source of truth for who the buzz targets (no separate audience query).
+    const recipientIds = await writeNotification({
       type: "new_job",
       title: buzz.title,
       body: buzz.body,
@@ -70,8 +82,49 @@ export async function dispatchNewIntakeNotifications(
       audience: "members",
       excludeUserId: input.submitterUserId,
     });
+
+    // Best-effort push enhancement, isolated from the bell write above: a buzz
+    // failure (registry error, APNs misconfig, transport drop) must never undo
+    // the durable bell record or surface to the Intake flow.
+    try {
+      await buzzDevices(supabase, recipientIds, buzz, push);
+    } catch (pushErr) {
+      console.error("[new-intake notify] push failed:", pushErr);
+    }
   } catch (err) {
     // Best-effort: never let a notify failure surface to the Intake flow.
     console.error("[new-intake notify] dispatch failed:", err);
   }
+}
+
+/**
+ * Best-effort push enhancement: buzz the enrolled iOS devices of the members
+ * who just received the in-app bell. Looks up their device addresses, builds the
+ * APNs payload from the same buzz-wording, and sends. Returns silently when no
+ * targeted member has an enrolled device (web/desktop-only teams get the bell
+ * and nothing more).
+ */
+async function buzzDevices(
+  supabase: SupabaseClient,
+  recipientIds: string[],
+  buzz: IntakeBuzz,
+  push: SendDeps,
+): Promise<void> {
+  const tokens = await listDeviceTokensForUsers(supabase, recipientIds);
+  if (tokens.length === 0) return;
+
+  const payload: ApplePushPayload = {
+    title: buzz.title,
+    body: buzz.body,
+    sound: buzz.sound,
+    href: buzz.href,
+  };
+  const result = await send(tokens, payload, push);
+
+  // Drop the addresses Apple reported dead (unregistered / bad token) so we
+  // stop buzzing uninstalled apps. See src/lib/notifications/device-tokens.ts.
+  const dead = result.outcomes
+    .filter((o) => o.status === "prunable")
+    .map((o) => o.token);
+  await pruneDeviceTokens(supabase, dead);
 }

--- a/src/lib/notifications/write.ts
+++ b/src/lib/notifications/write.ts
@@ -18,7 +18,7 @@ export interface WriteNotificationInput {
   //   "members" — every active member of the org, any role (e.g. new-intake)
   audience?: "admins" | "members";
   // When fanning out, omit this user — e.g. the submitter who triggered the
-  // event and need not be told of their own action. See ADR 0016.
+  // event and need not be told of their own action. See ADR 0018.
   excludeUserId?: string | null;
   // Org scope for the notification row(s). Required — writeNotification uses a
   // service client, so it cannot resolve the active org from a session JWT.
@@ -28,9 +28,15 @@ export interface WriteNotificationInput {
   organizationId: string;
 }
 
+/**
+ * Write the notification row(s) and return the user ids actually notified — the
+ * single source of truth for "who got told". A best-effort follow-on (e.g. the
+ * new-intake push fan-out in #673) reuses this exact set so the audience can't
+ * drift between the in-app bell and the buzz.
+ */
 export async function writeNotification(
   input: WriteNotificationInput,
-): Promise<void> {
+): Promise<string[]> {
   const supabase = createServiceClient();
   const orgId = input.organizationId;
 
@@ -50,7 +56,7 @@ export async function writeNotification(
       .from("notifications")
       .insert({ ...row, user_id: input.userId });
     if (error) throw new Error(`notifications insert: ${error.message}`);
-    return;
+    return [input.userId];
   }
 
   // Fan out: one row per active member of this org. Role lives on
@@ -74,9 +80,10 @@ export async function writeNotification(
     .map((m) => m.user_id)
     .filter((userId) => userId !== input.excludeUserId);
 
-  if (recipientIds.length === 0) return;
+  if (recipientIds.length === 0) return [];
 
   const rows = recipientIds.map((userId: string) => ({ ...row, user_id: userId }));
   const { error } = await supabase.from("notifications").insert(rows);
   if (error) throw new Error(`notifications bulk insert: ${error.message}`);
+  return recipientIds;
 }


### PR DESCRIPTION
Closes #673.

Completes the new-intake push feature (#667): the dispatcher now buzzes real
iPhones, end-to-end.

## What changed
After the new-intake dispatcher writes the in-app **bell** rows, it now also
buzzes the targeted members' enrolled iOS devices:

1. Looks up each recipient's device addresses via the registry (#671).
2. Builds the APNs payload from the **same** per-Urgency buzz-wording —
   title/body, per-tier sound, and the `/jobs/{id}` deep link.
3. Sends via the Apple sender (#672).
4. Prunes any addresses Apple reports dead (410 Unregistered / bad token).

### Best-effort by contract
The push runs in its own `try/catch`, isolated from the bell write: a registry
error, APNs misconfig, or transport drop can **never** undo the durable bell
record or surface to the Intake flow. Web/desktop sessions and devices that
never enrolled keep getting the bell and nothing more.

### Single source of truth for the audience
`writeNotification` now returns the recipient user ids it actually notified, so
the buzz fan-out reuses the **exact** bell audience instead of re-querying it —
the bell and the buzz can't drift (ADR 0018; user story 25). Backward-compatible:
all other callers ignore the new return value.

### Drive-by
Fixed the stale ADR links in the two touched files (`0016` → `0018`; `0016` is
the unrelated email-template ADR). Six other new-intake feature files carry the
same stale ref — left for a separate cleanup to keep this PR focused.

## Tests
New dispatcher push-fan-out tests (real `send` + injected fake APNs transport):
- buzzes **exactly** the targeted devices (not the submitter's, not other-org's)
- emergency-tier payload (title/body/`emergency.caf`/`/jobs/{id}`)
- no-device / web members get the **bell only**; no enrolled members → transport never called
- prunes the dead address, leaves the live one
- never throws when the sender errors (bell still written, nothing pruned)
- survives a token-lookup error without blocking the bell

`51 passing` across `notifications` / `push` / `intake` & `push` routes.
`tsc` adds no new errors (4 pre-existing on the branch base, in untouched files).
`eslint` clean on all changed files.

## Verification still owed (manual)
End-to-end buzz on a real device (TestFlight) — there is no CI path for APNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)