### PR TITLE
feat(jobs): signed contract auto-advances Lead or Lost → Active (#721)

### DIFF
--- a/src/lib/contracts/finalize.test.ts
+++ b/src/lib/contracts/finalize.test.ts
@@ -231,20 +231,37 @@ function buildClient(state: {
 
   function updateBuilder(table: string, values: Record<string, unknown>) {
     const filters: Filters = {};
+    // Apply the update to every row matching every `.eq()` filter (the same
+    // atomic guard Postgres applies), returning the affected rows.
+    function apply(): { affected: Record<string, unknown>[]; error: PendingError | null } {
+      state.updates[table] = state.updates[table] ?? [];
+      state.updates[table].push({ values, filters });
+      const err = state.errors[`${table}.update`];
+      if (err) return { affected: [], error: err };
+      const affected = (state.rows[table] ?? []).filter((r) => matchesFilters(r, filters));
+      for (const row of affected) Object.assign(row, values);
+      return { affected, error: null };
+    }
     const builder = {
       eq(col: string, val: unknown) {
         filters[col] = val;
         return builder;
       },
+      // `.update(...).eq(...).select(...).maybeSingle()` — returns the affected
+      // row so a guarded update can tell whether it actually landed.
+      select(_cols?: string) {
+        void _cols;
+        return {
+          async maybeSingle() {
+            const { affected, error } = apply();
+            if (error) return { data: null, error };
+            return { data: affected[0] ?? null, error: null };
+          },
+        };
+      },
       then(resolve: (v: { data: unknown; error: PendingError | null }) => unknown) {
-        state.updates[table] = state.updates[table] ?? [];
-        state.updates[table].push({ values, filters });
-        const err = state.errors[`${table}.update`];
-        if (err) return resolve({ data: null, error: err });
-        for (const row of state.rows[table] ?? []) {
-          if (matchesFilters(row, filters)) Object.assign(row, values);
-        }
-        return resolve({ data: null, error: null });
+        const { error } = apply();
+        return resolve({ data: null, error });
       },
     };
     return builder;
@@ -751,6 +768,118 @@ describe("finalizeSignedContract — signer with null email", () => {
       signer_id: "sig-empty",
       skipped_reason: "no_signer_email",
     });
+  });
+});
+
+describe("finalizeSignedContract — job auto-advance (#721)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("advances a Lead (new) Job to in_progress when the contract is finalized", async () => {
+    const fake = makeSupabaseFake();
+    const { contract, signers } = seedHappyPathFake(fake);
+    fake.seed("jobs", [{ id: contract.job_id, status: "new" }]);
+
+    const result = await finalizeSignedContract({
+      supabase: fake.client as never,
+      contract,
+      template: makeTemplate(),
+      signers,
+      customerInputs: {},
+      signedAt: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    expect(result.wasAlreadyFinalized).toBe(false);
+    const jobUpdates = fake.updates["jobs"] ?? [];
+    expect(jobUpdates).toHaveLength(1);
+    expect(jobUpdates[0]).toMatchObject({
+      values: { status: "in_progress" },
+      filters: { id: contract.job_id },
+    });
+  });
+
+  it("revives a Lost (cancelled) Job to in_progress when the contract is finalized", async () => {
+    const fake = makeSupabaseFake();
+    const { contract, signers } = seedHappyPathFake(fake);
+    fake.seed("jobs", [{ id: contract.job_id, status: "cancelled" }]);
+
+    await finalizeSignedContract({
+      supabase: fake.client as never,
+      contract,
+      template: makeTemplate(),
+      signers,
+      customerInputs: {},
+      signedAt: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    const jobUpdates = fake.updates["jobs"] ?? [];
+    expect(jobUpdates).toHaveLength(1);
+    expect(jobUpdates[0]).toMatchObject({ values: { status: "in_progress" } });
+  });
+
+  it("leaves an Active (in_progress) Job unchanged — signing never moves it backward", async () => {
+    const fake = makeSupabaseFake();
+    const { contract, signers } = seedHappyPathFake(fake);
+    fake.seed("jobs", [{ id: contract.job_id, status: "in_progress" }]);
+
+    await finalizeSignedContract({
+      supabase: fake.client as never,
+      contract,
+      template: makeTemplate(),
+      signers,
+      customerInputs: {},
+      signedAt: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    expect(fake.updates["jobs"] ?? []).toHaveLength(0);
+  });
+
+  it("does not touch the Job when re-finalizing an already-signed contract (idempotent)", async () => {
+    const fake = makeSupabaseFake();
+    fake.seed("contracts", [
+      {
+        id: "c-1",
+        organization_id: "org-1",
+        status: "signed",
+        signed_pdf_path: "org-1/contracts/c-1-signed.pdf",
+      },
+    ]);
+    // A Job that has since moved on (e.g. Collections) must stay put.
+    fake.seed("jobs", [{ id: "job-1", status: "pending_invoice" }]);
+    const stale = makeContract({ id: "c-1", status: "viewed", signed_pdf_path: null });
+
+    const result = await finalizeSignedContract({
+      supabase: fake.client as never,
+      contract: stale,
+      template: makeTemplate(),
+      signers: [makeSigner()],
+      customerInputs: {},
+      signedAt: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    expect(result.wasAlreadyFinalized).toBe(true);
+    expect(fake.updates["jobs"] ?? []).toHaveLength(0);
+  });
+
+  it("still finalizes the contract when the Job update is rejected (best-effort)", async () => {
+    const fake = makeSupabaseFake();
+    const { contract, signers } = seedHappyPathFake(fake);
+    fake.seed("jobs", [{ id: contract.job_id, status: "new" }]);
+    fake.setError("jobs.update", { message: "rls denied" });
+
+    const result = await finalizeSignedContract({
+      supabase: fake.client as never,
+      contract,
+      template: makeTemplate(),
+      signers,
+      customerInputs: {},
+      signedAt: new Date("2026-05-13T12:00:00Z"),
+    });
+
+    // Signing succeeded end-to-end even though the status nudge failed.
+    expect(result.wasAlreadyFinalized).toBe(false);
+    expect(result.signedPdfPath).toBe("org-1/contracts/c-1-signed.pdf");
   });
 });
 

--- a/src/lib/contracts/finalize.ts
+++ b/src/lib/contracts/finalize.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { advanceJobOnContractSigned } from "@/lib/job-status-transitions";
 import { writeContractEvent } from "./audit";
 import { resolveMergeValues } from "./resolve-merge-values";
 import { resolveEmailTemplate } from "./email-merge-fields";
@@ -391,6 +392,13 @@ export async function finalizeSignedContract(
   }
 
   const sealed = await sealContract(args);
+
+  // The one automatic Job-status move (#721): a signed contract advances a
+  // Lead or Lost Job to Active. Best-effort and idempotent — placed after the
+  // seal so a re-finalize early-returns above and never re-advances; a status
+  // hiccup must never break a legally-completed signing.
+  await advanceJobOnContractSigned(supabase, contract.job_id);
+
   const notifications = await dispatchNotifications(
     supabase,
     contract,

--- a/src/lib/job-status-transitions.test.ts
+++ b/src/lib/job-status-transitions.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  advanceJobOnContractSigned,
+  nextStatusOnContractSigned,
+} from "./job-status-transitions";
+
+// Issue #721 (PRD #719, ADR 0022) — finalizing a signed contract is the one
+// automatic Job-status move: a Lead (`new`) or a Lost (`cancelled`) Job
+// advances to Active (`in_progress`). Signing never moves a Job backward, so
+// an Active/Collections/Closed Job is left untouched. The snake_case keys are
+// frozen (ADR 0022); the decision branches on keys, never labels.
+
+describe("nextStatusOnContractSigned", () => {
+  it("advances a Lead (new) Job to Active (in_progress)", () => {
+    expect(nextStatusOnContractSigned("new")).toBe("in_progress");
+  });
+
+  it("revives a Lost (cancelled) Job to Active (in_progress)", () => {
+    expect(nextStatusOnContractSigned("cancelled")).toBe("in_progress");
+  });
+
+  // Signing never moves a Job backward: Active / Collections / Closed stay put.
+  const noOp: Array<[string, string]> = [
+    ["in_progress", "Active"],
+    ["pending_invoice", "Collections"],
+    ["completed", "Closed"],
+  ];
+  it.each(noOp)("leaves %s (%s) unchanged — no backward move", (key) => {
+    expect(nextStatusOnContractSigned(key)).toBeNull();
+  });
+
+  it("no-ops on an unknown status key", () => {
+    expect(nextStatusOnContractSigned("archived")).toBeNull();
+    expect(nextStatusOnContractSigned("")).toBeNull();
+  });
+});
+
+// ---------- jobs fake ----------------------------------------------------
+//
+// Minimal Supabase stand-in for the calls advanceJobOnContractSigned issues:
+// `from("jobs").select("status").eq("id", …).maybeSingle()` and the guarded
+// write `from("jobs").update({ status }).eq("id", …).eq("status", …)
+// .select("status").maybeSingle()`. `.eq()` filters compose (id AND status),
+// so a write only lands when the live row still matches every filter — the
+// same atomic guard Postgres applies. Tracks update payloads + filters and
+// mutates the seeded row so a follow-up read reflects the write. Errors can be
+// injected per operation; `mutateAfterRead` flips the live row right after the
+// read resolves to simulate a concurrent writer in the read→write window.
+
+function makeJobsFake(
+  initial: { id: string; status: string } | null,
+  opts: {
+    selectError?: boolean;
+    updateError?: boolean;
+    selectThrows?: boolean;
+    updateThrows?: boolean;
+    mutateAfterRead?: string;
+  } = {},
+) {
+  const updates: Array<{
+    values: Record<string, unknown>;
+    filters: Record<string, unknown>;
+  }> = [];
+  const row = initial ? { ...initial } : null;
+
+  function matches(filters: Record<string, unknown>): boolean {
+    if (!row) return false;
+    for (const [k, v] of Object.entries(filters)) {
+      if ((row as Record<string, unknown>)[k] !== v) return false;
+    }
+    return true;
+  }
+
+  const client = {
+    from(_table: string) {
+      void _table;
+      return {
+        select(_cols?: string) {
+          void _cols;
+          const filters: Record<string, unknown> = {};
+          const b = {
+            eq(c: string, v: unknown) {
+              filters[c] = v;
+              return b;
+            },
+            async maybeSingle() {
+              if (opts.selectThrows) throw new Error("select rejected");
+              if (opts.selectError) {
+                return { data: null, error: { message: "select boom" } };
+              }
+              if (!matches(filters)) return { data: null, error: null };
+              const snapshot = { ...(row as Record<string, unknown>) };
+              if (opts.mutateAfterRead !== undefined && row) {
+                row.status = opts.mutateAfterRead;
+              }
+              return { data: snapshot, error: null };
+            },
+          };
+          return b;
+        },
+        update(values: Record<string, unknown>) {
+          const filters: Record<string, unknown> = {};
+          function apply() {
+            updates.push({ values, filters: { ...filters } });
+            if (opts.updateThrows) throw new Error("update rejected");
+            if (opts.updateError) {
+              return { data: null, error: { message: "rls denied" } };
+            }
+            if (matches(filters) && row) {
+              Object.assign(row, values);
+              return { data: { ...row }, error: null };
+            }
+            return { data: null, error: null };
+          }
+          const b = {
+            eq(c: string, v: unknown) {
+              filters[c] = v;
+              return b;
+            },
+            select(_cols?: string) {
+              void _cols;
+              return {
+                async maybeSingle() {
+                  return apply();
+                },
+              };
+            },
+            then(resolve: (r: unknown) => unknown) {
+              return resolve(apply());
+            },
+          };
+          return b;
+        },
+      };
+    },
+  };
+  return { client, updates, getRow: () => row };
+}
+
+describe("advanceJobOnContractSigned", () => {
+  it("advances a Lead (new) Job to in_progress and persists the write", async () => {
+    const fake = makeJobsFake({ id: "job-1", status: "new" });
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-1");
+
+    expect(result).toBe("in_progress");
+    expect(fake.updates).toHaveLength(1);
+    expect(fake.updates[0]).toMatchObject({
+      values: { status: "in_progress" },
+      filters: { id: "job-1" },
+    });
+    expect(fake.getRow()?.status).toBe("in_progress");
+  });
+
+  // The read and write are two statements: a concurrent writer (the #722 status
+  // dropdown, or a sibling signing) can move the Job in the window between them.
+  // The write must re-assert the status is unchanged so it can never clobber a
+  // Job that has moved on — signing never moves a Job backward.
+  it("does not clobber a Job whose status changed between the read and the write", async () => {
+    const fake = makeJobsFake(
+      { id: "job-race", status: "new" },
+      { mutateAfterRead: "completed" },
+    );
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-race");
+
+    expect(result).toBeNull();
+    expect(fake.getRow()?.status).toBe("completed");
+  });
+
+  it("revives a Lost (cancelled) Job to in_progress", async () => {
+    const fake = makeJobsFake({ id: "job-lost", status: "cancelled" });
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-lost");
+
+    expect(result).toBe("in_progress");
+    expect(fake.getRow()?.status).toBe("in_progress");
+  });
+
+  it("leaves an Active (in_progress) Job untouched and issues no write", async () => {
+    const fake = makeJobsFake({ id: "job-2", status: "in_progress" });
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-2");
+
+    expect(result).toBeNull();
+    expect(fake.updates).toHaveLength(0);
+    expect(fake.getRow()?.status).toBe("in_progress");
+  });
+
+  it("no-ops on a null/empty jobId without touching the database", async () => {
+    const fake = makeJobsFake({ id: "job-3", status: "new" });
+
+    expect(await advanceJobOnContractSigned(fake.client as never, null)).toBeNull();
+    expect(await advanceJobOnContractSigned(fake.client as never, undefined)).toBeNull();
+    expect(await advanceJobOnContractSigned(fake.client as never, "")).toBeNull();
+    expect(fake.updates).toHaveLength(0);
+    expect(fake.getRow()?.status).toBe("new");
+  });
+
+  // Best-effort: a status hiccup must never break a legally-completed signing.
+  it("returns null when the jobs update is rejected (does not report a false advance)", async () => {
+    const fake = makeJobsFake({ id: "job-7", status: "new" }, { updateError: true });
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-7");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the jobs read returns an error", async () => {
+    const fake = makeJobsFake({ id: "job-8", status: "new" }, { selectError: true });
+
+    const result = await advanceJobOnContractSigned(fake.client as never, "job-8");
+
+    expect(result).toBeNull();
+    expect(fake.updates).toHaveLength(0);
+  });
+
+  it("swallows a thrown DB failure and resolves to null instead of propagating", async () => {
+    const reading = makeJobsFake({ id: "job-9", status: "new" }, { selectThrows: true });
+    await expect(
+      advanceJobOnContractSigned(reading.client as never, "job-9"),
+    ).resolves.toBeNull();
+
+    const writing = makeJobsFake({ id: "job-10", status: "new" }, { updateThrows: true });
+    await expect(
+      advanceJobOnContractSigned(writing.client as never, "job-10"),
+    ).resolves.toBeNull();
+  });
+});

--- a/src/lib/job-status-transitions.ts
+++ b/src/lib/job-status-transitions.ts
@@ -1,0 +1,71 @@
+// src/lib/job-status-transitions.ts
+//
+// The one automatic Job-status move (PRD #719, ADR 0022, issue #721):
+// finalizing a signed contract advances a Lead or a Lost Job to Active.
+// Signing never moves a Job backward — an Active, Collections, or Closed Job
+// is left untouched. The snake_case keys are FROZEN (ADR 0022); this module
+// branches on keys, never labels.
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * The status a Job should move to when its contract is finalized as signed,
+ * or `null` when signing must NOT change the status.
+ */
+export function nextStatusOnContractSigned(current: string): string | null {
+  return current === "new" || current === "cancelled" ? "in_progress" : null;
+}
+
+/**
+ * Apply the signed-contract auto-advance to a Job, in place. Reads the Job's
+ * *live* status (the contract snapshot may be stale), applies
+ * {@link nextStatusOnContractSigned}, and writes only when there is a move to
+ * make. Returns the status it advanced to, or `null` when it left the Job
+ * unchanged (already Active/Collections/Closed, missing job, or no jobId).
+ *
+ * The write re-asserts the just-read status in its filter, so the database
+ * applies the guard atomically: if a concurrent writer (the manual status
+ * dropdown, or a sibling signing) has moved the Job in the read→write window,
+ * the update matches zero rows and the Job is left untouched. Signing can
+ * therefore never clobber a Job backward, even under a race.
+ */
+export async function advanceJobOnContractSigned(
+  supabase: SupabaseClient,
+  jobId: string | null | undefined,
+): Promise<string | null> {
+  if (!jobId) return null;
+
+  try {
+    const { data, error } = await supabase
+      .from("jobs")
+      .select("status")
+      .eq("id", jobId)
+      .maybeSingle<{ status: string }>();
+    if (error || !data) return null;
+
+    const next = nextStatusOnContractSigned(data.status);
+    if (!next) return null;
+
+    const { data: updated, error: updateError } = await supabase
+      .from("jobs")
+      .update({ status: next })
+      .eq("id", jobId)
+      .eq("status", data.status)
+      .select("status")
+      .maybeSingle<{ status: string }>();
+    if (updateError) {
+      console.error(
+        `[job-status] auto-advance update failed for job ${jobId}:`,
+        updateError.message,
+      );
+      return null;
+    }
+    return updated ? next : null;
+  } catch (e) {
+    console.error(
+      `[job-status] auto-advance threw for job ${jobId}:`,
+      e instanceof Error ? e.message : String(e),
+    );
+    return null;
+  }
+}


### PR DESCRIPTION
## What & why

Finalizing a signed contract is the one automatic Job-status move (PRD #719, ADR 0022): a **Lead** (`new`) or a **Lost** (`cancelled`) Job advances to **Active** (`in_progress`). Signing never moves a Job backward — **Active**, **Collections**, and **Closed** are left untouched. Reviving a Lost Job on signature is intentional.

Closes #721.

## How

- **New deep module `job-status-transitions`:**
  - `nextStatusOnContractSigned(current)` — a pure decision that branches on the frozen snake_case keys (never labels) and returns the target status or `null`. Unit-tested for every status key.
  - `advanceJobOnContractSigned(supabase, jobId)` — a best-effort writer that reads the Job's *live* status, applies the decision, and writes only when there's a move.
- **Wired at the single finalize choke point** (`finalizeSignedContract`), after the seal — so it fires for **both** the remote and in-person signing paths, and a re-finalize early-returns above it (**idempotent for free**). The dead `mark_contract_signed` RPC is intentionally not touched.
- **Best-effort:** a status hiccup is swallowed (logged, returns `null`) so it can never break a legally-completed signing.
- **Race-safe:** the write re-asserts the just-read status in its filter (`.eq("status", …)`), so the database applies the guard **atomically**. If a concurrent writer (the manual status dropdown, or a sibling signing) moves the Job in the read→write window, the update matches zero rows and the Job is left untouched — signing can never clobber a Job backward, even under a race.

## Test plan

Built strictly RED→GREEN (tracer-bullet TDD).

- `job-status-transitions.test.ts` (14) — pure decision per status key (Lead→Active, Lost revival, Active/Collections/Closed no-op, unknown-key no-op) + the writer (persist, revive, leave-untouched, null/empty jobId, update-rejected, read-error, thrown-swallowed, **and the concurrent-move guard**).
- `finalize.test.ts` (+5) — integration: Lead→Active, Lost revival, Active unchanged, idempotent re-finalize (a Job that moved on to Collections stays put), and best-effort survival when the Job update is rejected.

Verification:
- Full contracts dir + transitions: **120/120 pass** (15 files).
- `tsc --noEmit`: no errors in touched files (overall count unchanged vs. the known-red baseline).
- `eslint` on all four touched files: clean.

## Merge ordering note

This branch cites **ADR 0022** in code comments, but that ADR is PRD #719's artifact and is not yet on `main`. The decision logic here is fully self-contained (keys are hardcoded; the ADR is referenced only for traceability), so nothing breaks if it's absent — but please **land this after #719/ADR 0022** so the `(ADR 0022)` citations resolve to a real decision record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
