### PR TITLE
feat(jobs): stage-grouped sections with headers + counts; "Open jobs" stat (#723)

### DIFF
--- a/src/app/jobs/page.tsx
+++ b/src/app/jobs/page.tsx
@@ -5,11 +5,13 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase";
 import { Job } from "@/lib/types";
 import JobCard from "@/components/job-card";
-import JobListRow, { JobListHeader } from "@/components/job-list-row";
+import JobListRow from "@/components/job-list-row";
 import JobComfortableRow from "@/components/job-comfortable-row";
 import JobsViewToggle from "@/components/jobs-view-toggle";
+import { JobStageSections } from "@/components/job-stage-sections";
 import { useJobsViewMode } from "@/lib/jobs/use-jobs-view-mode";
 import { loadJobsWithCover } from "@/lib/jobs/jobs-with-cover";
+import { buildJobSections, countOpenJobs } from "@/lib/jobs/build-job-sections";
 import { Briefcase, FileText, CalendarDays, Flame, RotateCcw, Trash2, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useConfig } from "@/lib/config-context";
@@ -63,7 +65,7 @@ export default function JobsPage() {
 
   // Compute stats from all active (non-trashed) jobs.
   const [stats, setStats] = useState({
-    active: 0,
+    open: 0,
     emergency: 0,
     pendingInvoice: 0,
     thisMonth: 0,
@@ -83,9 +85,7 @@ export default function JobsPage() {
       const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
       setStats({
-        active: allJobs.filter(
-          (j) => j.status !== "completed" && j.status !== "cancelled"
-        ).length,
+        open: countOpenJobs(allJobs),
         emergency: allJobs.filter(
           (j) =>
             j.urgency === "emergency" &&
@@ -103,16 +103,37 @@ export default function JobsPage() {
     fetchStats();
   }, []);
 
-  // Sort: emergencies first, then by date — except in trash, where the
-  // API has already sorted by deletion time (most recent first).
-  const sortedJobs =
-    filter === "trash"
-      ? jobs
-      : [...jobs].sort((a, b) => {
-          if (a.urgency === "emergency" && b.urgency !== "emergency") return -1;
-          if (b.urgency === "emergency" && a.urgency !== "emergency") return 1;
-          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
-        });
+  // Each stage section renders its Jobs in the page's current view-mode layout.
+  // (buildJobSections orders Jobs newest-first within a section; emergency
+  // pinning across sections is #726 and the hide-Closed/Lost toggle is #728 —
+  // both out of scope here.)
+  const renderJobsForMode = (sectionJobs: Job[]) => {
+    if (mode === "list") {
+      return (
+        <div className="space-y-2">
+          {sectionJobs.map((job) => (
+            <JobListRow key={job.id} job={job} />
+          ))}
+        </div>
+      );
+    }
+    if (mode === "comfortable") {
+      return (
+        <div className="space-y-2">
+          {sectionJobs.map((job) => (
+            <JobComfortableRow key={job.id} job={job} />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {sectionJobs.map((job) => (
+          <JobCard key={job.id} job={job} />
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className="max-w-6xl animate-fade-slide-up">
@@ -128,8 +149,8 @@ export default function JobsPage() {
       {/* Stat cards — gradient hero style */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
         <StatCard
-          label="Active Jobs"
-          value={stats.active}
+          label="Open jobs"
+          value={stats.open}
           icon={Briefcase}
           gradient="gradient-primary"
         />
@@ -184,7 +205,7 @@ export default function JobsPage() {
       {/* Job list */}
       {loading ? (
         <div className="text-center py-12 text-muted-foreground/60">Loading jobs...</div>
-      ) : sortedJobs.length === 0 ? (
+      ) : jobs.length === 0 ? (
         <div className="text-center py-12">
           <p className="text-muted-foreground text-lg">
             {filter === "trash" ? "Trash is empty" : "No jobs found"}
@@ -197,29 +218,15 @@ export default function JobsPage() {
         </div>
       ) : filter === "trash" ? (
         <div className="space-y-3">
-          {sortedJobs.map((job) => (
+          {jobs.map((job) => (
             <TrashRow key={job.id} job={job} onChange={fetchJobs} />
           ))}
         </div>
-      ) : mode === "list" ? (
-        <div className="space-y-2">
-          <JobListHeader />
-          {sortedJobs.map((job) => (
-            <JobListRow key={job.id} job={job} />
-          ))}
-        </div>
-      ) : mode === "comfortable" ? (
-        <div className="space-y-2">
-          {sortedJobs.map((job) => (
-            <JobComfortableRow key={job.id} job={job} />
-          ))}
-        </div>
       ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {sortedJobs.map((job) => (
-            <JobCard key={job.id} job={job} />
-          ))}
-        </div>
+        <JobStageSections
+          sections={buildJobSections(jobs)}
+          renderJobs={renderJobsForMode}
+        />
       )}
     </div>
   );

--- a/src/components/job-stage-sections.test.tsx
+++ b/src/components/job-stage-sections.test.tsx
@@ -1,0 +1,103 @@
+// Issue #723 — Jobs page stage-grouped sections (presentational component).
+//
+// <JobStageSections> renders the sections from buildJobSections as colored
+// stage headers carrying a count, delegating each section's Job rendering to a
+// `renderJobs` prop so grouping stays orthogonal to the page's view-mode
+// (grid / list / comfortable).
+
+import { describe, expect, it } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import type { Job } from "@/lib/types";
+import { buildJobSections } from "@/lib/jobs/build-job-sections";
+import { JobStageSections } from "./job-stage-sections";
+
+function makeJob(over: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "J-0001",
+    contact_id: "c-1",
+    status: "new",
+    urgency: "scheduled",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "1 Test St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    insurance_contact_id: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    created_at: "2026-05-27T10:00:00Z",
+    ...over,
+  } as Job;
+}
+
+describe("<JobStageSections>", () => {
+  it("renders a header per populated stage, in page order", () => {
+    const sections = buildJobSections([
+      makeJob({ id: "a", status: "in_progress" }),
+      makeJob({ id: "l", status: "new" }),
+      makeJob({ id: "c", status: "pending_invoice" }),
+    ]);
+
+    render(<JobStageSections sections={sections} renderJobs={() => null} />);
+
+    const headers = screen.getAllByRole("heading", { level: 2 });
+    expect(headers.map((h) => h.textContent)).toEqual([
+      expect.stringContaining("Active"),
+      expect.stringContaining("Lead"),
+      expect.stringContaining("Collections"),
+    ]);
+  });
+
+  it("shows each section's Job count in its header", () => {
+    const sections = buildJobSections([
+      makeJob({ id: "a1", status: "in_progress" }),
+      makeJob({ id: "a2", status: "in_progress" }),
+      makeJob({ id: "l1", status: "new" }),
+    ]);
+
+    render(<JobStageSections sections={sections} renderJobs={() => null} />);
+
+    expect(screen.getByTestId("section-in_progress-count").textContent).toBe(
+      "2",
+    );
+    expect(screen.getByTestId("section-new-count").textContent).toBe("1");
+  });
+
+  it("renders each section's Jobs under its own header via renderJobs", () => {
+    const sections = buildJobSections([
+      makeJob({ id: "active-1", status: "in_progress" }),
+      makeJob({ id: "lead-1", status: "new" }),
+    ]);
+
+    render(
+      <JobStageSections
+        sections={sections}
+        renderJobs={(jobs) => (
+          <ul>
+            {jobs.map((j) => (
+              <li key={j.id}>{j.id}</li>
+            ))}
+          </ul>
+        )}
+      />,
+    );
+
+    const activeSection = screen.getByTestId("section-in_progress");
+    expect(within(activeSection).getByText("active-1")).toBeTruthy();
+    expect(within(activeSection).queryByText("lead-1")).toBeNull();
+  });
+});

--- a/src/components/job-stage-sections.tsx
+++ b/src/components/job-stage-sections.tsx
@@ -1,0 +1,52 @@
+// Issue #723 — Jobs page stage-grouped sections (presentational component).
+//
+// Renders the sections from buildJobSections as colored stage headers carrying
+// a count, then delegates each section's Job rendering to the `renderJobs`
+// prop — so grouping stays orthogonal to the page's view-mode (grid / list /
+// comfortable) and this component stays free of data fetching.
+
+import type { ReactNode } from "react";
+import type { Job } from "@/lib/types";
+import type { JobSection } from "@/lib/jobs/build-job-sections";
+
+interface JobStageSectionsProps {
+  sections: JobSection[];
+  /** Renders a section's Jobs in the page's current view-mode layout. */
+  renderJobs: (jobs: Job[]) => ReactNode;
+}
+
+export function JobStageSections({
+  sections,
+  renderJobs,
+}: JobStageSectionsProps) {
+  return (
+    <div className="space-y-8">
+      {sections.map((section) => (
+        <section key={section.key} data-testid={`section-${section.key}`}>
+          <div
+            className="mb-3 flex items-center gap-2 border-b pb-2"
+            style={{ borderColor: `${section.presentation.accentColor}33` }}
+          >
+            <h2
+              className="text-sm font-bold uppercase tracking-wide"
+              style={{ color: section.presentation.accentColor }}
+            >
+              {section.presentation.label}
+            </h2>
+            <span
+              data-testid={`section-${section.key}-count`}
+              className="rounded-full px-2 py-0.5 text-xs font-semibold"
+              style={{
+                backgroundColor: section.presentation.badge.bg,
+                color: section.presentation.badge.text,
+              }}
+            >
+              {section.count}
+            </span>
+          </div>
+          {renderJobs(section.jobs)}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/jobs/build-job-sections.test.ts
+++ b/src/lib/jobs/build-job-sections.test.ts
@@ -1,0 +1,141 @@
+// Issue #723 — Jobs page stage-grouped sections.
+//
+// `buildJobSections` is the pure sort-and-group function behind the Jobs page's
+// stage sections. It groups Jobs by their frozen status key into the page's
+// display order — Active → Lead → Collections → Closed → Lost — newest-first
+// within each section, sourcing each section's label/color/icon from the #720
+// status-presentation module (the single source of truth, ADR 0022).
+//
+// Note: the page's section order is Active-first (work-priority), which is
+// intentionally NOT the module's lifecycle sortRank (Lead-first). Emergency
+// pinning (#726) and the hide-Closed/Lost toggle (#728) are separate slices.
+
+import { describe, expect, it } from "vitest";
+import type { Job } from "@/lib/types";
+import { buildJobSections, countOpenJobs } from "./build-job-sections";
+
+function makeJob(over: Partial<Job> = {}): Job {
+  return {
+    id: "job-1",
+    job_number: "J-0001",
+    contact_id: "c-1",
+    status: "new",
+    urgency: "scheduled",
+    damage_type: "water",
+    damage_source: null,
+    property_address: "1 Test St",
+    property_type: "single_family",
+    property_sqft: null,
+    property_stories: null,
+    affected_areas: null,
+    insurance_company: null,
+    insurance_contact_id: null,
+    claim_number: null,
+    policy_number: null,
+    payer_type: null,
+    date_of_loss: null,
+    deductible: null,
+    estimated_crew_labor_cost: null,
+    hoa_name: null,
+    hoa_contact_name: null,
+    hoa_contact_phone: null,
+    hoa_contact_email: null,
+    access_notes: null,
+    cover_photo_id: null,
+    created_at: "2026-05-27T10:00:00Z",
+    ...over,
+  } as Job;
+}
+
+describe("buildJobSections", () => {
+  it("groups Jobs into stage sections ordered Active → Lead → Collections → Closed → Lost", () => {
+    const jobs = [
+      makeJob({ id: "lead", status: "new" }),
+      makeJob({ id: "active", status: "in_progress" }),
+      makeJob({ id: "collections", status: "pending_invoice" }),
+      makeJob({ id: "closed", status: "completed" }),
+      makeJob({ id: "lost", status: "cancelled" }),
+    ];
+
+    const sections = buildJobSections(jobs);
+
+    expect(sections.map((s) => s.key)).toEqual([
+      "in_progress",
+      "new",
+      "pending_invoice",
+      "completed",
+      "cancelled",
+    ]);
+  });
+
+  it("counts the Jobs in each section", () => {
+    const jobs = [
+      makeJob({ id: "a1", status: "in_progress" }),
+      makeJob({ id: "a2", status: "in_progress" }),
+      makeJob({ id: "l1", status: "new" }),
+    ];
+
+    const sections = buildJobSections(jobs);
+    const active = sections.find((s) => s.key === "in_progress");
+    const lead = sections.find((s) => s.key === "new");
+
+    expect(active?.count).toBe(2);
+    expect(lead?.count).toBe(1);
+  });
+
+  it("orders Jobs newest-first within a section", () => {
+    const jobs = [
+      makeJob({ id: "older", status: "in_progress", created_at: "2026-05-01T00:00:00Z" }),
+      makeJob({ id: "newest", status: "in_progress", created_at: "2026-05-30T00:00:00Z" }),
+      makeJob({ id: "middle", status: "in_progress", created_at: "2026-05-15T00:00:00Z" }),
+    ];
+
+    const sections = buildJobSections(jobs);
+    const active = sections.find((s) => s.key === "in_progress");
+
+    expect(active?.jobs.map((j) => j.id)).toEqual(["newest", "middle", "older"]);
+  });
+
+  it("labels and colors each section from the status-presentation module", () => {
+    const sections = buildJobSections([
+      makeJob({ id: "a", status: "in_progress" }),
+      makeJob({ id: "x", status: "cancelled" }),
+    ]);
+    const active = sections.find((s) => s.key === "in_progress");
+    const lost = sections.find((s) => s.key === "cancelled");
+
+    expect(active?.presentation.label).toBe("Active");
+    expect(active?.presentation.accentColor).toBe("#0E9F6E");
+    // Lost is visually distinct from Closed's grey (the point of #720).
+    expect(lost?.presentation.label).toBe("Lost 😢");
+    expect(lost?.presentation.accentColor).toBe("#E44B4A");
+  });
+
+  it("returns no sections for an empty Job list", () => {
+    expect(buildJobSections([])).toEqual([]);
+  });
+
+  it("omits stages that hold no Jobs", () => {
+    const sections = buildJobSections([
+      makeJob({ id: "a", status: "in_progress" }),
+      makeJob({ id: "l", status: "new" }),
+    ]);
+    // Only Active and Lead are populated — Collections/Closed/Lost are hidden.
+    expect(sections.map((s) => s.key)).toEqual(["in_progress", "new"]);
+  });
+});
+
+describe("countOpenJobs", () => {
+  it("counts only the open stages — Lead + Active + Collections", () => {
+    const jobs = [
+      makeJob({ id: "a1", status: "in_progress" }),
+      makeJob({ id: "a2", status: "in_progress" }),
+      makeJob({ id: "l1", status: "new" }),
+      makeJob({ id: "c1", status: "pending_invoice" }),
+      makeJob({ id: "x1", status: "completed" }),
+      makeJob({ id: "x2", status: "cancelled" }),
+    ];
+
+    expect(countOpenJobs(jobs)).toBe(4);
+  });
+});

--- a/src/lib/jobs/build-job-sections.ts
+++ b/src/lib/jobs/build-job-sections.ts
@@ -1,0 +1,67 @@
+// Issue #723 — Jobs page stage-grouped sections.
+//
+// The pure sort-and-group function behind the Jobs page's stage sections:
+// groups Jobs by their frozen status key (ADR 0022) into the page's display
+// order, sourcing each section's label/color/icon from the #720
+// status-presentation module.
+//
+// The section order is Active-first — the work-priority order the owner agreed
+// for the Jobs page — which is intentionally NOT the module's lifecycle
+// sortRank (Lead-first, used by the status picker). So the order lives here, as
+// the page's own concern; the module remains the source of presentation facets.
+
+import type { Job } from "@/lib/types";
+import {
+  getJobStatusPresentation,
+  isOpenJobStatus,
+  type JobStatusPresentation,
+} from "@/lib/job-status-presentation";
+
+/** Jobs-page section display order: Active → Lead → Collections → Closed → Lost. */
+const SECTION_ORDER = [
+  "in_progress",
+  "new",
+  "pending_invoice",
+  "completed",
+  "cancelled",
+] as const;
+
+export interface JobSection {
+  /** Frozen snake_case status key (ADR 0022). */
+  key: string;
+  /** Label / accent color / icon for the section header (from the #720 module). */
+  presentation: JobStatusPresentation;
+  /** The section's Jobs. */
+  jobs: Job[];
+  /** Number of Jobs in the section (what the header badge shows). */
+  count: number;
+}
+
+export function buildJobSections(jobs: Job[]): JobSection[] {
+  return SECTION_ORDER.map((key) => {
+    const sectionJobs = jobs
+      .filter((job) => job.status === key)
+      .sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+    return {
+      key,
+      presentation: getJobStatusPresentation(key),
+      jobs: sectionJobs,
+      count: sectionJobs.length,
+    };
+    // Empty stages get no header — hidden until they hold at least one Job.
+  }).filter((section) => section.count > 0);
+}
+
+/**
+ * Count of Open jobs — the headline "Open jobs" stat. Open = the Lead, Active,
+ * and Collections stages (per the #720 module's isOpen verdict); Closed and
+ * Lost don't count.
+ */
+export function countOpenJobs(
+  jobs: ReadonlyArray<{ status: string }>,
+): number {
+  return jobs.filter((job) => isOpenJobStatus(job.status)).length;
+}


### PR DESCRIPTION
## Summary

Implements #723 (a slice of parent #719, the Job-status pipeline) via strict TDD.

Replaces the Jobs page's flat list with **stage-grouped sections** in pipeline order — **Active → Lead → Collections → Closed → Lost** — each rendered as a colored section header carrying a **count**, with Jobs sorted **newest-first** within each section. Also renames the headline stat to **"Open jobs"** (Lead + Active + Collections).

## What changed

- **`src/lib/jobs/build-job-sections.ts`** (new) — pure `buildJobSections()` sorts/groups Jobs by their frozen status key (ADR 0022) into the page's display order and hides empty stages; `countOpenJobs()` implements the "Open jobs" rule. The #720 status-presentation module stays the single source of truth for each section's label/color/icon.
- **`src/components/job-stage-sections.tsx`** (new) — presentational `<JobStageSections>`: colored header + count badge per section, delegating each section's Job rendering via a `renderJobs` prop so grouping stays orthogonal to the page's view-mode (grid / list / comfortable).
- **`src/app/jobs/page.tsx`** — wires the sections in and relabels the stat.

## Design note: section order ≠ module sortRank

The page's section order is **Active-first** (work-priority order, agreed with the owner during `/grill-with-docs`), which is intentionally **not** the #720 module's `sortRank` (lifecycle / Lead-first, used by the status picker). The order lives in `buildJobSections` as the page's own concern; the #720 module is untouched.

## Acceptance criteria

- [x] Ordered, labeled, colored sections: Active, Lead, Collections, Closed, Lost
- [x] Accurate per-section count
- [x] Newest-first within each section
- [x] "Open jobs" stat = Lead + Active + Collections
- [x] Pure sort-and-group function unit-tested (order, counts, newest-first) + component test asserting headers render in order with counts

## Tests

10 new tests, all green:

- `build-job-sections.test.ts` (7): section order, per-section counts, newest-first ordering, label/color sourced from the module, empty-list → `[]`, empty-stage omission, and `countOpenJobs`.
- `job-stage-sections.test.tsx` (3): headers render in page order, counts shown in headers, Jobs delegated under the correct section.

`tsc --noEmit` is clean on all touched files; lint is clean on the new files. The one remaining `page.tsx` lint finding is the pre-existing, repo-wide `react-hooks/set-state-in-effect` on the untouched `fetchJobs` effect — not introduced here.

## Behavior note

List mode no longer renders the old flat `<JobListHeader />` column-label row — it doesn't fit per-section grouping.

## Out of scope (separate slices)

- Emergency pinning to the absolute top — #726
- Hide-Closed / Lost toggle + lazy-load — #728

🤖 Generated with [Claude Code](https://claude.com/claude-code)
