### PR TITLE
docs(push): repoint new-intake comment links to ADR 0018 (#673)

### DIFF
--- a/src/app/api/intake/notify/route.ts
+++ b/src/app/api/intake/notify/route.ts
@@ -5,7 +5,7 @@ import { dispatchNewIntakeNotifications } from "@/lib/notifications/dispatch-new
 
 // POST /api/intake/notify — the client calls this best-effort right after an
 // Intake's Job is inserted, to fan out the in-app bell to the rest of the
-// Organization (see docs/adr/0016-new-intake-push-notifications.md).
+// Organization (see docs/adr/0018-new-intake-push-notifications.md).
 //
 // Logged-in only: any member who just logged an Intake may trigger its
 // notifications. The fan-out itself runs with the Service client (RLS

--- a/src/app/api/push/register/route.ts
+++ b/src/app/api/push/register/route.ts
@@ -12,7 +12,7 @@ export const runtime = "nodejs";
 // owner is the authenticated caller (`ctx.userId`) and the write goes through
 // the Service client (RLS bypassed): the route must never trust a
 // client-supplied user id. No push is sent here — this slice only fills the
-// device-address registry. See docs/adr/0016-new-intake-push-notifications.md.
+// device-address registry. See docs/adr/0018-new-intake-push-notifications.md.
 export const POST = withRequestContext(
   { serviceClient: true },
   async (request, ctx) => {

--- a/src/components/intake-form.test.tsx
+++ b/src/components/intake-form.test.tsx
@@ -451,7 +451,7 @@ describe("IntakeForm — referrer left blank (#302)", () => {
 // After a Job is created, the form fires a best-effort POST to
 // /api/intake/notify so the rest of the Organization gets an in-app bell. The
 // call must never block or break Intake submission (the Job is already saved).
-// See docs/adr/0016-new-intake-push-notifications.md.
+// See docs/adr/0018-new-intake-push-notifications.md.
 
 function notifyCalls() {
   const fetchMock = global.fetch as unknown as ReturnType<typeof vi.fn>;

--- a/src/components/intake-form.tsx
+++ b/src/components/intake-form.tsx
@@ -317,7 +317,7 @@ export default function IntakeForm({ testMode = false }: { testMode?: boolean } 
 
       // Best-effort: fan out the in-app bell to the rest of the Organization.
       // The Job is already saved, so a failed notify must never surface to the
-      // office user or block navigation. See ADR 0016 (#669).
+      // office user or block navigation. See ADR 0018 (#669).
       try {
         await fetch("/api/intake/notify", {
           method: "POST",

--- a/src/lib/notifications/device-tokens.ts
+++ b/src/lib/notifications/device-tokens.ts
@@ -8,7 +8,7 @@
 //
 // This slice only fills the registry — no buzz is sent here. The new-intake
 // dispatcher will later read it via listDeviceTokensForUsers. See
-// docs/adr/0016-new-intake-push-notifications.md and issue #671.
+// docs/adr/0018-new-intake-push-notifications.md and issue #671.
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 

--- a/src/lib/notifications/intake-buzz.ts
+++ b/src/lib/notifications/intake-buzz.ts
@@ -1,7 +1,7 @@
 // Buzz-wording for a new-intake notification: the pure mapping from a Job's
 // customer-facing facts to the title/body/sound/deep-link a bell row (and a
 // later push) carries. Title and sound vary by the Job's **Urgency** tier; an
-// 🚨 emergency leads the title. See docs/adr/0016-new-intake-push-notifications.md.
+// 🚨 emergency leads the title. See docs/adr/0018-new-intake-push-notifications.md.
 
 export type IntakeUrgency = "emergency" | "urgent" | "scheduled";
 


### PR DESCRIPTION
Follow-up to #736. The six remaining new-intake feature files still cited
`docs/adr/0016-new-intake-push-notifications.md` (and one bare `ADR 0016`) — a
stale ref from an ADR renumber at merge. `0016` is actually the unrelated
`0016-email-template-authorization-is-a-db-backstop.md`; the real path is `0018`.

Files repointed (comment-only, no behavior change):
- `src/app/api/intake/notify/route.ts`
- `src/app/api/push/register/route.ts`
- `src/components/intake-form.tsx`
- `src/components/intake-form.test.tsx`
- `src/lib/notifications/intake-buzz.ts`
- `src/lib/notifications/device-tokens.ts`

`grep -rn "0016" src` now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)