### PR TITLE
feat(timesheets): clock in / out of a Job (#701)

### DIFF
--- a/src/app/api/time/active/route.test.ts
+++ b/src/app/api/time/active/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeClient,
+  memberTables,
+} from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+function req(): Request {
+  return new Request("http://test/api/time/active", { method: "GET" });
+}
+
+function useUser(opts: Parameters<typeof fakeClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(fakeClient(opts) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// issue #701 — the app-wide status bar reads the caller's current Open session.
+describe("GET /api/time/active — permission gate (#701)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks track_time", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GET /api/time/active — current Open session (#701)", () => {
+  it("returns the caller's Open session, labeled with its Job, when one exists", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        time_sessions: [
+          // An open session (no ended_at) and a closed one — only the open one is active.
+          { id: "open-1", job_id: "job-9", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-19T12:00:00Z", ended_at: null },
+          { id: "closed-1", job_id: "job-8", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-18T09:00:00Z", ended_at: "2026-06-18T12:00:00Z" },
+        ],
+        jobs: [
+          { id: "job-9", job_number: "J-1009", property_address: "12 Maple St" },
+        ],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.active).toEqual({
+      sessionId: "open-1",
+      jobId: "job-9",
+      startedAt: "2026-06-19T12:00:00Z",
+      job: { job_number: "J-1009", property_address: "12 Maple St" },
+    });
+  });
+
+  it("returns null when the caller has no Open session", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        time_sessions: [
+          { id: "closed-1", job_id: "job-8", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-18T09:00:00Z", ended_at: "2026-06-18T12:00:00Z" },
+        ],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.active).toBeNull();
+  });
+});

--- a/src/app/api/time/active/route.ts
+++ b/src/app/api/time/active/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { loadOpenSession } from "@/lib/time-sessions";
+
+// GET /api/time/active — the caller's current Open Time session, or null
+// (issue #701). Drives the app-wide "On the clock" status bar, which labels the
+// session with its Job ("On 12 Maple St · …"), so the open session is enriched
+// with the Job's address and number. Gated on `track_time`.
+export const GET = withRequestContext({ permission: "track_time" }, async (_request, ctx) => {
+  const open = await loadOpenSession(ctx.supabase, ctx.userId, ctx.orgId);
+  if (!open) {
+    return NextResponse.json({ active: null }, { status: 200 });
+  }
+
+  const { data: job } = await ctx.supabase
+    .from("jobs")
+    .select("job_number, property_address")
+    .eq("id", open.jobId)
+    .maybeSingle();
+  const jobRow = job as { job_number: string; property_address: string } | null;
+
+  return NextResponse.json(
+    {
+      active: {
+        ...open,
+        job: jobRow
+          ? { job_number: jobRow.job_number, property_address: jobRow.property_address }
+          : null,
+      },
+    },
+    { status: 200 },
+  );
+});

--- a/src/app/api/time/clock-in/route.test.ts
+++ b/src/app/api/time/clock-in/route.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeClient,
+  memberTables,
+} from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+function req(body?: unknown): Request {
+  return new Request("http://test/api/time/clock-in", {
+    method: "POST",
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+function useUser(opts: Parameters<typeof fakeClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(fakeClient(opts) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// issue #701 — clocking in is a Time mutation gated on `track_time`. The
+// wrapper denies an unauthenticated request before the handler runs.
+describe("POST /api/time/clock-in — permission gate (#701)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(req({ jobId: "job-1" }), noParams);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks track_time", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+    const res = await POST(req({ jobId: "job-1" }), noParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when a track_time holder sends no jobId", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+    });
+    const res = await POST(req({}), noParams);
+    expect(res.status).toBe(400);
+  });
+});
+
+// The mutation itself. The pure decision (open / already-open / switch) is
+// owned and tested by session-lifecycle.ts; these tests assert the route
+// loads the worker's Open session, hands it to that decision, and performs
+// the decided writes through the atomic clock_in_to_job RPC.
+function trackTimeClient(opts: {
+  userId?: string;
+  openSession?: { id: string; job_id: string; started_at: string } | null;
+}) {
+  const userId = opts.userId ?? "u-1";
+  const openSession = opts.openSession;
+  return fakeClient({
+    user: { id: userId },
+    tables: {
+      ...memberTables({ userId, role: "crew_member", grants: ["track_time"] }),
+      // A real open row carries the owner and Org; the route loads it filtered
+      // on both. ended_at/deleted_at left unset so `is(…, null)` matches.
+      time_sessions: openSession
+        ? [{ ...openSession, user_id: userId, organization_id: "org-1" }]
+        : [],
+    },
+  });
+}
+
+describe("POST /api/time/clock-in — clocking in (#701)", () => {
+  it("with no Open session: clocks in via clock_in_to_job, returns the new session", async () => {
+    const client = trackTimeClient({ openSession: null });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req({ jobId: "job-1" }), noParams);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.jobId).toBe("job-1");
+    expect(body.switched).toBe(false);
+    expect(typeof body.sessionId).toBe("string");
+
+    expect(client.rpcCalls).toHaveLength(1);
+    expect(client.rpcCalls[0].name).toBe("clock_in_to_job");
+    const args = client.rpcCalls[0].args;
+    expect(args.p_job_id).toBe("job-1");
+    expect(args.p_user_id).toBe("u-1");
+    expect(args.p_organization_id).toBe("org-1");
+    expect(args.p_actor).toBe("u-1");
+    expect(args.p_session_id).toBe(body.sessionId);
+    expect(args.p_close_session_id).toBeNull();
+    expect(args.p_close_ended_at).toBeNull();
+  });
+
+  it("already Open on the same Job: returns the existing session, writes nothing", async () => {
+    const client = trackTimeClient({
+      openSession: { id: "open-1", job_id: "job-1", started_at: "2026-06-19T12:00:00Z" },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req({ jobId: "job-1" }), noParams);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.sessionId).toBe("open-1");
+    expect(body.alreadyOpen).toBe(true);
+
+    expect(client.rpcCalls).toHaveLength(0);
+  });
+
+  it("Open on a different Job: switches — closes the prior session and opens the new one atomically", async () => {
+    const client = trackTimeClient({
+      openSession: { id: "open-1", job_id: "job-1", started_at: "2026-06-19T12:00:00Z" },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req({ jobId: "job-2" }), noParams);
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.jobId).toBe("job-2");
+    expect(body.switched).toBe(true);
+    expect(body.closedJobId).toBe("job-1");
+    expect(typeof body.sessionId).toBe("string");
+    expect(body.sessionId).not.toBe("open-1");
+
+    // One atomic call closes open-1 and opens the new session in the same RPC.
+    expect(client.rpcCalls).toHaveLength(1);
+    expect(client.rpcCalls[0].name).toBe("clock_in_to_job");
+    const args = client.rpcCalls[0].args;
+    expect(args.p_job_id).toBe("job-2");
+    expect(args.p_user_id).toBe("u-1");
+    expect(args.p_organization_id).toBe("org-1");
+    expect(args.p_session_id).toBe(body.sessionId);
+    expect(args.p_close_session_id).toBe("open-1");
+    // The prior session ends at the same instant the new one starts.
+    expect(args.p_close_ended_at).toBe(body.startedAt);
+  });
+
+  it("when the atomic write fails (e.g. an open-session race), surfaces an error — never a false 201", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+      rpcError: { message: "duplicate key value violates unique constraint" },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req({ jobId: "job-1" }), noParams);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+});

--- a/src/app/api/time/clock-in/route.ts
+++ b/src/app/api/time/clock-in/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { planClockIn } from "@/lib/session-lifecycle";
+import { loadOpenSession } from "@/lib/time-sessions";
+
+// POST /api/time/clock-in — clock the caller in to a Job (issue #701).
+// Gated on `track_time`.
+export const POST = withRequestContext(
+  { permission: "track_time" },
+  async (request, ctx) => {
+    const body = (await request.json().catch(() => null)) as { jobId?: string } | null;
+    if (!body?.jobId) {
+      return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+    }
+
+    // Server stamps the instant in UTC (ADR 0020) — never trust a client clock.
+    const at = new Date().toISOString();
+
+    // Load the worker's current Open session and let the pure lifecycle rules
+    // decide the action.
+    const open = await loadOpenSession(ctx.supabase, ctx.userId, ctx.orgId);
+
+    const plan = planClockIn(open, { jobId: body.jobId, at });
+
+    if (plan.type === "already-open" && open) {
+      // Already On the clock for this Job — nothing to write.
+      return NextResponse.json(
+        { sessionId: open.sessionId, jobId: open.jobId, startedAt: open.startedAt, alreadyOpen: true },
+        { status: 200 },
+      );
+    }
+
+    // A `switch` carries the prior session to close in the same atomic RPC, so
+    // the worker is never On the clock for two Jobs (nor for none) mid-switch.
+    const switched = plan.type === "switch";
+    const sessionId = randomUUID();
+    const { error } = await ctx.supabase.rpc("clock_in_to_job", {
+      p_session_id: sessionId,
+      p_organization_id: ctx.orgId,
+      p_job_id: body.jobId,
+      p_user_id: ctx.userId,
+      p_started_at: at,
+      p_actor: ctx.userId,
+      p_close_session_id: switched ? plan.close.sessionId : null,
+      p_close_ended_at: switched ? plan.close.endedAt : null,
+    });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(
+      switched
+        ? { sessionId, jobId: body.jobId, startedAt: at, switched: true, closedJobId: open!.jobId }
+        : { sessionId, jobId: body.jobId, startedAt: at, switched: false },
+      { status: 201 },
+    );
+  },
+);

--- a/src/app/api/time/clock-out/route.test.ts
+++ b/src/app/api/time/clock-out/route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { POST } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeClient,
+  memberTables,
+} from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+function req(): Request {
+  return new Request("http://test/api/time/clock-out", { method: "POST" });
+}
+
+function useUser(opts: Parameters<typeof fakeClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(fakeClient(opts) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// issue #701 — clocking out is a Time mutation gated on `track_time`.
+describe("POST /api/time/clock-out — permission gate (#701)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await POST(req(), noParams);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks track_time", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+    const res = await POST(req(), noParams);
+    expect(res.status).toBe(403);
+  });
+});
+
+// The mutation. The pure decision (close / nothing-open) is owned by
+// session-lifecycle.ts; these tests assert the route loads the worker's Open
+// session, hands it to that decision, and performs the decided close via the
+// atomic clock_out_session RPC.
+function trackTimeClient(opts: {
+  userId?: string;
+  openSession?: { id: string; job_id: string; started_at: string } | null;
+}) {
+  const userId = opts.userId ?? "u-1";
+  const openSession = opts.openSession;
+  return fakeClient({
+    user: { id: userId },
+    tables: {
+      ...memberTables({ userId, role: "crew_member", grants: ["track_time"] }),
+      time_sessions: openSession
+        ? [{ ...openSession, user_id: userId, organization_id: "org-1" }]
+        : [],
+    },
+  });
+}
+
+describe("POST /api/time/clock-out — clocking out (#701)", () => {
+  it("with an Open session: closes it via clock_out_session, returns the closed session", async () => {
+    const client = trackTimeClient({
+      openSession: { id: "open-1", job_id: "job-1", started_at: "2026-06-19T12:00:00Z" },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req(), noParams);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.closed).toBe(true);
+    expect(body.sessionId).toBe("open-1");
+    expect(body.jobId).toBe("job-1");
+    expect(typeof body.endedAt).toBe("string");
+
+    expect(client.rpcCalls).toHaveLength(1);
+    expect(client.rpcCalls[0].name).toBe("clock_out_session");
+    const args = client.rpcCalls[0].args;
+    expect(args.p_session_id).toBe("open-1");
+    expect(args.p_organization_id).toBe("org-1");
+    expect(args.p_actor).toBe("u-1");
+    expect(args.p_ended_at).toBe(body.endedAt);
+  });
+
+  it("with no Open session: idempotent no-op — closed:false, writes nothing", async () => {
+    const client = trackTimeClient({ openSession: null });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req(), noParams);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.closed).toBe(false);
+
+    expect(client.rpcCalls).toHaveLength(0);
+  });
+
+  it("when the atomic close fails, surfaces an error — never a false success", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        time_sessions: [
+          { id: "open-1", job_id: "job-1", started_at: "2026-06-19T12:00:00Z", user_id: "u-1", organization_id: "org-1" },
+        ],
+      },
+      rpcError: { message: "session not found or already closed" },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await POST(req(), noParams);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+});

--- a/src/app/api/time/clock-out/route.ts
+++ b/src/app/api/time/clock-out/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+import { planClockOut } from "@/lib/session-lifecycle";
+import { loadOpenSession } from "@/lib/time-sessions";
+
+// POST /api/time/clock-out — clock the caller out of their Open Job (issue #701).
+// Gated on `track_time`.
+export const POST = withRequestContext(
+  { permission: "track_time" },
+  async (_request, ctx) => {
+    // Server stamps the instant in UTC (ADR 0020) — never trust a client clock.
+    const at = new Date().toISOString();
+
+    // Load the worker's current Open session and let the pure lifecycle rules
+    // decide whether there is anything to close.
+    const open = await loadOpenSession(ctx.supabase, ctx.userId, ctx.orgId);
+
+    const plan = planClockOut(open, at);
+
+    if (plan.type === "nothing-open" || !open) {
+      // Idempotent — clocking out with nothing Open is a no-op, not an error.
+      return NextResponse.json({ closed: false }, { status: 200 });
+    }
+
+    const { error } = await ctx.supabase.rpc("clock_out_session", {
+      p_session_id: plan.sessionId,
+      p_organization_id: ctx.orgId,
+      p_ended_at: plan.endedAt,
+      p_actor: ctx.userId,
+    });
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(
+      { closed: true, sessionId: open.sessionId, jobId: open.jobId, endedAt: plan.endedAt },
+      { status: 200 },
+    );
+  },
+);

--- a/src/app/api/time/clockable-jobs/route.test.ts
+++ b/src/app/api/time/clockable-jobs/route.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeClient,
+  memberTables,
+} from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+function req(): Request {
+  return new Request("http://test/api/time/clockable-jobs", { method: "GET" });
+}
+
+function useUser(opts: Parameters<typeof fakeClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(fakeClient(opts) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// issue #701 — the active-Job picker loads the Jobs a worker can clock into
+// (Active jobs: not completed, not cancelled, not trashed) plus the worker's
+// recently-clocked Job ids so it can surface them first. Filtering/ranking by
+// the typed query happens client-side via rankPickerJobs.
+describe("GET /api/time/clockable-jobs (#701)", () => {
+  it("returns Active Jobs (with customer) and the worker's recently-clocked ids", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        jobs: [
+          { id: "job-a", organization_id: "org-1", job_number: "J-1", property_address: "12 Maple St", status: "in_progress", deleted_at: null, contact: { full_name: "Ada Lovelace" } },
+          { id: "job-b", organization_id: "org-1", job_number: "J-2", property_address: "9 Oak Ave", status: "scheduled", deleted_at: null, contact: null },
+          { id: "job-done", organization_id: "org-1", job_number: "J-3", property_address: "1 Done Rd", status: "completed", deleted_at: null, contact: null },
+          { id: "job-cancelled", organization_id: "org-1", job_number: "J-4", property_address: "2 Gone Rd", status: "cancelled", deleted_at: null, contact: null },
+          { id: "job-trashed", organization_id: "org-1", job_number: "J-5", property_address: "3 Trash Ln", status: "in_progress", deleted_at: "2026-06-01T00:00:00Z", contact: null },
+        ],
+        // Seeded most-recent-first (the fake ignores .order); the route dedupes
+        // preserving first occurrence, so the older job-a row collapses away.
+        time_sessions: [
+          { job_id: "job-b", user_id: "u-1", organization_id: "org-1", deleted_at: null },
+          { job_id: "job-a", user_id: "u-1", organization_id: "org-1", deleted_at: null },
+          { job_id: "job-b", user_id: "u-1", organization_id: "org-1", deleted_at: null },
+        ],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Only the two Active Jobs survive; completed / cancelled / trashed are out.
+    expect(body.jobs.map((j: { id: string }) => j.id).sort()).toEqual(["job-a", "job-b"]);
+    const jobA = body.jobs.find((j: { id: string }) => j.id === "job-a");
+    expect(jobA).toEqual({
+      id: "job-a",
+      job_number: "J-1",
+      property_address: "12 Maple St",
+      contact: { full_name: "Ada Lovelace" },
+    });
+    expect(body.recentJobIds).toEqual(["job-b", "job-a"]);
+  });
+
+  it("normalizes a one-element array contact embed to a single object", async () => {
+    // PostgREST can surface a to-one embed as a one-element array; the picker
+    // expects a single { full_name } (or null).
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        jobs: [
+          { id: "job-a", organization_id: "org-1", job_number: "J-1", property_address: "12 Maple St", status: "in_progress", deleted_at: null, contact: [{ full_name: "Ada Lovelace" }] },
+        ],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req(), noParams);
+    const body = await res.json();
+    expect(body.jobs[0].contact).toEqual({ full_name: "Ada Lovelace" });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks track_time", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/app/api/time/clockable-jobs/route.ts
+++ b/src/app/api/time/clockable-jobs/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// GET /api/time/clockable-jobs — the Active Jobs a worker can clock into, plus
+// the worker's recently-clocked Job ids so the active-Job picker can surface
+// them first (issue #701). "Active" means alive: status neither `completed`
+// nor `cancelled`, and not trashed (CONTEXT.md "Active job"). The picker filters
+// and ranks by the typed query client-side via rankPickerJobs, so this endpoint
+// returns the full candidate list (the customer name comes along for the
+// name-search) and the recency order, not a pre-filtered slice.
+// Gated on `track_time`.
+
+interface JobRow {
+  id: string;
+  job_number: string;
+  property_address: string;
+  // PostgREST returns a to-one embed as an object, but can surface it as a
+  // one-element array; normalize both to a single { full_name } or null.
+  contact: { full_name: string } | { full_name: string }[] | null;
+}
+
+function normalizeContact(
+  contact: JobRow["contact"],
+): { full_name: string } | null {
+  const one = Array.isArray(contact) ? contact[0] : contact;
+  return one ? { full_name: one.full_name } : null;
+}
+
+export const GET = withRequestContext({ permission: "track_time" }, async (_request, ctx) => {
+  const { data: jobsData, error: jobsError } = await ctx.supabase
+    .from("jobs")
+    .select("id, job_number, property_address, contact:contacts(full_name)")
+    .eq("organization_id", ctx.orgId)
+    .is("deleted_at", null)
+    .not("status", "eq", "completed")
+    .not("status", "eq", "cancelled")
+    .order("created_at", { ascending: false });
+  if (jobsError) {
+    return NextResponse.json({ error: jobsError.message }, { status: 500 });
+  }
+
+  const jobs = ((jobsData ?? []) as unknown as JobRow[]).map((j) => ({
+    id: j.id,
+    job_number: j.job_number,
+    property_address: j.property_address,
+    contact: normalizeContact(j.contact),
+  }));
+
+  // The worker's own sessions, most recent first; dedupe to the distinct Job
+  // ids in recency order. RLS backstops Organization isolation; the explicit
+  // user_id filter keeps a worker to their OWN recency (never a coworker's).
+  const { data: recentData, error: recentError } = await ctx.supabase
+    .from("time_sessions")
+    .select("job_id")
+    .eq("user_id", ctx.userId)
+    .eq("organization_id", ctx.orgId)
+    .is("deleted_at", null)
+    .order("started_at", { ascending: false });
+  if (recentError) {
+    return NextResponse.json({ error: recentError.message }, { status: 500 });
+  }
+
+  const recentJobIds: string[] = [];
+  for (const row of (recentData ?? []) as { job_id: string }[]) {
+    if (!recentJobIds.includes(row.job_id)) {
+      recentJobIds.push(row.job_id);
+    }
+  }
+
+  return NextResponse.json({ jobs, recentJobIds }, { status: 200 });
+});

--- a/src/app/api/time/sessions/route.test.ts
+++ b/src/app/api/time/sessions/route.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/supabase-server", () => ({
+  createServerSupabaseClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase-api", () => ({
+  createServiceClient: vi.fn(),
+}));
+vi.mock("@/lib/supabase/get-active-org", () => ({
+  getActiveOrganizationId: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { createServerSupabaseClient } from "@/lib/supabase-server";
+import { getActiveOrganizationId } from "@/lib/supabase/get-active-org";
+import {
+  fakeClient,
+  memberTables,
+} from "@/lib/request-context/__test-utils__/request-context-fakes";
+
+const noParams = { params: Promise.resolve({}) };
+function req(jobId?: string): Request {
+  const url = jobId
+    ? `http://test/api/time/sessions?jobId=${jobId}`
+    : "http://test/api/time/sessions";
+  return new Request(url, { method: "GET" });
+}
+
+function useUser(opts: Parameters<typeof fakeClient>[0]) {
+  vi.mocked(createServerSupabaseClient).mockResolvedValue(fakeClient(opts) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(getActiveOrganizationId).mockResolvedValue("org-1");
+});
+
+// issue #701 — reading recorded hours is gated on `track_time`.
+describe("GET /api/time/sessions — permission gate (#701)", () => {
+  it("returns 401 when unauthenticated", async () => {
+    useUser({ user: null });
+    const res = await GET(req("job-1"), noParams);
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when the caller lacks track_time", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: [] }),
+    });
+    const res = await GET(req("job-1"), noParams);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 when a track_time holder omits jobId", async () => {
+    useUser({
+      user: { id: "u-1" },
+      tables: memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+    });
+    const res = await GET(req(), noParams);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/time/sessions — own hours only (#701)", () => {
+  it("returns only the caller's own sessions for the Job — never a coworker's", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        time_sessions: [
+          // The caller's two sessions on job-1.
+          { id: "s-mine-1", job_id: "job-1", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-18T09:00:00Z", ended_at: "2026-06-18T12:00:00Z" },
+          { id: "s-mine-2", job_id: "job-1", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-19T12:00:00Z", ended_at: null },
+          // A coworker's session on the same Job — MUST NOT be returned.
+          { id: "s-coworker", job_id: "job-1", user_id: "u-2", organization_id: "org-1", started_at: "2026-06-18T08:00:00Z", ended_at: "2026-06-18T17:00:00Z" },
+          // The caller's own session on a DIFFERENT Job — MUST NOT be returned.
+          { id: "s-other-job", job_id: "job-2", user_id: "u-1", organization_id: "org-1", started_at: "2026-06-17T09:00:00Z", ended_at: "2026-06-17T10:00:00Z" },
+        ],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req("job-1"), noParams);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    const ids = body.sessions.map((s: { sessionId: string }) => s.sessionId).sort();
+    expect(ids).toEqual(["s-mine-1", "s-mine-2"]);
+  });
+
+  it("returns an empty list when the caller has no sessions on the Job", async () => {
+    const client = fakeClient({
+      user: { id: "u-1" },
+      tables: {
+        ...memberTables({ userId: "u-1", role: "crew_member", grants: ["track_time"] }),
+        time_sessions: [],
+      },
+    });
+    vi.mocked(createServerSupabaseClient).mockResolvedValue(client as never);
+
+    const res = await GET(req("job-1"), noParams);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sessions).toEqual([]);
+  });
+});

--- a/src/app/api/time/sessions/route.ts
+++ b/src/app/api/time/sessions/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { withRequestContext } from "@/lib/request-context/with-request-context";
+
+// GET /api/time/sessions?jobId=… — the caller's OWN recorded Time sessions for
+// a Job (issue #701). A worker only ever sees their own hours; that filter is
+// applied here at the app layer (RLS only backstops Organization isolation).
+// Gated on `track_time`.
+export const GET = withRequestContext({ permission: "track_time" }, async (request, ctx) => {
+  const jobId = new URL(request.url).searchParams.get("jobId");
+  if (!jobId) {
+    return NextResponse.json({ error: "jobId is required" }, { status: 400 });
+  }
+
+  // OWN hours only: filter on the caller's own user_id at the app layer. Most
+  // recent first so the live (open) session leads the list.
+  const { data, error } = await ctx.supabase
+    .from("time_sessions")
+    .select("id, job_id, started_at, ended_at")
+    .eq("user_id", ctx.userId)
+    .eq("organization_id", ctx.orgId)
+    .eq("job_id", jobId)
+    .is("deleted_at", null)
+    .order("started_at", { ascending: false });
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const sessions = ((data ?? []) as Record<string, unknown>[]).map((row) => ({
+    sessionId: row.id as string,
+    jobId: row.job_id as string,
+    startedAt: row.started_at as string,
+    endedAt: (row.ended_at as string | null) ?? null,
+  }));
+  return NextResponse.json({ sessions }, { status: 200 });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { getFirstName } from "@/lib/first-name";
 import { StatStrip } from "@/components/dashboard/stat-strip";
 import { NewJobsSection } from "@/components/dashboard/new-jobs-section";
 import { UnreadResponsesSection } from "@/components/dashboard/unread-responses-section";
+import HomeClockControl from "@/components/time/home-clock-control";
 
 export default function DashboardPage() {
   const { profile } = useAuth();
@@ -30,6 +31,8 @@ export default function DashboardPage() {
           {firstName ? `Welcome back, ${firstName}.` : "Welcome back."}
         </p>
       </div>
+
+      <HomeClockControl />
 
       <StatStrip
         newJobsCount={newJobsCount}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Sidebar from "@/components/nav";
 import { useSidebarCollapse } from "@/lib/sidebar-collapse-context";
+import { OnTheClockProvider } from "@/lib/on-the-clock-context";
+import OnTheClockBar from "@/components/time/on-the-clock-bar";
 import { cn } from "@/lib/utils";
 
 const AUTH_ROUTES = ["/login", "/logout", "/set-password"];
@@ -52,8 +54,12 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   // navbar when the rail is open); elsewhere it follows the persisted pref.
   const effectiveCollapsed = isBuilderRoute ? !railExpanded : collapsed;
 
+  // The On-the-clock state + persistent status bar live inside the app chrome
+  // (issue #701) — never on the auth / public / fullscreen routes handled by
+  // the early return above, so the bar can't surface on the login screen or the
+  // customer-facing handoff surfaces.
   return (
-    <>
+    <OnTheClockProvider>
       <Sidebar
         forceCollapsed={isBuilderRoute ? !railExpanded : undefined}
         onToggleRail={
@@ -68,6 +74,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
       >
         {isFullBleed ? children : <div className="p-6 lg:p-8">{children}</div>}
       </main>
-    </>
+      <OnTheClockBar />
+    </OnTheClockProvider>
   );
 }

--- a/src/components/job-detail.tsx
+++ b/src/components/job-detail.tsx
@@ -78,6 +78,7 @@ import { toast } from "sonner";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import JobPhotosTab from "@/components/job-photos-tab";
+import JobTimeTab from "@/components/job-time-tab";
 import PhotoPreloader from "@/components/photo-preloader";
 import { useAuth } from "@/lib/auth-context";
 
@@ -547,6 +548,17 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           )}>
             {photoCount}
           </span>
+        </button>
+        <button
+          onClick={() => setActiveTab("time")}
+          className={cn(
+            "px-6 py-2.5 text-sm font-medium -mb-[2px] border-b-2 transition-colors",
+            activeTab === "time"
+              ? "text-[#2B5EA7] border-[#2B5EA7] font-semibold"
+              : "text-muted-foreground border-transparent hover:text-foreground"
+          )}
+        >
+          Time
         </button>
       </div>
 
@@ -1076,6 +1088,16 @@ export default function JobDetail({ jobId }: { jobId: string }) {
           onSelectPhoto={(photo, orderedPhotos) => {
             setViewerPhotos(orderedPhotos);
             setSelectedPhoto(photo);
+          }}
+        />
+      )}
+
+      {activeTab === "time" && (
+        <JobTimeTab
+          job={{
+            id: jobId,
+            property_address: job.property_address,
+            job_number: job.job_number,
           }}
         />
       )}

--- a/src/components/job-time-tab.tsx
+++ b/src/components/job-time-tab.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Clock } from "lucide-react";
+
+import { formatElapsed } from "@/lib/elapsed";
+import { useOnTheClock } from "@/lib/on-the-clock-context";
+import ClockInConfirmation from "@/components/time/clock-in-confirmation";
+
+// The Job detail "Time" tab (issue #701, `?tab=time`). A worker can Clock in to
+// THIS Job directly (the Job is known, so no picker — straight to the
+// confirmation) and review their OWN recorded hours for it. They never see
+// other workers' sessions: the /api/time/sessions endpoint filters to the
+// caller's own user_id.
+
+interface RecordedSession {
+  sessionId: string;
+  jobId: string;
+  startedAt: string;
+  endedAt: string | null;
+}
+
+function formatRange(startedAt: string, endedAt: string | null): string {
+  const start = new Date(startedAt);
+  const day = start.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const startTime = start.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+  if (!endedAt) return `${day} · ${startTime} – now`;
+  const endTime = new Date(endedAt).toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${day} · ${startTime} – ${endTime}`;
+}
+
+function duration(session: RecordedSession): string {
+  if (!session.endedAt) return "Open";
+  const ms = new Date(session.endedAt).getTime() - new Date(session.startedAt).getTime();
+  return formatElapsed(ms);
+}
+
+export default function JobTimeTab({
+  job,
+}: {
+  job: { id: string; property_address: string; job_number: string };
+}) {
+  const { active, canTrackTime } = useOnTheClock();
+  const [sessions, setSessions] = useState<RecordedSession[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+
+  const onThisJob = active?.jobId === job.id;
+
+  const load = useCallback(async () => {
+    if (!canTrackTime) {
+      setLoading(false);
+      return;
+    }
+    try {
+      const res = await fetch(`/api/time/sessions?jobId=${encodeURIComponent(job.id)}`);
+      if (!res.ok) throw new Error("load failed");
+      const data = (await res.json()) as { sessions: RecordedSession[] };
+      setSessions(Array.isArray(data.sessions) ? data.sessions : []);
+    } catch {
+      setSessions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [canTrackTime, job.id]);
+
+  // Reload when the worker's clock state changes (a new clock-in/out here or
+  // elsewhere) so this Job's hours stay current.
+  useEffect(() => {
+    void load();
+  }, [load, active]);
+
+  if (!canTrackTime) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">
+        Time tracking isn&apos;t enabled for your account.
+      </p>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-6">
+        {onThisJob ? (
+          <div className="flex items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-800">
+            <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-emerald-500" aria-hidden />
+            <p className="text-sm font-medium">You&apos;re on the clock for this Job.</p>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="flex items-center justify-center gap-2 rounded-xl bg-emerald-600 px-5 py-3 text-base font-bold text-white shadow-sm hover:bg-emerald-700"
+          >
+            <Clock size={18} />
+            Clock in to this Job
+          </button>
+        )}
+      </div>
+
+      <h3 className="mb-3 text-sm font-semibold text-foreground">Your recorded hours</h3>
+      {loading ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>
+      ) : sessions.length === 0 ? (
+        <p className="py-6 text-center text-sm text-muted-foreground">
+          No recorded hours yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-xl border border-border">
+          {sessions.map((session) => (
+            <li
+              key={session.sessionId}
+              className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+            >
+              <span className="text-muted-foreground">
+                {formatRange(session.startedAt, session.endedAt)}
+              </span>
+              <span
+                className={
+                  session.endedAt
+                    ? "font-semibold tabular-nums text-foreground"
+                    : "font-semibold text-emerald-600"
+                }
+              >
+                {duration(session)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {confirming && (
+        <ClockInConfirmation
+          job={job}
+          onClose={() => setConfirming(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/time/clock-in-confirmation.tsx
+++ b/src/components/time/clock-in-confirmation.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { Clock, X } from "lucide-react";
+import { toast } from "sonner";
+
+import { useOnTheClock } from "@/lib/on-the-clock-context";
+
+// The loud, full-screen confirmation shown before a session starts (issue
+// #701, AC2). It names the Job in large type so a wrong-Job pick is caught
+// instantly, then commits the clock-in on confirm. Owning the commit here keeps
+// the auto-close-on-switch message (AC4) in one place for both entry points
+// (the home-screen picker and the Job detail Time tab).
+
+export interface ClockInTarget {
+  id: string;
+  property_address: string;
+  job_number?: string;
+}
+
+export default function ClockInConfirmation({
+  job,
+  onClose,
+}: {
+  job: ClockInTarget;
+  /** Called when the overlay dismisses; `started` is true once a session began. */
+  onClose: (started: boolean) => void;
+}) {
+  const { clockIn } = useOnTheClock();
+  const [busy, setBusy] = useState(false);
+
+  async function confirm() {
+    setBusy(true);
+    const result = await clockIn(job.id);
+    setBusy(false);
+
+    if (!result.ok) {
+      toast.error("Could not clock in", {
+        description: result.error ?? "Please try again.",
+      });
+      return;
+    }
+    if (result.alreadyOpen) {
+      toast(`Already clocked in to ${job.property_address}`);
+    } else if (result.switched) {
+      toast.success(`Clocked in to ${job.property_address}`, {
+        description: "Your previous session was clocked out.",
+      });
+    } else {
+      toast.success(`Clocked in to ${job.property_address}`);
+    }
+    onClose(true);
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] flex flex-col items-center justify-center gap-8 bg-emerald-600 px-6 text-center text-white">
+      <button
+        type="button"
+        onClick={() => onClose(false)}
+        aria-label="Cancel"
+        className="absolute right-4 top-[calc(1rem+env(safe-area-inset-top))] rounded-full p-2 text-white/80 hover:bg-white/15 hover:text-white"
+      >
+        <X size={24} />
+      </button>
+
+      <div className="flex flex-col items-center gap-3">
+        <span className="flex size-16 items-center justify-center rounded-full bg-white/15">
+          <Clock size={32} />
+        </span>
+        <p className="text-sm font-medium uppercase tracking-wide text-white/80">
+          Clock in to
+        </p>
+        <h1 className="max-w-md text-4xl font-extrabold leading-tight">
+          {job.property_address}
+        </h1>
+        {job.job_number && (
+          <p className="text-base text-white/80">Job {job.job_number}</p>
+        )}
+      </div>
+
+      <div className="flex w-full max-w-xs flex-col gap-3">
+        <button
+          type="button"
+          onClick={confirm}
+          disabled={busy}
+          className="w-full rounded-xl bg-white px-6 py-4 text-lg font-bold text-emerald-700 shadow-lg hover:bg-white/90 disabled:opacity-70"
+        >
+          {busy ? "Starting…" : "Clock in"}
+        </button>
+        <button
+          type="button"
+          onClick={() => onClose(false)}
+          disabled={busy}
+          className="w-full rounded-xl px-6 py-3 text-base font-semibold text-white/90 hover:bg-white/10 disabled:opacity-70"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/time/clock-in-picker.tsx
+++ b/src/components/time/clock-in-picker.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Search } from "lucide-react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { rankPickerJobs, type PickerJob } from "@/lib/job-picker";
+import ClockInConfirmation from "@/components/time/clock-in-confirmation";
+
+// The active-Job picker (issue #701, AC2). Opened from the home-screen control,
+// it loads the Jobs a worker can clock into plus their recently-clocked order,
+// filters/ranks them as the worker types (the pure rankPickerJobs), and on
+// selection raises the full-screen confirmation that commits the clock-in.
+
+interface ClockableJobsResponse {
+  jobs: PickerJob[];
+  recentJobIds: string[];
+}
+
+export default function ClockInPicker({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [jobs, setJobs] = useState<PickerJob[]>([]);
+  const [recentJobIds, setRecentJobIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selected, setSelected] = useState<PickerJob | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      // Reset for the next open so a stale query/selection never lingers.
+      setQuery("");
+      setSelected(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    (async () => {
+      try {
+        const res = await fetch("/api/time/clockable-jobs");
+        if (!res.ok) throw new Error("load failed");
+        const data = (await res.json()) as ClockableJobsResponse;
+        if (cancelled) return;
+        setJobs(Array.isArray(data.jobs) ? data.jobs : []);
+        setRecentJobIds(Array.isArray(data.recentJobIds) ? data.recentJobIds : []);
+      } catch {
+        if (!cancelled) {
+          setJobs([]);
+          setRecentJobIds([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const ranked = rankPickerJobs(jobs, { query, recentJobIds });
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Clock in to a Job</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex items-center gap-2 rounded-lg border border-border px-3 py-2">
+            <Search size={16} className="shrink-0 text-muted-foreground" />
+            <input
+              autoFocus
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search by address, customer, or Job number…"
+              className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+            />
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {loading ? (
+              <p className="px-1 py-6 text-center text-sm text-muted-foreground">
+                Loading Jobs…
+              </p>
+            ) : ranked.length === 0 ? (
+              <p className="px-1 py-6 text-center text-sm text-muted-foreground">
+                {jobs.length === 0 ? "No active Jobs" : "No matching Jobs"}
+              </p>
+            ) : (
+              <ul className="flex flex-col">
+                {ranked.map((job) => (
+                  <li key={job.id}>
+                    <button
+                      type="button"
+                      onClick={() => setSelected(job)}
+                      className="flex w-full flex-col gap-0.5 rounded-lg px-3 py-2.5 text-left hover:bg-muted/60"
+                    >
+                      <span className="font-medium text-foreground">
+                        {job.property_address}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        Job {job.job_number}
+                        {job.contact?.full_name ? ` · ${job.contact.full_name}` : ""}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {selected && (
+        <ClockInConfirmation
+          job={selected}
+          onClose={(started) => {
+            setSelected(null);
+            if (started) onOpenChange(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/time/home-clock-control.tsx
+++ b/src/components/time/home-clock-control.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState } from "react";
+import { Clock } from "lucide-react";
+
+import { useOnTheClock } from "@/lib/on-the-clock-context";
+import ClockInPicker from "@/components/time/clock-in-picker";
+
+// The global one-tap home-screen control (issue #701). For a worker with
+// `track_time`, it's the fastest path onto the clock: one tap opens the
+// active-Job picker. When already On the clock it reflects that (the persistent
+// status bar owns the elapsed time + Clock out), so the home screen never lies
+// about the worker's state. Hidden entirely for anyone without `track_time`.
+export default function HomeClockControl() {
+  const { active, canTrackTime } = useOnTheClock();
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  if (!canTrackTime) return null;
+
+  return (
+    <section className="mb-6">
+      {active ? (
+        <div className="flex items-center gap-3 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-emerald-800">
+          <span className="size-2.5 shrink-0 animate-pulse rounded-full bg-emerald-500" aria-hidden />
+          <p className="text-sm font-medium">
+            You&apos;re on the clock — {active.job?.property_address ?? "your Job"}
+          </p>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setPickerOpen(true)}
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-600 px-5 py-4 text-base font-bold text-white shadow-sm hover:bg-emerald-700 sm:w-auto"
+        >
+          <Clock size={20} />
+          Clock in to a Job
+        </button>
+      )}
+
+      <ClockInPicker open={pickerOpen} onOpenChange={setPickerOpen} />
+    </section>
+  );
+}

--- a/src/components/time/on-the-clock-bar.test.tsx
+++ b/src/components/time/on-the-clock-bar.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { OnTheClockBarView } from "./on-the-clock-bar";
+
+afterEach(cleanup);
+
+// issue #701 — the persistent app-wide status bar. Its presentational core
+// renders "On <Job> · <elapsed> · Clock out" while On the clock, and nothing
+// when the worker is not clocked in.
+describe("OnTheClockBarView (#701)", () => {
+  it("renders nothing when the worker is not on the clock", () => {
+    const { container } = render(
+      <OnTheClockBarView session={null} elapsedLabel="" onClockOut={() => {}} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("names the Job, shows the elapsed time, and offers Clock out", () => {
+    render(
+      <OnTheClockBarView
+        session={{ addressLabel: "Maple St" }}
+        elapsedLabel="2h 14m"
+        onClockOut={() => {}}
+      />,
+    );
+    expect(screen.getByText(/On Maple St/)).toBeTruthy();
+    expect(screen.getByText("2h 14m")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /clock out/i })).toBeTruthy();
+  });
+
+  it("invokes onClockOut when the Clock out button is tapped", () => {
+    const onClockOut = vi.fn();
+    render(
+      <OnTheClockBarView
+        session={{ addressLabel: "Maple St" }}
+        elapsedLabel="2h 14m"
+        onClockOut={onClockOut}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /clock out/i }));
+    expect(onClockOut).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Clock out while a clock-out is in flight", () => {
+    const onClockOut = vi.fn();
+    render(
+      <OnTheClockBarView
+        session={{ addressLabel: "Maple St" }}
+        elapsedLabel="2h 14m"
+        onClockOut={onClockOut}
+        busy
+      />,
+    );
+    const button = screen.getByRole("button", { name: /clock out/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+});

--- a/src/components/time/on-the-clock-bar.tsx
+++ b/src/components/time/on-the-clock-bar.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { formatElapsed } from "@/lib/elapsed";
+import { useOnTheClock } from "@/lib/on-the-clock-context";
+
+// The persistent app-wide "On the clock" status bar (issue #701). This file's
+// presentational core, OnTheClockBarView, is pure: it renders the bar from the
+// session label + a pre-formatted elapsed string, or nothing when the worker is
+// not clocked in. The live elapsed ticking and the /api/time wiring live in the
+// container (OnTheClockBar) below.
+
+export interface OnTheClockSession {
+  /** What to show after "On " — e.g. the Job's property address. */
+  addressLabel: string;
+}
+
+export function OnTheClockBarView({
+  session,
+  elapsedLabel,
+  onClockOut,
+  busy,
+}: {
+  session: OnTheClockSession | null;
+  elapsedLabel: string;
+  onClockOut: () => void;
+  busy?: boolean;
+}) {
+  if (!session) return null;
+  return (
+    <div
+      role="status"
+      className="fixed inset-x-0 bottom-0 z-50 flex items-center justify-between gap-3 border-t border-emerald-700 bg-emerald-600 px-4 py-2.5 text-sm font-medium text-white shadow-lg pb-[calc(0.625rem+env(safe-area-inset-bottom))]"
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <span className="size-2 shrink-0 animate-pulse rounded-full bg-white/90" aria-hidden />
+        <span className="truncate">On {session.addressLabel}</span>
+        <span className="shrink-0 opacity-70" aria-hidden>·</span>
+        <span className="shrink-0 tabular-nums opacity-90">{elapsedLabel}</span>
+      </span>
+      <button
+        type="button"
+        onClick={onClockOut}
+        disabled={busy}
+        className="shrink-0 rounded-md bg-white/15 px-3 py-1.5 font-semibold hover:bg-white/25 disabled:opacity-60"
+      >
+        Clock out
+      </button>
+    </div>
+  );
+}
+
+// Container: the always-mounted, app-wide bar. Reads the shared clock state,
+// ticks the elapsed label every 30s (formatElapsed is minute-granular), and
+// stops the session on Clock out. Renders nothing until the worker is On the
+// clock, so it's invisible the rest of the time.
+export default function OnTheClockBar() {
+  const { active, clockOut } = useOnTheClock();
+  const [now, setNow] = useState(() => Date.now());
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 30_000);
+    return () => clearInterval(id);
+  }, [active]);
+
+  if (!active) return null;
+
+  const startedMs = new Date(active.startedAt).getTime();
+  const elapsedLabel = formatElapsed(now - startedMs);
+  const addressLabel = active.job?.property_address ?? "your Job";
+
+  async function handleClockOut() {
+    setBusy(true);
+    const result = await clockOut();
+    setBusy(false);
+    if (result.ok) {
+      toast.success("Clocked out");
+    } else {
+      toast.error("Could not clock out", { description: "Please try again." });
+    }
+  }
+
+  return (
+    <OnTheClockBarView
+      session={{ addressLabel }}
+      elapsedLabel={elapsedLabel}
+      onClockOut={handleClockOut}
+      busy={busy}
+    />
+  );
+}

--- a/src/lib/elapsed.test.ts
+++ b/src/lib/elapsed.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { formatElapsed } from "./elapsed";
+
+// issue #701 — the app-wide status bar shows live-updating elapsed time as a
+// compact "2h 14m". The component computes elapsed milliseconds; this pure
+// function renders it. Minute granularity (seconds are floored away).
+describe("formatElapsed (#701)", () => {
+  it("renders just-clocked-in as 0m", () => {
+    expect(formatElapsed(0)).toBe("0m");
+  });
+
+  it("floors sub-minute time to 0m", () => {
+    expect(formatElapsed(59 * 1000)).toBe("0m");
+  });
+
+  it("renders whole minutes under an hour", () => {
+    expect(formatElapsed(14 * 60 * 1000)).toBe("14m");
+  });
+
+  it("renders hours and minutes as '2h 14m'", () => {
+    expect(formatElapsed((2 * 60 + 14) * 60 * 1000)).toBe("2h 14m");
+  });
+
+  it("keeps the minutes segment on an exact hour ('2h 0m')", () => {
+    expect(formatElapsed(2 * 60 * 60 * 1000)).toBe("2h 0m");
+  });
+
+  it("clamps negative elapsed (clock skew) to 0m", () => {
+    expect(formatElapsed(-5 * 60 * 1000)).toBe("0m");
+  });
+});

--- a/src/lib/elapsed.ts
+++ b/src/lib/elapsed.ts
@@ -1,0 +1,9 @@
+// src/lib/elapsed.ts — render an elapsed duration for the On-the-clock status
+// bar (issue #701). Pure: takes elapsed milliseconds, returns a compact label.
+
+export function formatElapsed(ms: number): string {
+  const totalMinutes = Math.floor(Math.max(0, ms) / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+}

--- a/src/lib/job-picker.test.ts
+++ b/src/lib/job-picker.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { rankPickerJobs } from "./job-picker";
+
+// issue #701 — the active-Job picker lets a worker find the Job to clock into
+// by typing part of the address, the customer's name, or the job number, and
+// surfaces the Jobs they most recently clocked into first. This pure module is
+// that filter + ranking; the React picker feeds it candidate (Active) Jobs.
+
+const maple = {
+  id: "job-maple",
+  job_number: "J-1001",
+  property_address: "12 Maple St",
+  contact: { full_name: "Ada Lovelace" },
+};
+const oak = {
+  id: "job-oak",
+  job_number: "J-1002",
+  property_address: "988 Oak Ave",
+  contact: { full_name: "Grace Hopper" },
+};
+const pine = {
+  id: "job-pine",
+  job_number: "J-1003",
+  property_address: "5 Pine Ct",
+  contact: { full_name: "Alan Turing" },
+};
+
+describe("rankPickerJobs (#701)", () => {
+  it("filters by a case-insensitive property-address substring", () => {
+    const result = rankPickerJobs([maple, oak], { query: "maple", recentJobIds: [] });
+    expect(result.map((j) => j.id)).toEqual(["job-maple"]);
+  });
+
+  it("filters by the customer's name", () => {
+    const result = rankPickerJobs([maple, oak], { query: "grace", recentJobIds: [] });
+    expect(result.map((j) => j.id)).toEqual(["job-oak"]);
+  });
+
+  it("filters by the job number", () => {
+    const result = rankPickerJobs([maple, oak], { query: "1002", recentJobIds: [] });
+    expect(result.map((j) => j.id)).toEqual(["job-oak"]);
+  });
+
+  it("returns every candidate when the query is blank", () => {
+    const result = rankPickerJobs([maple, oak], { query: "   ", recentJobIds: [] });
+    expect(result.map((j) => j.id)).toEqual(["job-maple", "job-oak"]);
+  });
+
+  it("ranks recently-clocked Jobs first, in recency order, then the rest", () => {
+    const result = rankPickerJobs([maple, oak, pine], {
+      query: "",
+      recentJobIds: ["job-oak", "job-maple"],
+    });
+    expect(result.map((j) => j.id)).toEqual(["job-oak", "job-maple", "job-pine"]);
+  });
+
+  it("floats the recently-clocked Job to the top of a narrowed search", () => {
+    const elmA = { id: "elm-a", job_number: "J-2001", property_address: "1 Elm St" };
+    const elmB = { id: "elm-b", job_number: "J-2002", property_address: "2 Elm St" };
+    const result = rankPickerJobs([elmA, elmB, pine], {
+      query: "elm",
+      recentJobIds: ["elm-b"],
+    });
+    expect(result.map((j) => j.id)).toEqual(["elm-b", "elm-a"]);
+  });
+});

--- a/src/lib/job-picker.ts
+++ b/src/lib/job-picker.ts
@@ -1,0 +1,46 @@
+// Pure logic behind the active-Job picker (issue #701) — the search a worker
+// uses to find the Job to clock into. No Supabase, no React: it takes the
+// candidate (Active) Jobs the picker loaded plus the worker's recently-clocked
+// Job ids and returns the filtered, ranked list to render.
+//
+// A narrow input shape (id, job_number, property_address, optional contact)
+// rather than the full Job type — a real Job satisfies it structurally, and
+// tests stay readable.
+
+export interface PickerJob {
+  id: string;
+  job_number: string;
+  property_address: string;
+  contact?: { full_name: string } | null;
+}
+
+export interface RankPickerJobsOptions {
+  /** Raw text typed into the picker's search box. */
+  query: string;
+  /** The worker's own Job ids, most-recently-clocked first. */
+  recentJobIds: string[];
+}
+
+export function rankPickerJobs(
+  jobs: PickerJob[],
+  { query, recentJobIds }: RankPickerJobsOptions,
+): PickerJob[] {
+  const needle = query.trim().toLowerCase();
+  const matches = jobs.filter((job) => {
+    const haystacks = [
+      job.property_address,
+      job.contact?.full_name ?? "",
+      job.job_number,
+    ];
+    return haystacks.some((field) => field.toLowerCase().includes(needle));
+  });
+
+  // Recently-clocked Jobs lead, in recency order; everything else keeps its
+  // input order behind them. Array.prototype.sort is stable, so a constant
+  // rank for the never-clocked tail preserves their relative order.
+  const rankOf = (job: PickerJob) => {
+    const i = recentJobIds.indexOf(job.id);
+    return i === -1 ? Number.POSITIVE_INFINITY : i;
+  };
+  return matches.slice().sort((a, b) => rankOf(a) - rankOf(b));
+}

--- a/src/lib/on-the-clock-context.tsx
+++ b/src/lib/on-the-clock-context.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { useAuth } from "@/lib/auth-context";
+
+// App-wide "On the clock" state (issue #701). One source of truth for whether
+// the current worker has an Open Time session, shared by the persistent status
+// bar, the home-screen control, and the Job detail Time tab so all three stay
+// in sync. The granular `track_time` permission gates clocking in/out; when the
+// caller lacks it we never poll and clock-in is a no-op.
+
+export interface ActiveSession {
+  sessionId: string;
+  jobId: string;
+  startedAt: string;
+  job: { property_address: string; job_number: string } | null;
+}
+
+/** Mirrors the POST /api/time/clock-in response so callers can react to a
+ *  Job switch (auto-closed prior session) or an idempotent re-clock-in. */
+export interface ClockInResult {
+  ok: boolean;
+  sessionId?: string;
+  jobId?: string;
+  switched?: boolean;
+  closedJobId?: string;
+  alreadyOpen?: boolean;
+  error?: string;
+}
+
+interface OnTheClockValue {
+  active: ActiveSession | null;
+  /** True once the initial /api/time/active fetch has resolved. */
+  ready: boolean;
+  canTrackTime: boolean;
+  clockIn: (jobId: string) => Promise<ClockInResult>;
+  clockOut: () => Promise<{ ok: boolean }>;
+  refresh: () => Promise<void>;
+}
+
+const OnTheClockContext = createContext<OnTheClockValue | null>(null);
+
+export function OnTheClockProvider({ children }: { children: ReactNode }) {
+  const { user, hasPermission } = useAuth();
+  const canTrackTime = Boolean(user) && hasPermission("track_time");
+
+  const [active, setActive] = useState<ActiveSession | null>(null);
+  const [ready, setReady] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!canTrackTime) {
+      setActive(null);
+      setReady(true);
+      return;
+    }
+    try {
+      const res = await fetch("/api/time/active");
+      if (!res.ok) {
+        setActive(null);
+        return;
+      }
+      const data = (await res.json()) as { active: ActiveSession | null };
+      setActive(data.active ?? null);
+    } catch {
+      // Network hiccup — keep the last known state rather than flicker.
+    } finally {
+      setReady(true);
+    }
+  }, [canTrackTime]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const clockIn = useCallback(
+    async (jobId: string): Promise<ClockInResult> => {
+      if (!canTrackTime) return { ok: false, error: "not permitted" };
+      try {
+        const res = await fetch("/api/time/clock-in", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jobId }),
+        });
+        const data = (await res.json().catch(() => ({}))) as Partial<ClockInResult>;
+        if (!res.ok) {
+          return { ok: false, error: data.error ?? "Could not clock in" };
+        }
+        await refresh();
+        return { ok: true, ...data };
+      } catch {
+        return { ok: false, error: "Could not clock in" };
+      }
+    },
+    [canTrackTime, refresh],
+  );
+
+  const clockOut = useCallback(async (): Promise<{ ok: boolean }> => {
+    if (!canTrackTime) return { ok: false };
+    try {
+      const res = await fetch("/api/time/clock-out", { method: "POST" });
+      if (!res.ok) return { ok: false };
+      // Optimistically clear, then reconcile with the server.
+      setActive(null);
+      await refresh();
+      return { ok: true };
+    } catch {
+      return { ok: false };
+    }
+  }, [canTrackTime, refresh]);
+
+  return (
+    <OnTheClockContext.Provider
+      value={{ active, ready, canTrackTime, clockIn, clockOut, refresh }}
+    >
+      {children}
+    </OnTheClockContext.Provider>
+  );
+}
+
+export function useOnTheClock(): OnTheClockValue {
+  const ctx = useContext(OnTheClockContext);
+  if (!ctx) {
+    throw new Error("useOnTheClock must be used within an OnTheClockProvider");
+  }
+  return ctx;
+}

--- a/src/lib/permissions/permission-keys.ts
+++ b/src/lib/permissions/permission-keys.ts
@@ -64,6 +64,10 @@ export const PERMISSION_CATALOG = [
   // Defaults live in `role-defaults.ts`: Admin ON, Crew Lead ON, Crew Member OFF.
   { key: "view_phone", label: "View Phone", group: "Phone" },
 
+  // #701 (epic #699) — per-Job timesheets: clock in / out of a Job.
+  // Defaults live in `role-defaults.ts`: Admin ON, Crew Lead ON, Crew Member ON.
+  { key: "track_time", label: "Track Time", group: "Time" },
+
   { key: "manage_reports", label: "Manage Reports", group: "Reports" },
 
   { key: "manage_templates", label: "Manage Estimate Templates", group: "Templates" },

--- a/src/lib/permissions/role-defaults.test.ts
+++ b/src/lib/permissions/role-defaults.test.ts
@@ -45,3 +45,44 @@ describe("ROLE_DEFAULTS — view_phone defaults (PRD #304)", () => {
     expect(entry?.group).toBe("Phone");
   });
 });
+
+// issue #701 (parent epic #699) — per-Job timesheets.
+//
+// Pins the role-default grants for `track_time`, the permission that gates
+// clocking in / out of a Job:
+//
+//   | Role        | Default |
+//   | ----------- | ------- |
+//   | Admin       | ON      |
+//   | Crew Lead   | ON      |
+//   | Crew Member | ON      |   <- unlike view_phone: workers clock themselves in
+//   | Custom      | OFF     |
+//
+// Crew Member is ON here because tracking time on a Job is core crew work —
+// the whole point of the feature is the people doing the labor recording it.
+// `custom` stays empty (admins hand-pick). The SQL `set_default_permissions`
+// mirrors this; the migration shipping with #701 keeps the two in sync.
+
+describe("ROLE_DEFAULTS — track_time defaults (#701)", () => {
+  it("includes track_time in admin's defaults (admins get every catalog key)", () => {
+    expect(ROLE_DEFAULTS.admin).toContain("track_time");
+  });
+
+  it("includes track_time in crew_lead's defaults", () => {
+    expect(ROLE_DEFAULTS.crew_lead).toContain("track_time");
+  });
+
+  it("includes track_time in crew_member's defaults (workers clock themselves in)", () => {
+    expect(ROLE_DEFAULTS.crew_member).toContain("track_time");
+  });
+
+  it("excludes track_time from custom (the empty default)", () => {
+    expect(ROLE_DEFAULTS.custom).not.toContain("track_time");
+  });
+
+  it("registers track_time in the permission catalog under the Time group", () => {
+    const entry = PERMISSION_CATALOG.find((p) => p.key === "track_time");
+    expect(entry).toBeDefined();
+    expect(entry?.group).toBe("Time");
+  });
+});

--- a/src/lib/permissions/role-defaults.ts
+++ b/src/lib/permissions/role-defaults.ts
@@ -21,8 +21,9 @@ export const ROLE_DEFAULTS: Record<string, readonly PermissionKey[]> = {
     "view_billing", "record_payments",
     "view_email", "send_email",
     "view_phone",
+    "track_time",
     "manage_reports",
   ],
-  crew_member: ["view_jobs", "log_activities", "upload_photos"],
+  crew_member: ["view_jobs", "log_activities", "upload_photos", "track_time"],
   custom: [],
 };

--- a/src/lib/request-context/__test-utils__/request-context-fakes.ts
+++ b/src/lib/request-context/__test-utils__/request-context-fakes.ts
@@ -22,6 +22,7 @@ export interface QueryBuilder {
   select(cols?: string, opts?: { count?: "exact"; head?: boolean }): QueryBuilder;
   eq(col: string, val: unknown): QueryBuilder;
   is(col: string, val: unknown): QueryBuilder;
+  not(col: string, op: string, val: unknown): QueryBuilder;
   in(col: string, vals: unknown[]): QueryBuilder;
   gte(col: string, val: unknown): QueryBuilder;
   lte(col: string, val: unknown): QueryBuilder;
@@ -51,6 +52,17 @@ function makeBuilder(rows: Row[]): QueryBuilder {
     },
     is(col, val) {
       filtered = filtered.filter((r) => (r[col] ?? null) === val);
+      return builder;
+    },
+    not(col, op, val) {
+      // PostgREST negation. We support the ops the routes actually chain —
+      // `.not(col, "eq", v)` and `.not(col, "is", v)` — and leave others as a
+      // no-op (the same pragmatic stance the range/order fakes take).
+      if (op === "eq") {
+        filtered = filtered.filter((r) => r[col] !== val);
+      } else if (op === "is") {
+        filtered = filtered.filter((r) => (r[col] ?? null) !== val);
+      }
       return builder;
     },
     in(col, vals) {
@@ -102,11 +114,20 @@ function makeBuilder(rows: Row[]): QueryBuilder {
 // A fake Supabase client. `user` is what `auth.getUser()` resolves; pass
 // `null` to simulate an unauthenticated request. `tables` seeds whatever
 // the wrapper or the route handler reads — an unseeded table reads empty.
+//
+// `rpc(name, args)` records every call on the returned client's `rpcCalls`
+// array (in order) and resolves to `{ data: null, error: rpcError ?? null }`.
+// `rpcCalls` is a test-only handle — not part of the supabase-js surface —
+// so a test can positively assert which atomic-transition RPC a mutation
+// route invoked via `ctx.supabase`, and with what decided writes. Set
+// `rpcError` to make the next RPC fail.
 export function fakeClient(opts: {
   user?: { id: string } | null;
   tables?: Record<string, Row[]>;
+  rpcError?: { message: string } | null;
 }) {
   const tables = opts.tables ?? {};
+  const rpcCalls: { name: string; args: Record<string, unknown> }[] = [];
   return {
     auth: {
       async getUser() {
@@ -116,6 +137,11 @@ export function fakeClient(opts: {
     from(table: string) {
       return makeBuilder(tables[table] ?? []);
     },
+    async rpc(name: string, args: Record<string, unknown>) {
+      rpcCalls.push({ name, args });
+      return { data: null, error: opts.rpcError ?? null };
+    },
+    rpcCalls,
   };
 }
 

--- a/src/lib/session-lifecycle.test.ts
+++ b/src/lib/session-lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  planClockIn,
+  planClockOut,
+  validateSpan,
+  validateCorrectedSpan,
+  type OpenSession,
+  type Span,
+  type SpanProblem,
+} from "./session-lifecycle";
+
+// #701 — Time sessions: a worker is On the clock for at most one Job at a time.
+// `planClockIn` is the pure decision that turns "this worker tapped Clock-in on
+// Job X" into the lifecycle action the server must perform — open a fresh
+// session, leave the current one alone, or auto-close the prior one first.
+// No I/O: it reads the worker's current Open session (if any) and the request.
+
+describe("planClockIn", () => {
+  it("opens a new session when the worker has nothing open", () => {
+    expect(
+      planClockIn(null, { jobId: "job-1", at: "2026-06-19T14:00:00Z" }),
+    ).toEqual({ type: "open" });
+  });
+
+  it("auto-closes the prior session when the worker clocks in to a different Job", () => {
+    const open: OpenSession = {
+      sessionId: "sess-A",
+      jobId: "job-1",
+      startedAt: "2026-06-19T12:00:00Z",
+    };
+    expect(
+      planClockIn(open, { jobId: "job-2", at: "2026-06-19T14:00:00Z" }),
+    ).toEqual({
+      type: "switch",
+      close: { sessionId: "sess-A", endedAt: "2026-06-19T14:00:00Z" },
+    });
+  });
+
+  it("is a no-op when the worker clocks in to the Job they are already On", () => {
+    const open: OpenSession = {
+      sessionId: "sess-A",
+      jobId: "job-1",
+      startedAt: "2026-06-19T12:00:00Z",
+    };
+    expect(
+      planClockIn(open, { jobId: "job-1", at: "2026-06-19T14:00:00Z" }),
+    ).toEqual({ type: "already-open" });
+  });
+});
+
+describe("planClockOut", () => {
+  it("closes the worker's Open session at the clock-out instant", () => {
+    const open: OpenSession = {
+      sessionId: "sess-A",
+      jobId: "job-1",
+      startedAt: "2026-06-19T12:00:00Z",
+    };
+    expect(planClockOut(open, "2026-06-19T15:30:00Z")).toEqual({
+      type: "close",
+      sessionId: "sess-A",
+      endedAt: "2026-06-19T15:30:00Z",
+    });
+  });
+
+  it("reports nothing-open when the worker has no Open session", () => {
+    expect(planClockOut(null, "2026-06-19T15:30:00Z")).toEqual({
+      type: "nothing-open",
+    });
+  });
+});
+
+describe("validateSpan", () => {
+  // A corrected (or hand-entered) span is only valid when the clock-out is
+  // strictly after the clock-in. One rule rejects both a zero-length span and
+  // a negative one.
+  const cases: Array<[string, string, string, SpanProblem | null]> = [
+    ["end after start", "2026-06-19T12:00:00Z", "2026-06-19T13:00:00Z", null],
+    [
+      "end equals start (zero-length)",
+      "2026-06-19T12:00:00Z",
+      "2026-06-19T12:00:00Z",
+      "ended-not-after-started",
+    ],
+    [
+      "end before start (negative)",
+      "2026-06-19T13:00:00Z",
+      "2026-06-19T12:00:00Z",
+      "ended-not-after-started",
+    ],
+  ];
+
+  it.each(cases)("%s → %s", (_label, startedAt, endedAt, expected) => {
+    expect(validateSpan(startedAt, endedAt)).toBe(expected);
+  });
+});
+
+describe("validateCorrectedSpan", () => {
+  // When a worker corrects or hand-enters a span, it must not collide with the
+  // hours they already have recorded on other sessions. Two spans collide when
+  // they share real elapsed time — a candidate that starts before another ends
+  // and ends after that other begins.
+  const noon: Span = {
+    startedAt: "2026-06-19T12:00:00Z",
+    endedAt: "2026-06-19T13:00:00Z",
+  };
+
+  it("rejects a candidate that overlaps an existing span", () => {
+    const candidate: Span = {
+      startedAt: "2026-06-19T12:30:00Z",
+      endedAt: "2026-06-19T13:30:00Z",
+    };
+    expect(validateCorrectedSpan(candidate, [noon])).toBe("overlap");
+  });
+
+  // Spans that merely sit next to each other — fully before, fully after, or
+  // touching exactly at an endpoint (one ends as the next begins) — do not
+  // collide and are accepted.
+  const clear: Array<[string, Span]> = [
+    [
+      "fully before",
+      { startedAt: "2026-06-19T10:00:00Z", endedAt: "2026-06-19T11:00:00Z" },
+    ],
+    [
+      "fully after",
+      { startedAt: "2026-06-19T14:00:00Z", endedAt: "2026-06-19T15:00:00Z" },
+    ],
+    [
+      "touching at the start",
+      { startedAt: "2026-06-19T11:00:00Z", endedAt: "2026-06-19T12:00:00Z" },
+    ],
+    [
+      "touching at the end",
+      { startedAt: "2026-06-19T13:00:00Z", endedAt: "2026-06-19T14:00:00Z" },
+    ],
+  ];
+
+  it.each(clear)("accepts a candidate %s an existing span", (_label, candidate) => {
+    expect(validateCorrectedSpan(candidate, [noon])).toBe(null);
+  });
+
+  it("reports the span itself is invalid before checking overlap", () => {
+    const backwards: Span = {
+      startedAt: "2026-06-19T13:00:00Z",
+      endedAt: "2026-06-19T12:00:00Z",
+    };
+    expect(validateCorrectedSpan(backwards, [])).toBe("ended-not-after-started");
+  });
+});

--- a/src/lib/session-lifecycle.ts
+++ b/src/lib/session-lifecycle.ts
@@ -1,0 +1,86 @@
+// src/lib/session-lifecycle.ts — the pure rules for a worker's Time sessions.
+//
+// A worker is On the clock for at most one Job at a time (the partial unique
+// index on time_sessions pins this at the database; these functions keep the
+// app from ever asking the database to break it). No I/O — callers pass the
+// worker's current Open session and the request; the functions return the
+// lifecycle action to perform.
+//
+// Timestamps are ISO-8601 UTC instants (ADR 0020 — hours are recorded in UTC).
+
+export type Instant = string;
+
+export interface OpenSession {
+  sessionId: string;
+  jobId: string;
+  startedAt: Instant;
+}
+
+export interface ClockInRequest {
+  jobId: string;
+  at: Instant;
+}
+
+export type ClockInPlan =
+  | { type: "open" }
+  | { type: "already-open" }
+  | { type: "switch"; close: { sessionId: string; endedAt: Instant } };
+
+export type ClockOutPlan =
+  | { type: "close"; sessionId: string; endedAt: Instant }
+  | { type: "nothing-open" };
+
+export interface Span {
+  startedAt: Instant;
+  endedAt: Instant;
+}
+
+export type SpanProblem = "ended-not-after-started" | "overlap";
+
+export function planClockIn(
+  open: OpenSession | null,
+  req: ClockInRequest,
+): ClockInPlan {
+  if (open === null) return { type: "open" };
+  if (open.jobId === req.jobId) return { type: "already-open" };
+  return {
+    type: "switch",
+    close: { sessionId: open.sessionId, endedAt: req.at },
+  };
+}
+
+export function planClockOut(
+  open: OpenSession | null,
+  at: Instant,
+): ClockOutPlan {
+  if (open === null) return { type: "nothing-open" };
+  return { type: "close", sessionId: open.sessionId, endedAt: at };
+}
+
+export function validateSpan(
+  startedAt: Instant,
+  endedAt: Instant,
+): SpanProblem | null {
+  if (Date.parse(endedAt) <= Date.parse(startedAt)) {
+    return "ended-not-after-started";
+  }
+  return null;
+}
+
+export function validateCorrectedSpan(
+  candidate: Span,
+  others: Span[],
+): SpanProblem | null {
+  const itself = validateSpan(candidate.startedAt, candidate.endedAt);
+  if (itself !== null) return itself;
+  const start = Date.parse(candidate.startedAt);
+  const end = Date.parse(candidate.endedAt);
+  for (const other of others) {
+    // Two spans share real time when each starts strictly before the other
+    // ends. Touching exactly at an endpoint is not an overlap.
+    if (start < Date.parse(other.endedAt) && Date.parse(other.startedAt) < end) {
+      return "overlap";
+    }
+  }
+  return null;
+}

--- a/src/lib/time-sessions.ts
+++ b/src/lib/time-sessions.ts
@@ -1,0 +1,38 @@
+// src/lib/time-sessions.ts — the thin I/O layer for a worker's Time sessions.
+//
+// The pure lifecycle rules live in session-lifecycle.ts; this module loads the
+// one piece of state those rules need — the worker's current Open session — so
+// a route can hand it to planClockIn / planClockOut. Kept separate so the rules
+// stay free of Supabase.
+//
+// Timestamps are ISO-8601 UTC instants (ADR 0020).
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { OpenSession } from "@/lib/session-lifecycle";
+
+// Load the caller's current Open session (ended_at IS NULL, not soft-deleted),
+// or null if they are not On the clock. At most one row can match — the partial
+// unique index on time_sessions pins one open session per worker — so a load
+// error degrades safely to null: any real double-open is still rejected by that
+// index at write time. `orgId` is `string | null` to match the Request Context
+// shape; a null org trivially has no Open session (the permission-gated callers
+// always pass a real org).
+export async function loadOpenSession(
+  supabase: SupabaseClient,
+  userId: string,
+  orgId: string | null,
+): Promise<OpenSession | null> {
+  const { data } = await supabase
+    .from("time_sessions")
+    .select("id, job_id, started_at")
+    .eq("user_id", userId)
+    .eq("organization_id", orgId)
+    .is("ended_at", null)
+    .is("deleted_at", null)
+    .order("started_at", { ascending: false })
+    .maybeSingle();
+  const row = data as { id: string; job_id: string; started_at: string } | null;
+  return row
+    ? { sessionId: row.id, jobId: row.job_id, startedAt: row.started_at }
+    : null;
+}

--- a/supabase/migration-660-smoke-test.sql
+++ b/supabase/migration-660-smoke-test.sql
@@ -1,0 +1,475 @@
+-- issue #701 (parent epic #699) — Time sessions foundation smoke test.
+--
+-- Purpose:   Self-checking script that verifies migration-660's schema
+--            invariants and the clock-in / clock-out RPCs. NOT part of the
+--            migration. Wrapped in begin; ... rollback; so the database is
+--            unchanged on a clean run. Every assertion raises on failure; a
+--            clean run prints only NOTICE lines.
+--
+-- Preconditions: migration-660 has been applied. Sections that need a real
+--            worker (the worker-XOR "both" case, the one-open-per-user index,
+--            and the RPCs) pick any existing auth.users row and skip
+--            themselves if the database has no users.
+--
+-- Run:       psql -f supabase/migration-660-smoke-test.sql
+--            (or paste into the Supabase SQL editor).
+--
+-- What it pins:
+--   1. Both tables exist with expected columns.
+--   2. capture_method accepts 'live' / 'hand', rejects anything else.
+--   3. Worker XOR: app-User-only OK, off-app-only OK, both rejected, neither
+--      rejected.
+--   4. ended_at must be NULL or strictly after started_at.
+--   5. event_type accepts all five values, rejects others.
+--   6. One Open session per app User (partial unique index); off-app rows are
+--      exempt (multiple Open off-app sessions allowed).
+--   7. clock_in_to_job logs 'created' and opens; clock_out_session closes and
+--      logs 'clocked_out'; a Job switch closes the prior session first; a
+--      double clock-out raises. The 'created' / 'clocked_out' events carry
+--      {field, old, new} metadata (started_at / ended_at, old null).
+--   8. time_session_events is append-only (RLS on; SELECT + INSERT policies
+--      only, no UPDATE / DELETE policy).
+--   9. time_sessions carries an org-isolation RLS policy.
+--  10. RLS behavior: a cross-Organization INSERT is denied, and a caller sees
+--      only its own Organization's time_sessions and time_session_events.
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- 1. Tables and key columns exist.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_missing text;
+begin
+  select string_agg(missing_col, ', ')
+    into v_missing
+  from (
+    select 'time_sessions.' || col as missing_col
+      from unnest(array[
+        'id', 'organization_id', 'job_id', 'user_id', 'off_app_worker_name',
+        'started_at', 'ended_at', 'capture_method', 'created_by',
+        'created_at', 'updated_at', 'deleted_at'
+      ]) as col
+     where not exists (
+       select 1 from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'time_sessions'
+          and column_name = col
+     )
+    union all
+    select 'time_session_events.' || col
+      from unnest(array[
+        'id', 'organization_id', 'time_session_id', 'event_type',
+        'actor', 'metadata', 'created_at'
+      ]) as col
+     where not exists (
+       select 1 from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'time_session_events'
+          and column_name = col
+     )
+  ) m;
+
+  if v_missing is not null then
+    raise exception 'migration-660 smoke: missing column(s): %', v_missing;
+  end if;
+  raise notice 'migration-660 smoke: tables + columns present';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Constraint + behavior tests. One do-block so locally declared ids stay
+--    in scope. Everything rolls back at the end.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_org_id          uuid := gen_random_uuid();
+  v_contact_id      uuid := gen_random_uuid();
+  v_job_id          uuid;
+  v_user_id         uuid;
+  v_have_real_user  boolean;
+  v_sess            uuid;
+  v_sess_a          uuid := gen_random_uuid();
+  v_sess_b          uuid := gen_random_uuid();
+  v_ended           timestamptz;
+  v_method          text;
+  v_count           int;
+  v_meta            jsonb;
+begin
+  select id into v_user_id from auth.users limit 1;
+  v_have_real_user := v_user_id is not null;
+
+  -- Tenant scaffolding: org → contact → job. An explicit job_number keeps the
+  -- set_job_number trigger from touching the per-org counter table.
+  insert into public.organizations (id, name, slug)
+    values (v_org_id, 'm660 smoke', 'm660-smoke-' || replace(v_org_id::text, '-', ''));
+  insert into public.contacts (id, organization_id, full_name, role)
+    values (v_contact_id, v_org_id, 'Homeowner A', 'homeowner');
+  insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
+    values (v_org_id, v_contact_id, 'water', '1 Maple St', 'SMOKE-660')
+    returning id into v_job_id;
+
+  -- ----- 2a. capture_method check (off-app worker so no real user needed) ---
+  begin
+    insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
+      values (v_org_id, v_job_id, 'Day Laborer', 'gps');
+    raise exception 'm660 smoke: capture_method accepted invalid value "gps"';
+  exception when check_violation then null;
+  end;
+
+  insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
+    values (v_org_id, v_job_id, 'Day Laborer', 'live'), (v_org_id, v_job_id, 'Day Laborer', 'hand');
+  delete from public.time_sessions where organization_id = v_org_id;
+  raise notice 'm660 smoke: capture_method — accepts live/hand, rejects "gps"';
+
+  -- ----- 2b. Worker XOR -----
+  -- off-app only: OK
+  insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
+    values (v_org_id, v_job_id, 'Off App Only', 'hand');
+  -- neither worker: rejected
+  begin
+    insert into public.time_sessions (organization_id, job_id, capture_method)
+      values (v_org_id, v_job_id, 'hand');
+    raise exception 'm660 smoke: worker XOR accepted a row with NEITHER user_id nor off_app_worker_name';
+  exception when check_violation then null;
+  end;
+
+  if v_have_real_user then
+    -- app User only: OK
+    insert into public.time_sessions (organization_id, job_id, user_id, capture_method)
+      values (v_org_id, v_job_id, v_user_id, 'live');
+    -- both: rejected
+    begin
+      insert into public.time_sessions (organization_id, job_id, user_id, off_app_worker_name, capture_method)
+        values (v_org_id, v_job_id, v_user_id, 'Both', 'live');
+      raise exception 'm660 smoke: worker XOR accepted a row with BOTH user_id and off_app_worker_name';
+    exception when check_violation then null;
+    end;
+    raise notice 'm660 smoke: worker XOR — user-only OK, off-app-only OK, both rejected, neither rejected';
+  else
+    raise notice 'm660 smoke: worker XOR — off-app-only OK, neither rejected (user-only / both skipped: no auth.users row)';
+  end if;
+  delete from public.time_sessions where organization_id = v_org_id;
+
+  -- ----- 2c. ended_at must be NULL or strictly after started_at -----
+  begin  -- zero-length
+    insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
+      values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T12:00:00Z', '2026-06-19T12:00:00Z');
+    raise exception 'm660 smoke: ended_at check accepted a zero-length span';
+  exception when check_violation then null;
+  end;
+  begin  -- negative
+    insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
+      values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T13:00:00Z', '2026-06-19T12:00:00Z');
+    raise exception 'm660 smoke: ended_at check accepted a negative span';
+  exception when check_violation then null;
+  end;
+  insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
+    values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T12:00:00Z', '2026-06-19T13:00:00Z'); -- positive OK
+  insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at)
+    values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T12:00:00Z'); -- Open (NULL) OK
+  delete from public.time_sessions where organization_id = v_org_id;
+  raise notice 'm660 smoke: ended_at — rejects zero-length and negative, accepts positive and Open(NULL)';
+
+  -- ----- 2d. event_type check (needs a session for the FK) -----
+  insert into public.time_sessions (id, organization_id, job_id, off_app_worker_name, capture_method)
+    values (gen_random_uuid(), v_org_id, v_job_id, 'Evt', 'hand')
+    returning id into v_sess;
+  begin
+    insert into public.time_session_events (organization_id, time_session_id, event_type)
+      values (v_org_id, v_sess, 'bogus');
+    raise exception 'm660 smoke: event_type accepted invalid value "bogus"';
+  exception when check_violation then null;
+  end;
+  insert into public.time_session_events (organization_id, time_session_id, event_type)
+    values
+      (v_org_id, v_sess, 'created'),
+      (v_org_id, v_sess, 'clocked_out'),
+      (v_org_id, v_sess, 'corrected'),
+      (v_org_id, v_sess, 'deleted'),
+      (v_org_id, v_sess, 'off_app_added');
+  delete from public.time_sessions where organization_id = v_org_id;  -- cascades events
+  raise notice 'm660 smoke: event_type — accepts all 5 values, rejects "bogus"';
+
+  -- ----- 2e. One Open session per app User; off-app exempt -----
+  -- Off-app: two Open rows allowed (user_id NULL excluded from the index).
+  insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
+    values (v_org_id, v_job_id, 'Open A', 'hand'), (v_org_id, v_job_id, 'Open B', 'hand');
+  select count(*) into v_count from public.time_sessions
+    where organization_id = v_org_id and ended_at is null;
+  if v_count <> 2 then
+    raise exception 'm660 smoke: expected 2 Open off-app sessions, found %', v_count;
+  end if;
+  delete from public.time_sessions where organization_id = v_org_id;
+
+  if v_have_real_user then
+    insert into public.time_sessions (id, organization_id, job_id, user_id, capture_method)
+      values (v_sess_a, v_org_id, v_job_id, v_user_id, 'live');
+    begin  -- a second Open session for the same User must violate the index
+      insert into public.time_sessions (organization_id, job_id, user_id, capture_method)
+        values (v_org_id, v_job_id, v_user_id, 'live');
+      raise exception 'm660 smoke: one-open-per-user index allowed a SECOND Open session';
+    exception when unique_violation then null;
+    end;
+    -- Closing the first frees the slot for a new Open session. ended_at must be
+    -- strictly after started_at; now() is transaction-stable (it equals the
+    -- session's now()-defaulted started_at within this begin/rollback), so push
+    -- it forward by an interval rather than reusing the identical instant.
+    update public.time_sessions set ended_at = now() + interval '1 hour' where id = v_sess_a;
+    insert into public.time_sessions (organization_id, job_id, user_id, capture_method)
+      values (v_org_id, v_job_id, v_user_id, 'live');
+    delete from public.time_sessions where organization_id = v_org_id;
+    raise notice 'm660 smoke: one-open-per-user — second Open rejected, allowed again after close';
+  else
+    raise notice 'm660 smoke: one-open-per-user (app User) skipped — no auth.users row; off-app exemption verified';
+  end if;
+
+  -- ----- 2f. RPCs: clock_in_to_job / clock_out_session / switch -----
+  if v_have_real_user then
+    v_sess_a := gen_random_uuid();
+    perform clock_in_to_job(
+      v_sess_a, v_org_id, v_job_id, v_user_id, '2026-06-19T12:00:00Z'::timestamptz, v_user_id);
+    select ended_at, capture_method into v_ended, v_method
+      from public.time_sessions where id = v_sess_a;
+    if v_ended is not null then
+      raise exception 'm660 smoke: clock_in_to_job left the session closed (ended_at set)';
+    end if;
+    if v_method <> 'live' then
+      raise exception 'm660 smoke: clock_in_to_job recorded capture_method % (expected live)', v_method;
+    end if;
+    select count(*) into v_count from public.time_session_events
+      where time_session_id = v_sess_a and event_type = 'created';
+    if v_count <> 1 then
+      raise exception 'm660 smoke: clock_in_to_job wrote % "created" events (expected 1)', v_count;
+    end if;
+    -- The 'created' event carries {field:'started_at', old:null, new:<started_at>}.
+    select metadata into v_meta from public.time_session_events
+      where time_session_id = v_sess_a and event_type = 'created';
+    if v_meta->>'field' is distinct from 'started_at'
+       or v_meta->'old' is distinct from 'null'::jsonb
+       or (v_meta->>'new')::timestamptz is distinct from '2026-06-19T12:00:00Z'::timestamptz then
+      raise exception 'm660 smoke: "created" event metadata is not {field:started_at, old:null, new:<started_at>}: %', v_meta;
+    end if;
+
+    perform clock_out_session(v_sess_a, v_org_id, '2026-06-19T15:00:00Z'::timestamptz, v_user_id);
+    select ended_at into v_ended from public.time_sessions where id = v_sess_a;
+    if v_ended is distinct from '2026-06-19T15:00:00Z'::timestamptz then
+      raise exception 'm660 smoke: clock_out_session did not set ended_at (got %)', v_ended;
+    end if;
+    select count(*) into v_count from public.time_session_events
+      where time_session_id = v_sess_a and event_type = 'clocked_out';
+    if v_count <> 1 then
+      raise exception 'm660 smoke: clock_out_session wrote % "clocked_out" events (expected 1)', v_count;
+    end if;
+    -- The 'clocked_out' event carries {field:'ended_at', old:null, new:<ended_at>}.
+    select metadata into v_meta from public.time_session_events
+      where time_session_id = v_sess_a and event_type = 'clocked_out';
+    if v_meta->>'field' is distinct from 'ended_at'
+       or v_meta->'old' is distinct from 'null'::jsonb
+       or (v_meta->>'new')::timestamptz is distinct from '2026-06-19T15:00:00Z'::timestamptz then
+      raise exception 'm660 smoke: "clocked_out" event metadata is not {field:ended_at, old:null, new:<ended_at>}: %', v_meta;
+    end if;
+
+    begin  -- double clock-out must raise (session no longer Open)
+      perform clock_out_session(v_sess_a, v_org_id, '2026-06-19T16:00:00Z'::timestamptz, v_user_id);
+      raise exception 'm660 smoke: a double clock-out did NOT raise';
+    exception
+      when raise_exception then null;  -- expected
+    end;
+
+    -- Switch: open A, then clock in to a Job with p_close_session_id => A.
+    delete from public.time_sessions where organization_id = v_org_id;
+    v_sess_a := gen_random_uuid();
+    v_sess_b := gen_random_uuid();
+    perform clock_in_to_job(
+      v_sess_a, v_org_id, v_job_id, v_user_id, '2026-06-19T12:00:00Z'::timestamptz, v_user_id);
+    perform clock_in_to_job(
+      v_sess_b, v_org_id, v_job_id, v_user_id, '2026-06-19T14:00:00Z'::timestamptz, v_user_id,
+      v_sess_a, '2026-06-19T14:00:00Z'::timestamptz);
+
+    select ended_at into v_ended from public.time_sessions where id = v_sess_a;
+    if v_ended is distinct from '2026-06-19T14:00:00Z'::timestamptz then
+      raise exception 'm660 smoke: switch did not auto-close the prior session (ended_at %)', v_ended;
+    end if;
+    select ended_at into v_ended from public.time_sessions where id = v_sess_b;
+    if v_ended is not null then
+      raise exception 'm660 smoke: switch left the new session closed';
+    end if;
+    select count(*) into v_count from public.time_session_events
+      where time_session_id = v_sess_a and event_type = 'clocked_out';
+    if v_count <> 1 then
+      raise exception 'm660 smoke: switch wrote % "clocked_out" events on prior session (expected 1)', v_count;
+    end if;
+    select count(*) into v_count from public.time_session_events
+      where time_session_id = v_sess_b and event_type = 'created';
+    if v_count <> 1 then
+      raise exception 'm660 smoke: switch wrote % "created" events on new session (expected 1)', v_count;
+    end if;
+    raise notice 'm660 smoke: RPCs — clock-in opens + logs created, clock-out closes + logs clocked_out, switch auto-closes prior, double clock-out raises';
+  else
+    raise notice 'm660 smoke: RPC checks skipped — no auth.users row available';
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 3. Append-only: time_session_events has RLS on and only SELECT + INSERT
+--    policies (no UPDATE / DELETE policy => those commands are denied).
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_rls_on      boolean;
+  v_write_pols  text;
+begin
+  select relrowsecurity into v_rls_on
+    from pg_class where oid = 'public.time_session_events'::regclass;
+  if not coalesce(v_rls_on, false) then
+    raise exception 'm660 smoke: RLS is not enabled on time_session_events';
+  end if;
+
+  -- polcmd 'w' = UPDATE, 'd' = DELETE, '*' = ALL. Any of these breaks append-only.
+  -- polcmd is the internal "char" type; cast so the || operator is unambiguous.
+  select string_agg(polname || '(' || polcmd::text || ')', ', ')
+    into v_write_pols
+  from pg_policy p
+  join pg_class c on c.oid = p.polrelid
+  where c.relname = 'time_session_events'
+    and p.polcmd in ('w', 'd', '*');
+
+  if v_write_pols is not null then
+    raise exception 'm660 smoke: time_session_events is not append-only — found mutating policy(ies): %', v_write_pols;
+  end if;
+  raise notice 'm660 smoke: time_session_events is append-only (RLS on; no UPDATE/DELETE/ALL policy)';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. time_sessions carries an org-isolation RLS policy.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_policy text;
+begin
+  select string_agg(polname, ', ')
+    into v_policy
+  from pg_policy p
+  join pg_class c on c.oid = p.polrelid
+  where c.relname = 'time_sessions'
+    and pg_get_expr(p.polqual, p.polrelid) ilike '%active_organization_id%';
+
+  if v_policy is null then
+    raise exception 'm660 smoke: time_sessions has no org-isolation RLS policy';
+  end if;
+  raise notice 'm660 smoke: time_sessions org-isolation policy present (%)', v_policy;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 5. RLS behavior — a cross-Organization INSERT is denied (AC #5). The caller
+--    is active in org B but the proposed row belongs to org A; the WITH CHECK
+--    (organization_id = nookleus.active_organization_id()) fails. An off-app
+--    session (user_id NULL) needs no auth.users row, so this runs always.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_org_a     uuid := '66000000-0000-0000-0000-0000000000a1';
+  v_org_b     uuid := '66000000-0000-0000-0000-0000000000b1';
+  v_contact_a uuid := '66000000-0000-0000-0000-0000000000c1';
+  v_job_a     uuid;
+  v_blocked   boolean := false;
+begin
+  insert into public.organizations (id, name, slug) values
+    (v_org_a, 'm660 rls A', 'm660-rls-a-' || replace(v_org_a::text, '-', '')),
+    (v_org_b, 'm660 rls B', 'm660-rls-b-' || replace(v_org_b::text, '-', ''));
+  insert into public.contacts (id, organization_id, full_name, role)
+    values (v_contact_a, v_org_a, 'RLS A', 'homeowner');
+  insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
+    values (v_org_a, v_contact_a, 'water', '1 RLS St', 'SMOKE-660-RLS-A')
+    returning id into v_job_a;
+
+  set local role authenticated;
+  set local request.jwt.claims =
+    '{"sub":"66000000-0000-0000-0000-0000000000f1","active_organization_id":"66000000-0000-0000-0000-0000000000b1","role":"authenticated"}';
+  begin
+    insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
+      values (v_org_a, v_job_a, 'Cross Org', 'hand');
+  exception when insufficient_privilege then v_blocked := true;
+  end;
+  reset role;
+
+  if not v_blocked then
+    raise exception 'm660 smoke: cross-org INSERT into another Organization was NOT denied';
+  end if;
+  raise notice 'm660 smoke: RLS — cross-org INSERT denied';
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- 6. RLS behavior — a caller sees only its OWN Organization's time_sessions
+--    and time_session_events (AC #5). Needs a real auth.users row for the
+--    membership EXISTS check, so it skips itself when the database has none.
+--    Sessions are seeded off-app (user_id NULL) under owner bypass, then read
+--    back as an authenticated member of org A.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_org_a     uuid := '66000000-0000-0000-0000-0000000000a2';
+  v_org_b     uuid := '66000000-0000-0000-0000-0000000000b2';
+  v_contact_a uuid := '66000000-0000-0000-0000-0000000000c2';
+  v_contact_b uuid := '66000000-0000-0000-0000-0000000000c3';
+  v_job_a     uuid;
+  v_job_b     uuid;
+  v_user      uuid;
+  v_s_a       uuid := gen_random_uuid();
+  v_s_b       uuid := gen_random_uuid();
+  v_count     bigint;
+  v_orgs      uuid[];
+  v_evt_count bigint;
+begin
+  select id into v_user from auth.users limit 1;
+  if v_user is null then
+    raise notice 'm660 smoke: RLS own-org visibility skipped — no auth.users row';
+    return;
+  end if;
+
+  insert into public.organizations (id, name, slug) values
+    (v_org_a, 'm660 vis A', 'm660-vis-a-' || replace(v_org_a::text, '-', '')),
+    (v_org_b, 'm660 vis B', 'm660-vis-b-' || replace(v_org_b::text, '-', ''));
+  insert into public.contacts (id, organization_id, full_name, role) values
+    (v_contact_a, v_org_a, 'Vis A', 'homeowner'),
+    (v_contact_b, v_org_b, 'Vis B', 'homeowner');
+  insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
+    values (v_org_a, v_contact_a, 'water', '1 Vis St', 'SMOKE-660-VIS-A') returning id into v_job_a;
+  insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
+    values (v_org_b, v_contact_b, 'water', '2 Vis St', 'SMOKE-660-VIS-B') returning id into v_job_b;
+
+  -- The caller is a member of org A only.
+  insert into public.user_organizations (user_id, organization_id, role)
+    values (v_user, v_org_a, 'crew_member');
+
+  -- One session + one event in each org (owner bypass; off-app rows).
+  insert into public.time_sessions (id, organization_id, job_id, off_app_worker_name, capture_method)
+    values (v_s_a, v_org_a, v_job_a, 'Vis A', 'hand'),
+           (v_s_b, v_org_b, v_job_b, 'Vis B', 'hand');
+  insert into public.time_session_events (organization_id, time_session_id, event_type)
+    values (v_org_a, v_s_a, 'created'),
+           (v_org_b, v_s_b, 'created');
+
+  -- Read back as the org-A member. (Capture under RLS, reset, then assert.)
+  set local role authenticated;
+  perform set_config(
+    'request.jwt.claims',
+    json_build_object('sub', v_user::text, 'active_organization_id', v_org_a::text, 'role', 'authenticated')::text,
+    true);
+
+  select count(*), array_agg(distinct organization_id) into v_count, v_orgs from public.time_sessions;
+  select count(*) into v_evt_count from public.time_session_events;
+
+  reset role;
+
+  if v_count <> 1 or v_orgs is distinct from array[v_org_a] then
+    raise exception 'm660 smoke: RLS own-org visibility — org-A caller saw % time_sessions (orgs=%); expected only org A''s 1', v_count, v_orgs;
+  end if;
+  if v_evt_count <> 1 then
+    raise exception 'm660 smoke: RLS own-org visibility — org-A caller saw % time_session_events; expected only org A''s 1', v_evt_count;
+  end if;
+  raise notice 'm660 smoke: RLS — caller sees only own-org time_sessions + time_session_events';
+end $$;
+
+rollback;

--- a/supabase/migration-660-time-sessions.sql
+++ b/supabase/migration-660-time-sessions.sql
@@ -1,0 +1,286 @@
+-- issue #701 (parent epic #699): Time sessions — Clock in / Clock out of a Job.
+--
+-- The foundation slice of per-Job timesheets. Two tables:
+--   time_sessions        — one row per stretch a worker is (or was) On the
+--                           clock for a Job. ended_at IS NULL means the
+--                           session is still Open (the worker is clocked in).
+--   time_session_events  — append-only audit trail; one row per thing that
+--                           happened to a session (clock-in, clock-out,
+--                           correction, delete, off-app add).
+--
+-- Worker identity:  A session's worker is EITHER an app User (user_id) OR an
+--                   off-app name (off_app_worker_name) — never both, never
+--                   neither. The chk_time_sessions_worker_xor constraint pins
+--                   this. Off-app workers are hand-entered by a teammate; they
+--                   have no login, so they never hold an Open live session in
+--                   practice (the one-open-session index below only constrains
+--                   app Users).
+--
+-- One Job at a time:  An app User can have at most one Open session across the
+--                   whole org. The partial unique index
+--                   uniq_time_sessions_one_open_per_user pins this at the
+--                   database; src/lib/session-lifecycle.ts keeps the app from
+--                   ever asking the database to break it (auto-closing the
+--                   prior session when a worker clocks in to a different Job).
+--
+-- No location (ADR 0019):  we deliberately do NOT store GPS / lat-long. Hours
+--                   are recorded in UTC (ADR 0020) — every timestamptz here is
+--                   a UTC instant; local display is the UI's job.
+--
+-- Own-hours visibility:  RLS here is the org-isolation backstop only
+--                   (tenant_isolation_*, the same shape as jobs / contacts).
+--                   "A worker sees only their OWN hours" is enforced one layer
+--                   up — the recorded-hours query filters user_id = the caller
+--                   — so that admins / crew_leads can be granted broader
+--                   visibility later (parent epic #699) without a policy
+--                   rewrite. The granular `track_time` permission that gates
+--                   clock-in lives in our own tables, not the JWT, so RLS
+--                   cannot see it; the Route Handlers enforce it.
+--
+-- Append-only audit:  time_session_events carries SELECT + INSERT policies and
+--                   nothing else. With RLS enabled and no UPDATE / DELETE
+--                   policy, those commands are denied — the trail can only grow
+--                   (the same enforcement contract_events relies on).
+--
+-- Atomic transitions:  clock_in_to_job() and clock_out_session() wrap the
+--                   session write and its audit event in one statement each so
+--                   a partial failure can't leave a session without its event
+--                   (mirrors the contracts RPCs in migration-build33). The app
+--                   decides WHICH transition to run (session-lifecycle.ts); the
+--                   RPC just performs the decided writes atomically, including
+--                   auto-closing a prior session on a Job switch.
+--
+-- Depends on: schema.sql (organizations, user_organizations,
+--             nookleus.active_organization_id(), update_updated_at()), jobs,
+--             auth.users.
+--
+-- Smoke test: supabase/migration-660-smoke-test.sql.
+--
+-- Revert:    see -- ROLLBACK --- block at the bottom.
+
+-- ---------------------------------------------------------------------------
+-- 1. time_sessions — one stretch On the clock for a Job.
+-- ---------------------------------------------------------------------------
+create table if not exists public.time_sessions (
+  id                  uuid primary key default gen_random_uuid(),
+  organization_id     uuid not null references public.organizations(id) on delete restrict,
+  job_id              uuid not null references public.jobs(id) on delete cascade,
+  -- The worker: an app User (user_id) XOR an off-app name. RESTRICT on user_id
+  -- so a User who has recorded hours can't be hard-deleted out from under the
+  -- payroll record (same call as referral_partner_calls.user_id).
+  user_id             uuid references auth.users(id) on delete restrict,
+  off_app_worker_name text,
+  started_at          timestamptz not null default now(),
+  -- NULL → Open (worker is clocked in). A non-NULL ended_at must be strictly
+  -- after started_at — the database backstop for validateSpan() in
+  -- session-lifecycle.ts (no zero-length or negative sessions).
+  ended_at            timestamptz,
+  capture_method      text not null
+                        check (capture_method in ('live', 'hand')),
+  created_by          uuid references auth.users(id) on delete set null,
+  created_at          timestamptz not null default now(),
+  updated_at          timestamptz not null default now(),
+  deleted_at          timestamptz,
+  constraint chk_time_sessions_worker_xor check (
+    (user_id is not null and off_app_worker_name is null)
+    or (user_id is null and off_app_worker_name is not null)
+  ),
+  constraint chk_time_sessions_ended_after_started check (
+    ended_at is null or ended_at > started_at
+  )
+);
+
+-- Org-scoped list + soft-delete filter (Job detail Time tab, recorded-hours).
+create index if not exists idx_time_sessions_org
+  on public.time_sessions (organization_id, deleted_at);
+
+-- Sessions for one Job, newest first (Job detail Time tab).
+create index if not exists idx_time_sessions_job
+  on public.time_sessions (job_id, started_at desc)
+  where deleted_at is null;
+
+-- A worker's own sessions, newest first (own recorded-hours, recently-clocked
+-- ranking in the active-Job picker).
+create index if not exists idx_time_sessions_user_recent
+  on public.time_sessions (organization_id, user_id, started_at desc)
+  where deleted_at is null and user_id is not null;
+
+-- The invariant: at most one Open session per app User, org-wide. Off-app rows
+-- (user_id IS NULL) are exempt — they are hand-entered, not live.
+create unique index if not exists uniq_time_sessions_one_open_per_user
+  on public.time_sessions (organization_id, user_id)
+  where ended_at is null and deleted_at is null and user_id is not null;
+
+create trigger trg_time_sessions_updated_at
+  before update on public.time_sessions
+  for each row execute function update_updated_at();
+
+alter table public.time_sessions enable row level security;
+
+-- Org-isolation backstop. Own-hours filtering + track_time gating are
+-- app-layer (see header).
+create policy tenant_isolation_time_sessions
+  on public.time_sessions for all to authenticated
+  using (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = time_sessions.organization_id
+    )
+  )
+  with check (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = time_sessions.organization_id
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 2. time_session_events — append-only audit trail.
+-- ---------------------------------------------------------------------------
+create table if not exists public.time_session_events (
+  id                uuid primary key default gen_random_uuid(),
+  organization_id   uuid not null references public.organizations(id) on delete restrict,
+  time_session_id   uuid not null references public.time_sessions(id) on delete cascade,
+  event_type        text not null
+                      check (event_type in (
+                        'created',
+                        'clocked_out',
+                        'corrected',
+                        'deleted',
+                        'off_app_added'
+                      )),
+  -- Who performed the action. SET NULL so the trail survives the actor's
+  -- account being removed.
+  actor             uuid references auth.users(id) on delete set null,
+  -- Every event records the field it set as { field, old, new }: a 'created'
+  -- carries the started_at it set (old null), a 'clocked_out' the ended_at it
+  -- set (old null), a 'corrected' the before/after of the edited field.
+  metadata          jsonb,
+  created_at        timestamptz not null default now()
+);
+
+create index if not exists idx_time_session_events_session
+  on public.time_session_events (time_session_id, created_at desc);
+
+create index if not exists idx_time_session_events_org
+  on public.time_session_events (organization_id);
+
+alter table public.time_session_events enable row level security;
+
+-- Append-only: SELECT + INSERT only. No UPDATE / DELETE policy, so with RLS on
+-- those commands are denied and the trail can only grow.
+create policy tenant_isolation_time_session_events_select
+  on public.time_session_events for select to authenticated
+  using (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = time_session_events.organization_id
+    )
+  );
+
+create policy tenant_isolation_time_session_events_insert
+  on public.time_session_events for insert to authenticated
+  with check (
+    organization_id is not null
+    and organization_id = nookleus.active_organization_id()
+    and exists (
+      select 1 from public.user_organizations uo
+       where uo.user_id = auth.uid()
+         and uo.organization_id = time_session_events.organization_id
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- 3. RPCs — atomic clock-in / clock-out. SECURITY INVOKER (the default) so
+--    they run under the caller's RLS. The app pre-computes the decision
+--    (session-lifecycle.ts) and the new session id; the RPC performs the
+--    decided writes plus their audit events in one statement.
+-- ---------------------------------------------------------------------------
+
+-- Opens a session for p_job_id and logs 'created'. When p_close_session_id is
+-- supplied (a Job switch), the prior Open session is closed at p_close_ended_at
+-- and logged 'clocked_out' first — all in one transaction so the one-open
+-- index never sees two Open rows for the worker.
+create or replace function clock_in_to_job(
+  p_session_id        uuid,
+  p_organization_id   uuid,
+  p_job_id            uuid,
+  p_user_id           uuid,
+  p_started_at        timestamptz,
+  p_actor             uuid,
+  p_close_session_id  uuid default null,
+  p_close_ended_at    timestamptz default null
+) returns uuid as $$
+begin
+  if p_close_session_id is not null then
+    update public.time_sessions
+       set ended_at = p_close_ended_at
+     where id = p_close_session_id and ended_at is null;
+    if found then
+      insert into public.time_session_events
+        (organization_id, time_session_id, event_type, actor, metadata)
+        values (p_organization_id, p_close_session_id, 'clocked_out', p_actor,
+                jsonb_build_object('field', 'ended_at', 'old', null, 'new', p_close_ended_at));
+    end if;
+  end if;
+
+  insert into public.time_sessions
+    (id, organization_id, job_id, user_id, started_at, capture_method, created_by)
+    values
+    (p_session_id, p_organization_id, p_job_id, p_user_id, p_started_at, 'live', p_actor);
+
+  insert into public.time_session_events
+    (organization_id, time_session_id, event_type, actor, metadata)
+    values (p_organization_id, p_session_id, 'created', p_actor,
+            jsonb_build_object('field', 'started_at', 'old', null, 'new', p_started_at));
+
+  return p_session_id;
+end;
+$$ language plpgsql;
+
+-- Closes an Open session at p_ended_at and logs 'clocked_out'. Raises if the
+-- session isn't Open (already closed or unknown) so a double clock-out is a
+-- loud no-op rather than a silent second event.
+create or replace function clock_out_session(
+  p_session_id      uuid,
+  p_organization_id uuid,
+  p_ended_at        timestamptz,
+  p_actor           uuid
+) returns void as $$
+begin
+  update public.time_sessions
+     set ended_at = p_ended_at
+   where id = p_session_id and ended_at is null;
+  if not found then
+    raise exception 'time session % is not open', p_session_id;
+  end if;
+
+  insert into public.time_session_events
+    (organization_id, time_session_id, event_type, actor, metadata)
+    values (p_organization_id, p_session_id, 'clocked_out', p_actor,
+            jsonb_build_object('field', 'ended_at', 'old', null, 'new', p_ended_at));
+end;
+$$ language plpgsql;
+
+-- ROLLBACK ---
+-- drop function if exists clock_out_session(uuid, uuid, timestamptz, uuid);
+-- drop function if exists clock_in_to_job(uuid, uuid, uuid, uuid, timestamptz, uuid, uuid, timestamptz);
+-- drop policy if exists tenant_isolation_time_session_events_insert on public.time_session_events;
+-- drop policy if exists tenant_isolation_time_session_events_select on public.time_session_events;
+-- drop table if exists public.time_session_events;
+-- drop policy if exists tenant_isolation_time_sessions on public.time_sessions;
+-- drop trigger if exists trg_time_sessions_updated_at on public.time_sessions;
+-- drop index if exists public.uniq_time_sessions_one_open_per_user;
+-- drop index if exists public.idx_time_sessions_user_recent;
+-- drop index if exists public.idx_time_sessions_job;
+-- drop index if exists public.idx_time_sessions_org;
+-- drop table if exists public.time_sessions;

--- a/supabase/migration-661-smoke-test.sql
+++ b/supabase/migration-661-smoke-test.sql
@@ -1,17 +1,17 @@
 -- issue #701 (parent epic #699) — Time sessions foundation smoke test.
 --
--- Purpose:   Self-checking script that verifies migration-660's schema
+-- Purpose:   Self-checking script that verifies migration-661's schema
 --            invariants and the clock-in / clock-out RPCs. NOT part of the
 --            migration. Wrapped in begin; ... rollback; so the database is
 --            unchanged on a clean run. Every assertion raises on failure; a
 --            clean run prints only NOTICE lines.
 --
--- Preconditions: migration-660 has been applied. Sections that need a real
+-- Preconditions: migration-661 has been applied. Sections that need a real
 --            worker (the worker-XOR "both" case, the one-open-per-user index,
 --            and the RPCs) pick any existing auth.users row and skip
 --            themselves if the database has no users.
 --
--- Run:       psql -f supabase/migration-660-smoke-test.sql
+-- Run:       psql -f supabase/migration-661-smoke-test.sql
 --            (or paste into the Supabase SQL editor).
 --
 -- What it pins:
@@ -72,9 +72,9 @@ begin
   ) m;
 
   if v_missing is not null then
-    raise exception 'migration-660 smoke: missing column(s): %', v_missing;
+    raise exception 'migration-661 smoke: missing column(s): %', v_missing;
   end if;
-  raise notice 'migration-660 smoke: tables + columns present';
+  raise notice 'migration-661 smoke: tables + columns present';
 end $$;
 
 -- ---------------------------------------------------------------------------
@@ -102,25 +102,25 @@ begin
   -- Tenant scaffolding: org → contact → job. An explicit job_number keeps the
   -- set_job_number trigger from touching the per-org counter table.
   insert into public.organizations (id, name, slug)
-    values (v_org_id, 'm660 smoke', 'm660-smoke-' || replace(v_org_id::text, '-', ''));
+    values (v_org_id, 'm661 smoke', 'm661-smoke-' || replace(v_org_id::text, '-', ''));
   insert into public.contacts (id, organization_id, full_name, role)
     values (v_contact_id, v_org_id, 'Homeowner A', 'homeowner');
   insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
-    values (v_org_id, v_contact_id, 'water', '1 Maple St', 'SMOKE-660')
+    values (v_org_id, v_contact_id, 'water', '1 Maple St', 'SMOKE-661')
     returning id into v_job_id;
 
   -- ----- 2a. capture_method check (off-app worker so no real user needed) ---
   begin
     insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
       values (v_org_id, v_job_id, 'Day Laborer', 'gps');
-    raise exception 'm660 smoke: capture_method accepted invalid value "gps"';
+    raise exception 'm661 smoke: capture_method accepted invalid value "gps"';
   exception when check_violation then null;
   end;
 
   insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method)
     values (v_org_id, v_job_id, 'Day Laborer', 'live'), (v_org_id, v_job_id, 'Day Laborer', 'hand');
   delete from public.time_sessions where organization_id = v_org_id;
-  raise notice 'm660 smoke: capture_method — accepts live/hand, rejects "gps"';
+  raise notice 'm661 smoke: capture_method — accepts live/hand, rejects "gps"';
 
   -- ----- 2b. Worker XOR -----
   -- off-app only: OK
@@ -130,7 +130,7 @@ begin
   begin
     insert into public.time_sessions (organization_id, job_id, capture_method)
       values (v_org_id, v_job_id, 'hand');
-    raise exception 'm660 smoke: worker XOR accepted a row with NEITHER user_id nor off_app_worker_name';
+    raise exception 'm661 smoke: worker XOR accepted a row with NEITHER user_id nor off_app_worker_name';
   exception when check_violation then null;
   end;
 
@@ -142,12 +142,12 @@ begin
     begin
       insert into public.time_sessions (organization_id, job_id, user_id, off_app_worker_name, capture_method)
         values (v_org_id, v_job_id, v_user_id, 'Both', 'live');
-      raise exception 'm660 smoke: worker XOR accepted a row with BOTH user_id and off_app_worker_name';
+      raise exception 'm661 smoke: worker XOR accepted a row with BOTH user_id and off_app_worker_name';
     exception when check_violation then null;
     end;
-    raise notice 'm660 smoke: worker XOR — user-only OK, off-app-only OK, both rejected, neither rejected';
+    raise notice 'm661 smoke: worker XOR — user-only OK, off-app-only OK, both rejected, neither rejected';
   else
-    raise notice 'm660 smoke: worker XOR — off-app-only OK, neither rejected (user-only / both skipped: no auth.users row)';
+    raise notice 'm661 smoke: worker XOR — off-app-only OK, neither rejected (user-only / both skipped: no auth.users row)';
   end if;
   delete from public.time_sessions where organization_id = v_org_id;
 
@@ -155,13 +155,13 @@ begin
   begin  -- zero-length
     insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
       values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T12:00:00Z', '2026-06-19T12:00:00Z');
-    raise exception 'm660 smoke: ended_at check accepted a zero-length span';
+    raise exception 'm661 smoke: ended_at check accepted a zero-length span';
   exception when check_violation then null;
   end;
   begin  -- negative
     insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
       values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T13:00:00Z', '2026-06-19T12:00:00Z');
-    raise exception 'm660 smoke: ended_at check accepted a negative span';
+    raise exception 'm661 smoke: ended_at check accepted a negative span';
   exception when check_violation then null;
   end;
   insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at, ended_at)
@@ -169,7 +169,7 @@ begin
   insert into public.time_sessions (organization_id, job_id, off_app_worker_name, capture_method, started_at)
     values (v_org_id, v_job_id, 'Span', 'hand', '2026-06-19T12:00:00Z'); -- Open (NULL) OK
   delete from public.time_sessions where organization_id = v_org_id;
-  raise notice 'm660 smoke: ended_at — rejects zero-length and negative, accepts positive and Open(NULL)';
+  raise notice 'm661 smoke: ended_at — rejects zero-length and negative, accepts positive and Open(NULL)';
 
   -- ----- 2d. event_type check (needs a session for the FK) -----
   insert into public.time_sessions (id, organization_id, job_id, off_app_worker_name, capture_method)
@@ -178,7 +178,7 @@ begin
   begin
     insert into public.time_session_events (organization_id, time_session_id, event_type)
       values (v_org_id, v_sess, 'bogus');
-    raise exception 'm660 smoke: event_type accepted invalid value "bogus"';
+    raise exception 'm661 smoke: event_type accepted invalid value "bogus"';
   exception when check_violation then null;
   end;
   insert into public.time_session_events (organization_id, time_session_id, event_type)
@@ -189,7 +189,7 @@ begin
       (v_org_id, v_sess, 'deleted'),
       (v_org_id, v_sess, 'off_app_added');
   delete from public.time_sessions where organization_id = v_org_id;  -- cascades events
-  raise notice 'm660 smoke: event_type — accepts all 5 values, rejects "bogus"';
+  raise notice 'm661 smoke: event_type — accepts all 5 values, rejects "bogus"';
 
   -- ----- 2e. One Open session per app User; off-app exempt -----
   -- Off-app: two Open rows allowed (user_id NULL excluded from the index).
@@ -198,7 +198,7 @@ begin
   select count(*) into v_count from public.time_sessions
     where organization_id = v_org_id and ended_at is null;
   if v_count <> 2 then
-    raise exception 'm660 smoke: expected 2 Open off-app sessions, found %', v_count;
+    raise exception 'm661 smoke: expected 2 Open off-app sessions, found %', v_count;
   end if;
   delete from public.time_sessions where organization_id = v_org_id;
 
@@ -208,7 +208,7 @@ begin
     begin  -- a second Open session for the same User must violate the index
       insert into public.time_sessions (organization_id, job_id, user_id, capture_method)
         values (v_org_id, v_job_id, v_user_id, 'live');
-      raise exception 'm660 smoke: one-open-per-user index allowed a SECOND Open session';
+      raise exception 'm661 smoke: one-open-per-user index allowed a SECOND Open session';
     exception when unique_violation then null;
     end;
     -- Closing the first frees the slot for a new Open session. ended_at must be
@@ -219,9 +219,9 @@ begin
     insert into public.time_sessions (organization_id, job_id, user_id, capture_method)
       values (v_org_id, v_job_id, v_user_id, 'live');
     delete from public.time_sessions where organization_id = v_org_id;
-    raise notice 'm660 smoke: one-open-per-user — second Open rejected, allowed again after close';
+    raise notice 'm661 smoke: one-open-per-user — second Open rejected, allowed again after close';
   else
-    raise notice 'm660 smoke: one-open-per-user (app User) skipped — no auth.users row; off-app exemption verified';
+    raise notice 'm661 smoke: one-open-per-user (app User) skipped — no auth.users row; off-app exemption verified';
   end if;
 
   -- ----- 2f. RPCs: clock_in_to_job / clock_out_session / switch -----
@@ -232,15 +232,15 @@ begin
     select ended_at, capture_method into v_ended, v_method
       from public.time_sessions where id = v_sess_a;
     if v_ended is not null then
-      raise exception 'm660 smoke: clock_in_to_job left the session closed (ended_at set)';
+      raise exception 'm661 smoke: clock_in_to_job left the session closed (ended_at set)';
     end if;
     if v_method <> 'live' then
-      raise exception 'm660 smoke: clock_in_to_job recorded capture_method % (expected live)', v_method;
+      raise exception 'm661 smoke: clock_in_to_job recorded capture_method % (expected live)', v_method;
     end if;
     select count(*) into v_count from public.time_session_events
       where time_session_id = v_sess_a and event_type = 'created';
     if v_count <> 1 then
-      raise exception 'm660 smoke: clock_in_to_job wrote % "created" events (expected 1)', v_count;
+      raise exception 'm661 smoke: clock_in_to_job wrote % "created" events (expected 1)', v_count;
     end if;
     -- The 'created' event carries {field:'started_at', old:null, new:<started_at>}.
     select metadata into v_meta from public.time_session_events
@@ -248,18 +248,18 @@ begin
     if v_meta->>'field' is distinct from 'started_at'
        or v_meta->'old' is distinct from 'null'::jsonb
        or (v_meta->>'new')::timestamptz is distinct from '2026-06-19T12:00:00Z'::timestamptz then
-      raise exception 'm660 smoke: "created" event metadata is not {field:started_at, old:null, new:<started_at>}: %', v_meta;
+      raise exception 'm661 smoke: "created" event metadata is not {field:started_at, old:null, new:<started_at>}: %', v_meta;
     end if;
 
     perform clock_out_session(v_sess_a, v_org_id, '2026-06-19T15:00:00Z'::timestamptz, v_user_id);
     select ended_at into v_ended from public.time_sessions where id = v_sess_a;
     if v_ended is distinct from '2026-06-19T15:00:00Z'::timestamptz then
-      raise exception 'm660 smoke: clock_out_session did not set ended_at (got %)', v_ended;
+      raise exception 'm661 smoke: clock_out_session did not set ended_at (got %)', v_ended;
     end if;
     select count(*) into v_count from public.time_session_events
       where time_session_id = v_sess_a and event_type = 'clocked_out';
     if v_count <> 1 then
-      raise exception 'm660 smoke: clock_out_session wrote % "clocked_out" events (expected 1)', v_count;
+      raise exception 'm661 smoke: clock_out_session wrote % "clocked_out" events (expected 1)', v_count;
     end if;
     -- The 'clocked_out' event carries {field:'ended_at', old:null, new:<ended_at>}.
     select metadata into v_meta from public.time_session_events
@@ -267,12 +267,12 @@ begin
     if v_meta->>'field' is distinct from 'ended_at'
        or v_meta->'old' is distinct from 'null'::jsonb
        or (v_meta->>'new')::timestamptz is distinct from '2026-06-19T15:00:00Z'::timestamptz then
-      raise exception 'm660 smoke: "clocked_out" event metadata is not {field:ended_at, old:null, new:<ended_at>}: %', v_meta;
+      raise exception 'm661 smoke: "clocked_out" event metadata is not {field:ended_at, old:null, new:<ended_at>}: %', v_meta;
     end if;
 
     begin  -- double clock-out must raise (session no longer Open)
       perform clock_out_session(v_sess_a, v_org_id, '2026-06-19T16:00:00Z'::timestamptz, v_user_id);
-      raise exception 'm660 smoke: a double clock-out did NOT raise';
+      raise exception 'm661 smoke: a double clock-out did NOT raise';
     exception
       when raise_exception then null;  -- expected
     end;
@@ -289,25 +289,25 @@ begin
 
     select ended_at into v_ended from public.time_sessions where id = v_sess_a;
     if v_ended is distinct from '2026-06-19T14:00:00Z'::timestamptz then
-      raise exception 'm660 smoke: switch did not auto-close the prior session (ended_at %)', v_ended;
+      raise exception 'm661 smoke: switch did not auto-close the prior session (ended_at %)', v_ended;
     end if;
     select ended_at into v_ended from public.time_sessions where id = v_sess_b;
     if v_ended is not null then
-      raise exception 'm660 smoke: switch left the new session closed';
+      raise exception 'm661 smoke: switch left the new session closed';
     end if;
     select count(*) into v_count from public.time_session_events
       where time_session_id = v_sess_a and event_type = 'clocked_out';
     if v_count <> 1 then
-      raise exception 'm660 smoke: switch wrote % "clocked_out" events on prior session (expected 1)', v_count;
+      raise exception 'm661 smoke: switch wrote % "clocked_out" events on prior session (expected 1)', v_count;
     end if;
     select count(*) into v_count from public.time_session_events
       where time_session_id = v_sess_b and event_type = 'created';
     if v_count <> 1 then
-      raise exception 'm660 smoke: switch wrote % "created" events on new session (expected 1)', v_count;
+      raise exception 'm661 smoke: switch wrote % "created" events on new session (expected 1)', v_count;
     end if;
-    raise notice 'm660 smoke: RPCs — clock-in opens + logs created, clock-out closes + logs clocked_out, switch auto-closes prior, double clock-out raises';
+    raise notice 'm661 smoke: RPCs — clock-in opens + logs created, clock-out closes + logs clocked_out, switch auto-closes prior, double clock-out raises';
   else
-    raise notice 'm660 smoke: RPC checks skipped — no auth.users row available';
+    raise notice 'm661 smoke: RPC checks skipped — no auth.users row available';
   end if;
 end $$;
 
@@ -323,7 +323,7 @@ begin
   select relrowsecurity into v_rls_on
     from pg_class where oid = 'public.time_session_events'::regclass;
   if not coalesce(v_rls_on, false) then
-    raise exception 'm660 smoke: RLS is not enabled on time_session_events';
+    raise exception 'm661 smoke: RLS is not enabled on time_session_events';
   end if;
 
   -- polcmd 'w' = UPDATE, 'd' = DELETE, '*' = ALL. Any of these breaks append-only.
@@ -336,9 +336,9 @@ begin
     and p.polcmd in ('w', 'd', '*');
 
   if v_write_pols is not null then
-    raise exception 'm660 smoke: time_session_events is not append-only — found mutating policy(ies): %', v_write_pols;
+    raise exception 'm661 smoke: time_session_events is not append-only — found mutating policy(ies): %', v_write_pols;
   end if;
-  raise notice 'm660 smoke: time_session_events is append-only (RLS on; no UPDATE/DELETE/ALL policy)';
+  raise notice 'm661 smoke: time_session_events is append-only (RLS on; no UPDATE/DELETE/ALL policy)';
 end $$;
 
 -- ---------------------------------------------------------------------------
@@ -356,9 +356,9 @@ begin
     and pg_get_expr(p.polqual, p.polrelid) ilike '%active_organization_id%';
 
   if v_policy is null then
-    raise exception 'm660 smoke: time_sessions has no org-isolation RLS policy';
+    raise exception 'm661 smoke: time_sessions has no org-isolation RLS policy';
   end if;
-  raise notice 'm660 smoke: time_sessions org-isolation policy present (%)', v_policy;
+  raise notice 'm661 smoke: time_sessions org-isolation policy present (%)', v_policy;
 end $$;
 
 -- ---------------------------------------------------------------------------
@@ -376,12 +376,12 @@ declare
   v_blocked   boolean := false;
 begin
   insert into public.organizations (id, name, slug) values
-    (v_org_a, 'm660 rls A', 'm660-rls-a-' || replace(v_org_a::text, '-', '')),
-    (v_org_b, 'm660 rls B', 'm660-rls-b-' || replace(v_org_b::text, '-', ''));
+    (v_org_a, 'm661 rls A', 'm661-rls-a-' || replace(v_org_a::text, '-', '')),
+    (v_org_b, 'm661 rls B', 'm661-rls-b-' || replace(v_org_b::text, '-', ''));
   insert into public.contacts (id, organization_id, full_name, role)
     values (v_contact_a, v_org_a, 'RLS A', 'homeowner');
   insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
-    values (v_org_a, v_contact_a, 'water', '1 RLS St', 'SMOKE-660-RLS-A')
+    values (v_org_a, v_contact_a, 'water', '1 RLS St', 'SMOKE-661-RLS-A')
     returning id into v_job_a;
 
   set local role authenticated;
@@ -395,9 +395,9 @@ begin
   reset role;
 
   if not v_blocked then
-    raise exception 'm660 smoke: cross-org INSERT into another Organization was NOT denied';
+    raise exception 'm661 smoke: cross-org INSERT into another Organization was NOT denied';
   end if;
-  raise notice 'm660 smoke: RLS — cross-org INSERT denied';
+  raise notice 'm661 smoke: RLS — cross-org INSERT denied';
 end $$;
 
 -- ---------------------------------------------------------------------------
@@ -424,20 +424,20 @@ declare
 begin
   select id into v_user from auth.users limit 1;
   if v_user is null then
-    raise notice 'm660 smoke: RLS own-org visibility skipped — no auth.users row';
+    raise notice 'm661 smoke: RLS own-org visibility skipped — no auth.users row';
     return;
   end if;
 
   insert into public.organizations (id, name, slug) values
-    (v_org_a, 'm660 vis A', 'm660-vis-a-' || replace(v_org_a::text, '-', '')),
-    (v_org_b, 'm660 vis B', 'm660-vis-b-' || replace(v_org_b::text, '-', ''));
+    (v_org_a, 'm661 vis A', 'm661-vis-a-' || replace(v_org_a::text, '-', '')),
+    (v_org_b, 'm661 vis B', 'm661-vis-b-' || replace(v_org_b::text, '-', ''));
   insert into public.contacts (id, organization_id, full_name, role) values
     (v_contact_a, v_org_a, 'Vis A', 'homeowner'),
     (v_contact_b, v_org_b, 'Vis B', 'homeowner');
   insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
-    values (v_org_a, v_contact_a, 'water', '1 Vis St', 'SMOKE-660-VIS-A') returning id into v_job_a;
+    values (v_org_a, v_contact_a, 'water', '1 Vis St', 'SMOKE-661-VIS-A') returning id into v_job_a;
   insert into public.jobs (organization_id, contact_id, damage_type, property_address, job_number)
-    values (v_org_b, v_contact_b, 'water', '2 Vis St', 'SMOKE-660-VIS-B') returning id into v_job_b;
+    values (v_org_b, v_contact_b, 'water', '2 Vis St', 'SMOKE-661-VIS-B') returning id into v_job_b;
 
   -- The caller is a member of org A only.
   insert into public.user_organizations (user_id, organization_id, role)
@@ -464,12 +464,12 @@ begin
   reset role;
 
   if v_count <> 1 or v_orgs is distinct from array[v_org_a] then
-    raise exception 'm660 smoke: RLS own-org visibility — org-A caller saw % time_sessions (orgs=%); expected only org A''s 1', v_count, v_orgs;
+    raise exception 'm661 smoke: RLS own-org visibility — org-A caller saw % time_sessions (orgs=%); expected only org A''s 1', v_count, v_orgs;
   end if;
   if v_evt_count <> 1 then
-    raise exception 'm660 smoke: RLS own-org visibility — org-A caller saw % time_session_events; expected only org A''s 1', v_evt_count;
+    raise exception 'm661 smoke: RLS own-org visibility — org-A caller saw % time_session_events; expected only org A''s 1', v_evt_count;
   end if;
-  raise notice 'm660 smoke: RLS — caller sees only own-org time_sessions + time_session_events';
+  raise notice 'm661 smoke: RLS — caller sees only own-org time_sessions + time_session_events';
 end $$;
 
 rollback;

--- a/supabase/migration-661-time-sessions.sql
+++ b/supabase/migration-661-time-sessions.sql
@@ -54,7 +54,7 @@
 --             nookleus.active_organization_id(), update_updated_at()), jobs,
 --             auth.users.
 --
--- Smoke test: supabase/migration-660-smoke-test.sql.
+-- Smoke test: supabase/migration-661-smoke-test.sql.
 --
 -- Revert:    see -- ROLLBACK --- block at the bottom.
 

--- a/supabase/migration-661-track-time-permission.sql
+++ b/supabase/migration-661-track-time-permission.sql
@@ -1,0 +1,191 @@
+-- migration-661-track-time-permission.sql
+--
+-- issue #701 (parent epic #699) — per-Job timesheets: clock in / out of a Job.
+--
+-- Adds the `track_time` permission key to existing memberships across every
+-- Organization, with role-based defaults pinned by `role-defaults.test.ts`
+-- against #701 § Permission:
+--
+--   | Role        | Default |
+--   | ----------- | ------- |
+--   | Admin       | ON      |
+--   | Crew Lead   | ON      |
+--   | Crew Member | ON      |   <- unlike view_phone: workers clock themselves in
+--   | Custom      | OFF     |
+--   | (other)     | OFF     |
+--
+-- Two stages, mirroring migration-306 (view_phone):
+--
+--   1. Rewrite `set_default_permissions(uuid, text)` so memberships seeded by
+--      a future re-run include `track_time` per the role defaults. The
+--      function writes to both `user_organization_permissions` (source of
+--      truth) and `user_permissions` (legacy table kept in sync during 18a).
+--   2. Backfill: insert a (membership, 'track_time', granted) row for every
+--      existing `user_organizations` row, where `granted` follows the role
+--      defaults. Idempotent — `do nothing` on conflict respects manual toggles.
+--
+-- WHY an explicit crew_member branch (the one structural change vs. 306):
+--   view_phone was OFF for BOTH crew_member and custom, so it could sit out of
+--   `member_perms` and let the shared `else` branch (which serves crew_member,
+--   custom, and any other role) cover both. track_time DIVERGES: crew_member
+--   is ON but custom is OFF. So we split crew_member into its own branch
+--   (member_perms + track_time) and leave the `else` branch's grants exactly as
+--   they were — custom and any unknown role keep their prior keys and never
+--   pick up track_time. No existing key's grant changes for any role.
+--
+-- Note: `set_default_permissions` has no live trigger; the app seeds new
+--   members directly from the TS `ROLE_DEFAULTS` table (POST /api/settings/
+--   users). This function is the database mirror, exercised only when a future
+--   migration re-runs the per-membership backfill loop (as build35/build67a
+--   did). Keeping it in sync here preserves that mirror for #701.
+--
+-- Depends on migration-306 (the current set_default_permissions body) and
+--   build48 (the (p_user_organization_id, p_role) signature).
+
+-- ---------------------------------------------------------------------------
+-- 1. Refresh set_default_permissions to include track_time. Added to
+--    all_perms (admin gets every key) and lead_perms; crew_member gets its own
+--    branch = member_perms + track_time. member_perms (the `else` branch:
+--    custom and any other role) is unchanged, so custom stays OFF.
+-- ---------------------------------------------------------------------------
+create or replace function public.set_default_permissions(p_user_organization_id uuid, p_role text)
+returns void
+language plpgsql
+as $$
+declare
+  all_perms text[] := array[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'view_phone',
+    'track_time',
+    'manage_reports', 'access_settings',
+    'log_expenses', 'manage_vendors', 'manage_contract_templates', 'manage_expense_categories',
+    'view_accounting', 'manage_accounting'
+  ];
+  admin_perms text[] := all_perms;
+  lead_perms text[] := array[
+    'view_jobs', 'edit_jobs', 'create_jobs',
+    'log_activities', 'upload_photos', 'edit_photos',
+    'view_billing', 'record_payments',
+    'view_email', 'send_email',
+    'view_phone',
+    'track_time',
+    'manage_reports',
+    'log_expenses'
+  ];
+  -- The `else` branch (custom + any other role). Unchanged from migration-306 —
+  -- deliberately WITHOUT track_time, so custom stays OFF.
+  member_perms text[] := array[
+    'view_jobs', 'log_activities', 'upload_photos',
+    'log_expenses'
+  ];
+  -- Crew Member: the member baseline PLUS track_time (workers clock in/out
+  -- themselves — the whole point of the feature is the labor recording it).
+  crew_member_perms text[] := member_perms || array['track_time'];
+  granted_perms text[];
+  perm text;
+  v_user_id uuid;
+begin
+  select user_id into v_user_id from public.user_organizations where id = p_user_organization_id;
+  if v_user_id is null then
+    raise exception 'set_default_permissions: user_organization % not found', p_user_organization_id;
+  end if;
+
+  if p_role = 'admin' then
+    granted_perms := admin_perms;
+  elsif p_role = 'crew_lead' then
+    granted_perms := lead_perms;
+  elsif p_role = 'crew_member' then
+    granted_perms := crew_member_perms;
+  else
+    granted_perms := member_perms;
+  end if;
+
+  foreach perm in array all_perms loop
+    -- New source of truth
+    insert into public.user_organization_permissions (user_organization_id, permission_key, granted)
+    values (p_user_organization_id, perm, perm = any(granted_perms))
+    on conflict (user_organization_id, permission_key) do update set granted = excluded.granted;
+
+    -- Legacy table — kept in sync during 18a until the deprecation cleanup migration drops it.
+    insert into public.user_permissions (user_id, permission_key, granted)
+    values (v_user_id, perm, perm = any(granted_perms))
+    on conflict (user_id, permission_key) do update set granted = excluded.granted;
+  end loop;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Backfill: insert (membership, 'track_time', granted) for every existing
+--    user_organizations row. granted = ON for admin/crew_lead/crew_member,
+--    OFF for custom and any other role. DO NOTHING on conflict keeps the
+--    migration idempotent and never overwrites an existing manual toggle.
+-- ---------------------------------------------------------------------------
+insert into public.user_organization_permissions (user_organization_id, permission_key, granted)
+select uo.id,
+       'track_time',
+       case when uo.role in ('admin', 'crew_lead', 'crew_member') then true else false end
+  from public.user_organizations uo
+ on conflict (user_organization_id, permission_key) do nothing;
+
+-- Legacy user_permissions: one row per user. If a user holds memberships in
+-- multiple Organizations with different roles, the legacy row stores one truth
+-- — "any admin/crew_lead/crew_member membership grants it" — so the legacy row
+-- never under-reports a grant the new table has.
+insert into public.user_permissions (user_id, permission_key, granted)
+select uo.user_id,
+       'track_time',
+       bool_or(uo.role in ('admin', 'crew_lead', 'crew_member'))
+  from public.user_organizations uo
+ group by uo.user_id
+ on conflict (user_id, permission_key) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- 3. Safety assertion: every existing membership now has a track_time row.
+--    Aborts loudly rather than leaving a half-applied state. The grant-matches-
+--    role checks are soft (NOTICE) because pre-existing manual toggles are
+--    legitimate and the DO NOTHING above preserves them.
+-- ---------------------------------------------------------------------------
+do $$
+declare
+  v_unset_count int;
+  v_expected_on_off_count int;
+  v_unexpected_on_count int;
+begin
+  select count(*) into v_unset_count
+    from public.user_organizations uo
+    left join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'track_time'
+   where uop.id is null;
+
+  if v_unset_count <> 0 then
+    raise exception 'migration-661: % memberships missing track_time row after backfill', v_unset_count;
+  end if;
+
+  select count(*) into v_expected_on_off_count
+    from public.user_organizations uo
+    join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'track_time'
+   where uo.role in ('admin', 'crew_lead', 'crew_member')
+     and uop.granted = false;
+
+  if v_expected_on_off_count > 0 then
+    raise notice 'migration-661: % admin/crew_lead/crew_member memberships hold track_time OFF (likely pre-existing manual toggle, not aborted)', v_expected_on_off_count;
+  end if;
+
+  select count(*) into v_unexpected_on_count
+    from public.user_organizations uo
+    join public.user_organization_permissions uop
+      on uop.user_organization_id = uo.id
+     and uop.permission_key = 'track_time'
+   where uo.role not in ('admin', 'crew_lead', 'crew_member')
+     and uop.granted = true;
+
+  if v_unexpected_on_count > 0 then
+    raise notice 'migration-661: % custom/other memberships hold track_time ON (likely pre-existing manual toggle, not aborted)', v_unexpected_on_count;
+  end if;
+end $$;

--- a/supabase/migration-662-track-time-permission.sql
+++ b/supabase/migration-662-track-time-permission.sql
@@ -1,4 +1,4 @@
--- migration-661-track-time-permission.sql
+-- migration-662-track-time-permission.sql
 --
 -- issue #701 (parent epic #699) — per-Job timesheets: clock in / out of a Job.
 --
@@ -162,7 +162,7 @@ begin
    where uop.id is null;
 
   if v_unset_count <> 0 then
-    raise exception 'migration-661: % memberships missing track_time row after backfill', v_unset_count;
+    raise exception 'migration-662: % memberships missing track_time row after backfill', v_unset_count;
   end if;
 
   select count(*) into v_expected_on_off_count
@@ -174,7 +174,7 @@ begin
      and uop.granted = false;
 
   if v_expected_on_off_count > 0 then
-    raise notice 'migration-661: % admin/crew_lead/crew_member memberships hold track_time OFF (likely pre-existing manual toggle, not aborted)', v_expected_on_off_count;
+    raise notice 'migration-662: % admin/crew_lead/crew_member memberships hold track_time OFF (likely pre-existing manual toggle, not aborted)', v_expected_on_off_count;
   end if;
 
   select count(*) into v_unexpected_on_count
@@ -186,6 +186,6 @@ begin
      and uop.granted = true;
 
   if v_unexpected_on_count > 0 then
-    raise notice 'migration-661: % custom/other memberships hold track_time ON (likely pre-existing manual toggle, not aborted)', v_unexpected_on_count;
+    raise notice 'migration-662: % custom/other memberships hold track_time ON (likely pre-existing manual toggle, not aborted)', v_unexpected_on_count;
   end if;
 end $$;


### PR DESCRIPTION
## What this does

Foundation tracer bullet for per-Job timesheets (parent epic #699). A crew member can **Clock in** to an active Job, **Clock out**, **switch Jobs** (auto-closing the prior session), and review **only their own** recorded hours. Built with rigid TDD (pure modules → server → UI), reading `node_modules/next/dist/docs/` before touching any route/server/page/component code.

## Acceptance criteria

- [x] **Clock in from both entry points → Open session; clock out closes it; appears in own hours.** Global `HomeClockControl` and `JobTimeTab` (`?tab=time` on Job detail). `POST /api/time/clock-in` opens a session (`ended_at NULL`); `POST /api/time/clock-out` sets `ended_at`; `GET /api/time/sessions?jobId=` lists the caller's own hours.
- [x] **Picker filters by address/customer/Job number, recently-clocked first; full-screen confirmation names the Job.** `ClockInPicker` over `GET /api/time/clockable-jobs` (active Jobs + recently-clocked ids); `rankPickerJobs` does filter+rank; `ClockInConfirmation` is a loud full-screen overlay naming the Job before the session starts.
- [x] **Persistent app-wide status bar: current Job, live elapsed, one-tap Clock out.** `OnTheClockBar` + `OnTheClockProvider` mounted in `AppShell` (never on auth/public/fullscreen routes); `formatElapsed` ticks every 30s ("On Maple St · 2h 14m · Clock out").
- [x] **Clock into a second Job auto-closes the first + tells the worker; exactly one Open after.** `session-lifecycle.planClockIn` decides the close; `clock_in_to_job(..., p_close_session_id, ...)` closes prior + opens new atomically; `ClockInConfirmation` surfaces "Your previous session was clocked out."
- [x] **Smoke test asserts: 2nd-Open rejected; worker CHECK rejects both/neither; own-org-only visibility under RLS; cross-org INSERT denied.** `migration-661-smoke-test.sql` (partial unique index, worker XOR, RLS visibility, cross-org INSERT).
- [x] **Every clock-in writes `created`, every clock-out `clocked_out`, each with actor + `{field, old, new}` metadata; append-only.** RPCs write the events with metadata; `time_session_events` has SELECT+INSERT policies only (UPDATE/DELETE denied).
- [x] **session-lifecycle pure module, table-driven tests.** `session-lifecycle.test.ts`: one Open per worker, new clock-in closes prior, correction validation (clock-out strictly after; negative/zero-length/overlapping spans rejected).
- [x] **Pinned role-defaults test for `track_time`.** Registered in the catalog; defaults ON for admin/crew_lead/crew_member, OFF for `custom`; `role-defaults.test.ts` pins TS `ROLE_DEFAULTS` ↔ SQL `set_default_permissions` in sync (migration-662).
- [x] **Revoked `track_time` → can't clock in; worker sees only own hours.** All clock routes are `withRequestContext({ permission: "track_time" })`-gated (403 when revoked) and the UI hides the control when the grant is absent; `/api/time/sessions` filters `user_id = caller`.

## Design notes

- **No location (ADR 0019); UTC instants only (ADR 0020).** Org-isolation RLS (`tenant_isolation_*`) is the backstop; "own hours only" is enforced one layer up (the query filters `user_id`) so admins/crew_leads can be granted broader visibility in a later slice without a policy rewrite.
- **One Open session per app User** pinned by a partial unique index; off-app workers (`user_id NULL`) are exempt. The pure module keeps the app from ever asking the DB to break it; the index is the race backstop.
- **Atomic transitions:** `clock_in_to_job` / `clock_out_session` wrap the session write and its audit event in one statement each.

## Verification

- **Live prod dry-run (BEGIN/ROLLBACK, non-destructive):** ran the full migration-661 DDL + smoke test and migration-662 backfill against production inside a rolled-back transaction. All schema invariants, both RPCs (open/close/switch/double-clock-out), append-only enforcement, and RLS behavior (cross-org INSERT denied; own-org-only visibility under a simulated authenticated caller) **pass**; the 662 backfill validated against the 8 live memberships (all admin/crew_lead → `track_time` ON). Post-rollback checks confirmed **nothing persisted**.
  - The dry-run surfaced and fixed **two smoke-test defects** (test-only, not the migration): `now()` is transaction-stable so a close-then-reopen tripped `ended_at > started_at` (now `now() + interval '1 hour'`), and `polcmd` is the internal `"char"` type needing an explicit `::text` cast.
- **Unit tests:** 115 green across 14 files (pure modules, route handlers over the request-context fakes, status-bar view).
- **tsc:** clean on all touched files (the only 3 errors are the pre-existing `report-pdf-apple-jpeg.test.ts` known-red cluster).

> **Note:** migrations **661 + 662 have been applied to prod** (recorded as `migration_661_time_sessions` and `migration_662_track_time_permission`). Post-apply verification confirms: `time_sessions` + `time_session_events` exist with RLS enabled; both RPCs (`clock_in_to_job`, `clock_out_session`) present; `set_default_permissions` now includes `track_time`; the backfill landed a `track_time` row on all 8 live memberships (2 admin + 6 crew_lead → ON; legacy `user_permissions` holds 7 rows = one per distinct user). The numbers 661/662 reflect a renumber from 660/661 after `migration-660-device-tokens` (#671) concurrently claimed slot 660 on `main`.

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)
