### PR TITLE
feat(financials): collection ring "paid ahead" state (#718)

### DIFF
--- a/src/components/job-detail/collection-ring.tsx
+++ b/src/components/job-detail/collection-ring.tsx
@@ -7,6 +7,10 @@ const NEUTRAL = {
   border: "1px solid rgba(255,255,255,0.08)",
 };
 
+// Paid-ahead is good news, not a maxed-out bill — tint it the same green as the
+// ring fill so it reads positively.
+const GOOD_NEWS = { color: "#5DCAA5" };
+
 // Presentational only — which state to show, the ring geometry, and the
 // numbers are all decided by the view-model deriver; this just lays them out.
 // The ring is a hand-rolled SVG arc, deliberately no charting dependency.
@@ -21,8 +25,9 @@ export default function CollectionRing({ ring }: { ring: CollectionRingState }) 
     );
   }
 
-  // collection-rate | clamped — both paint a ring; only collection-rate has a
-  // meaningful Outstanding (clamped/over-collected defers that to #718).
+  // collection-rate | paid-ahead — both paint a ring. collection-rate shows the
+  // Outstanding still owed; paid-ahead (Collected > Invoiced) shows the
+  // good-news over-amount instead.
   return (
     <div className="flex items-center gap-4 rounded-lg p-4" style={NEUTRAL}>
       <RingArc geometry={ring.geometry} />
@@ -35,6 +40,14 @@ export default function CollectionRing({ ring }: { ring: CollectionRingState }) 
           <div className="mt-0.5 text-xs text-neutral-400">
             <span>Outstanding</span>{" "}
             <span className="tabular-nums">{fmtCurrency(ring.outstanding)}</span>
+          </div>
+        )}
+        {ring.kind === "paid-ahead" && (
+          <div className="mt-0.5 text-xs">
+            <span style={GOOD_NEWS}>Paid ahead</span>{" "}
+            <span className="tabular-nums" style={GOOD_NEWS}>
+              {fmtCurrency(ring.overCollected)}
+            </span>
           </div>
         )}
       </div>

--- a/src/components/job-detail/financials-tab.test.tsx
+++ b/src/components/job-detail/financials-tab.test.tsx
@@ -171,4 +171,17 @@ describe("FinancialsTab phone collection ring", () => {
     expect(ring.queryByText(/Outstanding/)).toBeNull();
     expect(ring.queryByText(/-\$/)).toBeNull();
   });
+
+  // #718 — over-collection is framed as the good-news "paid ahead" state.
+  it("annotates an over-collected Job 'paid ahead' with the over-amount, in green", () => {
+    renderTab({ invoiced: 1000, collected: 1200 }); // $200 paid ahead
+
+    const ring = within(screen.getByTestId("collection-ring"));
+    expect(ring.getByText(/paid ahead/i)).toBeTruthy();
+
+    // Collected − Invoiced, a positive figure, coloured green so it reads as
+    // good news rather than a maxed-out bill
+    const amount = ring.getByText("$200");
+    expect(amount.style.color).toBe("rgb(93, 202, 165)"); // #5DCAA5
+  });
 });

--- a/src/components/job-detail/financials-view-model.test.ts
+++ b/src/components/job-detail/financials-view-model.test.ts
@@ -131,10 +131,10 @@ describe("financialsViewModel — cash-flow waterfall", () => {
   });
 });
 
-// #717 — the deriver also produces the phone collection ring's state: a
-// discriminated union (collection-rate / not-invoiced-yet / clamped) carrying
-// the ring geometry, so the component renders without any branch logic of its
-// own. Invoiced is billing context here, separate from the waterfall math.
+// #717/#718 — the deriver also produces the phone collection ring's state: a
+// discriminated union (collection-rate / not-invoiced-yet / paid-ahead)
+// carrying the ring geometry, so the component renders without any branch logic
+// of its own. Invoiced is billing context here, separate from the waterfall math.
 describe("financialsViewModel — collection ring", () => {
   it("derives a collection-rate ring with Outstanding when Invoiced > 0", () => {
     const vm = financialsViewModel({
@@ -172,10 +172,13 @@ describe("financialsViewModel — collection ring", () => {
     }
   });
 
-  it("clamps an over-collected Job (Collected > Invoiced) to a full ring", () => {
+  // #718 — over-collection is its own "paid ahead" state: the ring still caps
+  // at a full 100% (never overflowing), and it carries the over-amount so the
+  // component can frame it as good news rather than a maxed-out bill.
+  it("flags an over-collected Job (Collected > Invoiced) as paid ahead, ring still full", () => {
     const vm = financialsViewModel({
       invoiced: 1000,
-      collected: 1200, // paid ahead — the dedicated annotation comes in #718
+      collected: 1200, // paid ahead
       expenses: 0,
       crew_labor: 0,
       margin_pct: 120,
@@ -183,11 +186,12 @@ describe("financialsViewModel — collection ring", () => {
     });
 
     const ring = vm.collectionRing;
-    expect(ring.kind).toBe("clamped");
-    if (ring.kind === "clamped") {
-      // a full ring, not a 120%-overflowing one
+    expect(ring.kind).toBe("paid-ahead");
+    if (ring.kind === "paid-ahead") {
+      // capped — a full ring, not a 120%-overflowing one
       expect(ring.geometry.percent).toBe(100);
       expect(ring.geometry.fraction).toBe(1);
+      expect(ring.overCollected).toBe(200); // Collected − Invoiced, paid ahead
     }
   });
 

--- a/src/components/job-detail/financials-view-model.ts
+++ b/src/components/job-detail/financials-view-model.ts
@@ -30,10 +30,12 @@ export type CollectionRing =
       collected: number;
     }
   | {
-      /** Collected > Invoiced: a full ring this slice; "paid ahead" lands in #718. */
-      kind: "clamped";
+      /** Collected > Invoiced: the ring caps at a full 100% and reads "paid ahead". */
+      kind: "paid-ahead";
       collected: number;
       invoiced: number;
+      /** Collected − Invoiced, the amount paid ahead of what's been billed */
+      overCollected: number;
       geometry: RingGeometry;
     };
 
@@ -53,11 +55,11 @@ function collectionRing(invoiced: number, collected: number): CollectionRing {
   const rate = collected / invoiced;
   const geometry = ringGeometry(rate);
 
-  // Paid ahead: clamp to a full ring this slice. The "paid ahead" annotation
-  // (and a meaningful over-amount) arrives in #718; Outstanding would be
-  // negative here, so it is deliberately omitted.
+  // Paid ahead: the ring caps at a full 100% (ringGeometry clamps the fraction)
+  // and we surface the over-amount so the component can frame it as good news.
+  // Outstanding would be negative here, so it is deliberately omitted.
   if (collected > invoiced) {
-    return { kind: "clamped", collected, invoiced, geometry };
+    return { kind: "paid-ahead", collected, invoiced, overCollected: collected - invoiced, geometry };
   }
 
   return {


### PR DESCRIPTION
## Summary

Refines the collection ring's over-collection case (Collected > Invoiced) from the generic clamp shipped in #717 into a first-class **"paid ahead"** state. The ring still caps at a full 100%, but it now reads as good news instead of a maxed-out bill.

- **View-model** (`financials-view-model.ts`) — the over-collected branch is now `kind: "paid-ahead"`, carrying `overCollected` (Collected − Invoiced). Geometry still clamps to a full ring.
- **Component** (`collection-ring.tsx`) — `paid-ahead` renders a **"Paid ahead $X"** line in green (`#5DCAA5`) in place of the Outstanding line. `collection-rate` and `not-invoiced-yet` are untouched.

Built TDD, two vertical cycles (view-model branch → component annotation).

## Acceptance criteria
- ✅ Collected > Invoiced → ring caps at 100%, annotated "paid ahead" (with the over-amount)
- ✅ Collected ≤ Invoiced unchanged from #717
- ✅ "paid ahead" branch covered by a view-model deriver unit test
- ✅ No new failures beyond the known-red baseline (clean base = working tree = 5 pre-existing tsc errors, none in touched files; 68/68 job-detail tests pass)

Closes #718

🤖 Generated with [Claude Code](https://claude.com/claude-code)